### PR TITLE
Remove the 32B alignment for MPIR_Request

### DIFF
--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -1528,7 +1528,7 @@ typedef struct MPID_Request {
 #ifdef MPID_DEV_REQUEST_DECL
     MPID_DEV_REQUEST_DECL
 #endif
-} MPID_Request ATTRIBUTE((__aligned__(32)));
+} MPID_Request;
 
 extern MPIU_Object_alloc_t MPID_Request_mem;
 /* Preallocated request objects */


### PR DESCRIPTION
The MPIR_Request structure is aligned to 32B and allocated through the
request memory object pool. The alignment was introduced for
potentially reducing false sharing in thread_multiple mode. Indirect
blocks in the pool, however, are dynamically allocated without
using aligned memory allocation. This does not guarantee 32B
alignment and causes segfaults when touching requests in indirect
blocks. To this point, there is no evidence of significant performance
improvement with this alignment. Thus this patch drops this alignment.

Fixes #2350