### PR TITLE
config: Cleanup MPL substitutions in Makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1190,8 +1190,7 @@ if test "$with_mpl_prefix" = "embedded" ; then
     PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpl/include], [CPPFLAGS])
     PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpl/include], [CPPFLAGS])
 
-    mplsrcdir="${master_top_builddir}/src/mpl"
-    mpllibdir="-L${master_top_builddir}/src/mpl"
+    mplsrcdir="src/mpl"
     mpllib="src/mpl/lib${MPLLIBNAME}.la"
 else
     # The user specified an already-installed MPL; just sanity check, don't

--- a/src/pm/gforker/Makefile.mk
+++ b/src/pm/gforker/Makefile.mk
@@ -16,7 +16,7 @@ if BUILD_PM_GFORKER
 if PRIMARY_PM_GFORKER
 bin_PROGRAMS += src/pm/gforker/mpiexec
 src_pm_gforker_mpiexec_SOURCES = src/pm/gforker/mpiexec.c 
-src_pm_gforker_mpiexec_LDADD = src/pm/util/libmpiexec.la -l$(MPLLIBNAME)
+src_pm_gforker_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpllib)
 src_pm_gforker_mpiexec_LDFLAGS = $(mpllibdir)
 EXTRA_src_pm_gforker_mpiexec_DEPENDENCIES = $(mpllib)
 # we may not want to add AM_CPPFLAGS for this program
@@ -24,7 +24,7 @@ src_pm_gforker_mpiexec_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 else !PRIMARY_PM_GFORKER
 bin_PROGRAMS += src/pm/gforker/mpiexec.gforker
 src_pm_gforker_mpiexec_gforker_SOURCES = src/pm/gforker/mpiexec.c 
-src_pm_gforker_mpiexec_gforker_LDADD = src/pm/util/libmpiexec.la -l$(MPLLIBNAME)
+src_pm_gforker_mpiexec_gforker_LDADD = src/pm/util/libmpiexec.la $(mpllib)
 src_pm_gforker_mpiexec_gforker_LDFLAGS = $(mpllibdir)
 EXTRA_src_pm_gforker_mpiexec_gforker_DEPENDENCIES = $(mpllib)
 # we may not want to add AM_CPPFLAGS for this program

--- a/src/pm/remshell/Makefile.mk
+++ b/src/pm/remshell/Makefile.mk
@@ -16,7 +16,7 @@ if BUILD_PM_REMSHELL
 if PRIMARY_PM_REMSHELL
 bin_PROGRAMS += src/pm/remshell/mpiexec
 src_pm_remshell_mpiexec_SOURCES = src/pm/remshell/mpiexec.c 
-src_pm_remshell_mpiexec_LDADD = src/pm/util/libmpiexec.la -l$(MPLLIBNAME)
+src_pm_remshell_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpllib)
 src_pm_remshell_mpiexec_LDFLAGS = $(mpllibdir)
 EXTRA_src_pm_remshell_mpiexec_DEPENDENCIES = $(mpllib)
 # we may not want to add AM_CPPFLAGS for this program
@@ -24,7 +24,7 @@ src_pm_remshell_mpiexec_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 else !PRIMARY_PM_REMSHELL
 bin_PROGRAMS += src/pm/remshell/mpiexec.remshell
 src_pm_remshell_mpiexec_remshell_SOURCES = src/pm/remshell/mpiexec.c 
-src_pm_remshell_mpiexec_remshell_LDADD = src/pm/util/libmpiexec.la -l$(MPLLIBNAME)
+src_pm_remshell_mpiexec_remshell_LDADD = src/pm/util/libmpiexec.la $(mpllib)
 src_pm_remshell_mpiexec_remshell_LDFLAGS = $(mpllibdir)
 EXTRA_src_pm_remshell_mpiexec_remshell_DEPENDENCIES = $(mpllib)
 # we may not want to add AM_CPPFLAGS for this program

--- a/src/pm/util/Makefile.mk
+++ b/src/pm/util/Makefile.mk
@@ -28,7 +28,7 @@ src_pm_util_libmpiexec_la_CFLAGS = -g $(AM_CFLAGS)
 src_pm_util_libmpiexec_la_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 
 # MPL
-src_pm_util_libmpiexec_la_LIBADD = -l$(MPLLIBNAME)
+src_pm_util_libmpiexec_la_LIBADD = $(mpllib)
 src_pm_util_libmpiexec_la_LDFLAGS = $(mpllibdir)
 EXTRA_src_pm_util_libmpiexec_la_DEPENDENCIES = $(mpllib)
 


### PR DESCRIPTION
Use the MPL library determined by configure in all cases. Avoid
cluttering up LDFLAGS in embedded mode.
