### PR TITLE
CH4/OFI: Do not clear flags for embedded OFI

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -139,11 +139,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         ofi_subdir_args="--enable-embedded"
 
         dnl Unset all of these env vars so they don't pollute the libfabric configuration
-        PAC_PUSH_ALL_FLAGS()
-        PAC_RESET_ALL_FLAGS()
-        PAC_APPEND_FLAG([$VISIBILITY_CFLAGS], [CFLAGS])
+        PAC_PUSH_FLAG(CPPFLAGS)
         PAC_CONFIG_SUBDIR_ARGS([src/mpid/ch4/netmod/ofi/libfabric],[$ofi_subdir_args],[],[AC_MSG_ERROR(libfabric configure failed)])
-        PAC_POP_ALL_FLAGS()
+        PAC_POP_FLAG(CPPFLAGS)
         PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpid/ch4/netmod/ofi/libfabric/include], [CPPFLAGS])
         PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpid/ch4/netmod/ofi/libfabric/include], [CPPFLAGS])
 


### PR DESCRIPTION
OFI is built as part of the MPICH library, so it should be subjected to
the same compile/link flags as the main configure. We save CPPFLAGS
however, as any additions by OFI should be self-contained.