### PR TITLE
Add namespace back to local functions.

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -111,17 +111,17 @@ static inline int MPIDI_handle_unexpected(void *buf,
 }
 
 #undef FUNCNAME
-#define FUNCNAME do_irecv
+#define FUNCNAME MPIDI_do_irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int do_irecv(void *buf,
-                           int count,
-                           MPI_Datatype datatype,
-                           int rank,
-                           int tag,
-                           MPIR_Comm * comm,
-                           int context_offset,
-                           MPIR_Request ** request, int alloc_req, uint64_t flags)
+static inline int MPIDI_do_irecv(void *buf,
+                                 int count,
+                                 MPI_Datatype datatype,
+                                 int rank,
+                                 int tag,
+                                 MPIR_Comm * comm,
+                                 int context_offset,
+                                 MPIR_Request ** request, int alloc_req, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL, *unexp_req = NULL;
@@ -226,7 +226,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4U_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CH4U_RECV);
 
-    mpi_errno = do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
+    mpi_errno =
+        MPIDI_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -382,7 +383,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4U_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CH4U_IRECV);
 
-    mpi_errno = do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
+    mpi_errno =
+        MPIDI_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
   fn_exit:

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -16,10 +16,11 @@
 #include "ch4r_proc.h"
 
 #undef FUNCNAME
-#define FUNCNAME prepare_recv_req
+#define FUNCNAME MPIDI_prepare_recv_req
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int prepare_recv_req(void *buf, int count, MPI_Datatype datatype, MPIR_Request * rreq)
+static inline int MPIDI_prepare_recv_req(void *buf, int count, MPI_Datatype datatype,
+                                         MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4U_PREPARE_RECV_BUFFER);
@@ -34,13 +35,13 @@ static inline int prepare_recv_req(void *buf, int count, MPI_Datatype datatype, 
 }
 
 #undef FUNCNAME
-#define FUNCNAME handle_unexpected
+#define FUNCNAME MPIDI_handle_unexpected
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int handle_unexpected(void *buf,
-                                    int count,
-                                    MPI_Datatype datatype,
-                                    MPIR_Comm * comm, int context_offset, MPIR_Request * rreq)
+static inline int MPIDI_handle_unexpected(void *buf,
+                                          int count,
+                                          MPI_Datatype datatype,
+                                          MPIR_Comm * comm, int context_offset, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int dt_contig;
@@ -154,7 +155,8 @@ static inline int do_irecv(void *buf,
         }
         else {
             *request = unexp_req;
-            mpi_errno = handle_unexpected(buf, count, datatype, root_comm, context_id, unexp_req);
+            mpi_errno =
+                MPIDI_handle_unexpected(buf, count, datatype, root_comm, context_id, unexp_req);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             goto fn_exit;
@@ -184,7 +186,7 @@ static inline int do_irecv(void *buf,
     MPIDI_CH4U_REQUEST(rreq, req->rreq.ignore) = mask_bits;
     MPIDI_CH4U_REQUEST(rreq, datatype) = datatype;
 
-    mpi_errno = prepare_recv_req(buf, count, datatype, rreq);
+    mpi_errno = MPIDI_prepare_recv_req(buf, count, datatype, rreq);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -16,12 +16,12 @@
 #include <../mpi/pt2pt/bsendutil.h>
 
 #undef FUNCNAME
-#define FUNCNAME am_isend
+#define FUNCNAME MPIDI_am_isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int am_isend(const void *buf, int count, MPI_Datatype datatype,
-                           int rank, int tag, MPIR_Comm * comm, int context_offset,
-                           MPIR_Request ** request, int is_blocking, int type)
+static inline int MPIDI_am_isend(const void *buf, int count, MPI_Datatype datatype,
+                                 int rank, int tag, MPIR_Comm * comm, int context_offset,
+                                 MPIR_Request ** request, int is_blocking, int type)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
@@ -77,14 +77,15 @@ static inline int am_isend(const void *buf, int count, MPI_Datatype datatype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME psend_init
+#define FUNCNAME MPIDI_psend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int psend_init(const void *buf,
-                             int count,
-                             MPI_Datatype datatype,
-                             int rank,
-                             int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
+static inline int MPIDI_psend_init(const void *buf,
+                                   int count,
+                                   MPI_Datatype datatype,
+                                   int rank,
+                                   int tag, MPIR_Comm * comm, int context_offset,
+                                   MPIR_Request ** request)
 {
     MPIR_Request *sreq;
     uint64_t match_bits;
@@ -130,7 +131,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0);
+    mpi_errno =
+        MPIDI_am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SEND);
     return mpi_errno;
@@ -151,7 +153,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ISEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 0, 0);
+    mpi_errno =
+        MPIDI_am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 0, 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_ISEND);
     return mpi_errno;
@@ -173,7 +176,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RSEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0);
+    mpi_errno =
+        MPIDI_am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RSEND);
     return mpi_errno;
@@ -195,7 +199,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IRSEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 0, 0);
+    mpi_errno =
+        MPIDI_am_isend(buf, count, datatype, rank, tag, comm, context_offset, request, 0, 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRSEND);
     return mpi_errno;
@@ -216,8 +221,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SSEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm,
-                         context_offset, request, 1, MPIDI_CH4U_SSEND_REQ);
+    mpi_errno = MPIDI_am_isend(buf, count, datatype, rank, tag, comm,
+                               context_offset, request, 1, MPIDI_CH4U_SSEND_REQ);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SSEND);
     return mpi_errno;
@@ -238,8 +243,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ISSEND);
 
-    mpi_errno = am_isend(buf, count, datatype, rank, tag, comm,
-                         context_offset, request, 0, MPIDI_CH4U_SSEND_REQ);
+    mpi_errno = MPIDI_am_isend(buf, count, datatype, rank, tag, comm,
+                               context_offset, request, 0, MPIDI_CH4U_SSEND_REQ);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_ISSEND);
     return mpi_errno;
@@ -372,7 +377,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send_init(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SEND_INIT);
 
-    mpi_errno = psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPIDI_psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
     MPIDI_CH4U_REQUEST((*request), p_type) = MPIDI_PTYPE_SEND;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SEND_INIT);
@@ -395,7 +400,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend_init(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_SSEND_INIT);
 
-    mpi_errno = psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPIDI_psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
     MPIDI_CH4U_REQUEST((*request), p_type) = MPIDI_PTYPE_SSEND;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_SSEND_INIT);
@@ -418,7 +423,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_bsend_init(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_BSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_BSEND_INIT);
 
-    mpi_errno = psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPIDI_psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
     MPIDI_CH4U_REQUEST((*request), p_type) = MPIDI_PTYPE_BSEND;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_BSEND_INIT);
@@ -441,7 +446,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend_init(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_RSEND_INIT);
 
-    mpi_errno = psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    mpi_errno = MPIDI_psend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
     MPIDI_CH4U_REQUEST((*request), p_type) = MPIDI_PTYPE_SEND;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RSEND_INIT);


### PR DESCRIPTION
We had removed the namespace in [fdf4bdad].  That was dumb.  Static
functions don't need a namespace only in .c files.  We still need to
namespace them in .h files to avoid conflicts when they are included
in .c files.