### PR TITLE
Workaround a gcc 5.3 compiler LTO bug

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -98,8 +98,8 @@ MPID_Thread_tls_t MPIR_Per_thread_key;
    If the Fortran binding is supported, these can be initialized to 
    their Fortran values (MPI only requires that they be valid between
    MPI_Init and MPI_Finalize) */
-MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUS_IGNORE = 0;
-MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUSES_IGNORE = 0;
+MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUS_IGNORE ATTRIBUTE((used)) = 0;
+MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUSES_IGNORE ATTRIBUTE((used)) = 0;
 
 /* This will help force the load of initinfo.o, which contains data about
    how MPICH was configured. */


### PR DESCRIPTION
The RedHat gcc version in devtoolset-4 has an LTO bug
that optimizes away the global environment variables
MPI_F_STATUS_IGNORE and MPI_F_STATUSES_IGNORE.

gcc version 5.3.1 20160406 (Red Hat 5.3.1-6) (GCC)

The workaround is to explicity tag these variables as used
