### PR TITLE
configure.ac: Use relative path to convenience lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1230,7 +1230,7 @@ AC_SUBST([opalib])
 if test "$with_openpa_prefix" = "embedded" ; then
     if test -e "${use_top_srcdir}/src/openpa" ; then
         opasrcdir="${master_top_builddir}/src/openpa"
-        opalib="${master_top_builddir}/src/openpa/src/lib${OPALIBNAME}.la"
+        opalib="src/openpa/src/lib${OPALIBNAME}.la"
         PAC_APPEND_FLAG([-I${use_top_srcdir}/src/openpa/src],[CPPFLAGS])
         PAC_APPEND_FLAG([-I${master_top_builddir}/src/openpa/src],[CPPFLAGS])
 


### PR DESCRIPTION
Using an absolute path to the OPA convenience lib is overkill. Use
relative path for consistency with other libs.