### PR TITLE
ch4/ofi:  progress loop threshold controls

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -23,23 +23,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];
+    int thresh = MPIDI_OFI_LOOP_PROGRESS;
     ssize_t ret;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
 
-    if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
-        mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1, 1);
-    else if (likely(1)) {
-        ret = fi_cq_read(MPIDI_Global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
+    while (thresh--) {
+        if (unlikely(MPIDI_OFI_get_buffered(wc, 1))) {
+            mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1, 1);
+        } else if (likely(1)) {
+            ret = fi_cq_read(MPIDI_Global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
-        if (likely(ret > 0))
-            mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret, 0);
-        else if (ret == -FI_EAGAIN)
-            mpi_errno = MPI_SUCCESS;
-        else
-            mpi_errno = MPIDI_OFI_handle_cq_error(vni, ret);
+            if (likely(ret > 0))
+                mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret, 0);
+            else if (ret == -FI_EAGAIN)
+                mpi_errno = MPI_SUCCESS;
+            else
+                mpi_errno = MPIDI_OFI_handle_cq_error(vni, ret);
+        }
     }
 
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -21,6 +21,23 @@
 #include "ch4_types.h"
 #include "mpidch4r.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_OFI_NUM_CQ_ENTRIES
+      category    : CH4_OFI
+      type        : int
+      default     : 4
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        The maximum number of completion queue entries to grab from OFI at one time.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 #define __SHORT_FILE__                          \
     (strrchr(__FILE__,'/')                      \
      ? strrchr(__FILE__,'/')+1                  \
@@ -168,7 +185,7 @@ static inline int MPIDI_OFI_comm_to_ep(MPIR_Comm * comm_ptr, int rank)
 
 #define MPIDI_OFI_DO_SEND        0
 #define MPIDI_OFI_DO_INJECT      1
-#define MPIDI_OFI_NUM_CQ_ENTRIES 8
+#define MPIDI_OFI_NUM_CQ_ENTRIES MPIR_CVAR_CH4_OFI_NUM_CQ_ENTRIES
 
 /* Typedefs */
 enum {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -35,6 +35,17 @@ cvars:
       description : >-
         The maximum number of completion queue entries to grab from OFI at one time.
 
+    - name        : MPIR_CVAR_CH4_OFI_LOOP_PROGRESS
+      category    : CH4_OFI
+      type        : int
+      default     : 100
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        The number of times to loop in the progress engine to grab entries from
+        the OFI completion queue.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -186,6 +197,7 @@ static inline int MPIDI_OFI_comm_to_ep(MPIR_Comm * comm_ptr, int rank)
 #define MPIDI_OFI_DO_SEND        0
 #define MPIDI_OFI_DO_INJECT      1
 #define MPIDI_OFI_NUM_CQ_ENTRIES MPIR_CVAR_CH4_OFI_NUM_CQ_ENTRIES
+#define MPIDI_OFI_LOOP_PROGRESS  MPIR_CVAR_CH4_OFI_LOOP_PROGRESS
 
 /* Typedefs */
 enum {


### PR DESCRIPTION
Some providers allow for multiple cq entries to be copied to the stack
CQ entries may use storage on the stack that can cause misses, so these thresholds
are a tuning knob to control how many entries to populate onto the stack.
