### PR TITLE
Enable MPL_thread_create() to use Utility Thread Offloading interface (UTI)

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -593,11 +593,14 @@ AS_CASE([$enable_yield],
 #######################################################################
 ## START OF THREADS CODE
 #######################################################################
+PAC_SET_HEADER_LIB_PATH(uti)
+
 AC_ARG_WITH([thread-package],
 [  --with-thread-package=package     Thread package to use. Supported thread packages include:
         posix or pthreads - POSIX threads (default, if required)
         solaris - Solaris threads (Solaris OS only)
         win - windows threads
+        uti - POSIX threads plus Utility Thread Offloading library
         none - no threads
 ],,with_thread_package=posix)
 
@@ -615,8 +618,10 @@ fi
 
 THREAD_PACKAGE_NAME=MPL_THREAD_PACKAGE_INVALID
 case $with_thread_package in
-    posix|pthreads)
-	with_thread_package=posix
+    posix|pthreads|uti)
+	if test "${with_thread_package}" = "pthreads" ; then
+	    with_thread_package=posix
+	fi
 	AC_CHECK_HEADERS(pthread.h)
 
         # If pthreads library is found, just include it on the link line. We don't try
@@ -684,7 +689,18 @@ void f1(void *a) { return; }],
 
 	PAC_FUNC_NEEDS_DECL([#include <pthread.h>],pthread_mutexattr_settype)
 
-        THREAD_PACKAGE_NAME=MPL_THREAD_PACKAGE_POSIX
+	if test "${with_thread_package}" = "uti" ; then
+	    PAC_CHECK_HEADER_LIB(uti.h,uti,uti_attr_init,have_uti=yes,have_uti=no)
+	    if test "${have_uti}" = "yes" ; then
+		AC_MSG_NOTICE([Using POSIX and Utility Thread Offloading library for thread package])
+	    else
+		AC_MSG_ERROR([Unable to find Utility Thread Offloading library])
+	    fi
+	    THREAD_PACKAGE_NAME=MPL_THREAD_PACKAGE_UTI
+	else
+	    AC_MSG_NOTICE([POSIX will be used for thread package.])
+	    THREAD_PACKAGE_NAME=MPL_THREAD_PACKAGE_POSIX
+	fi
 	;;
     solaris)
 	AC_CHECK_HEADERS(thread.h)

--- a/src/mpl/include/mpl_thread.h
+++ b/src/mpl/include/mpl_thread.h
@@ -15,8 +15,9 @@
 #define MPL_THREAD_PACKAGE_POSIX   2
 #define MPL_THREAD_PACKAGE_SOLARIS 3
 #define MPL_THREAD_PACKAGE_WIN     4
+#define MPL_THREAD_PACKAGE_UTI     5
 
-#if defined(MPL_THREAD_PACKAGE_NAME) && (MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_POSIX)
+#if defined(MPL_THREAD_PACKAGE_NAME) && (MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_POSIX || MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_UTI)
 #  include "mpl_thread_posix.h"
 #elif defined(MPL_THREAD_PACKAGE_NAME) && (MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_SOLARIS)
 #  include "mpl_thread_solaris.h"
@@ -31,7 +32,7 @@ typedef void (*MPL_thread_func_t) (void *data);
 #define MPL_thread_mutex_create(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = 0;}
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = 0;}
 #else
-#  error "thread package not defined or unknown"
+#  error "thread package (MPL_THREAD_PACKAGE_NAME) not defined or unknown"
 #endif
 
 /* Error values */

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -6,6 +6,10 @@
 
 #include "mpl.h"
 
+#if MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_UTI
+#include "uti.h"
+#endif
+
 MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 /* This file currently implements these as a preprocessor if/elif/else sequence.
@@ -16,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
  * header files and included as needed. [goodell@ 2009-06-24] */
 
 /* Implementation specific function definitions (usually in the form of macros) */
-#if MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_POSIX
+#if MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_POSIX || MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_UTI
 
 /*
  * struct MPLI_thread_info
@@ -53,9 +57,43 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
         pthread_attr_init(&attr);
         pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
 
+#if MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_UTI
+        uti_attr_t *uti_attr = NULL;
+        err = uti_attr_init(uti_attr);
+        if (err) {
+            goto uti_exit;
+        }
+
+        /* Give a hint that it's beneficial to put the thread
+         * on the same NUMA-node as the creator */
+        err = UTI_ATTR_SAME_NUMA_DOMAIN(uti_attr);
+        if (err) {
+            goto uti_destroy_and_exit;
+        }
+
+        /* Give a hint that the thread repeatedly monitors a device
+         * using CPU. */
+        err = UTI_ATTR_CPU_INTENSIVE(uti_attr);
+        if (err) {
+            goto uti_destroy_and_exit;
+        }
+
+        err = uti_pthread_create(idp, &attr, MPLI_thread_start, thread_info, uti_attr);
+        if (err) {
+            goto uti_destroy_and_exit;
+        }
+
+      uti_destroy_and_exit:
+        err = uti_attr_destroy(uti_attr);
+        if (err) {
+            goto uti_exit;
+        }
+
+      uti_exit:;
+#else
         err = pthread_create(idp, &attr, MPLI_thread_start, thread_info);
         /* FIXME: convert error to an MPL_THREAD_ERR value */
-
+#endif
         pthread_attr_destroy(&attr);
     }
     else {


### PR DESCRIPTION
1. Add configure options to switch codes in MPL_thread_create()
You can make MPL_thread_create() to use the interface by specifying
'--with-thread-package=uti' in configure. The interface is an extension to pthread interface.

2. Add configure options to specify the locations of the header file and the library
The locations of the header file and library are specified by either '--with-uti=yes', which means
the standard directories, or '--with-uti=PATH', which means PATH/{lib,include}.

UTI source:
[uti-14e3512.tar.gz](https://github.com/pmodels/mpich/files/574493/uti-14e3512.tar.gz)

The slides explaining the motivation of UTI:
[utility_thread_API-r4.6.pdf](https://github.com/pmodels/mpich/files/574492/utility_thread_API-r4.6.pdf)