### PR TITLE
CH4/OFI: Add embedded libfabric to .gitignore

### DIFF
--- a/src/mpid/ch4/netmod/ofi/.gitignore
+++ b/src/mpid/ch4/netmod/ofi/.gitignore
@@ -1,0 +1,1 @@
+libfabric/


### PR DESCRIPTION
If there is an embedded libfabric for CH4, put it in the .gitignore