### PR TITLE
romio: initialize some global variables

### DIFF
--- a/src/mpi/romio/adio/common/ad_tuning.c
+++ b/src/mpi/romio/adio/common/ad_tuning.c
@@ -21,12 +21,12 @@
 
 #include "ad_tuning.h"
 
-int     romio_write_aggmethod;
-int     romio_read_aggmethod;
-int     romio_onesided_no_rmw;
-int     romio_onesided_always_rmw;
-int     romio_onesided_inform_rmw;
-int 	romio_tunegather;
+int     romio_write_aggmethod = 0;
+int     romio_read_aggmethod = 0;
+int     romio_onesided_no_rmw = 0;
+int     romio_onesided_always_rmw = 0;
+int     romio_onesided_inform_rmw = 0;
+int     romio_tunegather = 1;
 
 /* set internal variables for tuning environment variables */
 /** \page mpiio_vars MPIIO Configuration


### PR DESCRIPTION
Clang (clang++) on Mac OS complains that those variables are Undefined
symbols at linking time. It seems that uninitialized global variables
are stored in a common section and are not visible to the user program
at linking time. When initialized, Clang put them in the initialized
data section and become visible.
