### PR TITLE
[Request for Comment - DO NOT MERGE] Add -static-mpi to only compile libmpi as a static library

### DIFF
--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -103,6 +103,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -245,7 +251,7 @@ if [ "$linking" = yes ] ; then
         $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
-        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs}
         rc=$?
     fi
 else

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -103,6 +103,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -254,7 +260,7 @@ if [ "$linking" = yes ] ; then
         $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
-        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs}
         rc=$?
     fi
 else

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -100,6 +100,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -193,7 +199,7 @@ fi
 # options (if any)
 cxxlibs=
 if [ "@MPICXXLIBNAME@" != "@MPILIBNAME@" ] ; then
-    cxxlibs="-l@MPICXXLIBNAME@"
+    cxxlibs="$STATIC_PRELIB -l@MPICXXLIBNAME@ $STATIC_POSTLIB"
 fi
 
 PROFILE_FOO=
@@ -243,7 +249,7 @@ if [ "$linking" = yes ] ; then
         $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs}
         rc=$?
     fi
 else

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -100,6 +100,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -202,7 +208,7 @@ fi
 # options (if any)
 cxxlibs=
 if [ "@MPICXXLIBNAME@" != "@MPILIBNAME@" ] ; then
-    cxxlibs="-l@MPICXXLIBNAME@"
+    cxxlibs="$STATIC_PRELIB -l@MPICXXLIBNAME@ $STATIC_POSTLIB"
 fi
 
 PROFILE_FOO=
@@ -252,7 +258,7 @@ if [ "$linking" = yes ] ; then
         $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} $allargs -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} $allargs -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs}
         rc=$?
     fi
 else

--- a/src/env/mpif77.bash.in
+++ b/src/env/mpif77.bash.in
@@ -107,6 +107,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -295,7 +301,7 @@ if [ "$linking" = yes ] ; then
         $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
-        $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
+        $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
         rc=$?
     fi
 else

--- a/src/env/mpif77.sh.in
+++ b/src/env/mpif77.sh.in
@@ -106,6 +106,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -267,7 +273,7 @@ fi
 # options (if any)
 f77libs=
 if [ "@MPIFCLIBNAME@" != "@MPILIBNAME@" ] ; then
-    f77libs="-l@MPIFCLIBNAME@"
+    f77libs="$STATIC_PRELIB -l@MPIFCLIBNAME@ $STATIC_POSTLIB"
 fi
 
 PROFILE_FOO=
@@ -317,7 +323,7 @@ if [ "$linking" = yes ] ; then
         $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
-        $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} $allargs -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
+        $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} $allargs -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
         rc=$?
     fi
 else

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -120,6 +120,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -336,7 +342,7 @@ if [ "$linking" = yes ] ; then
         $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}"
         rc=$?
     else
-        $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
+        $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir $STATIC_PRELIB -l@MPIFCLIBNAME@ $STATIC_POSTLIB $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
         rc=$?
     fi
 else

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -119,6 +119,12 @@ for arg in "$@" ; do
     -static)
     interlib_deps=no
     ;;
+    -static-mpi)
+    interlib_deps=no
+    addarg=no
+    STATIC_PRELIB=-Wl,-Bstatic
+    STATIC_POSTLIB=-Wl,-Bdynamic
+    ;;
     -echo)
     addarg=no
     set -x
@@ -352,7 +358,7 @@ if [ "$linking" = yes ] ; then
         $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} $allargs
         rc=$?
     else
-        $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} $allargs $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
+        $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} $allargs $FCINCDIRS $FCMODDIRS -L$libdir $STATIC_PRELIB -l@MPIFCLIBNAME@ $STATIC_POSTLIB $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $STATIC_PRELIB -l@MPILIBNAME@ @LPMPILIBNAME@ $STATIC_POSTLIB $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
         rc=$?
     fi
 else


### PR DESCRIPTION
This PR adds an option to the compile scripts to only compile libmpi as a static library.
A lot of Linux system installs do not support a full complement of static libraries (including libc, libdl, librt, etc).  It might still be desirable to build MPI into the application to allow for LTO optimizations and other general static lib improvements.

There may be a couple more issues:
1)  The patch assumes -Wl,-Bstatic and -Wl,-Bdynamic, which may not work on other platforms.  Looking for a little help on how to generalize this to other platforms via a configure option.
2)  -static and -static-mpi options should be somehow mutually exlusive (or -static should supersede the option).
