### PR TITLE
tests: fixed wrong variable type declaration

### DIFF
--- a/test/mpi/threads/comm/idup_comm_gen.c
+++ b/test/mpi/threads/comm/idup_comm_gen.c
@@ -18,7 +18,7 @@
 #define NUM_IDUPS   5
 
 MPI_Comm comms[NUM_THREADS];
-MPI_Comm errs[NUM_THREADS] = { 0 };
+int errs[NUM_THREADS] = { 0 };
 
 int verbose = 0;
 


### PR DESCRIPTION
In test/mpi/threads/comm/idup_comm_gen.c, errs should be an array of
integers not an array of communicators.
