### PR TITLE
Get rid of static inline attributes

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -207,14 +207,13 @@ static inline int MPIDI_do_irecv(void *buf,
 #define FUNCNAME MPIDIG_mpi_recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm,
-                                             int context_offset, MPI_Status * status,
-                                             MPIR_Request ** request)
+static inline int MPIDIG_mpi_recv(void *buf,
+                                  MPI_Aint count,
+                                  MPI_Datatype datatype,
+                                  int rank,
+                                  int tag,
+                                  MPIR_Comm * comm,
+                                  int context_offset, MPI_Status * status, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RECV);
@@ -236,13 +235,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
 #define FUNCNAME MPIDIG_mpi_recv_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv_init(void *buf,
-                                                  int count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag,
-                                                  MPIR_Comm * comm,
-                                                  int context_offset, MPIR_Request ** request)
+static inline int MPIDIG_mpi_recv_init(void *buf,
+                                       int count,
+                                       MPI_Datatype datatype,
+                                       int rank,
+                                       int tag,
+                                       MPIR_Comm * comm,
+                                       int context_offset, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -275,10 +274,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv_init(void *buf,
 #define FUNCNAME MPIDIG_mpi_imrecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPIDIG_mpi_imrecv(void *buf,
+                                    MPI_Aint count,
+                                    MPI_Datatype datatype,
+                                    MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -326,10 +325,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
 #define FUNCNAME MPIDIG_mrecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mrecv(void *buf,
-                                          MPI_Aint count,
-                                          MPI_Datatype datatype,
-                                          MPIR_Request * message, MPI_Status * status)
+static inline int MPIDIG_mrecv(void *buf,
+                               MPI_Aint count,
+                               MPI_Datatype datatype, MPIR_Request * message, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS, active_flag;
     MPI_Request req_handle;
@@ -363,13 +361,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mrecv(void *buf,
 #define FUNCNAME MPIDIG_mpi_irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+static inline int MPIDIG_mpi_irecv(void *buf,
+                                   MPI_Aint count,
+                                   MPI_Datatype datatype,
+                                   int rank,
+                                   int tag,
+                                   MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRECV);
@@ -390,7 +387,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
 #define FUNCNAME MPIDIG_mpi_cancel_recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_cancel_recv(MPIR_Request * rreq)
+static inline int MPIDIG_mpi_cancel_recv(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS, found;
     MPIR_Comm *root_comm;

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -118,12 +118,12 @@ static inline int MPIDI_psend_init(const void *buf,
 #define FUNCNAME MPIDIG_mpi_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
-                                             MPI_Aint count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag, MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+static inline int MPIDIG_mpi_send(const void *buf,
+                                  MPI_Aint count,
+                                  MPI_Datatype datatype,
+                                  int rank,
+                                  int tag, MPIR_Comm * comm, int context_offset,
+                                  MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SEND);
@@ -140,12 +140,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
 #define FUNCNAME MPIDIG_mpi_isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag, MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+static inline int MPIDIG_mpi_isend(const void *buf,
+                                   MPI_Aint count,
+                                   MPI_Datatype datatype,
+                                   int rank,
+                                   int tag, MPIR_Comm * comm, int context_offset,
+                                   MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISEND);
@@ -163,12 +163,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
 #define FUNCNAME MPIDIG_mpi_rsend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag, MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+static inline int MPIDIG_mpi_rsend(const void *buf,
+                                   MPI_Aint count,
+                                   MPI_Datatype datatype,
+                                   int rank,
+                                   int tag, MPIR_Comm * comm, int context_offset,
+                                   MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_RSEND);
@@ -186,12 +186,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
 #define FUNCNAME MPIDIG_mpi_irsend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIR_Request ** request)
+static inline int MPIDIG_mpi_irsend(const void *buf,
+                                    MPI_Aint count,
+                                    MPI_Datatype datatype,
+                                    int rank,
+                                    int tag, MPIR_Comm * comm, int context_offset,
+                                    MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IRSEND);
@@ -208,12 +208,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
 #define FUNCNAME MPIDIG_mpi_ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
-                                              int tag, MPIR_Comm * comm, int context_offset,
-                                              MPIR_Request ** request)
+static inline int MPIDIG_mpi_ssend(const void *buf,
+                                   MPI_Aint count,
+                                   MPI_Datatype datatype,
+                                   int rank,
+                                   int tag, MPIR_Comm * comm, int context_offset,
+                                   MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_SSEND);
@@ -230,12 +230,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
 #define FUNCNAME MPIDIG_mpi_issend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag, MPIR_Comm * comm, int context_offset,
-                                               MPIR_Request ** request)
+static inline int MPIDIG_mpi_issend(const void *buf,
+                                    MPI_Aint count,
+                                    MPI_Datatype datatype,
+                                    int rank,
+                                    int tag, MPIR_Comm * comm, int context_offset,
+                                    MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ISSEND);
@@ -252,12 +252,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
 #define FUNCNAME MPIDIG_mpi_send_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send_init(const void *buf,
-                                                  int count,
-                                                  MPI_Datatype datatype,
-                                                  int rank,
-                                                  int tag, MPIR_Comm * comm, int context_offset,
-                                                  MPIR_Request ** request)
+static inline int MPIDIG_mpi_send_init(const void *buf,
+                                       int count,
+                                       MPI_Datatype datatype,
+                                       int rank,
+                                       int tag, MPIR_Comm * comm, int context_offset,
+                                       MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -275,12 +275,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send_init(const void *buf,
 #define FUNCNAME MPIDIG_mpi_ssend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend_init(const void *buf,
-                                                   int count,
-                                                   MPI_Datatype datatype,
-                                                   int rank,
-                                                   int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+static inline int MPIDIG_mpi_ssend_init(const void *buf,
+                                        int count,
+                                        MPI_Datatype datatype,
+                                        int rank,
+                                        int tag, MPIR_Comm * comm, int context_offset,
+                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -298,12 +298,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend_init(const void *buf,
 #define FUNCNAME MPIDIG_mpi_bsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_bsend_init(const void *buf,
-                                                   int count,
-                                                   MPI_Datatype datatype,
-                                                   int rank,
-                                                   int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+static inline int MPIDIG_mpi_bsend_init(const void *buf,
+                                        int count,
+                                        MPI_Datatype datatype,
+                                        int rank,
+                                        int tag, MPIR_Comm * comm, int context_offset,
+                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -321,12 +321,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_bsend_init(const void *buf,
 #define FUNCNAME MPIDIG_mpi_rsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend_init(const void *buf,
-                                                   int count,
-                                                   MPI_Datatype datatype,
-                                                   int rank,
-                                                   int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+static inline int MPIDIG_mpi_rsend_init(const void *buf,
+                                        int count,
+                                        MPI_Datatype datatype,
+                                        int rank,
+                                        int tag, MPIR_Comm * comm, int context_offset,
+                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -344,7 +344,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend_init(const void *buf,
 #define FUNCNAME MPIDIG_mpi_cancel_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_cancel_send(MPIR_Request * sreq)
+static inline int MPIDIG_mpi_cancel_send(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/generic/mpidig_startall.h
+++ b/src/mpid/ch4/generic/mpidig_startall.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDIG_mpi_startall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * requests[])
+static inline int MPIDIG_mpi_startall(int count, MPIR_Request * requests[])
 {
     int mpi_errno = MPI_SUCCESS, i;
 

--- a/src/mpid/ch4/include/mpid_ticketlock.h
+++ b/src/mpid/ch4/include/mpid_ticketlock.h
@@ -21,7 +21,7 @@ typedef union MPIDI_CH4_Ticket_lock {
     } s;
 } MPIDI_CH4_Ticket_lock MPL_ATTR_ALIGNED(MPIDI_CH4_CACHELINE_SIZE);
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_acquire(MPIDI_CH4_Ticket_lock * m)
+static inline void MPIDI_CH4I_Thread_mutex_acquire(MPIDI_CH4_Ticket_lock * m)
 {
     uint16_t u = __sync_fetch_and_add(&m->s.clients, 1);
 
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_acquire(MPIDI_CH4_Ticket_l
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_ACQUIRE);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_release(MPIDI_CH4_Ticket_lock * m)
+static inline void MPIDI_CH4I_Thread_mutex_release(MPIDI_CH4_Ticket_lock * m)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_RELEASE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_RELEASE);
@@ -45,7 +45,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_release(MPIDI_CH4_Ticket_l
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_RELEASE);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4I_Thread_mutex_try_acquire(MPIDI_CH4_Ticket_lock * m)
+static inline int MPIDI_CH4I_Thread_mutex_try_acquire(MPIDI_CH4_Ticket_lock * m)
 {
     uint16_t u = m->s.clients;
     uint16_t u2 = u + 1;
@@ -63,8 +63,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4I_Thread_mutex_try_acquire(MPIDI_CH4_Ticke
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_lock(MPIDI_CH4_Ticket_lock * m,
-                                                           int *mpi_error)
+static inline void MPIDI_CH4I_Thread_mutex_lock(MPIDI_CH4_Ticket_lock * m, int *mpi_error)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_LOCK);
@@ -75,8 +74,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_lock(MPIDI_CH4_Ticket_lock
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_LOCK);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_unlock(MPIDI_CH4_Ticket_lock * m,
-                                                             int *mpi_error)
+static inline void MPIDI_CH4I_Thread_mutex_unlock(MPIDI_CH4_Ticket_lock * m, int *mpi_error)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_UNLOCK);
@@ -87,8 +85,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_unlock(MPIDI_CH4_Ticket_lo
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_UNLOCK);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_create(MPIDI_CH4_Ticket_lock * m,
-                                                             int *mpi_error)
+static inline void MPIDI_CH4I_Thread_mutex_create(MPIDI_CH4_Ticket_lock * m, int *mpi_error)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_CREATE);
@@ -99,8 +96,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_create(MPIDI_CH4_Ticket_lo
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_CREATE);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_destroy(MPIDI_CH4_Ticket_lock * m,
-                                                              int *mpi_error)
+static inline void MPIDI_CH4I_Thread_mutex_destroy(MPIDI_CH4_Ticket_lock * m, int *mpi_error)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_DESTROY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4I_THREAD_MUTEX_DESTROY);
@@ -116,7 +112,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_destroy(MPIDI_CH4_Ticket_l
 /* 2)  Implement it from scratch                                                      */
 /* Currently only async.c is using condition variables, so we should figure out what  */
 /* we really want from the cv implementations                                         */
-MPL_STATIC_INLINE_PREFIX void
+static inline void
 MPIDI_CH4I_Thread_cond_wait(MPIDU_Thread_cond_t * cond, MPIDI_CH4_Ticket_lock * m, int *mpi_error)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4I_THREAD_COND_WAIT);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -17,7 +17,7 @@
  * netmod.
  */
 #define MPIDI_CH4I_API(rc,fcnname,...)            \
-  MPL_STATIC_INLINE_PREFIX rc MPID_##fcnname(__VA_ARGS__)
+  static inline rc MPID_##fcnname(__VA_ARGS__)
 
 MPIDI_CH4I_API(int, Init, int *, char ***, int, int *, int *, int *);
 MPIDI_CH4I_API(int, InitCompleted, void);
@@ -238,8 +238,8 @@ int MPID_Abort(struct MPIR_Comm *comm, int mpi_errno, int exit_code, const char 
  * similar to the functions above. Other CH4-level functions should call this
  * function to query locality. This function will determine whether to call the
  * netmod or CH4U locality functions. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4_rank_is_local(int rank, MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
+static inline int MPIDI_CH4_rank_is_local(int rank, MPIR_Comm * comm);
+static inline int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 
 /* Include netmod prototypes */
 #include <netmod.h>

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -17,7 +17,7 @@
  * netmod.
  */
 #define MPIDI_CH4I_API(rc,fcnname,...)            \
-  MPL_STATIC_INLINE_PREFIX rc MPID_##fcnname(__VA_ARGS__) MPL_STATIC_INLINE_SUFFIX
+  MPL_STATIC_INLINE_PREFIX rc MPID_##fcnname(__VA_ARGS__)
 
 MPIDI_CH4I_API(int, Init, int *, char ***, int, int *, int *, int *);
 MPIDI_CH4I_API(int, InitCompleted, void);

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -14,7 +14,7 @@
 #include "mpir_datatype.h"
 #include "mpidch4.h"
 
-MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
+static inline void MPID_Request_create_hook(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_CREATE_HOOK);
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_REQUEST_CREATE_HOOK);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
+static inline void MPID_Request_free_hook(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_FREE_HOOK);
@@ -40,7 +40,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
     return;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPID_Request_destroy_hook(MPIR_Request * req)
+static inline void MPID_Request_destroy_hook(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_DESTROY_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_DESTROY_HOOK);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -193,9 +193,9 @@ typedef struct {
 #define MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req)  NULL
 #endif
 
-MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(struct MPIR_Request *req);
-MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(struct MPIR_Request *req);
-MPL_STATIC_INLINE_PREFIX void MPID_Request_destroy_hook(struct MPIR_Request *req);
+static inline void MPID_Request_create_hook(struct MPIR_Request *req);
+static inline void MPID_Request_free_hook(struct MPIR_Request *req);
+static inline void MPID_Request_destroy_hook(struct MPIR_Request *req);
 
 typedef struct MPIDI_CH4U_win_shared_info {
     uint32_t disp_unit;
@@ -455,8 +455,8 @@ extern MPIDI_av_table_t *MPIDI_av_table0;
 #define MPID_Comm_create_hook   MPIDI_Comm_create_hook
 #define MPID_Comm_free_hook     MPIDI_Comm_free_hook
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Type_commit_hook(MPIR_Datatype * type);
-MPL_STATIC_INLINE_PREFIX int MPIDI_Type_free_hook(MPIR_Datatype * type);
+static inline int MPIDI_Type_commit_hook(MPIR_Datatype * type);
+static inline int MPIDI_Type_free_hook(MPIR_Datatype * type);
 
 #define MPID_Type_commit_hook   MPIDI_Type_commit_hook
 #define MPID_Type_free_hook     MPIDI_Type_free_hook

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -618,222 +618,172 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int *n_vnis_provided)
-    MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
+                                                    int spawned, int *n_vnis_provided);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,
-                                                       MPIR_Comm * comm, MPIR_Comm **
-                                                       newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm *
-                                                          comm_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr,
-                                                    char *port_name) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_close_port(const char *port_name)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_close_port(const char *port_name);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
                                                       int root, MPIR_Comm * comm,
-                                                      MPIR_Comm **
-                                                      newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr,
-                                                  size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                  const void *am_hdr, size_t am_hdr_sz);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype,
-                                               MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Datatype datatype, MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                MPI_Datatype datatype, MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                        size_t am_hdr_sz);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                      int handler_id, const void *am_hdr,
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request * sreq);
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                    int *lpid_ptr,
-                                                    MPL_bool is_remote) MPL_STATIC_INLINE_SUFFIX;
+                                                    int *lpid_ptr, MPL_bool is_remote);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                      char **local_upids) MPL_STATIC_INLINE_SUFFIX;
+                                                      char **local_upids);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                      char *remote_upids,
-                                                      int **remote_lupids) MPL_STATIC_INLINE_SUFFIX;
+                                                      char *remote_upids, int **remote_lupids);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                  int size,
-                                                                  const int lpids[])
-    MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm *
-                                                           comm) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request *
-                                                           req) MPL_STATIC_INLINE_SUFFIX;
+                                                                  int size, const int lpids[]);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm);
+MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req);
+MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPI_Datatype datatype, int rank, int tag,
                                                MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count,
-                                                   MPIR_Request *
-                                                   requests[]) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[]);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
                                                     MPI_Datatype datatype, int rank, int tag,
                                                     MPIR_Comm * comm, int context_offset,
                                                     MPIDI_av_entry_t * addr,
-                                                    MPIR_Request **
-                                                    request) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
                                                      MPIDI_av_entry_t * addr,
-                                                     MPIR_Request **
-                                                     request) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
                                                      MPIDI_av_entry_t * addr,
-                                                     MPIR_Request **
-                                                     request) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
                                                      MPIDI_av_entry_t * addr,
-                                                     MPIR_Request **
-                                                     request) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr,
-                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
                                                     int rank, int tag, MPIR_Comm * comm,
                                                     int context_offset, MPIDI_av_entry_t * addr,
-                                                    MPIR_Request **
-                                                    request) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Status * status, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 MPIR_Request * message,
-                                                 MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request * message, MPIR_Request ** rreqp);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq);
 MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
-                                                      MPL_memory_class class)
-    MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPL_memory_class class);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
                                                   int context_offset, MPIDI_av_entry_t * addr,
                                                   int *flag, MPIR_Request ** message,
-                                                  MPI_Status * status) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPI_Status * status);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIDI_av_entry_t * addr,
-                                                 int *flag,
-                                                 MPI_Status * status) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_set_info(MPIR_Win * win,
-                                                       MPIR_Info * info) MPL_STATIC_INLINE_SUFFIX;
+                                                 int *flag, MPI_Status * status);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int rank,
                                                            MPI_Aint * size, int *disp_unit,
-                                                           void *baseptr) MPL_STATIC_INLINE_SUFFIX;
+                                                           void *baseptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr, int origin_count,
                                               MPI_Datatype origin_datatype, int target_rank,
                                               MPI_Aint target_disp, int target_count,
                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert,
-                                                    MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_complete(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert,
-                                                   MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_wait(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_test(MPIR_Win * win,
-                                                   int *flag) MPL_STATIC_INLINE_SUFFIX;
+                                              MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_complete(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_wait(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                   MPIR_Win * win,
-                                                   MPIDI_av_entry_t *
-                                                   addr) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Win * win, MPIDI_av_entry_t * addr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win,
-                                                     MPIDI_av_entry_t *
-                                                     addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_get_info(MPIR_Win * win,
-                                                       MPIR_Info **
-                                                       info_p_p) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr, int origin_count,
                                               MPI_Datatype origin_datatype, int target_rank,
                                               MPI_Aint target_disp, int target_count,
                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_fence(int assert,
-                                                    MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                              MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
                                                      MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                     MPIR_Win ** win_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Win ** win_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr, int origin_count,
                                                      MPI_Datatype origin_datatype, int target_rank,
                                                      MPI_Aint target_disp, int target_count,
                                                      MPI_Datatype target_datatype, MPI_Op op,
-                                                     MPIR_Win * win,
-                                                     MPIDI_av_entry_t *
-                                                     addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base,
-                                                     MPI_Aint size) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Win * win, MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
                                                               MPIR_Info * info_ptr,
                                                               MPIR_Comm * comm_ptr, void **base_ptr,
-                                                              MPIR_Win **
-                                                              win_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Win ** win_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr, int origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
                                                MPI_Aint target_disp, int target_count,
                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win,
-                                                          MPIDI_av_entry_t *
-                                                          addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_detach(MPIR_Win * win,
-                                                     const void *base) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
                                                            const void *compare_addr,
                                                            void *result_addr, MPI_Datatype datatype,
                                                            int target_rank, MPI_Aint target_disp,
-                                                           MPIR_Win * win,
-                                                           MPIDI_av_entry_t *
-                                                           addr) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Win * win, MPIDI_av_entry_t * addr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr, int origin_count,
                                                       MPI_Datatype origin_datatype, int target_rank,
                                                       MPI_Aint target_disp, int target_count,
                                                       MPI_Datatype target_datatype, MPI_Op op,
                                                       MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                      MPIR_Request **
-                                                      request) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr, int origin_count,
                                                           MPI_Datatype origin_datatype,
                                                           void *result_addr, int result_count,
@@ -842,35 +792,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_add
                                                           int target_count,
                                                           MPI_Datatype target_datatype, MPI_Op op,
                                                           MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                          MPIR_Request **
-                                                          request) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
                                                        MPI_Datatype datatype, int target_rank,
                                                        MPI_Aint target_disp, MPI_Op op,
-                                                       MPIR_Win * win,
-                                                       MPIDI_av_entry_t *
-                                                       addr) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Win * win, MPIDI_av_entry_t * addr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_unit,
                                                        MPIR_Info * info, MPIR_Comm * comm,
-                                                       void *baseptr,
-                                                       MPIR_Win ** win) MPL_STATIC_INLINE_SUFFIX;
+                                                       void *baseptr, MPIR_Win ** win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win,
-                                                    MPIDI_av_entry_t *
-                                                    addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win *
-                                                              win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                             MPIR_Win **
-                                                             win) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Win ** win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr, int origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
                                                MPI_Aint target_disp, int target_count,
                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr,
-                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_sync(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_sync(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr, int origin_count,
                                                          MPI_Datatype origin_datatype,
                                                          void *result_addr, int result_count,
@@ -878,118 +820,92 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
                                                          int target_rank, MPI_Aint target_disp,
                                                          int target_count,
                                                          MPI_Datatype target_datatype, MPI_Op op,
-                                                         MPIR_Win * win,
-                                                         MPIDI_av_entry_t *
-                                                         addr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock_all(int assert,
-                                                       MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int target,
-                                                    MPIR_Comm * comm) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Win * win, MPIDI_av_entry_t * addr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm,
                                                   MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                  void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
                                                 int root, MPIR_Comm * comm,
                                                 MPIR_Errflag_t * errflag,
-                                                void *algo_parameters_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
                                                     MPI_Datatype datatype, MPI_Op op,
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                    void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                    void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Errflag_t *
-                                                    errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t *
-                                                     errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm,
-                                                  MPIR_Errflag_t *
-                                                  errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                    const int *displs, MPI_Datatype sendtype,
                                                    void *recvbuf, int recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t *
-                                                   errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const int *recvcounts, const int *displs,
                                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t *
-                                                  errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Errflag_t *
-                                                   errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
                                                     const int *sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const int *recvcounts,
                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Errflag_t *
-                                                    errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
                                                     const int *sdispls,
                                                     const MPI_Datatype sendtypes[], void *recvbuf,
                                                     const int *recvcounts, const int *rdispls,
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Errflag_t *
-                                                    errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                 void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const int *recvcounts,
                                                          MPI_Datatype datatype, MPI_Op op,
                                                          MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t *
-                                                         errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                int recvcount, MPI_Datatype datatype,
                                                                MPI_Op op, MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t *
-                                                               errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
                                                              int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm *
-                                                             comm) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               const int *recvcounts,
                                                               const int *displs,
                                                               MPI_Datatype recvtype,
-                                                              MPIR_Comm *
-                                                              comm) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
                                                              const int *sendcounts,
                                                              const int *sdispls,
@@ -997,8 +913,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf
                                                              const int *recvcounts,
                                                              const int *rdispls,
                                                              MPI_Datatype recvtype,
-                                                             MPIR_Comm *
-                                                             comm) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
                                                              const int *sendcounts,
                                                              const MPI_Aint * sdispls,
@@ -1006,33 +921,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf
                                                              void *recvbuf, const int *recvcounts,
                                                              const MPI_Aint * rdispls,
                                                              const MPI_Datatype * recvtypes,
-                                                             MPIR_Comm *
-                                                             comm) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm *
-                                                            comm) MPL_STATIC_INLINE_SUFFIX;
+                                                            MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               int recvcount, MPI_Datatype recvtype,
                                                               MPIR_Comm * comm,
-                                                              MPIR_Request **
-                                                              req) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int *recvcounts,
                                                                const int *displs,
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
-                                                               MPIR_Request **
-                                                               req) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
                                                              int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm,
-                                                             MPIR_Request **
-                                                             req) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
                                                               const int *sendcounts,
                                                               const int *sdispls,
@@ -1041,8 +950,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbu
                                                               const int *rdispls,
                                                               MPI_Datatype recvtype,
                                                               MPIR_Comm * comm,
-                                                              MPIR_Request **
-                                                              req) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
                                                               const int *sendcounts,
                                                               const MPI_Aint * sdispls,
@@ -1051,117 +959,95 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbu
                                                               const MPI_Aint * rdispls,
                                                               const MPI_Datatype * recvtypes,
                                                               MPIR_Comm * comm,
-                                                              MPIR_Request **
-                                                              req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Request ** req);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm,
-                                                 MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                 int root, MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
                                                      MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
                                                      const int *sdispls, MPI_Datatype sendtype,
                                                      void *recvbuf, const int *recvcounts,
                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
                                                      const int *sdispls,
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
                                                      const int *recvcounts, const int *rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm,
-                                                  MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm,
-                                                  MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                 int recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm,
-                                                                MPIR_Request **
-                                                                req) MPL_STATIC_INLINE_SUFFIX;
+                                                                MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const int *recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm,
-                                                          MPIR_Request **
-                                                          req) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr,
-                                                  MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
                                                     void *recvbuf, int recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr,
-                                                    MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm,
-                                                       MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                            MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1169,7 +1055,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1177,62 +1063,52 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            void *recvbuf, const int recvcounts[],
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                      MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm,
-                                                                MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm,
-                                                      MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm * comm, MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
                                                          int root, MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           const int *sendcounts, const int *displs,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
                                                                     int sendcount,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                    MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
                                                                      int sendcount,
                                                                      MPI_Datatype sendtype,
@@ -1241,16 +1117,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                     MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
                                                                    int sendcount,
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm,
-                                                                   MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                   MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                                     const int sendcounts[],
                                                                     const int sdispls[],
@@ -1260,8 +1134,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                                    MPIR_Sched_t s);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                                     const int sendcounts[],
                                                                     const MPI_Aint sdispls[],
@@ -1271,13 +1144,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
-    MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype *
-                                                           datatype_p) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype *
-                                                         datatype_p) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p) MPL_STATIC_INLINE_SUFFIX;
+                                                                    MPIR_Sched_t s);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p);
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p);
 
 #endif /* NETMOD_H_INCLUDED */

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -616,538 +616,508 @@ extern MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 extern int MPIDI_num_netmods;
 extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
-                                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int *n_vnis_provided);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
-                                                       int root, int timeout,
-                                                       MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_close_port(const char *port_name);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
-                                                      int root, MPIR_Comm * comm,
-                                                      MPIR_Comm ** newcomm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                               const void *am_hdr, size_t am_hdr_sz,
-                                               const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                struct iovec *am_hdrs, size_t iov_len,
-                                                const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
-                                                        int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
-                                                     int handler_id, const void *am_hdr,
-                                                     size_t am_hdr_sz, const void *data,
-                                                     MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                    int *lpid_ptr, MPL_bool is_remote);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                      char **local_upids);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                      char *remote_upids, int **remote_lupids);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                  int size, const int lpids[]);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[]);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
-                                                    MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int context_offset,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
-                                                    int rank, int tag, MPIR_Comm * comm,
-                                                    int context_offset, MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                               int rank, int tag, MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq);
-MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
-                                                      MPL_memory_class class);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
-                                                  int context_offset, MPIDI_av_entry_t * addr,
-                                                  int *flag, MPIR_Request ** message,
-                                                  MPI_Status * status);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
-                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                 int *flag, MPI_Status * status);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int rank,
-                                                           MPI_Aint * size, int *disp_unit,
-                                                           void *baseptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr, int origin_count,
-                                              MPI_Datatype origin_datatype, int target_rank,
-                                              MPI_Aint target_disp, int target_count,
-                                              MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_complete(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_wait(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                   MPIR_Win * win, MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win,
-                                                     MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr, int origin_count,
-                                              MPI_Datatype origin_datatype, int target_rank,
-                                              MPI_Aint target_disp, int target_count,
-                                              MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
-                                                     MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                     MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr, int origin_count,
-                                                     MPI_Datatype origin_datatype, int target_rank,
-                                                     MPI_Aint target_disp, int target_count,
-                                                     MPI_Datatype target_datatype, MPI_Op op,
-                                                     MPIR_Win * win, MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
-                                                              MPIR_Info * info_ptr,
-                                                              MPIR_Comm * comm_ptr, void **base_ptr,
-                                                              MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win,
-                                                          MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
-                                                           const void *compare_addr,
-                                                           void *result_addr, MPI_Datatype datatype,
-                                                           int target_rank, MPI_Aint target_disp,
-                                                           MPIR_Win * win, MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr, int origin_count,
-                                                      MPI_Datatype origin_datatype, int target_rank,
-                                                      MPI_Aint target_disp, int target_count,
-                                                      MPI_Datatype target_datatype, MPI_Op op,
-                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                      MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr, int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr, int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank, MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype, MPI_Op op,
-                                                          MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                          MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
-                                                       MPI_Datatype datatype, int target_rank,
-                                                       MPI_Aint target_disp, MPI_Op op,
-                                                       MPIR_Win * win, MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_unit,
-                                                       MPIR_Info * info, MPIR_Comm * comm,
-                                                       void *baseptr, MPIR_Win ** win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win,
-                                                    MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                             MPIR_Win ** win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_sync(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr, int origin_count,
-                                                         MPI_Datatype origin_datatype,
-                                                         void *result_addr, int result_count,
-                                                         MPI_Datatype result_datatype,
-                                                         int target_rank, MPI_Aint target_disp,
-                                                         int target_count,
-                                                         MPI_Datatype target_datatype, MPI_Op op,
-                                                         MPIR_Win * win, MPIDI_av_entry_t * addr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm,
-                                                  MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm,
-                                                MPIR_Errflag_t * errflag,
-                                                void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                    void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+static inline int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
+                                         MPIR_Comm * comm_world, MPIR_Comm * comm_self,
+                                         int spawned, int *n_vnis_provided);
+static inline int MPIDI_NM_mpi_finalize_hook(void);
+static inline int MPIDI_NM_get_vni_attr(int vni);
+static inline int MPIDI_NM_progress(int vni, int blocking);
+static inline int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
+                                            int root, int timeout,
+                                            MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
+static inline int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
+static inline int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
+static inline int MPIDI_NM_mpi_close_port(const char *port_name);
+static inline int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
+                                           int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
+static inline int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
+                                       const void *am_hdr, size_t am_hdr_sz);
+static inline int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
+                                    const void *am_hdr, size_t am_hdr_sz,
+                                    const void *data, MPI_Count count,
+                                    MPI_Datatype datatype, MPIR_Request * sreq);
+static inline int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                     struct iovec *am_hdrs, size_t iov_len,
+                                     const void *data, MPI_Count count,
+                                     MPI_Datatype datatype, MPIR_Request * sreq);
+static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
+                                             int handler_id, const void *am_hdr, size_t am_hdr_sz);
+static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+                                          int handler_id, const void *am_hdr,
+                                          size_t am_hdr_sz, const void *data,
+                                          MPI_Count count, MPI_Datatype datatype,
+                                          MPIR_Request * sreq);
+static inline size_t MPIDI_NM_am_hdr_max_sz(void);
+static inline int MPIDI_NM_am_recv(MPIR_Request * req);
+static inline int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
+                                         int *lpid_ptr, MPL_bool is_remote);
+static inline int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
+                                           char **local_upids);
+static inline int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size,
+                                           char *remote_upids, int **remote_lupids);
+static inline int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
+                                                       int size, const int lpids[]);
+static inline int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm);
+static inline void MPIDI_NM_am_request_init(MPIR_Request * req);
+static inline void MPIDI_NM_am_request_finalize(MPIR_Request * req);
+static inline int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, int rank, int tag,
+                                    MPIR_Comm * comm, int context_offset,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[]);
+static inline int MPIDI_NM_mpi_send_init(const void *buf, int count,
+                                         MPI_Datatype datatype, int rank, int tag,
+                                         MPIR_Comm * comm, int context_offset,
+                                         MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset,
+                                      MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq);
+static inline int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
+                                         int rank, int tag, MPIR_Comm * comm,
+                                         int context_offset, MPIDI_av_entry_t * addr,
+                                         MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                    int rank, int tag, MPIR_Comm * comm,
+                                    int context_offset, MPIDI_av_entry_t * addr,
+                                    MPI_Status * status, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                     int rank, int tag, MPIR_Comm * comm,
+                                     int context_offset, MPIDI_av_entry_t * addr,
+                                     MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                      MPIR_Request * message, MPIR_Request ** rreqp);
+static inline int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq);
+static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
+                                           MPL_memory_class class);
+static inline int MPIDI_NM_mpi_free_mem(void *ptr);
+static inline int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
+                                       int context_offset, MPIDI_av_entry_t * addr,
+                                       int *flag, MPIR_Request ** message, MPI_Status * status);
+static inline int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
+                                      int context_offset, MPIDI_av_entry_t * addr,
+                                      int *flag, MPI_Status * status);
+static inline int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
+static inline int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int rank,
+                                                MPI_Aint * size, int *disp_unit, void *baseptr);
+static inline int MPIDI_NM_mpi_put(const void *origin_addr, int origin_count,
+                                   MPI_Datatype origin_datatype, int target_rank,
+                                   MPI_Aint target_disp, int target_count,
+                                   MPI_Datatype target_datatype, MPIR_Win * win,
+                                   MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_complete(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_wait(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag);
+static inline int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert,
+                                        MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
+static inline int MPIDI_NM_mpi_get(void *origin_addr, int origin_count,
+                                   MPI_Datatype origin_datatype, int target_rank,
+                                   MPI_Aint target_disp, int target_count,
+                                   MPI_Datatype target_datatype, MPIR_Win * win,
+                                   MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr);
+static inline int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
+                                          MPIR_Info * info, MPIR_Comm * comm_ptr,
+                                          MPIR_Win ** win_ptr);
+static inline int MPIDI_NM_mpi_accumulate(const void *origin_addr, int origin_count,
+                                          MPI_Datatype origin_datatype, int target_rank,
+                                          MPI_Aint target_disp, int target_count,
+                                          MPI_Datatype target_datatype, MPI_Op op,
+                                          MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
+static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
+                                                   MPIR_Info * info_ptr,
+                                                   MPIR_Comm * comm_ptr, void **base_ptr,
+                                                   MPIR_Win ** win_ptr);
+static inline int MPIDI_NM_mpi_rput(const void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base);
+static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
+                                                const void *compare_addr,
+                                                void *result_addr, MPI_Datatype datatype,
+                                                int target_rank, MPI_Aint target_disp,
+                                                MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_raccumulate(const void *origin_addr, int origin_count,
+                                           MPI_Datatype origin_datatype, int target_rank,
+                                           MPI_Aint target_disp, int target_count,
+                                           MPI_Datatype target_datatype, MPI_Op op,
+                                           MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                           MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr, int origin_count,
+                                               MPI_Datatype origin_datatype,
+                                               void *result_addr, int result_count,
+                                               MPI_Datatype result_datatype,
+                                               int target_rank, MPI_Aint target_disp,
+                                               int target_count,
+                                               MPI_Datatype target_datatype, MPI_Op op,
+                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                               MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
+                                            MPI_Datatype datatype, int target_rank,
+                                            MPI_Aint target_disp, MPI_Op op,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_unit,
+                                            MPIR_Info * info, MPIR_Comm * comm,
+                                            void *baseptr, MPIR_Win ** win);
+static inline int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
+                                                  MPIR_Win ** win);
+static inline int MPIDI_NM_mpi_rget(void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request);
+static inline int MPIDI_NM_mpi_win_sync(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win);
+static inline int MPIDI_NM_mpi_get_accumulate(const void *origin_addr, int origin_count,
+                                              MPI_Datatype origin_datatype,
+                                              void *result_addr, int result_count,
+                                              MPI_Datatype result_datatype,
+                                              int target_rank, MPI_Aint target_disp,
+                                              int target_count,
+                                              MPI_Datatype target_datatype, MPI_Op op,
+                                              MPIR_Win * win, MPIDI_av_entry_t * addr);
+static inline int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win);
+static inline int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm);
+static inline int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av);
+static inline int MPIDI_NM_mpi_barrier(MPIR_Comm * comm,
+                                       MPIR_Errflag_t * errflag, void *algo_parameters_ptr);
+static inline int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+                                     int root, MPIR_Comm * comm,
+                                     MPIR_Errflag_t * errflag, void *algo_parameters_ptr);
+static inline int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
+                                         MPI_Datatype datatype, MPI_Op op,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                         void *algo_parameters_ptr);
+static inline int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int *recvcounts, const int *displs,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm,
+                                          MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
+                                        const int *displs, MPI_Datatype sendtype,
+                                        void *recvbuf, int recvcount,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      int recvcount, MPI_Datatype recvtype, int root,
+                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const int *recvcounts, const int *displs,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                       MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
+                                         const int *sdispls, MPI_Datatype sendtype,
+                                         void *recvbuf, const int *recvcounts,
+                                         const int *rdispls, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
+                                         const int *sdispls,
+                                         const MPI_Datatype sendtypes[], void *recvbuf,
+                                         const int *recvcounts, const int *rdispls,
+                                         const MPI_Datatype recvtypes[],
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op, int root,
+                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
+                                      void *algo_parameters_ptr);
+static inline int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
+                                              const int *recvcounts,
+                                              MPI_Datatype datatype, MPI_Op op,
+                                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                    int recvcount, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm_ptr,
+                                                    MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                    MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                      MPIR_Errflag_t * errflag);
+static inline int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                   const int *displs, MPI_Datatype sendtype,
-                                                   void *recvbuf, int recvcount,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *displs,
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
+                                                  const int *sendcounts,
+                                                  const int *sdispls,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  const int *recvcounts,
+                                                  const int *rdispls,
+                                                  MPI_Datatype recvtype, MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
+                                                  const int *sendcounts,
+                                                  const MPI_Aint * sdispls,
+                                                  const MPI_Datatype * sendtypes,
+                                                  void *recvbuf, const int *recvcounts,
+                                                  const MPI_Aint * rdispls,
+                                                  const MPI_Datatype * recvtypes, MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  const int *recvcounts, const int *displs,
-                                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm);
+static inline int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls, MPI_Datatype sendtype,
-                                                    void *recvbuf, const int *recvcounts,
-                                                    const int *rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls,
-                                                    const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int *recvcounts, const int *rdispls,
-                                                    const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                         const int *recvcounts,
-                                                         MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                               int recvcount, MPI_Datatype datatype,
-                                                               MPI_Op op, MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
-                                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *displs,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                             const int *sendcounts,
-                                                             const int *sdispls,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             const int *recvcounts,
-                                                             const int *rdispls,
-                                                             MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                             const int *sendcounts,
-                                                             const MPI_Aint * sdispls,
-                                                             const MPI_Datatype * sendtypes,
-                                                             void *recvbuf, const int *recvcounts,
-                                                             const MPI_Aint * rdispls,
-                                                             const MPI_Datatype * recvtypes,
-                                                             MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm,
-                                                              MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *displs,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const int *sdispls,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *rdispls,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm,
-                                                              MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const MPI_Aint * sdispls,
-                                                              const MPI_Datatype * sendtypes,
-                                                              void *recvbuf, const int *recvcounts,
-                                                              const MPI_Aint * rdispls,
-                                                              const MPI_Datatype * recvtypes,
-                                                              MPIR_Comm * comm,
-                                                              MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
-                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                    MPI_Datatype sendtype, void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *displs,
+                                                    MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const int *sdispls,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *rdispls,
+                                                   MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const MPI_Aint * sdispls,
+                                                   const MPI_Datatype * sendtypes,
+                                                   void *recvbuf, const int *recvcounts,
+                                                   const MPI_Aint * rdispls,
+                                                   const MPI_Datatype * recvtypes,
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
+                                      int root, MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           const int *recvcounts, const int *displs,
+                                           MPI_Datatype recvtype, MPIR_Comm * comm,
+                                           MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                          MPI_Datatype datatype, MPI_Op op,
+                                          MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls, MPI_Datatype sendtype,
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls,
+                                          const MPI_Datatype sendtypes[], void *recvbuf,
+                                          const int *recvcounts, const int *rdispls,
+                                          const MPI_Datatype recvtypes[],
+                                          MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op,
+                                       MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int *recvcounts, const int *displs,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                     int recvcount,
                                                      MPI_Datatype datatype, MPI_Op op,
                                                      MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
-                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
-                                                     const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm,
-                                                                MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
-                                                          MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
-                                                       MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            const int *recvcounts,
-                                                            const int *displs,
-                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
-                                                           int count, MPI_Datatype datatype,
+static inline int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
+                                               const int *recvcounts,
+                                               MPI_Datatype datatype, MPI_Op op,
+                                               MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                     MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
+                                         const int *displs, MPI_Datatype sendtype,
+                                         void *recvbuf, int recvcount,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm_ptr, MPIR_Request ** req);
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
+                                            MPI_Datatype datatype, int root,
+                                            MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                int recvcount, MPI_Datatype recvtype,
+                                                MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 const int *recvcounts,
+                                                 const int *displs,
+                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                 MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
+                                                int count, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               int recvcount, MPI_Datatype recvtype,
+                                               MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
+                                                const int sendcounts[],
+                                                const int sdispls[],
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                const int recvcounts[],
+                                                const int rdispls[],
+                                                MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
+                                                const int sendcounts[],
+                                                const int sdispls[],
+                                                const MPI_Datatype sendtypes[],
+                                                void *recvbuf, const int recvcounts[],
+                                                const int rdispls[],
+                                                const MPI_Datatype recvtypes[],
+                                                MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
+                                             int count, MPI_Datatype datatype, MPI_Op op,
+                                             MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
+                                             MPI_Datatype sendtype, void *recvbuf,
+                                             int recvcount, MPI_Datatype recvtype,
+                                             int root, MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              const int *recvcounts, const int *displs,
+                                              MPI_Datatype recvtype, int root,
+                                              MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
+                                                           void *recvbuf, int recvcount,
+                                                           MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
                                                            MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
-                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
-                                                           const int sendcounts[],
-                                                           const int sdispls[],
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           const int recvcounts[],
-                                                           const int rdispls[],
-                                                           MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
-                                                           const int sendcounts[],
-                                                           const int sdispls[],
-                                                           const MPI_Datatype sendtypes[],
-                                                           void *recvbuf, const int recvcounts[],
-                                                           const int rdispls[],
-                                                           const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
-                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
-                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                         const int *recvcounts, const int *displs,
-                                                         MPI_Datatype recvtype, int root,
+static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
+                                                     const int recvcounts[],
+                                                     MPI_Datatype datatype, MPI_Op op,
+                                                     MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
+                                             int count, MPI_Datatype datatype, MPI_Op op,
+                                             int root, MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
+                                           MPI_Datatype datatype, MPI_Op op,
+                                           MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              int recvcount, MPI_Datatype recvtype,
+                                              int root, MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
+                                               const int *sendcounts, const int *displs,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               int recvcount, MPI_Datatype recvtype,
+                                               int root, MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
+                                                         int sendcount,
+                                                         MPI_Datatype sendtype,
+                                                         void *recvbuf, int recvcount,
+                                                         MPI_Datatype recvtype,
                                                          MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
-                                                                      void *recvbuf, int recvcount,
-                                                                      MPI_Datatype datatype,
-                                                                      MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
-                                                                const int recvcounts[],
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
-                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                         int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm,
-                                                         MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
-                                                          const int *sendcounts, const int *displs,
-                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
-                                                          int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
-                                                                    int sendcount,
-                                                                    MPI_Datatype sendtype,
-                                                                    void *recvbuf, int recvcount,
-                                                                    MPI_Datatype recvtype,
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
-                                                                     int sendcount,
-                                                                     MPI_Datatype sendtype,
-                                                                     void *recvbuf,
-                                                                     const int recvcounts[],
-                                                                     const int displs[],
-                                                                     MPI_Datatype recvtype,
-                                                                     MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
-                                                                   int sendcount,
-                                                                   MPI_Datatype sendtype,
-                                                                   void *recvbuf, int recvcount,
-                                                                   MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm,
-                                                                   MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
-                                                                    const int sendcounts[],
-                                                                    const int sdispls[],
-                                                                    MPI_Datatype sendtype,
-                                                                    void *recvbuf,
-                                                                    const int recvcounts[],
-                                                                    const int rdispls[],
-                                                                    MPI_Datatype recvtype,
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
-                                                                    const int sendcounts[],
-                                                                    const MPI_Aint sdispls[],
-                                                                    const MPI_Datatype sendtypes[],
-                                                                    void *recvbuf,
-                                                                    const int recvcounts[],
-                                                                    const MPI_Aint rdispls[],
-                                                                    const MPI_Datatype recvtypes[],
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p);
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p);
+static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
+                                                          int sendcount,
+                                                          MPI_Datatype sendtype,
+                                                          void *recvbuf,
+                                                          const int recvcounts[],
+                                                          const int displs[],
+                                                          MPI_Datatype recvtype,
+                                                          MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
+                                                        int sendcount,
+                                                        MPI_Datatype sendtype,
+                                                        void *recvbuf, int recvcount,
+                                                        MPI_Datatype recvtype,
+                                                        MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
+                                                         const int sendcounts[],
+                                                         const int sdispls[],
+                                                         MPI_Datatype sendtype,
+                                                         void *recvbuf,
+                                                         const int recvcounts[],
+                                                         const int rdispls[],
+                                                         MPI_Datatype recvtype,
+                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
+                                                         const int sendcounts[],
+                                                         const MPI_Aint sdispls[],
+                                                         const MPI_Datatype sendtypes[],
+                                                         void *recvbuf,
+                                                         const int recvcounts[],
+                                                         const MPI_Aint rdispls[],
+                                                         const MPI_Datatype recvtypes[],
+                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+static inline int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
+static inline int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p);
+static inline int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p);
+static inline int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p);
 
 #endif /* NETMOD_H_INCLUDED */

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -16,9 +16,9 @@
 #ifndef NETMOD_DIRECT
 #ifndef NETMOD_DISABLE_INLINES
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
-                                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int *n_vnis_provided)
+static inline int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
+                                         MPIR_Comm * comm_world, MPIR_Comm * comm_self,
+                                         int spawned, int *n_vnis_provided)
 {
     int ret;
 
@@ -32,7 +32,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
+static inline int MPIDI_NM_mpi_finalize_hook(void)
 {
     int ret;
 
@@ -45,7 +45,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni)
+static inline int MPIDI_NM_get_vni_attr(int vni)
 {
     int ret;
 
@@ -58,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     int ret;
 
@@ -71,9 +71,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
-                                                       int root, int timeout, MPIR_Comm * comm,
-                                                       MPIR_Comm ** newcomm_ptr)
+static inline int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
+                                            int root, int timeout, MPIR_Comm * comm,
+                                            MPIR_Comm ** newcomm_ptr)
 {
     int ret;
 
@@ -86,7 +86,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MP
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
+static inline int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
 {
     int ret;
 
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
+static inline int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
 {
     int ret;
 
@@ -112,7 +112,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_open_port(MPIR_Info * info_ptr, char *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_close_port(const char *port_name)
+static inline int MPIDI_NM_mpi_close_port(const char *port_name)
 {
     int ret;
 
@@ -125,9 +125,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_close_port(const char *port_name)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
-                                                      int root, MPIR_Comm * comm,
-                                                      MPIR_Comm ** newcomm_ptr)
+static inline int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
+                                           int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
 {
     int ret;
 
@@ -140,8 +139,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPI
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
+                                       const void *am_hdr, size_t am_hdr_sz)
 {
     int ret;
 
@@ -154,10 +153,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                               const void *am_hdr, size_t am_hdr_sz,
-                                               const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
+                                    const void *am_hdr, size_t am_hdr_sz,
+                                    const void *data, MPI_Count count,
+                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -171,10 +170,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                struct iovec *am_hdrs, size_t iov_len,
-                                                const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                     struct iovec *am_hdrs, size_t iov_len,
+                                     const void *data, MPI_Count count,
+                                     MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -188,9 +187,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                        int src_rank, int handler_id,
-                                                        const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
+                                             int src_rank, int handler_id,
+                                             const void *am_hdr, size_t am_hdr_sz)
 {
     int ret;
 
@@ -203,11 +202,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
-                                                     int handler_id, const void *am_hdr,
-                                                     size_t am_hdr_sz, const void *data,
-                                                     MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+                                          int handler_id, const void *am_hdr,
+                                          size_t am_hdr_sz, const void *data,
+                                          MPI_Count count, MPI_Datatype datatype,
+                                          MPIR_Request * sreq)
 {
     int ret;
 
@@ -221,7 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
+static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 {
     int ret;
 
@@ -234,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req)
+static inline int MPIDI_NM_am_recv(MPIR_Request * req)
 {
     int ret;
 
@@ -247,8 +246,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                    int *lpid_ptr, MPL_bool is_remote)
+static inline int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
+                                         int *lpid_ptr, MPL_bool is_remote)
 {
     int ret;
 
@@ -261,8 +260,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int id
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                      char **local_upids)
+static inline int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
+                                           char **local_upids)
 {
     int ret;
 
@@ -275,8 +274,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                      char *remote_upids, int **remote_lupids)
+static inline int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size,
+                                           char *remote_upids, int **remote_lupids)
 {
     int ret;
 
@@ -289,8 +288,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_upids_to_lupids(int size, size_t * remote_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                  int size, const int lpids[])
+static inline int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
+                                                       int size, const int lpids[])
 {
     int ret;
 
@@ -303,7 +302,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * ne
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
 {
     int ret;
 
@@ -316,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
 {
     int ret;
 
@@ -329,7 +328,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
+static inline void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_REQUEST_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_REQUEST_INIT);
@@ -339,7 +338,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_REQUEST_INIT);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
+static inline void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_REQUEST_FINALIZE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_REQUEST_FINALIZE);
@@ -349,10 +348,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_REQUEST_FINALIZE);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, int rank, int tag,
+                                    MPIR_Comm * comm, int context_offset,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -367,10 +366,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -385,7 +384,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[])
+static inline int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[])
 {
     int ret;
 
@@ -398,11 +397,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * req
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
-                                                    MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int context_offset,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_send_init(const void *buf, int count,
+                                         MPI_Datatype datatype, int rank, int tag,
+                                         MPIR_Comm * comm, int context_offset,
+                                         MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -416,11 +414,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -434,11 +431,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -452,11 +448,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -470,10 +465,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -488,10 +483,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset,
+                                      MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -506,7 +501,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
+static inline int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
 {
     int ret;
 
@@ -519,10 +514,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
-                                                    int rank, int tag, MPIR_Comm * comm,
-                                                    int context_offset, MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
+                                         int rank, int tag, MPIR_Comm * comm,
+                                         int context_offset, MPIDI_av_entry_t * addr,
+                                         MPIR_Request ** request)
 {
     int ret;
 
@@ -536,10 +531,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Da
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                               int rank, int tag, MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                    int rank, int tag, MPIR_Comm * comm,
+                                    int context_offset, MPIDI_av_entry_t * addr,
+                                    MPI_Status * status, MPIR_Request ** request)
 {
     int ret;
 
@@ -554,10 +549,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Da
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                     int rank, int tag, MPIR_Comm * comm,
+                                     int context_offset, MPIDI_av_entry_t * addr,
+                                     MPIR_Request ** request)
 {
     int ret;
 
@@ -572,8 +567,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                      MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int ret;
 
@@ -586,7 +581,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
+static inline int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
 {
     int ret;
 
@@ -599,8 +594,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
-                                                      MPL_memory_class class)
+static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
+                                           MPL_memory_class class)
 {
     void *ret;
 
@@ -613,7 +608,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr)
+static inline int MPIDI_NM_mpi_free_mem(void *ptr)
 {
     int ret;
 
@@ -626,10 +621,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
-                                                  int context_offset, MPIDI_av_entry_t * addr,
-                                                  int *flag, MPIR_Request ** message,
-                                                  MPI_Status * status)
+static inline int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
+                                       int context_offset, MPIDI_av_entry_t * addr,
+                                       int *flag, MPIR_Request ** message, MPI_Status * status)
 {
     int ret;
 
@@ -643,9 +637,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
-                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                 int *flag, MPI_Status * status)
+static inline int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
+                                      int context_offset, MPIDI_av_entry_t * addr,
+                                      int *flag, MPI_Status * status)
 {
     int ret;
 
@@ -658,7 +652,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source, int tag, MPIR_Comm 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
+static inline int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
 {
     int ret;
 
@@ -671,9 +665,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_set_info(MPIR_Win * win, MPIR_Info
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int rank,
-                                                           MPI_Aint * size, int *disp_unit,
-                                                           void *baseptr)
+static inline int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int rank,
+                                                MPI_Aint * size, int *disp_unit, void *baseptr)
 {
     int ret;
 
@@ -686,11 +679,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win, int r
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr, int origin_count,
-                                              MPI_Datatype origin_datatype, int target_rank,
-                                              MPI_Aint target_disp, int target_count,
-                                              MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_put(const void *origin_addr, int origin_count,
+                                   MPI_Datatype origin_datatype, int target_rank,
+                                   MPI_Aint target_disp, int target_count,
+                                   MPI_Datatype target_datatype, MPIR_Win * win,
+                                   MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -704,7 +697,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_put(const void *origin_addr, int origi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -717,7 +710,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_start(MPIR_Group * group, int asse
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_complete(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_complete(MPIR_Win * win)
 {
     int ret;
 
@@ -730,7 +723,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_complete(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -743,7 +736,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_post(MPIR_Group * group, int asser
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_wait(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_wait(MPIR_Win * win)
 {
     int ret;
 
@@ -756,7 +749,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_wait(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag)
+static inline int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag)
 {
     int ret;
 
@@ -769,8 +762,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                   MPIR_Win * win, MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert,
+                                        MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -783,8 +776,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win,
-                                                     MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -797,7 +789,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
+static inline int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
 {
     int ret;
 
@@ -810,11 +802,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr, int origin_count,
-                                              MPI_Datatype origin_datatype, int target_rank,
-                                              MPI_Aint target_disp, int target_count,
-                                              MPI_Datatype target_datatype, MPIR_Win * win,
-                                              MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_get(void *origin_addr, int origin_count,
+                                   MPI_Datatype origin_datatype, int target_rank,
+                                   MPI_Aint target_disp, int target_count,
+                                   MPI_Datatype target_datatype, MPIR_Win * win,
+                                   MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -828,7 +820,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get(void *origin_addr, int origin_coun
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
+static inline int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -841,7 +833,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -854,9 +846,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_fence(int assert, MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
-                                                     MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                     MPIR_Win ** win_ptr)
+static inline int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
+                                          MPIR_Info * info, MPIR_Comm * comm_ptr,
+                                          MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -869,11 +861,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create(void *base, MPI_Aint length
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr, int origin_count,
-                                                     MPI_Datatype origin_datatype, int target_rank,
-                                                     MPI_Aint target_disp, int target_count,
-                                                     MPI_Datatype target_datatype, MPI_Op op,
-                                                     MPIR_Win * win, MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_accumulate(const void *origin_addr, int origin_count,
+                                          MPI_Datatype origin_datatype, int target_rank,
+                                          MPI_Aint target_disp, int target_count,
+                                          MPI_Datatype target_datatype, MPI_Op op,
+                                          MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -888,7 +880,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_accumulate(const void *origin_addr, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size)
+static inline int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size)
 {
     int ret;
 
@@ -901,10 +893,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
-                                                              MPIR_Info * info_ptr,
-                                                              MPIR_Comm * comm_ptr,
-                                                              void **base_ptr, MPIR_Win ** win_ptr)
+static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
+                                                   MPIR_Info * info_ptr,
+                                                   MPIR_Comm * comm_ptr,
+                                                   void **base_ptr, MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -918,11 +910,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_rput(const void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -937,8 +929,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr, int orig
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win,
-                                                          MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -951,7 +942,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * w
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base)
+static inline int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base)
 {
     int ret;
 
@@ -964,12 +955,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
-                                                           const void *compare_addr,
-                                                           void *result_addr,
-                                                           MPI_Datatype datatype, int target_rank,
-                                                           MPI_Aint target_disp, MPIR_Win * win,
-                                                           MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
+                                                const void *compare_addr,
+                                                void *result_addr,
+                                                MPI_Datatype datatype, int target_rank,
+                                                MPI_Aint target_disp, MPIR_Win * win,
+                                                MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -983,13 +974,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr, int origin_count,
-                                                      MPI_Datatype origin_datatype,
-                                                      int target_rank, MPI_Aint target_disp,
-                                                      int target_count,
-                                                      MPI_Datatype target_datatype, MPI_Op op,
-                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                      MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_raccumulate(const void *origin_addr, int origin_count,
+                                           MPI_Datatype origin_datatype,
+                                           int target_rank, MPI_Aint target_disp,
+                                           int target_count,
+                                           MPI_Datatype target_datatype, MPI_Op op,
+                                           MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                           MPIR_Request ** request)
 {
     int ret;
 
@@ -1004,16 +995,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_raccumulate(const void *origin_addr, i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
-                                                          int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr, int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank, MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype, MPI_Op op,
-                                                          MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                          MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
+                                               int origin_count,
+                                               MPI_Datatype origin_datatype,
+                                               void *result_addr, int result_count,
+                                               MPI_Datatype result_datatype,
+                                               int target_rank, MPI_Aint target_disp,
+                                               int target_count,
+                                               MPI_Datatype target_datatype, MPI_Op op,
+                                               MPIR_Win * win, MPIDI_av_entry_t * addr,
+                                               MPIR_Request ** request)
 {
     int ret;
 
@@ -1029,10 +1020,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget_accumulate(const void *origin_add
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
-                                                       MPI_Datatype datatype, int target_rank,
-                                                       MPI_Aint target_disp, MPI_Op op,
-                                                       MPIR_Win * win, MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
+                                            MPI_Datatype datatype, int target_rank,
+                                            MPI_Aint target_disp, MPI_Op op,
+                                            MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -1046,9 +1037,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_unit,
-                                                       MPIR_Info * info, MPIR_Comm * comm,
-                                                       void *baseptr, MPIR_Win ** win)
+static inline int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_unit,
+                                            MPIR_Info * info, MPIR_Comm * comm,
+                                            void *baseptr, MPIR_Win ** win)
 {
     int ret;
 
@@ -1061,8 +1052,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_allocate(MPI_Aint size, int disp_u
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win,
-                                                    MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -1075,7 +1065,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win)
 {
     int ret;
 
@@ -1088,7 +1078,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win)
 {
     int ret;
 
@@ -1101,8 +1091,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                             MPIR_Win ** win)
+static inline int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
+                                                  MPIR_Win ** win)
 {
     int ret;
 
@@ -1115,11 +1105,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, M
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_rget(void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
@@ -1134,7 +1124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr, int origin_cou
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_sync(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_sync(MPIR_Win * win)
 {
     int ret;
 
@@ -1147,7 +1137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_sync(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win)
 {
     int ret;
 
@@ -1160,14 +1150,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr, int origin_count,
-                                                         MPI_Datatype origin_datatype,
-                                                         void *result_addr, int result_count,
-                                                         MPI_Datatype result_datatype,
-                                                         int target_rank, MPI_Aint target_disp,
-                                                         int target_count,
-                                                         MPI_Datatype target_datatype, MPI_Op op,
-                                                         MPIR_Win * win, MPIDI_av_entry_t * addr)
+static inline int MPIDI_NM_mpi_get_accumulate(const void *origin_addr, int origin_count,
+                                              MPI_Datatype origin_datatype,
+                                              void *result_addr, int result_count,
+                                              MPI_Datatype result_datatype,
+                                              int target_rank, MPI_Aint target_disp,
+                                              int target_count,
+                                              MPI_Datatype target_datatype, MPI_Op op,
+                                              MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     int ret;
 
@@ -1183,7 +1173,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_get_accumulate(const void *origin_addr
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win)
+static inline int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -1196,7 +1186,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * wi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm)
+static inline int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm)
 {
     int ret;
 
@@ -1209,7 +1199,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rank_is_local(int target, MPIR_Comm * comm
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av)
+static inline int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av)
 {
     int ret;
 
@@ -1222,8 +1212,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_av_is_local(MPIDI_av_entry_t * av)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ptr)
+static inline int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                       void *algo_parameters_ptr)
 {
     int ret;
 
@@ -1236,9 +1226,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm,
-                                                MPIR_Errflag_t * errflag, void *algo_parameters_ptr)
+static inline int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+                                     int root, MPIR_Comm * comm,
+                                     MPIR_Errflag_t * errflag, void *algo_parameters_ptr)
 {
     int ret;
 
@@ -1253,10 +1243,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                    void *algo_parameters_ptr)
+static inline int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
+                                         MPI_Datatype datatype, MPI_Op op,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                         void *algo_parameters_ptr)
 {
     int ret;
 
@@ -1271,10 +1261,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1288,11 +1278,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          const int *recvcounts, const int *displs,
+                                          MPI_Datatype recvtype, MPIR_Comm * comm,
+                                          MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1306,10 +1296,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1323,11 +1313,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                   const int *displs, MPI_Datatype sendtype,
-                                                   void *recvbuf, int recvcount,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
+                                        const int *displs, MPI_Datatype sendtype,
+                                        void *recvbuf, int recvcount,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1341,10 +1331,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      int recvcount, MPI_Datatype recvtype, int root,
+                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1358,11 +1348,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, int sendco
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  const int *recvcounts, const int *displs,
-                                                  MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       const int *recvcounts, const int *displs,
+                                       MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1376,10 +1366,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1393,11 +1383,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls, MPI_Datatype sendtype,
-                                                    void *recvbuf, const int *recvcounts,
-                                                    const int *rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
+                                         const int *sdispls, MPI_Datatype sendtype,
+                                         void *recvbuf, const int *recvcounts,
+                                         const int *rdispls, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1411,12 +1401,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                    const int *sdispls,
-                                                    const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int *recvcounts, const int *rdispls,
-                                                    const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
+                                         const int *sdispls,
+                                         const MPI_Datatype sendtypes[], void *recvbuf,
+                                         const int *recvcounts, const int *rdispls,
+                                         const MPI_Datatype recvtypes[],
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1430,10 +1420,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ptr)
+static inline int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op, int root,
+                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
+                                      void *algo_parameters_ptr)
 {
     int ret;
 
@@ -1447,11 +1437,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                         const int *recvcounts,
-                                                         MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
+                                              const int *recvcounts,
+                                              MPI_Datatype datatype, MPI_Op op,
+                                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1465,11 +1454,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                               int recvcount,
-                                                               MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                    int recvcount,
+                                                    MPI_Datatype datatype, MPI_Op op,
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1483,9 +1471,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
-                                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                    MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1498,9 +1486,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op,
+                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -1513,10 +1501,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recv
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm)
 {
     int ret;
 
@@ -1530,12 +1518,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgather(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *displs,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *displs,
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -1549,14 +1536,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_allgatherv(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                             const int *sendcounts,
-                                                             const int *sdispls,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             const int *recvcounts,
-                                                             const int *rdispls,
-                                                             MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf,
+                                                  const int *sendcounts,
+                                                  const int *sdispls,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  const int *recvcounts,
+                                                  const int *rdispls,
+                                                  MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -1571,14 +1557,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallv(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                             const int *sendcounts,
-                                                             const MPI_Aint * sdispls,
-                                                             const MPI_Datatype * sendtypes,
-                                                             void *recvbuf, const int *recvcounts,
-                                                             const MPI_Aint * rdispls,
-                                                             const MPI_Datatype * recvtypes,
-                                                             MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf,
+                                                  const int *sendcounts,
+                                                  const MPI_Aint * sdispls,
+                                                  const MPI_Datatype * sendtypes,
+                                                  void *recvbuf, const int *recvcounts,
+                                                  const MPI_Aint * rdispls,
+                                                  const MPI_Datatype * recvtypes, MPIR_Comm * comm)
 {
     int ret;
 
@@ -1593,10 +1578,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoallw(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm)
+static inline int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm)
 {
     int ret;
 
@@ -1610,10 +1595,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_neighbor_alltoall(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1627,14 +1612,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *displs,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                    MPI_Datatype sendtype,
+                                                    void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *displs,
+                                                    MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1648,10 +1632,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1665,14 +1649,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const int *sdispls,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *rdispls,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const int *sdispls,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *rdispls,
+                                                   MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1687,14 +1671,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const MPI_Aint * sdispls,
-                                                              const MPI_Datatype * sendtypes,
-                                                              void *recvbuf, const int *recvcounts,
-                                                              const MPI_Aint * rdispls,
-                                                              const MPI_Datatype * recvtypes,
-                                                              MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const MPI_Aint * sdispls,
+                                                   const MPI_Datatype * sendtypes,
+                                                   void *recvbuf, const int *recvcounts,
+                                                   const MPI_Aint * rdispls,
+                                                   const MPI_Datatype * recvtypes,
+                                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1709,7 +1693,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1722,8 +1706,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reques
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
+                                      int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1736,10 +1720,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, int count, MPI_Da
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iallgather(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1753,11 +1737,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
-                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           const int *recvcounts, const int *displs,
+                                           MPI_Datatype recvtype, MPIR_Comm * comm,
+                                           MPIR_Request ** req)
 {
     int ret;
 
@@ -1771,9 +1755,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                                     MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                          MPI_Datatype datatype, MPI_Op op,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1786,10 +1770,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1803,11 +1787,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls, MPI_Datatype sendtype,
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1821,12 +1805,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
-                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
-                                                     const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls,
+                                          const MPI_Datatype sendtypes[], void *recvbuf,
+                                          const int *recvcounts, const int *rdispls,
+                                          const MPI_Datatype recvtypes[],
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1840,9 +1824,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op,
+                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1855,10 +1839,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_igather(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1872,11 +1856,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_igatherv(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int *recvcounts, const int *displs,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1890,11 +1874,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm,
-                                                                MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                     int recvcount,
+                                                     MPI_Datatype datatype, MPI_Op op,
+                                                     MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1908,10 +1891,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
-                                                          MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
+                                               const int *recvcounts,
+                                               MPI_Datatype datatype, MPI_Op op,
+                                               MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1925,9 +1908,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int ret;
 
@@ -1941,9 +1924,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                     MPIR_Request ** req)
 {
     int ret;
 
@@ -1956,10 +1939,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iscatter(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -1973,11 +1956,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req)
+static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
+                                         const int *displs, MPI_Datatype sendtype,
+                                         void *recvbuf, int recvcount,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int ret;
 
@@ -1991,7 +1974,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2004,9 +1987,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
-                                                       MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
+                                            MPI_Datatype datatype, int root,
+                                            MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2019,10 +2002,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                int recvcount, MPI_Datatype recvtype,
+                                                MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2036,12 +2019,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            const int *recvcounts,
-                                                            const int *displs,
-                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 const int *recvcounts,
+                                                 const int *displs,
+                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                 MPIR_Sched_t s)
 {
     int ret;
 
@@ -2055,10 +2038,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
-                                                           int count, MPI_Datatype datatype,
-                                                           MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
+                                                int count, MPI_Datatype datatype,
+                                                MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2072,10 +2054,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
-                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               int recvcount, MPI_Datatype recvtype,
+                                               MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2089,14 +2071,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
-                                                           const int sendcounts[],
-                                                           const int sdispls[],
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           const int recvcounts[],
-                                                           const int rdispls[],
-                                                           MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
+                                                const int sendcounts[],
+                                                const int sdispls[],
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                const int recvcounts[],
+                                                const int rdispls[],
+                                                MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                MPIR_Sched_t s)
 {
     int ret;
 
@@ -2111,14 +2093,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
-                                                           const int sendcounts[],
-                                                           const int sdispls[],
-                                                           const MPI_Datatype sendtypes[],
-                                                           void *recvbuf, const int recvcounts[],
-                                                           const int rdispls[],
-                                                           const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
+                                                const int sendcounts[],
+                                                const int sdispls[],
+                                                const MPI_Datatype sendtypes[],
+                                                void *recvbuf, const int recvcounts[],
+                                                const int rdispls[],
+                                                const MPI_Datatype recvtypes[],
+                                                MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2133,9 +2115,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
+                                             int count, MPI_Datatype datatype, MPI_Op op,
+                                             MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2148,10 +2130,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, voi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
-                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
+                                             MPI_Datatype sendtype, void *recvbuf,
+                                             int recvcount, MPI_Datatype recvtype,
+                                             int root, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2165,11 +2147,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
-                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                         const int *recvcounts, const int *displs,
-                                                         MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              const int *recvcounts, const int *displs,
+                                              MPI_Datatype recvtype, int root,
+                                              MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2184,11 +2166,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
-                                                                      void *recvbuf, int recvcount,
-                                                                      MPI_Datatype datatype,
-                                                                      MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
+                                                           void *recvbuf, int recvcount,
+                                                           MPI_Datatype datatype,
+                                                           MPI_Op op, MPIR_Comm * comm,
+                                                           MPIR_Sched_t s)
 {
     int ret;
 
@@ -2202,10 +2184,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
-                                                                const int recvcounts[],
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
+                                                     const int recvcounts[],
+                                                     MPI_Datatype datatype, MPI_Op op,
+                                                     MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2219,9 +2201,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
-                                                        int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
+                                             int count, MPI_Datatype datatype, MPI_Op op,
+                                             int root, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2236,9 +2218,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, voi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
+                                           MPI_Datatype datatype, MPI_Op op,
+                                           MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2251,10 +2233,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
-                                                         MPI_Datatype sendtype, void *recvbuf,
-                                                         int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              int recvcount, MPI_Datatype recvtype,
+                                              int root, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2268,12 +2250,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
-                                                          const int *sendcounts, const int *displs,
-                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
-                                                          int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
+                                               const int *sendcounts, const int *displs,
+                                               MPI_Datatype sendtype, void *recvbuf,
+                                               int recvcount, MPI_Datatype recvtype,
+                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2287,13 +2268,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
-                                                                    int sendcount,
-                                                                    MPI_Datatype sendtype,
-                                                                    void *recvbuf, int recvcount,
-                                                                    MPI_Datatype recvtype,
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
+                                                         int sendcount,
+                                                         MPI_Datatype sendtype,
+                                                         void *recvbuf, int recvcount,
+                                                         MPI_Datatype recvtype,
+                                                         MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2307,15 +2287,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
-                                                                     int sendcount,
-                                                                     MPI_Datatype sendtype,
-                                                                     void *recvbuf,
-                                                                     const int recvcounts[],
-                                                                     const int displs[],
-                                                                     MPI_Datatype recvtype,
-                                                                     MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
+                                                          int sendcount,
+                                                          MPI_Datatype sendtype,
+                                                          void *recvbuf,
+                                                          const int recvcounts[],
+                                                          const int displs[],
+                                                          MPI_Datatype recvtype,
+                                                          MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2330,12 +2309,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
-                                                                   int sendcount,
-                                                                   MPI_Datatype sendtype,
-                                                                   void *recvbuf, int recvcount,
-                                                                   MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
+                                                        int sendcount,
+                                                        MPI_Datatype sendtype,
+                                                        void *recvbuf, int recvcount,
+                                                        MPI_Datatype recvtype,
+                                                        MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2349,16 +2328,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
-                                                                    const int sendcounts[],
-                                                                    const int sdispls[],
-                                                                    MPI_Datatype sendtype,
-                                                                    void *recvbuf,
-                                                                    const int recvcounts[],
-                                                                    const int rdispls[],
-                                                                    MPI_Datatype recvtype,
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
+                                                         const int sendcounts[],
+                                                         const int sdispls[],
+                                                         MPI_Datatype sendtype,
+                                                         void *recvbuf,
+                                                         const int recvcounts[],
+                                                         const int rdispls[],
+                                                         MPI_Datatype recvtype,
+                                                         MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2373,16 +2351,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
-                                                                    const int sendcounts[],
-                                                                    const MPI_Aint sdispls[],
-                                                                    const MPI_Datatype sendtypes[],
-                                                                    void *recvbuf,
-                                                                    const int recvcounts[],
-                                                                    const MPI_Aint rdispls[],
-                                                                    const MPI_Datatype recvtypes[],
-                                                                    MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
+                                                         const int sendcounts[],
+                                                         const MPI_Aint sdispls[],
+                                                         const MPI_Datatype sendtypes[],
+                                                         void *recvbuf,
+                                                         const int recvcounts[],
+                                                         const MPI_Aint rdispls[],
+                                                         const MPI_Datatype recvtypes[],
+                                                         MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -2399,7 +2376,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
 
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p)
+static inline int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p)
 {
     int ret;
 
@@ -2412,7 +2389,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datat
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p)
+static inline int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p)
 {
     int ret;
 
@@ -2425,7 +2402,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatyp
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p)
+static inline int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p)
 {
     int ret;
 
@@ -2438,7 +2415,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_commit_hook(MPIR_Op * op_p)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p)
+static inline int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p)
 {
     int ret;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -494,10 +494,9 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
 #define FUNCNAME MPIDI_OFI_do_emulated_inject
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
-                                                          const MPIDI_OFI_am_header_t * msg_hdrp,
-                                                          const void *am_hdr,
-                                                          size_t am_hdr_sz, int need_lock)
+static inline int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
+                                               const MPIDI_OFI_am_header_t * msg_hdrp,
+                                               const void *am_hdr, size_t am_hdr_sz, int need_lock)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -31,7 +31,7 @@ enum {
 #define MPIDI_OFI_MAX_ENDPOINTS_BITS_REGULAR    0
 
 /* This needs to be kept in sync with the order in globals.c */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
+static inline int MPIDI_OFI_get_set_number(const char *set_name)
 {
     if (!strcmp("psm", set_name)) {
         return MPIDI_OFI_SET_NUMBER_PSM;

--- a/src/mpid/ch4/netmod/ofi/ofi_coll_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll_impl.h
@@ -17,7 +17,7 @@
 #define FUNCNAME MPIDI_OFI_Barrier__recursive_doubling
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Barrier__recursive_doubling(MPIR_Comm * comm_ptr,
                                               MPIR_Errflag_t * errflag,
                                               MPIDI_OFI_coll_algo_container_t *
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_Bcast__binomial
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Bcast__binomial(void *buffer,
                                   int count,
                                   MPI_Datatype datatype,
@@ -55,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_Bcast__scatter_recursive_doubling_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Bcast__scatter_recursive_doubling_allgather(void *buffer,
                                                               int count,
                                                               MPI_Datatype datatype,
@@ -77,7 +77,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_Bcast__scatter_ring_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Bcast__scatter_ring_allgather(void *buffer,
                                                 int count,
                                                 MPI_Datatype datatype,
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_allreduce__recursive_doubling
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_allreduce__recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
@@ -119,7 +119,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_allreduce__reduce_scatter_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_allreduce__reduce_scatter_allgather(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
                                                       MPIR_Comm * comm_ptr,
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_reduce__reduce_scatter_gather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_reduce__reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, int root,
                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_reduce__binomial
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_reduce__binomial(const void *sendbuf, void *recvbuf, int count,
                                    MPI_Datatype datatype, MPI_Op op, int root,
                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,

--- a/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
@@ -5,7 +5,7 @@
 #include "coll_algo_params.h"
 #include "ofi_coll_impl.h"
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_OFI_coll_algo_container_t * MPIDI_OFI_Barrier_select(MPIR_Comm * comm_ptr,
                                                                MPIR_Errflag_t * errflag,
                                                                MPIDI_OFI_coll_algo_container_t *
@@ -15,7 +15,7 @@ MPL_STATIC_INLINE_PREFIX
     return (MPIDI_OFI_coll_algo_container_t *) & OFI_barrier__recursive_doubling_cnt;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Barrier_call(MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag,
                                MPIDI_OFI_coll_algo_container_t * ch4_algo_parameters_container)
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_OFI_coll_algo_container_t * MPIDI_OFI_Bcast_select(void *buffer, int count,
                                                              MPI_Datatype datatype,
                                                              int root,
@@ -66,7 +66,7 @@ MPL_STATIC_INLINE_PREFIX
     }
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Bcast_call(void *buffer, int count, MPI_Datatype datatype,
                              int root, MPIR_Comm * comm_ptr,
                              MPIR_Errflag_t * errflag,
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_OFI_coll_algo_container_t * MPIDI_OFI_Allreduce_select(const void *sendbuf,
                                                                  void *recvbuf,
                                                                  int count,
@@ -123,7 +123,7 @@ MPL_STATIC_INLINE_PREFIX
     }
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Allreduce_call(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op,
                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
@@ -152,7 +152,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_OFI_coll_algo_container_t * MPIDI_OFI_Reduce_select(const void *sendbuf,
                                                               void *recvbuf,
                                                               int count,
@@ -176,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX
     }
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_Reduce_call(const void *sendbuf, void *recvbuf, int count,
                               MPI_Datatype datatype, MPI_Op op, int root,
                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -17,10 +17,9 @@
 #include "ofi_control.h"
 #include "utlist.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc,
-                                                      MPIR_Request * req);
+static inline int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc)
+static inline int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc)
 {
     if (MPIDI_OFI_ENABLE_DATA)
         return wc->data;
@@ -32,8 +31,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry 
 #define FUNCNAME MPIDI_OFI_peek_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_event(struct fi_cq_tagged_entry *wc,
-                                                  MPIR_Request * rreq)
+static inline int MPIDI_OFI_peek_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     size_t count;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_NETMOD_PEEK_EVENT);
@@ -52,8 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_event(struct fi_cq_tagged_entry *wc,
 #define FUNCNAME MPIDI_OFI_peek_empty_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_empty_event(struct fi_cq_tagged_entry *wc,
-                                                        MPIR_Request * rreq)
+static inline int MPIDI_OFI_peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_NETMOD_PEEK_EMPTY_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_NETMOD_PEEK_EMPTY_EVENT);
@@ -83,8 +80,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_empty_event(struct fi_cq_tagged_entr
 #define FUNCNAME MPIDI_OFI_recv_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
-                                                  MPIR_Request * rreq, int event_id)
+static inline int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
+                                       MPIR_Request * rreq, int event_id)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint last;
@@ -177,8 +174,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
 #define FUNCNAME MPIDI_OFI_recv_huge_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry *wc,
-                                                       MPIR_Request * rreq)
+static inline int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_huge_recv_t *recv = NULL;
@@ -268,8 +264,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
 #define FUNCNAME MPIDI_OFI_send_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc,
-                                                  MPIR_Request * sreq, int event_id)
+static inline int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc,
+                                       MPIR_Request * sreq, int event_id)
 {
     int c;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_SEND_EVENT);
@@ -296,8 +292,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc,
 #define FUNCNAME MPIDI_OFI_send_huge_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_huge_event(struct fi_cq_tagged_entry *wc,
-                                                       MPIR_Request * sreq)
+static inline int MPIDI_OFI_send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int c;
@@ -350,8 +345,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_huge_event(struct fi_cq_tagged_entry
 #define FUNCNAME MPIDI_OFI_ssend_ack_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_ssend_ack_event(struct fi_cq_tagged_entry *wc,
-                                                       MPIR_Request * sreq)
+static inline int MPIDI_OFI_ssend_ack_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno;
     MPIDI_OFI_ssendack_request_t *req = (MPIDI_OFI_ssendack_request_t *) sreq;
@@ -365,7 +359,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_ssend_ack_event(struct fi_cq_tagged_entry
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX uintptr_t MPIDI_OFI_recv_rbase(MPIDI_OFI_huge_recv_t * recv)
+static inline uintptr_t MPIDI_OFI_recv_rbase(MPIDI_OFI_huge_recv_t * recv)
 {
     if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
         return 0;
@@ -378,8 +372,7 @@ MPL_STATIC_INLINE_PREFIX uintptr_t MPIDI_OFI_recv_rbase(MPIDI_OFI_huge_recv_t * 
 #define FUNCNAME MPIDI_OFI_get_huge_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc,
-                                                      MPIR_Request * req)
+static inline int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_huge_recv_t *recv = (MPIDI_OFI_huge_recv_t *) req;
@@ -441,8 +434,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry 
 #define FUNCNAME MPIDI_OFI_chunk_done_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_chunk_done_event(struct fi_cq_tagged_entry *wc,
-                                                        MPIR_Request * req)
+static inline int MPIDI_OFI_chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int c;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_CHUNK_DONE_EVENT);
@@ -463,8 +455,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_chunk_done_event(struct fi_cq_tagged_entr
 #define FUNCNAME MPIDI_OFI_inject_emu_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_inject_emu_event(struct fi_cq_tagged_entry *wc,
-                                                        MPIR_Request * req)
+static inline int MPIDI_OFI_inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int incomplete;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_EMU_EVENT);
@@ -486,8 +477,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_inject_emu_event(struct fi_cq_tagged_entr
 #define FUNCNAME MPIDI_OFI_rma_done_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc,
-                                                      MPIR_Request * in_req)
+static inline int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4_OFI_RMA_DONE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CH4_OFI_RMA_DONE_EVENT);
@@ -503,8 +493,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry 
 #define FUNCNAME MPIDI_OFI_accept_probe_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_accept_probe_event(struct fi_cq_tagged_entry *wc,
-                                                          MPIR_Request * rreq)
+static inline int MPIDI_OFI_accept_probe_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4_OFI_ACCEPT_PROBE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CH4_OFI_ACCEPT_PROBE_EVENT);
@@ -521,8 +510,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_accept_probe_event(struct fi_cq_tagged_en
 #define FUNCNAME MPIDI_OFI_dynproc_done_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dynproc_done_event(struct fi_cq_tagged_entry *wc,
-                                                          MPIR_Request * rreq)
+static inline int MPIDI_OFI_dynproc_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CH4_OFI_DYNPROC_DONE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CH4_OFI_DYNPROC_DONE_EVENT);
@@ -536,8 +524,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dynproc_done_event(struct fi_cq_tagged_en
 #define FUNCNAME MPIDI_OFI_am_isend_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_event(struct fi_cq_tagged_entry *wc,
-                                                      MPIR_Request * sreq)
+static inline int MPIDI_OFI_am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -578,8 +565,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_event(struct fi_cq_tagged_entry 
 #define FUNCNAME MPIDI_OFI_am_recv_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_recv_event(struct fi_cq_tagged_entry *wc,
-                                                     MPIR_Request * rreq)
+static inline int MPIDI_OFI_am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *am_hdr;
@@ -636,8 +622,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_recv_event(struct fi_cq_tagged_entry *
 #define FUNCNAME MPIDI_OFI_am_read_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_read_event(struct fi_cq_tagged_entry *wc,
-                                                     MPIR_Request * dont_use_me)
+static inline int MPIDI_OFI_am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -675,8 +660,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_read_event(struct fi_cq_tagged_entry *
 #define FUNCNAME MPIDI_OFI_am_repost_event
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_repost_event(struct fi_cq_tagged_entry *wc,
-                                                       MPIR_Request * rreq)
+static inline int MPIDI_OFI_am_repost_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_REPOST_BUFFER);
@@ -688,8 +672,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_repost_event(struct fi_cq_tagged_entry
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc,
-                                                         MPIR_Request * req, int buffered)
+static inline int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc,
+                                              MPIR_Request * req, int buffered)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -794,7 +778,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_ent
 #define FUNCNAME MPIDI_OFI_get_buffered
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *wc, ssize_t num)
+static inline int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *wc, ssize_t num)
 {
     int rc = 0;
 
@@ -826,8 +810,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *w
 #define FUNCNAME MPIDI_OFI_handle_cq_entries
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc,
-                                                         ssize_t num, int buffered)
+static inline int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc,
+                                              ssize_t num, int buffered)
 {
     int i, mpi_errno = MPI_SUCCESS;
     MPIR_Request *req;
@@ -850,7 +834,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_ent
 #define FUNCNAME MPIDI_OFI_handle_cq_error
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
+static inline int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_err_entry e;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -236,7 +236,7 @@
 
 #define WINFO(w,rank) MPIDI_CH4U_WINFO(w,rank)
 
-MPL_STATIC_INLINE_PREFIX uintptr_t MPIDI_OFI_winfo_base(MPIR_Win * w, int rank)
+static inline uintptr_t MPIDI_OFI_winfo_base(MPIR_Win * w, int rank)
 {
     if (MPIDI_OFI_ENABLE_MR_SCALABLE)
         return 0;
@@ -244,7 +244,7 @@ MPL_STATIC_INLINE_PREFIX uintptr_t MPIDI_OFI_winfo_base(MPIR_Win * w, int rank)
         return MPIDI_OFI_WIN(w).winfo[rank].base;
 }
 
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_winfo_mr_key(MPIR_Win * w, int rank)
+static inline uint64_t MPIDI_OFI_winfo_mr_key(MPIR_Win * w, int rank)
 {
     if (MPIDI_OFI_ENABLE_MR_SCALABLE)
         return MPIDI_OFI_WIN(w).mr_key;
@@ -252,12 +252,12 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_winfo_mr_key(MPIR_Win * w, int rank)
         return MPIDI_OFI_WIN(w).winfo[rank].mr_key;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_cntr_incr(MPIR_Win * win)
+static inline void MPIDI_OFI_win_cntr_incr(MPIR_Win * win)
 {
     (*MPIDI_OFI_WIN(win).issued_cntr)++;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
+static inline void MPIDI_OFI_cntr_incr()
 {
     MPIDI_Global.rma_issued_cntr++;
 }
@@ -278,30 +278,7 @@ void MPIDI_OFI_index_allocator_destroy(void *_indexmap);
 /* Common Utility functions used by the
  * C and C++ components
  */
-/* Set max size based on OFI acc ordering limit. */
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_check_acc_order_size(MPIR_Win * win, size_t max_size)
-{
-    /* Check ordering limit, a value of -1 guarantees ordering for any data size. */
-    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_WAR)
-        && MPIDI_Global.max_order_war != -1) {
-        /* An order size value of 0 indicates that ordering is not guaranteed. */
-        MPIR_Assert(MPIDI_Global.max_order_war != 0);
-        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_war);
-    }
-    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_WAW)
-        && MPIDI_Global.max_order_waw != -1) {
-        MPIR_Assert(MPIDI_Global.max_order_waw != 0);
-        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_waw);
-    }
-    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_RAW)
-        && MPIDI_Global.max_order_raw != -1) {
-        MPIR_Assert(MPIDI_Global.max_order_raw != 0);
-        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_raw);
-    }
-    return max_size;
-}
-
-MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_and_init(int extra)
+static inline MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_and_init(int extra)
 {
     MPIDI_OFI_win_request_t *req;
     req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
@@ -313,7 +290,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_an
     return req;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * req)
+static inline void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * req)
 {
     int in_use;
     MPIR_Assert(HANDLE_GET_MPI_KIND(req->handle) == MPIR_REQUEST);
@@ -325,7 +302,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
     }
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank)
+static inline fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, rank));
@@ -337,7 +314,7 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int 
     }
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av)
+static inline fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int ep_num = MPIDI_OFI_av_to_ep(&MPIDI_OFI_AV(av));
@@ -347,7 +324,7 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av)
     }
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int rank)
+static inline fi_addr_t MPIDI_OFI_to_phys(int rank)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int ep_num = 0;
@@ -358,13 +335,13 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int rank)
     }
 }
 
-MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_is_tag_sync(uint64_t match_bits)
+static inline bool MPIDI_OFI_is_tag_sync(uint64_t match_bits)
 {
     return (0 != (MPIDI_OFI_SYNC_SEND & match_bits));
 }
 
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_sendtag(MPIR_Context_id_t contextid,
-                                                         int source, int tag, uint64_t type)
+static inline uint64_t MPIDI_OFI_init_sendtag(MPIR_Context_id_t contextid,
+                                              int source, int tag, uint64_t type)
 {
     uint64_t match_bits;
     match_bits = contextid;
@@ -380,9 +357,8 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_sendtag(MPIR_Context_id_t conte
 }
 
 /* receive posting */
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_recvtag(uint64_t * mask_bits,
-                                                         MPIR_Context_id_t contextid,
-                                                         int source, int tag)
+static inline uint64_t MPIDI_OFI_init_recvtag(uint64_t * mask_bits,
+                                              MPIR_Context_id_t contextid, int source, int tag)
 {
     uint64_t match_bits = 0;
     *mask_bits = MPIDI_OFI_PROTOCOL_MASK;
@@ -410,17 +386,17 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_recvtag(uint64_t * mask_bits,
     return match_bits;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_init_get_tag(uint64_t match_bits)
+static inline int MPIDI_OFI_init_get_tag(uint64_t match_bits)
 {
     return ((int) (match_bits & MPIDI_OFI_TAG_MASK));
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_init_get_source(uint64_t match_bits)
+static inline int MPIDI_OFI_init_get_source(uint64_t match_bits)
 {
     return ((int) ((match_bits & MPIDI_OFI_SOURCE_MASK) >> MPIDI_OFI_TAG_BITS));
 }
 
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_OFI_context_to_request(void *context)
+static inline MPIR_Request *MPIDI_OFI_context_to_request(void *context)
 {
     char *base = (char *) context;
     return (MPIR_Request *) MPL_container_of(base, MPIR_Request, dev.ch4.netmod);
@@ -430,10 +406,9 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_OFI_context_to_request(void *contex
 #define FUNCNAME MPIDI_OFI_send_handler
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_handler(struct fid_ep *ep, const void *buf, size_t len,
-                                                    void *desc, uint32_t dest, fi_addr_t dest_addr,
-                                                    uint64_t tag, void *context, int is_inject,
-                                                    int do_lock)
+static inline int MPIDI_OFI_send_handler(struct fid_ep *ep, const void *buf, size_t len,
+                                         void *desc, uint32_t dest, fi_addr_t dest_addr,
+                                         uint64_t tag, void *context, int is_inject, int do_lock)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -458,7 +433,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_handler(struct fid_ep *ep, const voi
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_conn_manager_insert_conn(fi_addr_t conn, int rank, int state)
+static inline int MPIDI_OFI_conn_manager_insert_conn(fi_addr_t conn, int rank, int state)
 {
     int conn_id = -1;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_CONN_MANAGER_INSERT_CONN);
@@ -499,7 +474,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_conn_manager_insert_conn(fi_addr_t conn, 
     return conn_id;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_conn_manager_remove_conn(int conn_id)
+static inline int MPIDI_OFI_conn_manager_remove_conn(int conn_id)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_CONN_MANAGER_REMOVE_CONN);
@@ -516,7 +491,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_conn_manager_remove_conn(int conn_id)
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dynproc_send_disconnect(int conn_id)
+static inline int MPIDI_OFI_dynproc_send_disconnect(int conn_id)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -594,7 +569,7 @@ struct MPIDI_OFI_contig_blocks_params {
 #define FUNCNAME MPIDI_OFI_contig_count_block
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_contig_count_block(DLOOP_Offset * blocks_p,
                                      DLOOP_Type el_type,
                                      DLOOP_Offset rel_off, DLOOP_Buffer bufp, void *v_paramp)
@@ -643,8 +618,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_count_iov
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
-    size_t MPIDI_OFI_count_iov(int dt_count, MPI_Datatype dt_datatype, size_t max_pipe)
+static inline size_t MPIDI_OFI_count_iov(int dt_count, MPI_Datatype dt_datatype, size_t max_pipe)
 {
     struct MPIDI_OFI_contig_blocks_params params;
     MPIR_Segment dt_seg;
@@ -702,7 +676,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_OFI_align_iov_len
 #undef  FCNAME
 #define FCNAME   MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_align_iov_len(size_t len)
+static inline size_t MPIDI_OFI_align_iov_len(size_t len)
 {
     size_t pad = MPIDI_OFI_IOVEC_ALIGN - 1;
     size_t mask = ~pad;
@@ -715,7 +689,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_align_iov_len(size_t len)
 #define FUNCNAME MPIDI_OFI_aligned_next_iov
 #undef  FCNAME
 #define FCNAME   MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPIDI_OFI_aligned_next_iov(void *ptr)
+static inline void *MPIDI_OFI_aligned_next_iov(void *ptr)
 {
     return (void *) (uintptr_t) MPIDI_OFI_align_iov_len((size_t) ptr);
 }
@@ -724,7 +698,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_OFI_aligned_next_iov(void *ptr)
 #define FUNCNAME MPIDI_OFI_request_util_iov
 #undef  FCNAME
 #define FCNAME   MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX struct iovec *MPIDI_OFI_request_util_iov(MPIR_Request * req)
+static inline struct iovec *MPIDI_OFI_request_util_iov(MPIR_Request * req)
 {
 #if defined (MPL_HAVE_VAR_ATTRIBUTE_ALIGNED)
     return &MPIDI_OFI_REQUEST(req, util.iov);

--- a/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
@@ -116,9 +116,8 @@ do {                                                                         \
     MPIDI_OFI_next_seg_state2(seg_state,&origin_addr, &result_addr, &target_addr,&len); \
   } while (0)
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_segment_next(MPIDI_OFI_seg_state_t * state,
-                                                    DLOOP_VECTOR * out_vector,
-                                                    MPIDI_OFI_segment_side_t side)
+static inline int MPIDI_OFI_segment_next(MPIDI_OFI_seg_state_t * state,
+                                         DLOOP_VECTOR * out_vector, MPIDI_OFI_segment_side_t side)
 {
     DLOOP_VECTOR dloop;
     DLOOP_Offset last;
@@ -158,14 +157,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_segment_next(MPIDI_OFI_seg_state_t * stat
     return num_contig == 0 ? 1 : 0;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state(MPIDI_OFI_seg_state_t * seg_state,
-                                                       const void *origin,
-                                                       const MPI_Aint target,
-                                                       size_t origin_count,
-                                                       size_t target_count,
-                                                       size_t buf_limit,
-                                                       MPI_Datatype origin_type,
-                                                       MPI_Datatype target_type)
+static inline void MPIDI_OFI_init_seg_state(MPIDI_OFI_seg_state_t * seg_state,
+                                            const void *origin,
+                                            const MPI_Aint target,
+                                            size_t origin_count,
+                                            size_t target_count,
+                                            size_t buf_limit,
+                                            MPI_Datatype origin_type, MPI_Datatype target_type)
 {
     seg_state->buf_limit = buf_limit;
     seg_state->buf_limit_left = buf_limit;
@@ -182,17 +180,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state(MPIDI_OFI_seg_state_t * s
     MPIDI_OFI_INIT_SEG_STATE(origin, ORIGIN);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
-                                                        const void *origin,
-                                                        const void *result,
-                                                        const MPI_Aint target,
-                                                        size_t origin_count,
-                                                        size_t result_count,
-                                                        size_t target_count,
-                                                        size_t buf_limit,
-                                                        MPI_Datatype origin_type,
-                                                        MPI_Datatype result_type,
-                                                        MPI_Datatype target_type)
+static inline void MPIDI_OFI_init_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
+                                             const void *origin,
+                                             const void *result,
+                                             const MPI_Aint target,
+                                             size_t origin_count,
+                                             size_t result_count,
+                                             size_t target_count,
+                                             size_t buf_limit,
+                                             MPI_Datatype origin_type,
+                                             MPI_Datatype result_type, MPI_Datatype target_type)
 {
     seg_state->buf_limit = buf_limit;
     seg_state->buf_limit_left = buf_limit;
@@ -214,10 +211,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state2(MPIDI_OFI_seg_state_t * 
     MPIDI_OFI_INIT_SEG_STATE(result, RESULT);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state(MPIDI_OFI_seg_state_t * seg_state,
-                                                      uintptr_t * origin_addr_next,
-                                                      uintptr_t * target_addr_next,
-                                                      size_t * buf_len)
+static inline int MPIDI_OFI_next_seg_state(MPIDI_OFI_seg_state_t * seg_state,
+                                           uintptr_t * origin_addr_next,
+                                           uintptr_t * target_addr_next, size_t * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0)) {
         uintptr_t buf_size = MPL_MIN(MPL_MIN(seg_state->target_iov_len, seg_state->origin_iov_len),
@@ -233,11 +229,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state(MPIDI_OFI_seg_state_t * se
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
-                                                       uintptr_t * origin_addr_next,
-                                                       uintptr_t * result_addr_next,
-                                                       uintptr_t * target_addr_next,
-                                                       size_t * buf_len)
+static inline int MPIDI_OFI_next_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
+                                            uintptr_t * origin_addr_next,
+                                            uintptr_t * result_addr_next,
+                                            uintptr_t * target_addr_next, size_t * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0) &&
         (seg_state->result_iov_len != 0)) {
@@ -262,10 +257,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state2(MPIDI_OFI_seg_state_t * s
  *  Update the length of data that can fit into an iovec with current buffer limit left.
  *  (Used for functions taking two buffers -- origin, target)
  */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state(MPIDI_OFI_seg_state_t * seg_state,
-                                                      uintptr_t * next_origin_addr,
-                                                      uintptr_t * next_target_addr,
-                                                      size_t * buf_len)
+static inline int MPIDI_OFI_peek_seg_state(MPIDI_OFI_seg_state_t * seg_state,
+                                           uintptr_t * next_origin_addr,
+                                           uintptr_t * next_target_addr, size_t * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0)) {
         *next_origin_addr = seg_state->origin_addr;
@@ -286,11 +280,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state(MPIDI_OFI_seg_state_t * se
  *  Update the length of data that can fit into an iovec with current buffer limit left.
  *  (Used for functions taking three buffers -- origin, target, result)
  */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
-                                                       uintptr_t * next_origin_addr,
-                                                       uintptr_t * next_result_addr,
-                                                       uintptr_t * next_target_addr,
-                                                       size_t * buf_len)
+static inline int MPIDI_OFI_peek_seg_state2(MPIDI_OFI_seg_state_t * seg_state,
+                                            uintptr_t * next_origin_addr,
+                                            uintptr_t * next_result_addr,
+                                            uintptr_t * next_target_addr, size_t * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0) &&
         (seg_state->result_iov_len != 0)) {
@@ -309,13 +302,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state2(MPIDI_OFI_seg_state_t * s
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment(MPIDI_OFI_seg_state_t * seg_state,
-                                                     struct iovec *origin_iov,
-                                                     size_t origin_max_iovs,
-                                                     struct fi_rma_iov *target_iov,
-                                                     size_t target_max_iovs,
-                                                     size_t * origin_iovs_nout,
-                                                     size_t * target_iovs_nout)
+static inline int MPIDI_OFI_merge_segment(MPIDI_OFI_seg_state_t * seg_state,
+                                          struct iovec *origin_iov,
+                                          size_t origin_max_iovs,
+                                          struct fi_rma_iov *target_iov,
+                                          size_t target_max_iovs,
+                                          size_t * origin_iovs_nout, size_t * target_iovs_nout)
 {
     int rc;
     uintptr_t origin_addr = (uintptr_t) NULL, target_addr = (uintptr_t) NULL;
@@ -383,16 +375,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment(MPIDI_OFI_seg_state_t * seg
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment2(MPIDI_OFI_seg_state_t * seg_state,
-                                                      struct iovec *origin_iov,
-                                                      size_t origin_max_iovs,
-                                                      struct iovec *result_iov,
-                                                      size_t result_max_iovs,
-                                                      struct fi_rma_iov *target_iov,
-                                                      size_t target_max_iovs,
-                                                      size_t * origin_iovs_nout,
-                                                      size_t * result_iovs_nout,
-                                                      size_t * target_iovs_nout)
+static inline int MPIDI_OFI_merge_segment2(MPIDI_OFI_seg_state_t * seg_state,
+                                           struct iovec *origin_iov,
+                                           size_t origin_max_iovs,
+                                           struct iovec *result_iov,
+                                           size_t result_max_iovs,
+                                           struct fi_rma_iov *target_iov,
+                                           size_t target_max_iovs,
+                                           size_t * origin_iovs_nout,
+                                           size_t * result_iovs_nout, size_t * target_iovs_nout)
 {
     int rc;
     uintptr_t origin_addr = (uintptr_t) NULL, result_addr = (uintptr_t) NULL, target_addr =

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -30,11 +30,10 @@
 #define FUNCNAME MPIDI_OFI_recv_iov
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count,
-                                                int rank, uint64_t match_bits, uint64_t mask_bits,
-                                                MPIR_Comm * comm, MPIR_Context_id_t context_id,
-                                                MPIR_Request * rreq, MPIR_Datatype * dt_ptr,
-                                                uint64_t flags)
+static inline int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count,
+                                     int rank, uint64_t match_bits, uint64_t mask_bits,
+                                     MPIR_Comm * comm, MPIR_Context_id_t context_id,
+                                     MPIR_Request * rreq, MPIR_Datatype * dt_ptr, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL, *originv_huge = NULL;
@@ -175,15 +174,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count,
 #define FUNCNAME MPIDI_OFI_do_irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm,
-                                                int context_offset,
-                                                MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, int mode, uint64_t flags)
+static inline int MPIDI_OFI_do_irecv(void *buf,
+                                     MPI_Aint count,
+                                     MPI_Datatype datatype,
+                                     int rank,
+                                     int tag,
+                                     MPIR_Comm * comm,
+                                     int context_offset,
+                                     MPIDI_av_entry_t * addr,
+                                     MPIR_Request ** request, int mode, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -300,14 +299,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 #define FUNCNAME MPIDI_NM_mpi_recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv(void *buf,
+                                    MPI_Aint count,
+                                    MPI_Datatype datatype,
+                                    int rank,
+                                    int tag,
+                                    MPIR_Comm * comm,
+                                    int context_offset, MPIDI_av_entry_t * addr,
+                                    MPI_Status * status, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV);
@@ -331,14 +330,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
 #define FUNCNAME MPIDI_NM_mpi_recv_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
-                                                    int count,
-                                                    MPI_Datatype datatype,
-                                                    int rank,
-                                                    int tag,
-                                                    MPIR_Comm * comm,
-                                                    int context_offset, MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv_init(void *buf,
+                                         int count,
+                                         MPI_Datatype datatype,
+                                         int rank,
+                                         int tag,
+                                         MPIR_Comm * comm,
+                                         int context_offset, MPIDI_av_entry_t * addr,
+                                         MPIR_Request ** request)
 {
     MPIR_Request *rreq;
     int mpi_errno = MPI_SUCCESS;
@@ -385,10 +384,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
 #define FUNCNAME MPIDI_NM_mpi_imrecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
-                                                 MPI_Aint count,
-                                                 MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPIDI_NM_mpi_imrecv(void *buf,
+                                      MPI_Aint count,
+                                      MPI_Datatype datatype,
+                                      MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -419,13 +418,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
 #define FUNCNAME MPIDI_NM_mpi_irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_irecv(void *buf,
+                                     MPI_Aint count,
+                                     MPI_Datatype datatype,
+                                     int rank,
+                                     int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IRECV);
@@ -449,7 +448,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
 #define FUNCNAME MPIDI_NM_mpi_cancel_recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
+static inline int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
 {
 
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -75,7 +75,7 @@ static inline uint32_t MPIDI_OFI_winfo_disp_unit(MPIR_Win * win, int rank)
 #define FUNCNAME MPIDI_OFI_count_iovecs
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_OFI_count_iovecs(int origin_count,
                                int target_count,
                                int result_count,
@@ -145,17 +145,16 @@ static inline int MPIDI_OFI_query_datatype(MPI_Datatype dt,
     return rc;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * win,
-                                                                    int origin_count,
-                                                                    int target_count,
-                                                                    int target_rank,
-                                                                    MPI_Datatype origin_datatype,
-                                                                    MPI_Datatype target_datatype,
-                                                                    size_t max_pipe,
-                                                                    MPIDI_OFI_win_request_t **
-                                                                    winreq, uint64_t * flags,
-                                                                    struct fid_ep **ep,
-                                                                    MPIR_Request ** sigreq)
+static inline int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * win,
+                                                         int origin_count,
+                                                         int target_count,
+                                                         int target_rank,
+                                                         MPI_Datatype origin_datatype,
+                                                         MPI_Datatype target_datatype,
+                                                         size_t max_pipe,
+                                                         MPIDI_OFI_win_request_t **
+                                                         winreq, uint64_t * flags,
+                                                         struct fid_ep **ep, MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, alloc_iovs, alloc_iov_size;
@@ -189,17 +188,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win * win,
-                                                                       int origin_count,
-                                                                       int target_count,
-                                                                       int target_rank,
-                                                                       MPI_Datatype origin_datatype,
-                                                                       MPI_Datatype target_datatype,
-                                                                       size_t max_pipe,
-                                                                       MPIDI_OFI_win_request_t **
-                                                                       winreq, uint64_t * flags,
-                                                                       struct fid_ep **ep,
-                                                                       MPIR_Request ** sigreq)
+static inline int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win * win,
+                                                            int origin_count,
+                                                            int target_count,
+                                                            int target_rank,
+                                                            MPI_Datatype origin_datatype,
+                                                            MPI_Datatype target_datatype,
+                                                            size_t max_pipe,
+                                                            MPIDI_OFI_win_request_t **
+                                                            winreq, uint64_t * flags,
+                                                            struct fid_ep **ep,
+                                                            MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, alloc_iovs, alloc_iov_size;
@@ -233,24 +232,24 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_Win * win,
-                                                                           int origin_count,
-                                                                           int target_count,
-                                                                           int result_count,
-                                                                           int target_rank,
-                                                                           MPI_Op op,
-                                                                           MPI_Datatype
-                                                                           origin_datatype,
-                                                                           MPI_Datatype
-                                                                           target_datatype,
-                                                                           MPI_Datatype
-                                                                           result_datatype,
-                                                                           size_t max_pipe,
-                                                                           MPIDI_OFI_win_request_t
-                                                                           ** winreq,
-                                                                           uint64_t * flags,
-                                                                           struct fid_ep **ep,
-                                                                           MPIR_Request ** sigreq)
+static inline int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_Win * win,
+                                                                int origin_count,
+                                                                int target_count,
+                                                                int result_count,
+                                                                int target_rank,
+                                                                MPI_Op op,
+                                                                MPI_Datatype
+                                                                origin_datatype,
+                                                                MPI_Datatype
+                                                                target_datatype,
+                                                                MPI_Datatype
+                                                                result_datatype,
+                                                                size_t max_pipe,
+                                                                MPIDI_OFI_win_request_t
+                                                                ** winreq,
+                                                                uint64_t * flags,
+                                                                struct fid_ep **ep,
+                                                                MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, r_size, alloc_iovs, alloc_rma_iovs, alloc_iov_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -18,11 +18,11 @@
 #define FUNCNAME MPIDI_OFI_send_lightweight
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
-                                                        size_t data_sz,
-                                                        int rank,
-                                                        int tag, MPIR_Comm * comm,
-                                                        int context_offset, MPIDI_av_entry_t * addr)
+static inline int MPIDI_OFI_send_lightweight(const void *buf,
+                                             size_t data_sz,
+                                             int rank,
+                                             int tag, MPIR_Comm * comm,
+                                             int context_offset, MPIDI_av_entry_t * addr)
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t match_bits;
@@ -46,14 +46,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
 #define FUNCNAME MPIDI_OFI_send_lightweight_request
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
-                                                                size_t data_sz,
-                                                                int rank,
-                                                                int tag,
-                                                                MPIR_Comm * comm,
-                                                                int context_offset,
-                                                                MPIDI_av_entry_t * addr,
-                                                                MPIR_Request ** request)
+static inline int MPIDI_OFI_send_lightweight_request(const void *buf,
+                                                     size_t data_sz,
+                                                     int rank,
+                                                     int tag,
+                                                     MPIR_Comm * comm,
+                                                     int context_offset,
+                                                     MPIDI_av_entry_t * addr,
+                                                     MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t match_bits;
@@ -91,9 +91,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
 #define FUNCNAME MPIDI_OFI_send_iov
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
-                                                int rank, uint64_t match_bits, MPIR_Comm * comm,
-                                                MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
+static inline int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
+                                     int rank, uint64_t match_bits, MPIR_Comm * comm,
+                                     MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL, *originv_huge = NULL;
@@ -230,13 +230,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
 #define FUNCNAME MPIDI_OFI_send_normal
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint count,
-                                                   MPI_Datatype datatype, int rank, int tag,
-                                                   MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                   int dt_contig, size_t data_sz,
-                                                   MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
-                                                   uint64_t type)
+static inline int MPIDI_OFI_send_normal(const void *buf, MPI_Aint count,
+                                        MPI_Datatype datatype, int rank, int tag,
+                                        MPIR_Comm * comm, int context_offset,
+                                        MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                        int dt_contig, size_t data_sz,
+                                        MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb, uint64_t type)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -401,10 +400,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 #define FUNCNAME MPIDI_OFI_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                            int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                            MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                            int noreq, uint64_t syncflag)
+static inline int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                 int rank, int tag, MPIR_Comm * comm, int context_offset,
+                                 MPIDI_av_entry_t * addr, MPIR_Request ** request,
+                                 int noreq, uint64_t syncflag)
 {
     int dt_contig, mpi_errno;
     size_t data_sz;
@@ -437,11 +436,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 #define FUNCNAME MPIDI_OFI_persistent_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_persistent_send(const void *buf, int count,
-                                                       MPI_Datatype datatype, int rank, int tag,
-                                                       MPIR_Comm * comm, int context_offset,
-                                                       MPIDI_av_entry_t * addr,
-                                                       MPIR_Request ** request)
+static inline int MPIDI_OFI_persistent_send(const void *buf, int count,
+                                            MPI_Datatype datatype, int rank, int tag,
+                                            MPIR_Comm * comm, int context_offset,
+                                            MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     MPIR_Request *sreq;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PERSISTENT_SEND);
@@ -476,10 +474,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_persistent_send(const void *buf, int coun
 #define FUNCNAME MPIDI_NM_mpi_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
-                                               MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, int rank, int tag,
+                                    MPIR_Comm * comm, int context_offset,
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND);
@@ -502,10 +500,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
 #define FUNCNAME MPIDI_NM_mpi_ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SSEND);
@@ -530,10 +528,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
 #define FUNCNAME MPIDI_NM_mpi_isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ISEND);
@@ -557,10 +555,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
 #define FUNCNAME MPIDI_NM_mpi_issend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset,
+                                      MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ISSEND);
@@ -585,11 +583,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
 #define FUNCNAME MPIDI_NM_mpi_send_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
-                                                    MPI_Datatype datatype, int rank, int tag,
-                                                    MPIR_Comm * comm, int context_offset,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_send_init(const void *buf, int count,
+                                         MPI_Datatype datatype, int rank, int tag,
+                                         MPIR_Comm * comm, int context_offset,
+                                         MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND_INIT);
@@ -614,11 +611,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
 #define FUNCNAME MPIDI_NM_mpi_ssend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SSEND_INIT);
@@ -643,11 +639,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
 #define FUNCNAME MPIDI_NM_mpi_bsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_BSEND_INIT);
@@ -672,11 +667,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
 #define FUNCNAME MPIDI_NM_mpi_rsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIDI_av_entry_t * addr,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RSEND_INIT);
@@ -701,7 +695,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
 #define FUNCNAME MPIDI_NM_mpi_cancel_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
+static inline int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_CANCEL_SEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_startall.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_startall.h
@@ -18,7 +18,7 @@
 #define FUNCNAME MPIDI_NM_mpi_startall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[])
+static inline int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[])
 {
     int mpi_errno = MPI_SUCCESS, i;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_STARTALL);

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -156,10 +156,10 @@ static inline int MPIDI_UCX_recv(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
-                                                 MPI_Aint count,
-                                                 MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPIDI_NM_mpi_imrecv(void *buf,
+                                      MPI_Aint count,
+                                      MPI_Datatype datatype,
+                                      MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t data_sz;
@@ -217,39 +217,38 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               MPI_Aint count,
-                                               MPI_Datatype datatype,
-                                               int rank,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset,
-                                               MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv(void *buf,
+                                    MPI_Aint count,
+                                    MPI_Datatype datatype,
+                                    int rank,
+                                    int tag,
+                                    MPIR_Comm * comm,
+                                    int context_offset,
+                                    MPIDI_av_entry_t * addr,
+                                    MPI_Status * status, MPIR_Request ** request)
 {
     return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
-                                                MPI_Aint count,
-                                                MPI_Datatype datatype,
-                                                int rank,
-                                                int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_irecv(void *buf,
+                                     MPI_Aint count,
+                                     MPI_Datatype datatype,
+                                     int rank,
+                                     int tag,
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
-                                                    int count,
-                                                    MPI_Datatype datatype,
-                                                    int rank,
-                                                    int tag,
-                                                    MPIR_Comm * comm,
-                                                    int context_offset,
-                                                    MPIDI_av_entry_t * addr,
-                                                    MPIR_Request ** request)
+static inline int MPIDI_NM_mpi_recv_init(void *buf,
+                                         int count,
+                                         MPI_Datatype datatype,
+                                         int rank,
+                                         int tag,
+                                         MPIR_Comm * comm,
+                                         int context_offset,
+                                         MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_recv_init(buf, count, datatype, rank, tag, comm, context_offset, request);
 }

--- a/src/mpid/ch4/shm/glue/shm_am.h
+++ b/src/mpid/ch4/shm/glue/shm_am.h
@@ -11,9 +11,8 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
-                                                   int handler_id, const void *am_hdr,
-                                                   size_t am_hdr_sz)
+static inline int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
+                                        int handler_id, const void *am_hdr, size_t am_hdr_sz)
 {
     int ret;
 
@@ -26,10 +25,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
-                                                const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
+                                     const void *am_hdr, size_t am_hdr_sz,
+                                     const void *data, MPI_Count count,
+                                     MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -43,10 +42,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                 struct iovec *am_hdrs, size_t iov_len,
-                                                 const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                      struct iovec *am_hdrs, size_t iov_len,
+                                      const void *data, MPI_Count count,
+                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -60,9 +59,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                         int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
+                                              int src_rank, int handler_id,
+                                              const void *am_hdr, size_t am_hdr_sz)
 {
     int ret;
 
@@ -75,11 +74,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
-                                                      int src_rank, int handler_id,
-                                                      const void *am_hdr, size_t am_hdr_sz,
-                                                      const void *data, MPI_Count count,
-                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
+                                           int src_rank, int handler_id,
+                                           const void *am_hdr, size_t am_hdr_sz,
+                                           const void *data, MPI_Count count,
+                                           MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -93,7 +92,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
+static inline size_t MPIDI_SHM_am_hdr_max_sz(void)
 {
     int ret;
 
@@ -106,7 +105,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req)
+static inline int MPIDI_SHM_am_recv(MPIR_Request * req)
 {
     int ret;
 
@@ -119,7 +118,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request * req)
+static inline void MPIDI_SHM_am_request_init(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_REQUEST_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_REQUEST_INIT);
@@ -129,7 +128,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_REQUEST_INIT);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
+static inline void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_REQUEST_FINALIZE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_REQUEST_FINALIZE);

--- a/src/mpid/ch4/shm/glue/shm_coll.h
+++ b/src/mpid/ch4/shm/glue/shm_coll.h
@@ -11,8 +11,8 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_ctr)
+static inline int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                        void *algo_parameters_ctr)
 {
     int ret;
 
@@ -26,10 +26,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ctr)
+static inline int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+                                      int root, MPIR_Comm * comm,
+                                      MPIR_Errflag_t * errflag, void *algo_parameters_ctr)
 {
     int ret;
 
@@ -44,10 +43,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Da
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
-                                                     int count, MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_ctr)
+static inline int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
+                                          int count, MPI_Datatype datatype, MPI_Op op,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                          void *algo_parameters_ctr)
 {
     int ret;
 
@@ -62,10 +61,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -79,11 +78,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
-                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           const int *recvcounts, const int *displs,
+                                           MPI_Datatype recvtype, MPIR_Comm * comm,
+                                           MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -97,10 +96,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -114,11 +113,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
+                                         const int *displs, MPI_Datatype sendtype,
+                                         void *recvbuf, int recvcount,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -132,10 +131,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -149,11 +148,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int *recvcounts, const int *displs,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -167,10 +166,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -184,11 +183,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls, MPI_Datatype sendtype,
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -202,13 +201,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
-                                                     const MPI_Datatype sendtypes[],
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls,
-                                                     const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls,
+                                          const MPI_Datatype sendtypes[],
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls,
+                                          const MPI_Datatype recvtypes[],
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -222,10 +221,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ctr)
+static inline int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
+                                       void *algo_parameters_ctr)
 {
     int ret;
 
@@ -240,11 +239,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
-                                                          MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
+                                               const int *recvcounts,
+                                               MPI_Datatype datatype, MPI_Op op,
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -258,11 +256,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf,
-                                                                void *recvbuf, int recvcount,
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf,
+                                                     void *recvbuf, int recvcount,
+                                                     MPI_Datatype datatype, MPI_Op op,
+                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -276,9 +273,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
-                                                int count, MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
+                                     int count, MPI_Datatype datatype, MPI_Op op,
+                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -291,9 +288,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -306,11 +303,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype,
-                                                              void *recvbuf, int recvcount,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype,
+                                                   void *recvbuf, int recvcount,
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -324,13 +320,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *displs,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                    MPI_Datatype sendtype,
+                                                    void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *displs,
+                                                    MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -344,15 +339,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const int *sdispls,
-                                                              MPI_Datatype sendtype,
-                                                              void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *rdispls,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const int *sdispls,
+                                                   MPI_Datatype sendtype,
+                                                   void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *rdispls,
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -366,15 +360,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const MPI_Aint * sdispls,
-                                                              const MPI_Datatype * sendtypes,
-                                                              void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const MPI_Aint * rdispls,
-                                                              const MPI_Datatype * recvtypes,
-                                                              MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const MPI_Aint * sdispls,
+                                                   const MPI_Datatype * sendtypes,
+                                                   void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const MPI_Aint * rdispls,
+                                                   const MPI_Datatype * recvtypes, MPIR_Comm * comm)
 {
     int ret;
 
@@ -388,10 +381,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm)
 {
     int ret;
 
@@ -405,12 +398,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf, int recvcount,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
+                                                    MPI_Datatype sendtype,
+                                                    void *recvbuf, int recvcount,
+                                                    MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -424,15 +416,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf,
-                                                                int sendcount,
-                                                                MPI_Datatype sendtype,
-                                                                void *recvbuf,
-                                                                const int *recvcounts,
-                                                                const int *displs,
-                                                                MPI_Datatype recvtype,
-                                                                MPIR_Comm * comm,
-                                                                MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf,
+                                                     int sendcount,
+                                                     MPI_Datatype sendtype,
+                                                     void *recvbuf,
+                                                     const int *recvcounts,
+                                                     const int *displs,
+                                                     MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -446,11 +437,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype,
-                                                              void *recvbuf, int recvcount,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype,
+                                                   void *recvbuf, int recvcount,
+                                                   MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -464,16 +455,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                               const int *sendcounts,
-                                                               const int *sdispls,
-                                                               MPI_Datatype sendtype,
-                                                               void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *rdispls,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
+                                                    const int *sendcounts,
+                                                    const int *sdispls,
+                                                    MPI_Datatype sendtype,
+                                                    void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *rdispls,
+                                                    MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -487,16 +477,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                               const int *sendcounts,
-                                                               const MPI_Aint * sdispls,
-                                                               const MPI_Datatype * sendtypes,
-                                                               void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const MPI_Aint * rdispls,
-                                                               const MPI_Datatype * recvtypes,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
+                                                    const int *sendcounts,
+                                                    const MPI_Aint * sdispls,
+                                                    const MPI_Datatype * sendtypes,
+                                                    void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const MPI_Aint * rdispls,
+                                                    const MPI_Datatype * recvtypes,
+                                                    MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -510,7 +499,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -523,8 +512,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reque
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
+                                       int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -537,10 +526,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           int recvcount, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -554,11 +543,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
-                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
-                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            const int *recvcounts, const int *displs,
+                                            MPI_Datatype recvtype, MPIR_Comm * comm,
+                                            MPIR_Request ** req)
 {
     int ret;
 
@@ -572,9 +561,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
-                                                      int count, MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
+                                           int count, MPI_Datatype datatype, MPI_Op op,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -587,10 +576,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -604,11 +593,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
+                                           const int *sdispls, MPI_Datatype sendtype,
+                                           void *recvbuf, const int *recvcounts,
+                                           const int *rdispls, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -622,13 +611,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls,
-                                                      const MPI_Datatype sendtypes[],
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls,
-                                                      const MPI_Datatype recvtypes[],
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
+                                           const int *sdispls,
+                                           const MPI_Datatype sendtypes[],
+                                           void *recvbuf, const int *recvcounts,
+                                           const int *rdispls,
+                                           const MPI_Datatype recvtypes[],
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -642,9 +631,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
+                                        MPI_Datatype datatype, MPI_Op op,
+                                        MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -657,10 +646,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *re
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -674,11 +663,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int *recvcounts, const int *displs,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -692,11 +681,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf,
-                                                                 void *recvbuf, int recvcount,
-                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                 MPIR_Comm * comm,
-                                                                 MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf,
+                                                      void *recvbuf, int recvcount,
+                                                      MPI_Datatype datatype, MPI_Op op,
+                                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -710,10 +698,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                           const int *recvcounts,
-                                                           MPI_Datatype datatype, MPI_Op op,
-                                                           MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
+                                                const int *recvcounts,
+                                                MPI_Datatype datatype, MPI_Op op,
+                                                MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -726,9 +714,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
+                                        MPI_Datatype datatype, MPI_Op op, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int ret;
 
@@ -741,9 +729,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *re
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op,
+                                      MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -756,10 +744,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recv
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    int root, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -773,11 +761,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                     const int *displs, MPI_Datatype sendtype,
-                                                     void *recvbuf, int recvcount,
-                                                     MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+static inline int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
+                                          const int *displs, MPI_Datatype sendtype,
+                                          void *recvbuf, int recvcount,
+                                          MPI_Datatype recvtype, int root,
+                                          MPIR_Comm * comm_ptr, MPIR_Request ** req)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_dpm.h
+++ b/src/mpid/ch4/shm/glue/shm_dpm.h
@@ -11,9 +11,9 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
-                                                        int root, int timeout, MPIR_Comm * comm,
-                                                        MPIR_Comm ** newcomm_ptr)
+static inline int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
+                                             int root, int timeout, MPIR_Comm * comm,
+                                             MPIR_Comm ** newcomm_ptr)
 {
     int ret;
 
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, M
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
+static inline int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
 {
     int ret;
 
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
+static inline int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name)
 {
     int ret;
 
@@ -52,7 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_close_port(const char *port_name)
+static inline int MPIDI_SHM_mpi_close_port(const char *port_name)
 {
     int ret;
 
@@ -65,9 +65,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_close_port(const char *port_name)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
-                                                       int root, MPIR_Comm * comm,
-                                                       MPIR_Comm ** newcomm_ptr)
+static inline int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
+                                            int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_hooks.h
+++ b/src/mpid/ch4/shm/glue/shm_hooks.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm)
 {
     int ret;
 
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm)
+static inline int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm)
 {
     int ret;
 
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type)
+static inline int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type)
 {
     int ret;
 
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type)
+static inline int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type)
 {
     int ret;
 
@@ -63,7 +63,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op)
+static inline int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op)
 {
     int ret;
 
@@ -76,7 +76,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op)
+static inline int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_init.h
+++ b/src/mpid/ch4/shm/glue/shm_init.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided)
+static inline int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided)
 {
     int ret;
 
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
+static inline int MPIDI_SHM_mpi_finalize_hook(void)
 {
     int ret;
 
@@ -50,7 +50,7 @@ static inline int MPIDI_SHM_get_vni_attr(int vni)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking)
+static inline int MPIDI_SHM_progress(int vni, int blocking)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_mem.h
+++ b/src/mpid/ch4/shm/glue/shm_mem.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+static inline void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
 {
     void *ret;
 
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_free_mem(void *ptr)
+static inline int MPIDI_SHM_mpi_free_mem(void *ptr)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_misc.h
+++ b/src/mpid/ch4/shm/glue/shm_misc.h
@@ -11,8 +11,8 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                     int *lpid_ptr, MPL_bool is_remote)
+static inline int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
+                                          int *lpid_ptr, MPL_bool is_remote)
 {
     int ret;
 
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_node_id(MPIR_Comm * comm, int rank, int *id_p)
+static inline int MPIDI_SHM_get_node_id(MPIR_Comm * comm, int rank, int *id_p)
 {
     int ret;
 
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_node_id(MPIR_Comm * comm, int rank, i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_max_node_id(MPIR_Comm * comm, int *max_id_p)
+static inline int MPIDI_SHM_get_max_node_id(MPIR_Comm * comm, int *max_id_p)
 {
     int ret;
 
@@ -51,8 +51,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_max_node_id(MPIR_Comm * comm, int *ma
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                       char **local_upids)
+static inline int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
+                                            char **local_upids)
 {
     int ret;
 
@@ -65,8 +65,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                       char *remote_upids, int **remote_lupids)
+static inline int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size,
+                                            char *remote_upids, int **remote_lupids)
 {
     int ret;
 
@@ -79,8 +79,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_upids_to_lupids(int size, size_t * remote
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                   int size, const int lpids[])
+static inline int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
+                                                        int size, const int lpids[])
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_p2p.h
+++ b/src/mpid/ch4/shm/glue/shm_p2p.h
@@ -11,10 +11,9 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int ret;
 
@@ -27,10 +26,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int ret;
 
@@ -43,10 +41,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_send_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIR_Request ** request)
 {
     int ret;
 
@@ -59,10 +57,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request)
 {
     int ret;
 
@@ -76,10 +74,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request)
 {
     int ret;
 
@@ -93,10 +91,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request)
 {
     int ret;
 
@@ -110,10 +108,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int ret;
 
@@ -126,10 +123,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
+                                       MPI_Datatype datatype, int rank, int tag,
+                                       MPIR_Comm * comm, int context_offset,
+                                       MPIR_Request ** request)
 {
     int ret;
 
@@ -142,7 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint coun
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)
+static inline int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)
 {
     int ret;
 
@@ -155,9 +152,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
-                                                     int rank, int tag, MPIR_Comm * comm,
-                                                     int context_offset, MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
+                                          int rank, int tag, MPIR_Comm * comm,
+                                          int context_offset, MPIR_Request ** request)
 {
     int ret;
 
@@ -170,10 +167,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                     int rank, int tag, MPIR_Comm * comm,
+                                     int context_offset, MPI_Status * status,
+                                     MPIR_Request ** request)
 {
     int ret;
 
@@ -187,9 +184,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 int rank, int tag, MPIR_Comm * comm,
-                                                 int context_offset, MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                      int rank, int tag, MPIR_Comm * comm,
+                                      int context_offset, MPIR_Request ** request)
 {
     int ret;
 
@@ -202,8 +199,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                  MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                       MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int ret;
 
@@ -216,7 +213,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)
+static inline int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)
 {
     int ret;
 
@@ -229,9 +226,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
-                                                   int context_offset, int *flag,
-                                                   MPIR_Request ** message, MPI_Status * status)
+static inline int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
+                                        int context_offset, int *flag,
+                                        MPIR_Request ** message, MPI_Status * status)
 {
     int ret;
 
@@ -244,9 +241,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Com
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
-                                                  int context_offset, int *flag,
-                                                  MPI_Status * status)
+static inline int MPIDI_SHM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
+                                       int context_offset, int *flag, MPI_Status * status)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_rma.h
+++ b/src/mpid/ch4/shm/glue/shm_rma.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
+static inline int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
 {
     int ret;
 
@@ -24,9 +24,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Inf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,
-                                                            MPI_Aint * size, int *disp_unit,
-                                                            void *baseptr)
+static inline int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,
+                                                 MPI_Aint * size, int *disp_unit, void *baseptr)
 {
     int ret;
 
@@ -39,10 +38,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int ret;
 
@@ -56,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int orig
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -69,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int ass
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_complete(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_complete(MPIR_Win * win)
 {
     int ret;
 
@@ -82,7 +81,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_complete(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -95,7 +94,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int asse
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_wait(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_wait(MPIR_Win * win)
 {
     int ret;
 
@@ -108,7 +107,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_wait(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag)
+static inline int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag)
 {
     int ret;
 
@@ -121,8 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                    MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -135,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win)
 {
     int ret;
 
@@ -148,7 +146,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
+static inline int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
 {
     int ret;
 
@@ -161,10 +159,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Inf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int ret;
 
@@ -178,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_cou
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr)
+static inline int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -191,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win)
 {
     int ret;
 
@@ -204,9 +202,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
-                                                      MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                      MPIR_Win ** win_ptr)
+static inline int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
+                                           MPIR_Info * info, MPIR_Comm * comm_ptr,
+                                           MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -219,11 +217,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint lengt
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
-                                                      MPI_Datatype origin_datatype, int target_rank,
-                                                      MPI_Aint target_disp, int target_count,
-                                                      MPI_Datatype target_datatype, MPI_Op op,
-                                                      MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
+                                           MPI_Datatype origin_datatype, int target_rank,
+                                           MPI_Aint target_disp, int target_count,
+                                           MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win)
 {
     int ret;
 
@@ -238,7 +235,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size)
+static inline int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size)
 {
     int ret;
 
@@ -251,10 +248,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
-                                                               MPIR_Info * info_ptr,
-                                                               MPIR_Comm * comm_ptr,
-                                                               void **base_ptr, MPIR_Win ** win_ptr)
+static inline int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
+                                                    MPIR_Info * info_ptr,
+                                                    MPIR_Comm * comm_ptr,
+                                                    void **base_ptr, MPIR_Win ** win_ptr)
 {
     int ret;
 
@@ -268,11 +265,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
-                                                MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
-                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
+                                     MPI_Datatype origin_datatype, int target_rank,
+                                     MPI_Aint target_disp, int target_count,
+                                     MPI_Datatype target_datatype, MPIR_Win * win,
+                                     MPIR_Request ** request)
 {
     int ret;
 
@@ -286,7 +283,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, int ori
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * win)
 {
     int ret;
 
@@ -299,7 +296,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void *base)
+static inline int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void *base)
 {
     int ret;
 
@@ -312,12 +309,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_addr,
-                                                            const void *compare_addr,
-                                                            void *result_addr,
-                                                            MPI_Datatype datatype,
-                                                            int target_rank, MPI_Aint target_disp,
-                                                            MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_compare_and_swap(const void *origin_addr,
+                                                 const void *compare_addr,
+                                                 void *result_addr,
+                                                 MPI_Datatype datatype,
+                                                 int target_rank, MPI_Aint target_disp,
+                                                 MPIR_Win * win)
 {
     int ret;
 
@@ -331,12 +328,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_a
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       int target_rank, MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win, MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank, MPI_Aint target_disp,
+                                            int target_count,
+                                            MPI_Datatype target_datatype, MPI_Op op,
+                                            MPIR_Win * win, MPIR_Request ** request)
 {
     int ret;
 
@@ -351,15 +348,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
-                                                           int origin_count,
-                                                           MPI_Datatype origin_datatype,
-                                                           void *result_addr, int result_count,
-                                                           MPI_Datatype result_datatype,
-                                                           int target_rank, MPI_Aint target_disp,
-                                                           int target_count,
-                                                           MPI_Datatype target_datatype, MPI_Op op,
-                                                           MPIR_Win * win, MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
+                                                int origin_count,
+                                                MPI_Datatype origin_datatype,
+                                                void *result_addr, int result_count,
+                                                MPI_Datatype result_datatype,
+                                                int target_rank, MPI_Aint target_disp,
+                                                int target_count,
+                                                MPI_Datatype target_datatype, MPI_Op op,
+                                                MPIR_Win * win, MPIR_Request ** request)
 {
     int ret;
 
@@ -375,10 +372,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_ad
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr,
-                                                        void *result_addr, MPI_Datatype datatype,
-                                                        int target_rank, MPI_Aint target_disp,
-                                                        MPI_Op op, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr,
+                                             void *result_addr, MPI_Datatype datatype,
+                                             int target_rank, MPI_Aint target_disp,
+                                             MPI_Op op, MPIR_Win * win)
 {
     int ret;
 
@@ -392,9 +389,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_unit,
-                                                        MPIR_Info * info, MPIR_Comm * comm,
-                                                        void *baseptr, MPIR_Win ** win)
+static inline int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_unit,
+                                             MPIR_Info * info, MPIR_Comm * comm,
+                                             void *baseptr, MPIR_Win ** win)
 {
     int ret;
 
@@ -407,7 +404,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win)
 {
     int ret;
 
@@ -420,7 +417,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win)
 {
     int ret;
 
@@ -433,7 +430,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win)
 {
     int ret;
 
@@ -446,8 +443,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                              MPIR_Win ** win)
+static inline int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
+                                                   MPIR_Win ** win)
 {
     int ret;
 
@@ -460,11 +457,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
-                                                MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
-                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request)
+static inline int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
+                                     MPI_Datatype origin_datatype, int target_rank,
+                                     MPI_Aint target_disp, int target_count,
+                                     MPI_Datatype target_datatype, MPIR_Win * win,
+                                     MPIR_Request ** request)
 {
     int ret;
 
@@ -478,7 +475,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_co
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_sync(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_sync(MPIR_Win * win)
 {
     int ret;
 
@@ -491,7 +488,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_sync(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win)
 {
     int ret;
 
@@ -504,15 +501,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
-                                                          int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr, int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank, MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype, MPI_Op op,
-                                                          MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
+                                               int origin_count,
+                                               MPI_Datatype origin_datatype,
+                                               void *result_addr, int result_count,
+                                               MPI_Datatype result_datatype,
+                                               int target_rank, MPI_Aint target_disp,
+                                               int target_count,
+                                               MPI_Datatype target_datatype, MPI_Op op,
+                                               MPIR_Win * win)
 {
     int ret;
 
@@ -528,7 +525,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_add
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * win)
+static inline int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * win)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/glue/shm_startall.h
+++ b/src/mpid/ch4/shm/glue/shm_startall.h
@@ -14,7 +14,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count, MPIR_Request * requests[])
+static inline int MPIDI_SHM_mpi_startall(int count, MPIR_Request * requests[])
 {
     int ret;
 

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -14,410 +14,389 @@
 
 #include <mpidimpl.h>
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
-                                                        int root, int timeout, MPIR_Comm * comm,
-                                                        MPIR_Comm ** newcomm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_close_port(const char *port_name);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
-                                                       int root, MPIR_Comm * comm,
-                                                       MPIR_Comm ** newcomm_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr, size_t am_hdr_sz);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
-                                                const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                 struct iovec *am_hdrs, size_t iov_len,
-                                                 const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
-                                                         int handler_id, const void *am_hdr,
-                                                         size_t am_hdr_sz);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
-                                                      int handler_id, const void *am_hdr,
-                                                      size_t am_hdr_sz, const void *data,
-                                                      MPI_Count count, MPI_Datatype datatype,
-                                                      MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                     int *lpid_ptr, MPL_bool is_remote);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                       char **local_upids);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                       char *remote_upids, int **remote_lupids);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                   int size, const int lpids[]);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op);
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
-                                                MPI_Datatype datatype, int rank, int tag,
-                                                MPIR_Comm * comm, int context_offset,
-                                                MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count, MPIR_Request * requests[]);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
-                                                     MPI_Datatype datatype, int rank, int tag,
-                                                     MPIR_Comm * comm, int context_offset,
-                                                     MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
-                                                      MPI_Datatype datatype, int rank, int tag,
-                                                      MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, int rank, int tag,
-                                                 MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
-                                                  MPI_Datatype datatype, int rank, int tag,
-                                                  MPIR_Comm * comm, int context_offset,
-                                                  MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
-                                                     int rank, int tag, MPIR_Comm * comm,
-                                                     int context_offset, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                int rank, int tag, MPIR_Comm * comm,
-                                                int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 int rank, int tag, MPIR_Comm * comm,
-                                                 int context_offset, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                  MPIR_Request * message, MPIR_Request ** rreqp);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq);
-MPL_STATIC_INLINE_PREFIX void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_free_mem(void *ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
-                                                   int context_offset, int *flag,
-                                                   MPIR_Request ** message, MPI_Status * status);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
-                                                  int context_offset, int *flag,
-                                                  MPI_Status * status);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,
-                                                            MPI_Aint * size, int *disp_unit,
-                                                            void *baseptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int assert,
-                                                     MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_complete(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_wait(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                    MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
-                                               MPI_Datatype origin_datatype, int target_rank,
-                                               MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
-                                                      MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                      MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
-                                                      MPI_Datatype origin_datatype,
-                                                      int target_rank, MPI_Aint target_disp,
-                                                      int target_count,
-                                                      MPI_Datatype target_datatype, MPI_Op op,
-                                                      MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
-                                                               MPIR_Info * info_ptr,
-                                                               MPIR_Comm * comm_ptr,
-                                                               void **base_ptr,
-                                                               MPIR_Win ** win_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
-                                                MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
-                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void *base);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_addr,
-                                                            const void *compare_addr,
-                                                            void *result_addr,
-                                                            MPI_Datatype datatype,
-                                                            int target_rank, MPI_Aint target_disp,
-                                                            MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       int target_rank, MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
-                                                           int origin_count,
-                                                           MPI_Datatype origin_datatype,
-                                                           void *result_addr, int result_count,
-                                                           MPI_Datatype result_datatype,
-                                                           int target_rank, MPI_Aint target_disp,
-                                                           int target_count,
-                                                           MPI_Datatype target_datatype, MPI_Op op,
-                                                           MPIR_Win * win, MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
-                                                        MPI_Datatype datatype, int target_rank,
-                                                        MPI_Aint target_disp, MPI_Op op,
-                                                        MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_unit,
-                                                        MPIR_Info * info, MPIR_Comm * comm,
-                                                        void *baseptr, MPIR_Win ** win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                              MPIR_Win ** win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
-                                                MPI_Datatype origin_datatype, int target_rank,
-                                                MPI_Aint target_disp, int target_count,
-                                                MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_sync(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
-                                                          int origin_count,
-                                                          MPI_Datatype origin_datatype,
-                                                          void *result_addr, int result_count,
-                                                          MPI_Datatype result_datatype,
-                                                          int target_rank, MPI_Aint target_disp,
-                                                          int target_count,
-                                                          MPI_Datatype target_datatype, MPI_Op op,
-                                                          MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * win);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm,
-                                                   MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                                 int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
+static inline int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided);
+static inline int MPIDI_SHM_mpi_finalize_hook(void);
+static inline int MPIDI_SHM_get_vni_attr(int vni);
+static inline int MPIDI_SHM_progress(int vni, int blocking);
+static inline int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
+                                             int root, int timeout, MPIR_Comm * comm,
+                                             MPIR_Comm ** newcomm_ptr);
+static inline int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
+static inline int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
+static inline int MPIDI_SHM_mpi_close_port(const char *port_name);
+static inline int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
+                                            int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
+static inline int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
+                                        const void *am_hdr, size_t am_hdr_sz);
+static inline int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
+                                     const void *am_hdr, size_t am_hdr_sz,
+                                     const void *data, MPI_Count count,
+                                     MPI_Datatype datatype, MPIR_Request * sreq);
+static inline int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                      struct iovec *am_hdrs, size_t iov_len,
+                                      const void *data, MPI_Count count,
+                                      MPI_Datatype datatype, MPIR_Request * sreq);
+static inline int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
+                                              int handler_id, const void *am_hdr, size_t am_hdr_sz);
+static inline int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+                                           int handler_id, const void *am_hdr,
+                                           size_t am_hdr_sz, const void *data,
+                                           MPI_Count count, MPI_Datatype datatype,
+                                           MPIR_Request * sreq);
+static inline size_t MPIDI_SHM_am_hdr_max_sz(void);
+static inline int MPIDI_SHM_am_recv(MPIR_Request * req);
+static inline int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
+                                          int *lpid_ptr, MPL_bool is_remote);
+static inline int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
+                                            char **local_upids);
+static inline int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size,
+                                            char *remote_upids, int **remote_lupids);
+static inline int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
+                                                        int size, const int lpids[]);
+static inline int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type);
+static inline int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type);
+static inline int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op);
+static inline int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op);
+static inline void MPIDI_SHM_am_request_init(MPIR_Request * req);
+static inline void MPIDI_SHM_am_request_finalize(MPIR_Request * req);
+static inline int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype, int rank, int tag,
+                                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset,
+                                      MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_startall(int count, MPIR_Request * requests[]);
+static inline int MPIDI_SHM_mpi_send_init(const void *buf, int count,
+                                          MPI_Datatype datatype, int rank, int tag,
+                                          MPIR_Comm * comm, int context_offset,
+                                          MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
+                                           MPI_Datatype datatype, int rank, int tag,
+                                           MPIR_Comm * comm, int context_offset,
+                                           MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype, int rank, int tag,
+                                      MPIR_Comm * comm, int context_offset,
+                                      MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
+                                       MPI_Datatype datatype, int rank, int tag,
+                                       MPIR_Comm * comm, int context_offset,
+                                       MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq);
+static inline int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
+                                          int rank, int tag, MPIR_Comm * comm,
+                                          int context_offset, MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                     int rank, int tag, MPIR_Comm * comm,
+                                     int context_offset, MPI_Status * status,
+                                     MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                      int rank, int tag, MPIR_Comm * comm,
+                                      int context_offset, MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                       MPIR_Request * message, MPIR_Request ** rreqp);
+static inline int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq);
+static inline void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+static inline int MPIDI_SHM_mpi_free_mem(void *ptr);
+static inline int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
+                                        int context_offset, int *flag,
+                                        MPIR_Request ** message, MPI_Status * status);
+static inline int MPIDI_SHM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
+                                       int context_offset, int *flag, MPI_Status * status);
+static inline int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
+static inline int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,
+                                                 MPI_Aint * size, int *disp_unit, void *baseptr);
+static inline int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_complete(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_wait(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag);
+static inline int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int assert, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
+static inline int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
+                                    MPI_Datatype origin_datatype, int target_rank,
+                                    MPI_Aint target_disp, int target_count,
+                                    MPI_Datatype target_datatype, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr);
+static inline int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
+                                           MPIR_Info * info, MPIR_Comm * comm_ptr,
+                                           MPIR_Win ** win_ptr);
+static inline int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
+                                           MPI_Datatype origin_datatype,
+                                           int target_rank, MPI_Aint target_disp,
+                                           int target_count,
+                                           MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
+static inline int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
+                                                    MPIR_Info * info_ptr,
+                                                    MPIR_Comm * comm_ptr,
+                                                    void **base_ptr, MPIR_Win ** win_ptr);
+static inline int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
+                                     MPI_Datatype origin_datatype, int target_rank,
+                                     MPI_Aint target_disp, int target_count,
+                                     MPI_Datatype target_datatype, MPIR_Win * win,
+                                     MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void *base);
+static inline int MPIDI_SHM_mpi_compare_and_swap(const void *origin_addr,
+                                                 const void *compare_addr,
+                                                 void *result_addr,
+                                                 MPI_Datatype datatype,
+                                                 int target_rank, MPI_Aint target_disp,
+                                                 MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank, MPI_Aint target_disp,
+                                            int target_count,
+                                            MPI_Datatype target_datatype, MPI_Op op,
+                                            MPIR_Win * win, MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
+                                                int origin_count,
+                                                MPI_Datatype origin_datatype,
+                                                void *result_addr, int result_count,
+                                                MPI_Datatype result_datatype,
+                                                int target_rank, MPI_Aint target_disp,
+                                                int target_count,
+                                                MPI_Datatype target_datatype, MPI_Op op,
+                                                MPIR_Win * win, MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
+                                             MPI_Datatype datatype, int target_rank,
+                                             MPI_Aint target_disp, MPI_Op op, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_unit,
+                                             MPIR_Info * info, MPIR_Comm * comm,
+                                             void *baseptr, MPIR_Win ** win);
+static inline int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
+                                                   MPIR_Win ** win);
+static inline int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
+                                     MPI_Datatype origin_datatype, int target_rank,
+                                     MPI_Aint target_disp, int target_count,
+                                     MPI_Datatype target_datatype, MPIR_Win * win,
+                                     MPIR_Request ** request);
+static inline int MPIDI_SHM_mpi_win_sync(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
+                                               int origin_count,
+                                               MPI_Datatype origin_datatype,
+                                               void *result_addr, int result_count,
+                                               MPI_Datatype result_datatype,
+                                               int target_rank, MPI_Aint target_disp,
+                                               int target_count,
+                                               MPI_Datatype target_datatype, MPI_Op op,
+                                               MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * win);
+static inline int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm,
+                                        MPIR_Errflag_t * errflag, void *algo_parameters_ptr);
+static inline int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
+                                      int root, MPIR_Comm * comm,
+                                      MPIR_Errflag_t * errflag, void *algo_parameters_ptr);
+static inline int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
+                                          MPI_Datatype datatype, MPI_Op op,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                          void *algo_parameters_ptr);
+static inline int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           const int *recvcounts, const int *displs,
+                                           MPI_Datatype recvtype, MPIR_Comm * comm,
+                                           MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
+                                         const int *displs, MPI_Datatype sendtype,
+                                         void *recvbuf, int recvcount,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype, int root,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        const int *recvcounts, const int *displs,
+                                        MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls, MPI_Datatype sendtype,
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls,
+                                          const MPI_Datatype sendtypes[], void *recvbuf,
+                                          const int *recvcounts, const int *rdispls,
+                                          const MPI_Datatype recvtypes[],
+                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op, int root,
+                                       MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
+                                       void *algo_parameters_ptr);
+static inline int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
+                                               const int *recvcounts,
+                                               MPI_Datatype datatype, MPI_Op op,
+                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                     int recvcount,
                                                      MPI_Datatype datatype, MPI_Op op,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
-                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
+                                                     MPIR_Comm * comm_ptr,
+                                                     MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
+                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                     MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
+                                       MPI_Datatype datatype, MPI_Op op,
+                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag);
+static inline int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
-                                                    const int *displs, MPI_Datatype sendtype,
-                                                    void *recvbuf, int recvcount,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
+                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                    MPI_Datatype sendtype, void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *displs,
+                                                    MPI_Datatype recvtype, MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const int *sdispls,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int *recvcounts,
+                                                   const int *rdispls,
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
+                                                   const int *sendcounts,
+                                                   const MPI_Aint * sdispls,
+                                                   const MPI_Datatype * sendtypes,
+                                                   void *recvbuf, const int *recvcounts,
+                                                   const MPI_Aint * rdispls,
+                                                   const MPI_Datatype * recvtypes,
+                                                   MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts, const int *displs,
-                                                   MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm);
+static inline int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls,
-                                                     const MPI_Datatype sendtypes[], void *recvbuf,
-                                                     const int *recvcounts, const int *rdispls,
-                                                     const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ptr);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcounts,
-                                                          MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *displs,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const int *sdispls,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              const int *recvcounts,
-                                                              const int *rdispls,
-                                                              MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
-                                                              const int *sendcounts,
-                                                              const MPI_Aint * sdispls,
-                                                              const MPI_Datatype * sendtypes,
-                                                              void *recvbuf, const int *recvcounts,
-                                                              const MPI_Aint * rdispls,
-                                                              const MPI_Datatype * recvtypes,
-                                                              MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                               int recvcount, MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                                MPI_Datatype sendtype,
-                                                                void *recvbuf,
-                                                                const int *recvcounts,
-                                                                const int *displs,
-                                                                MPI_Datatype recvtype,
-                                                                MPIR_Comm * comm,
-                                                                MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                              MPI_Datatype sendtype, void *recvbuf,
-                                                              int recvcount, MPI_Datatype recvtype,
-                                                              MPIR_Comm * comm,
-                                                              MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
-                                                               const int *sendcounts,
-                                                               const int *sdispls,
-                                                               MPI_Datatype sendtype, void *recvbuf,
-                                                               const int *recvcounts,
-                                                               const int *rdispls,
-                                                               MPI_Datatype recvtype,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
-                                                               const int *sendcounts,
-                                                               const MPI_Aint * sdispls,
-                                                               const MPI_Datatype * sendtypes,
-                                                               void *recvbuf, const int *recvcounts,
-                                                               const MPI_Aint * rdispls,
-                                                               const MPI_Datatype * recvtypes,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                  int root, MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
-                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
-                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
+                                                     MPI_Datatype sendtype,
+                                                     void *recvbuf,
+                                                     const int *recvcounts,
+                                                     const int *displs,
+                                                     MPI_Datatype recvtype,
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   int recvcount, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
+                                                    const int *sendcounts,
+                                                    const int *sdispls,
+                                                    MPI_Datatype sendtype, void *recvbuf,
+                                                    const int *recvcounts,
+                                                    const int *rdispls,
+                                                    MPI_Datatype recvtype,
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
+                                                    const int *sendcounts,
+                                                    const MPI_Aint * sdispls,
+                                                    const MPI_Datatype * sendtypes,
+                                                    void *recvbuf, const int *recvcounts,
+                                                    const MPI_Aint * rdispls,
+                                                    const MPI_Datatype * recvtypes,
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
+                                       int root, MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           int recvcount, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            const int *recvcounts, const int *displs,
+                                            MPI_Datatype recvtype, MPIR_Comm * comm,
+                                            MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                           MPI_Datatype datatype, MPI_Op op,
+                                           MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
+                                           const int *sdispls, MPI_Datatype sendtype,
+                                           void *recvbuf, const int *recvcounts,
+                                           const int *rdispls, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
+                                           const int *sdispls,
+                                           const MPI_Datatype sendtypes[], void *recvbuf,
+                                           const int *recvcounts, const int *rdispls,
+                                           const MPI_Datatype recvtypes[],
+                                           MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
+                                        MPI_Datatype datatype, MPI_Op op,
+                                        MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int *recvcounts, const int *displs,
+                                         MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                                      int recvcount,
                                                       MPI_Datatype datatype, MPI_Op op,
                                                       MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls,
-                                                      const MPI_Datatype sendtypes[], void *recvbuf,
-                                                      const int *recvcounts, const int *rdispls,
-                                                      const MPI_Datatype recvtypes[],
-                                                      MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                                 int recvcount,
-                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                 MPIR_Comm * comm,
-                                                                 MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                           const int *recvcounts,
-                                                           MPI_Datatype datatype, MPI_Op op,
-                                                           MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
-                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** req);
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
-                                                     const int *displs, MPI_Datatype sendtype,
-                                                     void *recvbuf, int recvcount,
-                                                     MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
+                                                const int *recvcounts,
+                                                MPI_Datatype datatype, MPI_Op op,
+                                                MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
+                                        MPI_Datatype datatype, MPI_Op op, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
+                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                      MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype, int root,
+                                         MPIR_Comm * comm, MPIR_Request ** req);
+static inline int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
+                                          const int *displs, MPI_Datatype sendtype,
+                                          void *recvbuf, int recvcount,
+                                          MPI_Datatype recvtype, int root,
+                                          MPIR_Comm * comm_ptr, MPIR_Request ** req);
 
 #endif /* SHM_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -14,219 +14,168 @@
 
 #include <mpidimpl.h>
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
-                                                     int *n_vnis_provided) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,
-                                                        MPIR_Comm **
-                                                        newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm *
-                                                           comm_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr,
-                                                     char *port_name) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_close_port(const char *port_name)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Comm ** newcomm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_open_port(MPIR_Info * info_ptr, char *port_name);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_close_port(const char *port_name);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info,
                                                        int root, MPIR_Comm * comm,
-                                                       MPIR_Comm **
-                                                       newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr,
-                                                   size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                   const void *am_hdr, size_t am_hdr_sz);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                MPI_Datatype datatype, MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype,
-                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPI_Datatype datatype, MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                          int handler_id, const void *am_hdr,
-                                                         size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                         size_t am_hdr_sz);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                       int handler_id, const void *am_hdr,
                                                       size_t am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
-                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request * sreq);
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
-                                                     int *lpid_ptr,
-                                                     MPL_bool is_remote) MPL_STATIC_INLINE_SUFFIX;
+                                                     int *lpid_ptr, MPL_bool is_remote);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size,
-                                                       char **local_upids) MPL_STATIC_INLINE_SUFFIX;
+                                                       char **local_upids);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size,
-                                                       char *remote_upids,
-                                                       int **remote_lupids)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                       char *remote_upids, int **remote_lupids);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                                   int size,
-                                                                   const int lpids[])
-    MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm *
-                                                            comm) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm *
-                                                          comm) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype *
-                                                            type) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype *
-                                                          type) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request *
-                                                        req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request *
-                                                            req) MPL_STATIC_INLINE_SUFFIX;
+                                                                   int size, const int lpids[]);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_free_hook(MPIR_Comm * comm);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_commit_hook(MPIR_Datatype * type);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_type_free_hook(MPIR_Datatype * type);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_commit_hook(MPIR_Op * op);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op);
+MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request * req);
+MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count,
-                                                    MPIR_Request *
-                                                    requests[]) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count, MPIR_Request * requests[]);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
-                                                     MPIR_Request **
-                                                     request) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request **
-                                                      request) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request **
-                                                      request) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
-                                                      MPIR_Request **
-                                                      request) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
-                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
                                                   MPI_Datatype datatype, int rank, int tag,
                                                   MPIR_Comm * comm, int context_offset,
-                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request *
-                                                       sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_Datatype datatype,
                                                      int rank, int tag, MPIR_Comm * comm,
-                                                     int context_offset,
-                                                     MPIR_Request **
-                                                     request) MPL_STATIC_INLINE_SUFFIX;
+                                                     int context_offset, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPI_Status * status,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
-                                                 int context_offset,
-                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
+                                                 int context_offset, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                  MPIR_Request * message,
-                                                  MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request *
-                                                       rreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void *MPIDI_SHM_mpi_alloc_mem(size_t size,
-                                                       MPIR_Info *
-                                                       info_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_free_mem(void *ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Request * message, MPIR_Request ** rreqp);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq);
+MPL_STATIC_INLINE_PREFIX void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_free_mem(void *ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
                                                    int context_offset, int *flag,
-                                                   MPIR_Request ** message,
-                                                   MPI_Status * status) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Request ** message, MPI_Status * status);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source, int tag, MPIR_Comm * comm,
                                                   int context_offset, int *flag,
-                                                  MPI_Status * status) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win,
-                                                        MPIR_Info * info) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPI_Status * status);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_shared_query(MPIR_Win * win, int rank,
                                                             MPI_Aint * size, int *disp_unit,
-                                                            void *baseptr) MPL_STATIC_INLINE_SUFFIX;
+                                                            void *baseptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_put(const void *origin_addr, int origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
                                                MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype,
-                                               MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Datatype target_datatype, MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_start(MPIR_Group * group, int assert,
-                                                     MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_complete(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert,
-                                                    MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_wait(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_test(MPIR_Win * win,
-                                                    int *flag) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_complete(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_wait(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_test(MPIR_Win * win, int *flag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock(int lock_type, int rank, int assert,
-                                                    MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock(int rank,
-                                                      MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win,
-                                                        MPIR_Info **
-                                                        info_p_p) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock(int rank, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get(void *origin_addr, int origin_count,
                                                MPI_Datatype origin_datatype, int target_rank,
                                                MPI_Aint target_disp, int target_count,
-                                               MPI_Datatype target_datatype,
-                                               MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_fence(int assert,
-                                                     MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Datatype target_datatype, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_free(MPIR_Win ** win_ptr);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_fence(int assert, MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create(void *base, MPI_Aint length, int disp_unit,
                                                       MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                                      MPIR_Win ** win_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Win ** win_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_accumulate(const void *origin_addr, int origin_count,
                                                       MPI_Datatype origin_datatype,
                                                       int target_rank, MPI_Aint target_disp,
                                                       int target_count,
                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                      MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base,
-                                                      MPI_Aint size) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate_shared(MPI_Aint size, int disp_unit,
                                                                MPIR_Info * info_ptr,
                                                                MPIR_Comm * comm_ptr,
                                                                void **base_ptr,
-                                                               MPIR_Win **
-                                                               win_ptr) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Win ** win_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rput(const void *origin_addr, int origin_count,
                                                 MPI_Datatype origin_datatype, int target_rank,
                                                 MPI_Aint target_disp, int target_count,
                                                 MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local(int rank,
-                                                           MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_detach(MPIR_Win * win,
-                                                      const void *base) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local(int rank, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_detach(MPIR_Win * win, const void *base);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_compare_and_swap(const void *origin_addr,
                                                             const void *compare_addr,
                                                             void *result_addr,
                                                             MPI_Datatype datatype,
                                                             int target_rank, MPI_Aint target_disp,
-                                                            MPIR_Win *
-                                                            win) MPL_STATIC_INLINE_SUFFIX;
+                                                            MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_raccumulate(const void *origin_addr, int origin_count,
                                                        MPI_Datatype origin_datatype,
                                                        int target_rank, MPI_Aint target_disp,
                                                        int target_count,
                                                        MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win,
-                                                       MPIR_Request **
-                                                       request) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Win * win, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_addr,
                                                            int origin_count,
                                                            MPI_Datatype origin_datatype,
@@ -235,32 +184,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget_accumulate(const void *origin_ad
                                                            int target_rank, MPI_Aint target_disp,
                                                            int target_count,
                                                            MPI_Datatype target_datatype, MPI_Op op,
-                                                           MPIR_Win * win,
-                                                           MPIR_Request **
-                                                           request) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Win * win, MPIR_Request ** request);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_fetch_and_op(const void *origin_addr, void *result_addr,
                                                         MPI_Datatype datatype, int target_rank,
                                                         MPI_Aint target_disp, MPI_Op op,
-                                                        MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_allocate(MPI_Aint size, int disp_unit,
                                                         MPIR_Info * info, MPIR_Comm * comm,
-                                                        void *baseptr,
-                                                        MPIR_Win ** win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush(int rank,
-                                                     MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win *
-                                                               win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                                        void *baseptr, MPIR_Win ** win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush(int rank, MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_local_all(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_unlock_all(MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                              MPIR_Win **
-                                                              win) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Win ** win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rget(void *origin_addr, int origin_count,
                                                 MPI_Datatype origin_datatype, int target_rank,
                                                 MPI_Aint target_disp, int target_count,
                                                 MPI_Datatype target_datatype, MPIR_Win * win,
-                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_sync(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_sync(MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_flush_all(MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_addr,
                                                           int origin_count,
                                                           MPI_Datatype origin_datatype,
@@ -269,119 +212,91 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_get_accumulate(const void *origin_add
                                                           int target_rank, MPI_Aint target_disp,
                                                           int target_count,
                                                           MPI_Datatype target_datatype, MPI_Op op,
-                                                          MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock_all(int assert,
-                                                        MPIR_Win * win) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Win * win);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * win);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm,
                                                    MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                   void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
                                                  int root, MPIR_Comm * comm,
                                                  MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                 void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
                                                      MPI_Datatype datatype, MPI_Op op,
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                     void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Errflag_t *
-                                                     errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t *
-                                                      errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Errflag_t *
-                                                   errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const int *sendcounts,
                                                     const int *displs, MPI_Datatype sendtype,
                                                     void *recvbuf, int recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t *
-                                                    errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype, int root,
-                                                  MPIR_Comm * comm,
-                                                  MPIR_Errflag_t *
-                                                  errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Errflag_t *
-                                                   errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Errflag_t *
-                                                    errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const int *sendcounts,
                                                      const int *sdispls, MPI_Datatype sendtype,
                                                      void *recvbuf, const int *recvcounts,
                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Errflag_t *
-                                                     errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const int *sendcounts,
                                                      const int *sdispls,
                                                      const MPI_Datatype sendtypes[], void *recvbuf,
                                                      const int *recvcounts, const int *rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Errflag_t *
-                                                     errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op, int root,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_ptr)
-    MPL_STATIC_INLINE_SUFFIX;
+                                                  void *algo_parameters_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const int *recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t *
-                                                          errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                 int recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t *
-                                                                errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                                MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Errflag_t * errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm,
-                                                  MPIR_Errflag_t *
-                                                  errflag) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgather(const void *sendbuf, int sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               int recvcount, MPI_Datatype recvtype,
-                                                              MPIR_Comm *
-                                                              comm) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_allgatherv(const void *sendbuf, int sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                const int *recvcounts,
                                                                const int *displs,
                                                                MPI_Datatype recvtype,
-                                                               MPIR_Comm *
-                                                               comm) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbuf,
                                                               const int *sendcounts,
                                                               const int *sdispls,
@@ -389,8 +304,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallv(const void *sendbu
                                                               const int *recvcounts,
                                                               const int *rdispls,
                                                               MPI_Datatype recvtype,
-                                                              MPIR_Comm *
-                                                              comm) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbuf,
                                                               const int *sendcounts,
                                                               const MPI_Aint * sdispls,
@@ -398,19 +312,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoallw(const void *sendbu
                                                               void *recvbuf, const int *recvcounts,
                                                               const MPI_Aint * rdispls,
                                                               const MPI_Datatype * recvtypes,
-                                                              MPIR_Comm *
-                                                              comm) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_neighbor_alltoall(const void *sendbuf, int sendcount,
                                                              MPI_Datatype sendtype, void *recvbuf,
                                                              int recvcount, MPI_Datatype recvtype,
-                                                             MPIR_Comm *
-                                                             comm) MPL_STATIC_INLINE_SUFFIX;
+                                                             MPIR_Comm * comm);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgather(const void *sendbuf, int sendcount,
                                                                MPI_Datatype sendtype, void *recvbuf,
                                                                int recvcount, MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
-                                                               MPIR_Request **
-                                                               req) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *sendbuf, int sendcount,
                                                                 MPI_Datatype sendtype,
                                                                 void *recvbuf,
@@ -418,14 +329,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_allgatherv(const void *send
                                                                 const int *displs,
                                                                 MPI_Datatype recvtype,
                                                                 MPIR_Comm * comm,
-                                                                MPIR_Request **
-                                                                req) MPL_STATIC_INLINE_SUFFIX;
+                                                                MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoall(const void *sendbuf, int sendcount,
                                                               MPI_Datatype sendtype, void *recvbuf,
                                                               int recvcount, MPI_Datatype recvtype,
                                                               MPIR_Comm * comm,
-                                                              MPIR_Request **
-                                                              req) MPL_STATIC_INLINE_SUFFIX;
+                                                              MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendbuf,
                                                                const int *sendcounts,
                                                                const int *sdispls,
@@ -434,8 +343,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallv(const void *sendb
                                                                const int *rdispls,
                                                                MPI_Datatype recvtype,
                                                                MPIR_Comm * comm,
-                                                               MPIR_Request **
-                                                               req) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendbuf,
                                                                const int *sendcounts,
                                                                const MPI_Aint * sdispls,
@@ -444,90 +352,72 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendb
                                                                const MPI_Aint * rdispls,
                                                                const MPI_Datatype * recvtypes,
                                                                MPIR_Comm * comm,
-                                                               MPIR_Request **
-                                                               req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm,
-                                                    MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                               MPIR_Request ** req);
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                  int root, MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, int sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       int recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm,
-                                                      MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, int sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        const int *recvcounts, const int *displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Request **
-                                                       req) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm,
-                                                      MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, int sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf, const int *sendcounts,
                                                       const int *sdispls, MPI_Datatype sendtype,
                                                       void *recvbuf, const int *recvcounts,
                                                       const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm,
-                                                      MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf, const int *sendcounts,
                                                       const int *sdispls,
                                                       const MPI_Datatype sendtypes[], void *recvbuf,
                                                       const int *recvcounts, const int *rdispls,
                                                       const MPI_Datatype recvtypes[],
-                                                      MPIR_Comm * comm,
-                                                      MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                  int recvcount,
                                                                  MPI_Datatype datatype, MPI_Op op,
                                                                  MPIR_Comm * comm,
-                                                                 MPIR_Request **
-                                                                 req) MPL_STATIC_INLINE_SUFFIX;
+                                                                 MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                            const int *recvcounts,
                                                            MPI_Datatype datatype, MPI_Op op,
-                                                           MPIR_Comm * comm,
-                                                           MPIR_Request **
-                                                           req) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr,
-                                                   MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPIR_Comm * comm_ptr, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, int count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm,
-                                                    MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPIR_Comm * comm, MPIR_Request ** req);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf, const int *sendcounts,
                                                      const int *displs, MPI_Datatype sendtype,
                                                      void *recvbuf, int recvcount,
                                                      MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm_ptr,
-                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req);
 
 #endif /* SHM_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_coll_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_impl.h
@@ -17,7 +17,7 @@
 #define FUNCNAME MPIDI_POSIX_Barrier_recursive_doubling
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Barrier_recursive_doubling(MPIR_Comm * comm_ptr,
                                                MPIR_Errflag_t * errflag,
                                                MPIDI_POSIX_coll_algo_container_t *
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_Bcast_binomial
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Bcast_binomial(void *buffer,
                                    int count,
                                    MPI_Datatype datatype,
@@ -55,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_Bcast_scatter_recursive_doubling_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Bcast_scatter_recursive_doubling_allgather(void *buffer,
                                                                int count,
                                                                MPI_Datatype datatype,
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_Bcast_scatter_recursive_doubling_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Bcast_scatter_ring_allgather(void *buffer,
                                                  int count,
                                                  MPI_Datatype datatype,
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_allreduce__recursive_doubling
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_allreduce__recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
@@ -120,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_allreduce__reduce_scatter_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_allreduce__reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm_ptr,
@@ -141,7 +141,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_reduce__reduce_scatter_gather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_reduce__reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op, int root,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
@@ -161,7 +161,7 @@ MPL_STATIC_INLINE_PREFIX
 #define FUNCNAME MPIDI_POSIX_reduce__binomial
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_reduce__binomial(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, int root,
                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,

--- a/src/mpid/ch4/shm/posix/posix_coll_select.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_select.h
@@ -6,7 +6,7 @@
 #include "coll_algo_params.h"
 #include "posix_coll_impl.h"
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_POSIX_coll_algo_container_t * MPIDI_POSIX_Barrier_select(MPIR_Comm * comm_ptr,
                                                                    MPIR_Errflag_t * errflag,
                                                                    MPIDI_POSIX_coll_algo_container_t
@@ -17,7 +17,7 @@ MPL_STATIC_INLINE_PREFIX
     return (MPIDI_POSIX_coll_algo_container_t *) & POSIX_barrier__recursive_doubling_cnt;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Barrier_call(MPIR_Comm * comm_ptr,
                                  MPIR_Errflag_t * errflag,
                                  MPIDI_POSIX_coll_algo_container_t * ch4_algo_parameters_container)
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_POSIX_coll_algo_container_t * MPIDI_POSIX_Bcast_select(void *buffer,
                                                                  int count, MPI_Datatype
                                                                  datatype, int root,
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX
     }
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Bcast_call(void *buffer, int count, MPI_Datatype datatype,
                                int root, MPIR_Comm * comm_ptr,
                                MPIR_Errflag_t * errflag,
@@ -101,7 +101,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_POSIX_coll_algo_container_t * MPIDI_POSIX_Allreduce_select(const void *sendbuf,
                                                                      void *recvbuf,
                                                                      int count,
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX
 }
 
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Allreduce_call(const void *sendbuf, void *recvbuf,
                                    int count, MPI_Datatype datatype, MPI_Op op,
                                    MPIR_Comm * comm_ptr,
@@ -162,7 +162,7 @@ MPL_STATIC_INLINE_PREFIX
 }
 
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_POSIX_coll_algo_container_t * MPIDI_POSIX_Reduce_select(const void *sendbuf,
                                                                   void *recvbuf, int count,
                                                                   MPI_Datatype datatype,
@@ -186,7 +186,7 @@ MPL_STATIC_INLINE_PREFIX
     }
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_POSIX_Reduce_call(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, int root,
                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -15,7 +15,7 @@
 #include "ch4r_proc.h"
 #include "ch4_coll_select.h"
 
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     MPIDI_coll_algo_container_t *ch4_algo_parameters_container = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -31,8 +31,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * err
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype,
-                                        int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype,
+                             int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     MPIDI_coll_algo_container_t *ch4_algo_parameters_container = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -53,9 +53,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, int count, MPI_Datatype da
 
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
-                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                            MPIR_Errflag_t * errflag)
+static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
+                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                 MPIR_Errflag_t * errflag)
 {
     int ret = MPI_SUCCESS;
     MPIDI_coll_algo_container_t *ch4_algo_parameters_container = NULL;
@@ -73,10 +73,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Errflag_t * errflag)
+static inline int MPID_Allgather(const void *sendbuf, int sendcount,
+                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                 MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -90,11 +89,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                             MPIR_Errflag_t * errflag)
+static inline int MPID_Allgatherv(const void *sendbuf, int sendcount,
+                                  MPI_Datatype sendtype, void *recvbuf,
+                                  const int *recvcounts, const int *displs,
+                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -108,10 +106,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t * errflag)
+static inline int MPID_Scatter(const void *sendbuf, int sendcount,
+                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                               MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -125,10 +123,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const int *sendcounts,
-                                           const int *displs, MPI_Datatype sendtype,
-                                           void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                           int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+static inline int MPID_Scatterv(const void *sendbuf, const int *sendcounts,
+                                const int *displs, MPI_Datatype sendtype,
+                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -142,9 +140,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const int *sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPID_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                              int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -158,11 +156,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, int sendcount, MPI
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf,
-                                          const int *recvcounts, const int *displs,
-                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t * errflag)
+static inline int MPID_Gatherv(const void *sendbuf, int sendcount,
+                               MPI_Datatype sendtype, void *recvbuf,
+                               const int *recvcounts, const int *displs,
+                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                               MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -176,10 +174,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                           MPI_Datatype recvtype, MPIR_Comm * comm,
-                                           MPIR_Errflag_t * errflag)
+static inline int MPID_Alltoall(const void *sendbuf, int sendcount,
+                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -193,11 +190,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const int *sendcounts,
-                                            const int *sdispls, MPI_Datatype sendtype,
-                                            void *recvbuf, const int *recvcounts,
-                                            const int *rdispls, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag)
+static inline int MPID_Alltoallv(const void *sendbuf, const int *sendcounts,
+                                 const int *sdispls, MPI_Datatype sendtype,
+                                 void *recvbuf, const int *recvcounts,
+                                 const int *rdispls, MPI_Datatype recvtype,
+                                 MPIR_Comm * comm, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -211,11 +208,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const int *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const int sendcounts[],
-                                            const int sdispls[], const MPI_Datatype sendtypes[],
-                                            void *recvbuf, const int recvcounts[],
-                                            const int rdispls[], const MPI_Datatype recvtypes[],
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+static inline int MPID_Alltoallw(const void *sendbuf, const int sendcounts[],
+                                 const int sdispls[], const MPI_Datatype sendtypes[],
+                                 void *recvbuf, const int recvcounts[],
+                                 const int rdispls[], const MPI_Datatype recvtypes[],
+                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -229,9 +226,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
-                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                         int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+static inline int MPID_Reduce(const void *sendbuf, void *recvbuf,
+                              int count, MPI_Datatype datatype, MPI_Op op,
+                              int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret = MPI_SUCCESS;
     MPIDI_coll_algo_container_t *ch4_algo_parameters_container = NULL;
@@ -249,10 +246,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf,
-                                                 const int recvcounts[], MPI_Datatype datatype,
-                                                 MPI_Op op, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag)
+static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf,
+                                      const int recvcounts[], MPI_Datatype datatype,
+                                      MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -266,10 +262,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Errflag_t * errflag)
+static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                            int recvcount, MPI_Datatype datatype,
+                                            MPI_Op op, MPIR_Comm * comm_ptr,
+                                            MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -283,9 +279,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, int count,
-                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Errflag_t * errflag)
+static inline int MPID_Scan(const void *sendbuf, void *recvbuf, int count,
+                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                            MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -298,9 +294,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, int c
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, int count,
-                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                         MPIR_Errflag_t * errflag)
+static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, int count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                              MPIR_Errflag_t * errflag)
 {
     int ret;
 
@@ -313,10 +309,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm)
+static inline int MPID_Neighbor_allgather(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -330,10 +325,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      const int *recvcounts, const int *displs,
-                                                      MPI_Datatype recvtype, MPIR_Comm * comm)
+static inline int MPID_Neighbor_allgatherv(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           const int *recvcounts, const int *displs,
+                                           MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -347,11 +342,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgatherv(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                     const int *sdispls, MPI_Datatype sendtype,
-                                                     void *recvbuf, const int *recvcounts,
-                                                     const int *rdispls, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm)
+static inline int MPID_Neighbor_alltoallv(const void *sendbuf, const int *sendcounts,
+                                          const int *sdispls, MPI_Datatype sendtype,
+                                          void *recvbuf, const int *recvcounts,
+                                          const int *rdispls, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm)
 {
     int ret;
 
@@ -365,13 +360,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallv(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                     const MPI_Aint * sdispls,
-                                                     const MPI_Datatype * sendtypes, void *recvbuf,
-                                                     const int *recvcounts,
-                                                     const MPI_Aint * rdispls,
-                                                     const MPI_Datatype * recvtypes,
-                                                     MPIR_Comm * comm)
+static inline int MPID_Neighbor_alltoallw(const void *sendbuf, const int *sendcounts,
+                                          const MPI_Aint * sdispls,
+                                          const MPI_Datatype * sendtypes, void *recvbuf,
+                                          const int *recvcounts,
+                                          const MPI_Aint * rdispls,
+                                          const MPI_Datatype * recvtypes, MPIR_Comm * comm)
 {
     int ret;
 
@@ -385,10 +379,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoallw(const void *sendbuf, const 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm)
+static inline int MPID_Neighbor_alltoall(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm)
 {
     int ret;
 
@@ -402,10 +395,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_alltoall(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, int sendcount,
-                                                      MPI_Datatype sendtype, void *recvbuf,
-                                                      int recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ineighbor_allgather(const void *sendbuf, int sendcount,
+                                           MPI_Datatype sendtype, void *recvbuf,
+                                           int recvcount, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -419,11 +412,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather(const void *sendbuf, int s
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
-                                                       MPI_Datatype sendtype, void *recvbuf,
-                                                       const int *recvcounts, const int *displs,
-                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Request ** req)
+static inline int MPID_Ineighbor_allgatherv(const void *sendbuf, int sendcount,
+                                            MPI_Datatype sendtype, void *recvbuf,
+                                            const int *recvcounts, const int *displs,
+                                            MPI_Datatype recvtype, MPIR_Comm * comm,
+                                            MPIR_Request ** req)
 {
     int ret;
 
@@ -437,10 +430,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv(const void *sendbuf, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     int recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ineighbor_alltoall(const void *sendbuf, int sendcount,
+                                          MPI_Datatype sendtype, void *recvbuf,
+                                          int recvcount, MPI_Datatype recvtype,
+                                          MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -454,11 +447,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall(const void *sendbuf, int se
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *sendbuf, const int *sendcounts,
-                                                      const int *sdispls, MPI_Datatype sendtype,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const int *rdispls, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ineighbor_alltoallv(const void *sendbuf, const int *sendcounts,
+                                           const int *sdispls, MPI_Datatype sendtype,
+                                           void *recvbuf, const int *recvcounts,
+                                           const int *rdispls, MPI_Datatype recvtype,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -473,13 +466,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *sendbuf, const int *sendcounts,
-                                                      const MPI_Aint * sdispls,
-                                                      const MPI_Datatype * sendtypes,
-                                                      void *recvbuf, const int *recvcounts,
-                                                      const MPI_Aint * rdispls,
-                                                      const MPI_Datatype * recvtypes,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ineighbor_alltoallw(const void *sendbuf, const int *sendcounts,
+                                           const MPI_Aint * sdispls,
+                                           const MPI_Datatype * sendtypes,
+                                           void *recvbuf, const int *recvcounts,
+                                           const MPI_Aint * rdispls,
+                                           const MPI_Datatype * recvtypes,
+                                           MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -494,7 +487,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *sendbuf, const
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -507,8 +500,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request ** req
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, int count, MPI_Datatype datatype,
-                                         int root, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ibcast(void *buffer, int count, MPI_Datatype datatype,
+                              int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -521,10 +514,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, int count, MPI_Datatype d
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                             MPIR_Request ** req)
+static inline int MPID_Iallgather(const void *sendbuf, int sendcount,
+                                  MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -538,11 +530,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf,
-                                              const int *recvcounts, const int *displs,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm,
-                                              MPIR_Request ** req)
+static inline int MPID_Iallgatherv(const void *sendbuf, int sendcount,
+                                   MPI_Datatype sendtype, void *recvbuf,
+                                   const int *recvcounts, const int *displs,
+                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -556,9 +547,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, int sendcount
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf, int count,
-                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Request ** req)
+static inline int MPID_Iallreduce(const void *sendbuf, void *recvbuf, int count,
+                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                  MPIR_Request ** req)
 {
     int ret;
 
@@ -571,10 +562,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Request ** req)
+static inline int MPID_Ialltoall(const void *sendbuf, int sendcount,
+                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                 MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -588,11 +578,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const int *sendcounts,
-                                             const int *sdispls, MPI_Datatype sendtype,
-                                             void *recvbuf, const int *recvcounts,
-                                             const int *rdispls, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ialltoallv(const void *sendbuf, const int *sendcounts,
+                                  const int *sdispls, MPI_Datatype sendtype,
+                                  void *recvbuf, const int *recvcounts,
+                                  const int *rdispls, MPI_Datatype recvtype,
+                                  MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -606,11 +596,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const int *sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const int *sendcounts,
-                                             const int *sdispls, const MPI_Datatype * sendtypes,
-                                             void *recvbuf, const int *recvcounts,
-                                             const int *rdispls, const MPI_Datatype * recvtypes,
-                                             MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ialltoallw(const void *sendbuf, const int *sendcounts,
+                                  const int *sdispls, const MPI_Datatype * sendtypes,
+                                  void *recvbuf, const int *recvcounts,
+                                  const int *rdispls, const MPI_Datatype * recvtypes,
+                                  MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -624,9 +614,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const int *sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, int count,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                          MPIR_Request ** req)
+static inline int MPID_Iexscan(const void *sendbuf, void *recvbuf, int count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                               MPIR_Request ** req)
 {
     int ret;
 
@@ -639,10 +629,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Request ** req)
+static inline int MPID_Igather(const void *sendbuf, int sendcount,
+                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                               MPIR_Request ** req)
 {
     int ret;
 
@@ -656,11 +646,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf,
-                                           const int *recvcounts, const int *displs,
-                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                           MPIR_Request ** req)
+static inline int MPID_Igatherv(const void *sendbuf, int sendcount,
+                                MPI_Datatype sendtype, void *recvbuf,
+                                const int *recvcounts, const int *displs,
+                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                MPIR_Request ** req)
 {
     int ret;
 
@@ -674,10 +664,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
-                                                        int recvcount, MPI_Datatype datatype,
-                                                        MPI_Op op, MPIR_Comm * comm,
-                                                        MPIR_Request ** req)
+static inline int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
+                                             int recvcount, MPI_Datatype datatype,
+                                             MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -690,9 +679,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, voi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf,
-                                                  const int *recvcounts, MPI_Datatype datatype,
-                                                  MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf,
+                                       const int *recvcounts, MPI_Datatype datatype,
+                                       MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -705,9 +694,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *rec
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, int count,
-                                          MPI_Datatype datatype, MPI_Op op, int root,
-                                          MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Ireduce(const void *sendbuf, void *recvbuf, int count,
+                               MPI_Datatype datatype, MPI_Op op, int root,
+                               MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -720,9 +709,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, int count,
-                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                        MPIR_Request ** req)
+static inline int MPID_Iscan(const void *sendbuf, void *recvbuf, int count,
+                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                             MPIR_Request ** req)
 {
     int ret;
 
@@ -735,10 +724,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, int 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                           MPIR_Request ** req)
+static inline int MPID_Iscatter(const void *sendbuf, int sendcount,
+                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                MPIR_Request ** req)
 {
     int ret;
 
@@ -752,10 +741,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, int sendcount,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
-                                            const int *displs, MPI_Datatype sendtype,
-                                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                            int root, MPIR_Comm * comm, MPIR_Request ** req)
+static inline int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
+                                 const int *displs, MPI_Datatype sendtype,
+                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                 int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int ret;
 
@@ -769,7 +758,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -782,8 +771,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
+                                    int root, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret;
 
@@ -796,10 +785,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Data
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgather_sched(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Iallgather_sched(const void *sendbuf, int sendcount,
+                                        MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -813,11 +802,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgather_sched(const void *sendbuf, int send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                    MPIR_Sched_t s)
+static inline int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount,
+                                         MPI_Datatype sendtype, void *recvbuf,
+                                         const int *recvcounts, const int *displs,
+                                         MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -831,9 +819,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sen
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
+                                        MPI_Datatype datatype, MPI_Op op,
+                                        MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -846,10 +834,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *re
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall_sched(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ialltoall_sched(const void *sendbuf, int sendcount,
+                                       MPI_Datatype sendtype, void *recvbuf,
+                                       int recvcount, MPI_Datatype recvtype,
+                                       MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -863,11 +851,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall_sched(const void *sendbuf, int sendc
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv_sched(const void *sendbuf, const int sendcounts[],
-                                                   const int sdispls[], MPI_Datatype sendtype,
-                                                   void *recvbuf, const int recvcounts[],
-                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ialltoallv_sched(const void *sendbuf, const int sendcounts[],
+                                        const int sdispls[], MPI_Datatype sendtype,
+                                        void *recvbuf, const int recvcounts[],
+                                        const int rdispls[], MPI_Datatype recvtype,
+                                        MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -881,12 +869,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv_sched(const void *sendbuf, const in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcounts[],
-                                                   const int sdispls[],
-                                                   const MPI_Datatype sendtypes[], void *recvbuf,
-                                                   const int recvcounts[], const int rdispls[],
-                                                   const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                                   MPIR_Sched_t s)
+static inline int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcounts[],
+                                        const int sdispls[],
+                                        const MPI_Datatype sendtypes[], void *recvbuf,
+                                        const int recvcounts[], const int rdispls[],
+                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm,
+                                        MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -900,9 +888,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const in
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+static inline int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
+                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                     MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -915,10 +903,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igather_sched(const void *sendbuf, int sendcount,
-                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+static inline int MPID_Igather_sched(const void *sendbuf, int sendcount,
+                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                     MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -932,11 +920,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igather_sched(const void *sendbuf, int sendcou
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 const int *recvcounts, const int *displs,
-                                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+static inline int MPID_Igatherv_sched(const void *sendbuf, int sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      const int *recvcounts, const int *displs,
+                                      MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                      MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -950,10 +938,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendco
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
-                                                              int recvcount, MPI_Datatype datatype,
-                                                              MPI_Op op, MPIR_Comm * comm,
-                                                              MPIR_Sched_t s)
+static inline int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
+                                                   int recvcount, MPI_Datatype datatype,
+                                                   MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -967,10 +954,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbu
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
-                                                        const int recvcounts[],
-                                                        MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
+                                             const int recvcounts[],
+                                             MPI_Datatype datatype, MPI_Op op,
+                                             MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -983,9 +970,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, voi
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op, int root,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count,
+                                     MPI_Datatype datatype, MPI_Op op, int root,
+                                     MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -998,9 +985,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count,
-                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+static inline int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count,
+                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                   MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1013,10 +1000,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatter_sched(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Iscatter_sched(const void *sendbuf, int sendcount,
+                                      MPI_Datatype sendtype, void *recvbuf,
+                                      int recvcount, MPI_Datatype recvtype, int root,
+                                      MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1030,11 +1017,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatter_sched(const void *sendbuf, int sendco
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcounts,
-                                                  const int *displs, MPI_Datatype sendtype,
-                                                  void *recvbuf, int recvcount,
-                                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                  MPIR_Sched_t s)
+static inline int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcounts,
+                                       const int *displs, MPI_Datatype sendtype,
+                                       void *recvbuf, int recvcount,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm,
+                                       MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1048,10 +1035,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1065,12 +1052,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount,
-                                                             MPI_Datatype sendtype, void *recvbuf,
-                                                             const int recvcounts[],
-                                                             const int displs[],
-                                                             MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  const int recvcounts[],
+                                                  const int displs[],
+                                                  MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1084,10 +1071,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
+                                                MPI_Datatype sendtype, void *recvbuf,
+                                                int recvcount, MPI_Datatype recvtype,
+                                                MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1101,14 +1088,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall_sched(const void *sendbuf, 
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv_sched(const void *sendbuf,
-                                                            const int sendcounts[],
-                                                            const int sdispls[],
-                                                            MPI_Datatype sendtype, void *recvbuf,
-                                                            const int recvcounts[],
-                                                            const int rdispls[],
-                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+static inline int MPID_Ineighbor_alltoallv_sched(const void *sendbuf,
+                                                 const int sendcounts[],
+                                                 const int sdispls[],
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 const int recvcounts[],
+                                                 const int rdispls[],
+                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
+                                                 MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1123,14 +1110,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv_sched(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw_sched(const void *sendbuf,
-                                                            const int sendcounts[],
-                                                            const MPI_Aint sdispls[],
-                                                            const MPI_Datatype sendtypes[],
-                                                            void *recvbuf, const int recvcounts[],
-                                                            const MPI_Aint rdispls[],
-                                                            const MPI_Datatype recvtypes[],
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ineighbor_alltoallw_sched(const void *sendbuf,
+                                                 const int sendcounts[],
+                                                 const MPI_Aint sdispls[],
+                                                 const MPI_Datatype sendtypes[],
+                                                 void *recvbuf, const int recvcounts[],
+                                                 const MPI_Aint rdispls[],
+                                                 const MPI_Datatype recvtypes[],
+                                                 MPIR_Comm * comm, MPIR_Sched_t s)
 {
     int ret = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -18,10 +18,10 @@
 #define FUNCNAME MPIDI_Barrier_composition_alpha
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_composition_alpha(MPIR_Comm * comm,
-                                                             MPIR_Errflag_t * errflag,
-                                                             MPIDI_coll_algo_container_t *
-                                                             ch4_algo_parameters_container)
+static inline int MPIDI_Barrier_composition_alpha(MPIR_Comm * comm,
+                                                  MPIR_Errflag_t * errflag,
+                                                  MPIDI_coll_algo_container_t *
+                                                  ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *barrier_node_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -76,10 +76,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_composition_alpha(MPIR_Comm * comm,
 #define FUNCNAME MPIDI_Barrier_composition_beta
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_composition_beta(MPIR_Comm * comm,
-                                                            MPIR_Errflag_t * errflag,
-                                                            MPIDI_coll_algo_container_t *
-                                                            ch4_algo_parameters_container)
+static inline int MPIDI_Barrier_composition_beta(MPIR_Comm * comm,
+                                                 MPIR_Errflag_t * errflag,
+                                                 MPIDI_coll_algo_container_t *
+                                                 ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *barrier_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -98,10 +98,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_composition_beta(MPIR_Comm * comm,
 #define FUNCNAME MPIDI_Barrier_intercomm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intercomm(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     MPIDI_coll_algo_container_t *
-                                                     ch4_algo_parameters_container
-                                                     ATTRIBUTE((unused)))
+static inline int MPIDI_Barrier_intercomm(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                          MPIDI_coll_algo_container_t *
+                                          ch4_algo_parameters_container ATTRIBUTE((unused)))
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -119,12 +118,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intercomm(MPIR_Comm * comm, MPIR_Errf
 #define FUNCNAME MPIDI_Bcast_composition_alpha
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_alpha(void *buffer, int count,
-                                                           MPI_Datatype datatype, int root,
-                                                           MPIR_Comm * comm,
-                                                           MPIR_Errflag_t * errflag,
-                                                           MPIDI_coll_algo_container_t *
-                                                           ch4_algo_parameters_container)
+static inline int MPIDI_Bcast_composition_alpha(void *buffer, int count,
+                                                MPI_Datatype datatype, int root,
+                                                MPIR_Comm * comm,
+                                                MPIR_Errflag_t * errflag,
+                                                MPIDI_coll_algo_container_t *
+                                                ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *bcast_roots_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -174,12 +173,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_alpha(void *buffer, int cou
 #define FUNCNAME MPIDI_Bcast_composition_beta
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_beta(void *buffer, int count,
-                                                          MPI_Datatype datatype, int root,
-                                                          MPIR_Comm * comm,
-                                                          MPIR_Errflag_t * errflag,
-                                                          MPIDI_coll_algo_container_t *
-                                                          ch4_algo_parameters_container)
+static inline int MPIDI_Bcast_composition_beta(void *buffer, int count,
+                                               MPI_Datatype datatype, int root,
+                                               MPIR_Comm * comm,
+                                               MPIR_Errflag_t * errflag,
+                                               MPIDI_coll_algo_container_t *
+                                               ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *bcast_roots_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -235,12 +234,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_beta(void *buffer, int coun
 #define FUNCNAME MPIDI_Bcast_composition_gamma
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_gamma(void *buffer, int count,
-                                                           MPI_Datatype datatype, int root,
-                                                           MPIR_Comm * comm,
-                                                           MPIR_Errflag_t * errflag,
-                                                           MPIDI_coll_algo_container_t *
-                                                           ch4_algo_parameters_container)
+static inline int MPIDI_Bcast_composition_gamma(void *buffer, int count,
+                                                MPI_Datatype datatype, int root,
+                                                MPIR_Comm * comm,
+                                                MPIR_Errflag_t * errflag,
+                                                MPIDI_coll_algo_container_t *
+                                                ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *bcast_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -259,12 +258,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_gamma(void *buffer, int cou
 #define FUNCNAME MPIDI_Bcast_intercomm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intercomm(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t * errflag,
-                                                   MPIDI_coll_algo_container_t *
-                                                   ch4_algo_parameters_container
-                                                   ATTRIBUTE((unused)))
+static inline int MPIDI_Bcast_intercomm(void *buffer, int count, MPI_Datatype datatype,
+                                        int root, MPIR_Comm * comm,
+                                        MPIR_Errflag_t * errflag,
+                                        MPIDI_coll_algo_container_t *
+                                        ch4_algo_parameters_container ATTRIBUTE((unused)))
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -282,12 +280,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intercomm(void *buffer, int count, MPI_
 #define FUNCNAME MPIDI_Allreduce_composition_alpha
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_composition_alpha(const void *sendbuf, void *recvbuf,
-                                                               int count, MPI_Datatype datatype,
-                                                               MPI_Op op, MPIR_Comm * comm,
-                                                               MPIR_Errflag_t * errflag,
-                                                               MPIDI_coll_algo_container_t *
-                                                               ch4_algo_parameters_container)
+static inline int MPIDI_Allreduce_composition_alpha(const void *sendbuf, void *recvbuf,
+                                                    int count, MPI_Datatype datatype,
+                                                    MPI_Op op, MPIR_Comm * comm,
+                                                    MPIR_Errflag_t * errflag,
+                                                    MPIDI_coll_algo_container_t *
+                                                    ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *reduce_node_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -364,12 +362,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_composition_alpha(const void *sendb
 #define FUNCNAME MPIDI_Allreduce_composition_gamma
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_composition_beta(const void *sendbuf, void *recvbuf,
-                                                              int count, MPI_Datatype datatype,
-                                                              MPI_Op op, MPIR_Comm * comm,
-                                                              MPIR_Errflag_t * errflag,
-                                                              MPIDI_coll_algo_container_t *
-                                                              ch4_algo_parameters_container)
+static inline int MPIDI_Allreduce_composition_beta(const void *sendbuf, void *recvbuf,
+                                                   int count, MPI_Datatype datatype,
+                                                   MPI_Op op, MPIR_Comm * comm,
+                                                   MPIR_Errflag_t * errflag,
+                                                   MPIDI_coll_algo_container_t *
+                                                   ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *allred_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -390,12 +388,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_composition_beta(const void *sendbu
 #define FUNCNAME MPIDI_Allreduce_intercomm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intercomm(const void *sendbuf, void *recvbuf,
-                                                       int count, MPI_Datatype datatype, MPI_Op op,
-                                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                       MPIDI_coll_algo_container_t *
-                                                       ch4_algo_parameters_container
-                                                       ATTRIBUTE((unused)))
+static inline int MPIDI_Allreduce_intercomm(const void *sendbuf, void *recvbuf,
+                                            int count, MPI_Datatype datatype, MPI_Op op,
+                                            MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                            MPIDI_coll_algo_container_t *
+                                            ch4_algo_parameters_container ATTRIBUTE((unused)))
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -413,12 +410,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intercomm(const void *sendbuf, void
 #define FUNCNAME MPIDI_Reduce_composition_alpha
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_alpha(const void *sendbuf, void *recvbuf,
-                                                            int count, MPI_Datatype datatype,
-                                                            MPI_Op op, int root, MPIR_Comm * comm,
-                                                            MPIR_Errflag_t * errflag,
-                                                            MPIDI_coll_algo_container_t *
-                                                            ch4_algo_parameters_container)
+static inline int MPIDI_Reduce_composition_alpha(const void *sendbuf, void *recvbuf,
+                                                 int count, MPI_Datatype datatype,
+                                                 MPI_Op op, int root, MPIR_Comm * comm,
+                                                 MPIR_Errflag_t * errflag,
+                                                 MPIDI_coll_algo_container_t *
+                                                 ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -551,12 +548,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_alpha(const void *sendbuf,
 #define FUNCNAME MPIDI_Reduce_composition_beta
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_beta(const void *sendbuf, void *recvbuf,
-                                                           int count, MPI_Datatype datatype,
-                                                           MPI_Op op, int root, MPIR_Comm * comm,
-                                                           MPIR_Errflag_t * errflag,
-                                                           MPIDI_coll_algo_container_t *
-                                                           ch4_algo_parameters_container)
+static inline int MPIDI_Reduce_composition_beta(const void *sendbuf, void *recvbuf,
+                                                int count, MPI_Datatype datatype,
+                                                MPI_Op op, int root, MPIR_Comm * comm,
+                                                MPIR_Errflag_t * errflag,
+                                                MPIDI_coll_algo_container_t *
+                                                ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     void *reduce_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
@@ -577,12 +574,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_beta(const void *sendbuf, 
 #define FUNCNAME MPIDI_Reduce_intercomm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intercomm(const void *sendbuf, void *recvbuf, int count,
-                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                    MPIDI_coll_algo_container_t *
-                                                    ch4_algo_parameters_container
-                                                    ATTRIBUTE((unused)))
+static inline int MPIDI_Reduce_intercomm(const void *sendbuf, void *recvbuf, int count,
+                                         MPI_Datatype datatype, MPI_Op op, int root,
+                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                         MPIDI_coll_algo_container_t *
+                                         ch4_algo_parameters_container ATTRIBUTE((unused)))
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_coll_select.h
+++ b/src/mpid/ch4/src/ch4_coll_select.h
@@ -20,7 +20,7 @@
 #endif
 
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_coll_algo_container_t * MPIDI_CH4_Barrier_select(MPIR_Comm * comm,
                                                            MPIR_Errflag_t * errflag)
 {
@@ -35,7 +35,7 @@ MPL_STATIC_INLINE_PREFIX
     return (MPIDI_coll_algo_container_t *) & CH4_barrier_composition_beta_cnt;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_CH4_Barrier_call(MPIR_Comm * comm,
                                MPIR_Errflag_t * errflag,
                                MPIDI_coll_algo_container_t * ch4_algo_parameters_container)
@@ -62,7 +62,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_coll_algo_container_t * MPIDI_CH4_Bcast_select(void *buffer,
                                                          int count,
                                                          MPI_Datatype datatype,
@@ -92,7 +92,7 @@ MPL_STATIC_INLINE_PREFIX
     return (MPIDI_coll_algo_container_t *) & CH4_bcast_composition_gamma_cnt;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_CH4_Bcast_call(void *buffer, int count, MPI_Datatype datatype,
                              int root, MPIR_Comm * comm,
                              MPIR_Errflag_t * errflag,
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_coll_algo_container_t * MPIDI_CH4_Allreduce_select(const void *sendbuf,
                                                              void *recvbuf,
                                                              int count,
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX
     return (MPIDI_coll_algo_container_t *) & CH4_allreduce_composition_beta_cnt;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_CH4_Allreduce_call(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op,
                                  MPIR_Comm * comm, MPIR_Errflag_t * errflag,
@@ -191,7 +191,7 @@ MPL_STATIC_INLINE_PREFIX
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     MPIDI_coll_algo_container_t * MPIDI_CH4_Reduce_select(const void *sendbuf,
                                                           void *recvbuf,
                                                           int count,
@@ -221,7 +221,7 @@ MPL_STATIC_INLINE_PREFIX
 }
 
 
-MPL_STATIC_INLINE_PREFIX
+static inline
     int MPIDI_CH4_Reduce_call(const void *sendbuf, void *recvbuf, int count,
                               MPI_Datatype datatype, MPI_Op op, int root,
                               MPIR_Comm * comm, MPIR_Errflag_t * errflag,

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -15,7 +15,7 @@
 #include "ch4r_comm.h"
 #include "ch4i_comm.h"
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_AS_enabled(MPIR_Comm * comm)
+static inline int MPID_Comm_AS_enabled(MPIR_Comm * comm)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_AS_ENABLED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_AS_ENABLED);
@@ -26,8 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_AS_enabled(MPIR_Comm * comm)
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_reenable_anysource(MPIR_Comm * comm,
-                                                          MPIR_Group ** failed_group_ptr)
+static inline int MPID_Comm_reenable_anysource(MPIR_Comm * comm, MPIR_Group ** failed_group_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_REENABLE_ANYSOURCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_REENABLE_ANYSOURCE);
@@ -38,8 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_reenable_anysource(MPIR_Comm * comm,
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_remote_group_failed(MPIR_Comm * comm,
-                                                           MPIR_Group ** failed_group_ptr)
+static inline int MPID_Comm_remote_group_failed(MPIR_Comm * comm, MPIR_Group ** failed_group_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_REMOTE_GROUP_FAILED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_REMOTE_GROUP_FAILED);
@@ -50,8 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_remote_group_failed(MPIR_Comm * comm,
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_group_failed(MPIR_Comm * comm_ptr,
-                                                    MPIR_Group ** failed_group_ptr)
+static inline int MPID_Comm_group_failed(MPIR_Comm * comm_ptr, MPIR_Group ** failed_group_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_GROUP_FAILED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_GROUP_FAILED);
@@ -62,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_group_failed(MPIR_Comm * comm_ptr,
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_failure_ack(MPIR_Comm * comm_ptr)
+static inline int MPID_Comm_failure_ack(MPIR_Comm * comm_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_FAILURE_ACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_FAILURE_ACK);
@@ -73,8 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_failure_ack(MPIR_Comm * comm_ptr)
     return 0;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_failure_get_acked(MPIR_Comm * comm_ptr,
-                                                         MPIR_Group ** failed_group_ptr)
+static inline int MPID_Comm_failure_get_acked(MPIR_Comm * comm_ptr, MPIR_Group ** failed_group_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_FAILURE_GET_ACKED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_FAILURE_GET_ACKED);
@@ -85,7 +81,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_failure_get_acked(MPIR_Comm * comm_ptr,
     return 0;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_revoke(MPIR_Comm * comm_ptr, int is_remote)
+static inline int MPID_Comm_revoke(MPIR_Comm * comm_ptr, int is_remote)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_REVOKE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_REVOKE);
@@ -96,8 +92,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_revoke(MPIR_Comm * comm_ptr, int is_remot
     return 0;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_get_all_failed_procs(MPIR_Comm * comm_ptr,
-                                                            MPIR_Group ** failed_group, int tag)
+static inline int MPID_Comm_get_all_failed_procs(MPIR_Comm * comm_ptr,
+                                                 MPIR_Group ** failed_group, int tag)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_GET_ALL_FAILED_PROCS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_GET_ALL_FAILED_PROCS);
@@ -112,10 +108,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_get_all_failed_procs(MPIR_Comm * comm_ptr
 #define FUNCNAME MPIDI_Comm_split_type
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr,
-                                                   int split_type,
-                                                   int key, MPIR_Info * info_ptr,
-                                                   MPIR_Comm ** newcomm_ptr)
+static inline int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr,
+                                        int split_type,
+                                        int key, MPIR_Info * info_ptr, MPIR_Comm ** newcomm_ptr)
 {
     MPIR_Comm *comm_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -160,7 +155,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr,
 #define FUNCNAME MPIDI_Comm_create_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
+static inline int MPIDI_Comm_create_hook(MPIR_Comm * comm)
 {
     int mpi_errno;
     int i, *uniq_avtids;
@@ -233,7 +228,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
 #define FUNCNAME MPIDI_Comm_free_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_free_hook(MPIR_Comm * comm)
+static inline int MPIDI_Comm_free_hook(MPIR_Comm * comm)
 {
     int mpi_errno;
     int i, *uniq_avtids;
@@ -316,12 +311,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_free_hook(MPIR_Comm * comm)
 #define FUNCNAME MPID_Intercomm_exchange_map
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
-                                                         int local_leader,
-                                                         MPIR_Comm * peer_comm,
-                                                         int remote_leader,
-                                                         int *remote_size,
-                                                         int **remote_lupids, int *is_low_group)
+static inline int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
+                                              int local_leader,
+                                              MPIR_Comm * peer_comm,
+                                              int remote_leader,
+                                              int *remote_size,
+                                              int **remote_lupids, int *is_low_group)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -176,7 +176,7 @@ static inline MPIR_Context_id_t MPIDI_CH4U_win_to_context(const MPIR_Win * win)
 #define FUNCNAME MPIDI_CH4U_request_complete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_request_complete(MPIR_Request * req)
+static inline void MPIDI_CH4U_request_complete(MPIR_Request * req)
 {
     int incomplete;
 
@@ -194,8 +194,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_request_complete(MPIR_Request * req)
 #define FUNCNAME MPIDI_CH4U_win_target_add
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR_Win * win,
-                                                                            int rank)
+static inline MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR_Win * win, int rank)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_TARGET_ADD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_ADD);
@@ -221,8 +220,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR
 #define FUNCNAME MPIDI_CH4U_win_target_find
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_find(MPIR_Win * win,
-                                                                             int rank)
+static inline MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_find(MPIR_Win * win, int rank)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_TARGET_FIND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_FIND);
@@ -238,8 +236,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_find(MPI
 #define FUNCNAME MPIDI_CH4U_win_target_get
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_get(MPIR_Win * win,
-                                                                            int rank)
+static inline MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_get(MPIR_Win * win, int rank)
 {
     MPIDI_CH4U_win_target_t *target_ptr = MPIDI_CH4U_win_target_find(win, rank);
     if (!target_ptr)
@@ -251,8 +248,8 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_get(MPIR
 #define FUNCNAME MPIDI_CH4U_win_target_delete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_delete(MPIR_Win * win,
-                                                           MPIDI_CH4U_win_target_t * target_ptr)
+static inline void MPIDI_CH4U_win_target_delete(MPIR_Win * win,
+                                                MPIDI_CH4U_win_target_t * target_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_TARGET_DELETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_DELETE);
@@ -267,7 +264,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_delete(MPIR_Win * win,
 #define FUNCNAME MPIDI_CH4U_win_target_cleanall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_cleanall(MPIR_Win * win)
+static inline void MPIDI_CH4U_win_target_cleanall(MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_TARGET_CLEANALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_CLEANALL);
@@ -285,7 +282,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_cleanall(MPIR_Win * win)
 #define FUNCNAME MPIDI_CH4U_win_hash_clear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_hash_clear(MPIR_Win * win)
+static inline void MPIDI_CH4U_win_hash_clear(MPIR_Win * win)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_HASH_CLEAR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_HASH_CLEAR);
@@ -811,7 +808,7 @@ static inline void MPIDI_win_cmpl_cnts_incr(MPIR_Win * win, int target_rank,
 #define FUNCNAME MPIDI_win_remote_acc_cmpl_cnt_incr
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_win_remote_acc_cmpl_cnt_incr(MPIR_Win * win, int target_rank)
+static inline void MPIDI_win_remote_acc_cmpl_cnt_incr(MPIR_Win * win, int target_rank)
 {
     int c = 0;
     switch (MPIDI_CH4U_WIN(win, sync).access_epoch_type) {
@@ -834,7 +831,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_win_remote_acc_cmpl_cnt_incr(MPIR_Win * win,
 #define FUNCNAME MPIDI_win_remote_acc_cmpl_cnt_decr
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_win_remote_acc_cmpl_cnt_decr(MPIR_Win * win, int target_rank)
+static inline void MPIDI_win_remote_acc_cmpl_cnt_decr(MPIR_Win * win, int target_rank)
 {
     int c = 0;
     switch (MPIDI_CH4U_WIN(win, sync).access_epoch_type) {
@@ -951,7 +948,7 @@ static inline void MPIDI_win_check_group_local_completed(MPIR_Win * win,
 #define FUNCNAME MPIDI_CH4U_map_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_create(void **out_map, MPL_memory_class class)
+static inline void MPIDI_CH4U_map_create(void **out_map, MPL_memory_class class)
 {
     MPIDI_CH4U_map_t *map;
     map = MPL_malloc(sizeof(MPIDI_CH4U_map_t), class);
@@ -964,7 +961,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_create(void **out_map, MPL_memory_c
 #define FUNCNAME MPIDI_CH4U_map_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_destroy(void *in_map)
+static inline void MPIDI_CH4U_map_destroy(void *in_map)
 {
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
     MPIDI_CH4U_map_t *map = in_map;
@@ -977,8 +974,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_destroy(void *in_map)
 #define FUNCNAME MPIDI_CH4U_map_set
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void *val,
-                                                 MPL_memory_class class)
+static inline void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void *val, MPL_memory_class class)
 {
     MPIDI_CH4U_map_t *map;
     MPIDI_CH4U_map_entry_t *map_entry;
@@ -996,7 +992,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void
 #define FUNCNAME MPIDI_CH4U_map_erase
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_erase(void *in_map, uint64_t id)
+static inline void MPIDI_CH4U_map_erase(void *in_map, uint64_t id)
 {
     MPIDI_CH4U_map_t *map;
     MPIDI_CH4U_map_entry_t *map_entry;
@@ -1013,7 +1009,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_erase(void *in_map, uint64_t id)
 #define FUNCNAME MPIDI_CH4U_map_lookup
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_map_lookup(void *in_map, uint64_t id)
+static inline void *MPIDI_CH4U_map_lookup(void *in_map, uint64_t id)
 {
     void *rc;
     MPIDI_CH4U_map_t *map;
@@ -1035,7 +1031,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_map_lookup(void *in_map, uint64_t id)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* Wait until active message acc ops are done. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_wait_am_acc(MPIR_Win * win, int target_rank, int order_needed)
+static inline int MPIDI_CH4U_wait_am_acc(MPIR_Win * win, int target_rank, int order_needed)
 {
     int mpi_errno = MPI_SUCCESS;
     if (MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & order_needed) {

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -109,9 +109,8 @@ static inline int MPIDI_choose_netmod(void)
 #define FUNCNAME MPID_Init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
-                                       char ***argv,
-                                       int requested, int *provided, int *has_args, int *has_env)
+static inline int MPID_Init(int *argc,
+                            char ***argv, int requested, int *provided, int *has_args, int *has_env)
 {
     int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
     int avtid;
@@ -346,7 +345,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 #define FUNCNAME MPID_InitCompleted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_InitCompleted(void)
+static inline int MPID_InitCompleted(void)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INITCOMPLETED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INITCOMPLETED);
@@ -359,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_InitCompleted(void)
 #define FUNCNAME MPID_Finalize
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Finalize(void)
+static inline int MPID_Finalize(void)
 {
     int mpi_errno, thr_err;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_FINALIZE);
@@ -400,7 +399,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Finalize(void)
 #define FUNCNAME MPID_Get_universe_size
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get_universe_size(int *universe_size)
+static inline int MPID_Get_universe_size(int *universe_size)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno = PMI_SUCCESS;
@@ -428,7 +427,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_universe_size(int *universe_size)
 #define FUNCNAME MPID_Get_processor_name
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get_processor_name(char *name, int namelen, int *resultlen)
+static inline int MPID_Get_processor_name(char *name, int namelen, int *resultlen)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET_PROCESSOR_NAME);
@@ -471,8 +470,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_processor_name(char *name, int namelen, in
 #define FUNCNAME MPID_Alloc_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr,
-                                              MPL_memory_class class)
+static inline void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
     void *p;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);
@@ -488,7 +486,7 @@ MPL_STATIC_INLINE_PREFIX void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr,
 #define FUNCNAME MPID_Free_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Free_mem(void *ptr)
+static inline int MPID_Free_mem(void *ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_FREE_MEM);
@@ -510,8 +508,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Free_mem(void *ptr)
 #define FUNCNAME MPID_Comm_get_lpid
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_get_lpid(MPIR_Comm * comm_ptr,
-                                                int idx, int *lpid_ptr, MPL_bool is_remote)
+static inline int MPID_Comm_get_lpid(MPIR_Comm * comm_ptr,
+                                     int idx, int *lpid_ptr, MPL_bool is_remote)
 {
     int mpi_errno = MPI_SUCCESS;
     int avtid = 0, lpid = 0;
@@ -536,7 +534,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_get_lpid(MPIR_Comm * comm_ptr,
 #define FUNCNAME MPID_Get_node_id
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get_node_id(MPIR_Comm * comm, int rank, int *id_p)
+static inline int MPID_Get_node_id(MPIR_Comm * comm, int rank, int *id_p)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET_NODE_ID);
@@ -552,7 +550,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_node_id(MPIR_Comm * comm, int rank, int *i
 #define FUNCNAME MPID_Get_max_node_id
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get_max_node_id(MPIR_Comm * comm, int *max_id_p)
+static inline int MPID_Get_max_node_id(MPIR_Comm * comm, int *max_id_p)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET_MAX_NODE_ID);
@@ -568,8 +566,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_max_node_id(MPIR_Comm * comm, int *max_id_
 #define FUNCNAME MPID_Create_intercomm_from_lpids
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
-                                                              int size, const int lpids[])
+static inline int MPID_Create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr,
+                                                   int size, const int lpids[])
 {
     int mpi_errno = MPI_SUCCESS, i;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CREATE_INTERCOMM_FROM_LPIDS);
@@ -607,7 +605,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Create_intercomm_from_lpids(MPIR_Comm * newcom
 #define FUNCNAME MPID_Aint_add
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp)
+static inline MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp)
 {
     MPI_Aint result;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_ADD);
@@ -621,7 +619,7 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp)
 #define FUNCNAME MPID_Aint_diff
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2)
+static inline MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2)
 {
     MPI_Aint result;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_DIFF);
@@ -637,7 +635,7 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2)
 #define FUNCNAME MPIDI_Type_commit_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Type_commit_hook(MPIR_Datatype * type)
+static inline int MPIDI_Type_commit_hook(MPIR_Datatype * type)
 {
     int mpi_errno;
 
@@ -666,7 +664,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Type_commit_hook(MPIR_Datatype * type)
 #define FUNCNAME MPIDI_Type_free_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Type_free_hook(MPIR_Datatype * type)
+static inline int MPIDI_Type_free_hook(MPIR_Datatype * type)
 {
     int mpi_errno;
 
@@ -695,7 +693,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Type_free_hook(MPIR_Datatype * type)
 #define FUNCNAME MPIDI_Op_commit_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Op_commit_hook(MPIR_Op * op)
+static inline int MPIDI_Op_commit_hook(MPIR_Op * op)
 {
     int mpi_errno;
 
@@ -724,7 +722,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Op_commit_hook(MPIR_Op * op)
 #define FUNCNAME MPIDI_Op_free_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Op_free_hook(MPIR_Op * op)
+static inline int MPIDI_Op_free_hook(MPIR_Op * op)
 {
     int mpi_errno;
 

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -17,9 +17,8 @@
 #define FUNCNAME MPID_Probe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
-                                        int tag, MPIR_Comm * comm, int context_offset,
-                                        MPI_Status * status)
+static inline int MPID_Probe(int source,
+                             int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
 {
     int mpi_errno, flag = 0;
     MPIDI_av_entry_t *av = NULL;
@@ -64,11 +63,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
 #define FUNCNAME MPID_Mprobe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
-                                         int tag,
-                                         MPIR_Comm * comm,
-                                         int context_offset, MPIR_Request ** message,
-                                         MPI_Status * status)
+static inline int MPID_Mprobe(int source,
+                              int tag,
+                              MPIR_Comm * comm,
+                              int context_offset, MPIR_Request ** message, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS, flag = 0;
     MPIDI_av_entry_t *av = NULL;
@@ -128,11 +126,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
 #define FUNCNAME MPID_Improbe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
-                                          int tag,
-                                          MPIR_Comm * comm,
-                                          int context_offset,
-                                          int *flag, MPIR_Request ** message, MPI_Status * status)
+static inline int MPID_Improbe(int source,
+                               int tag,
+                               MPIR_Comm * comm,
+                               int context_offset,
+                               int *flag, MPIR_Request ** message, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_av_entry_t *av = NULL;
@@ -190,10 +188,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
 #define FUNCNAME MPID_Iprobe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Iprobe(int source,
-                                         int tag,
-                                         MPIR_Comm * comm,
-                                         int context_offset, int *flag, MPI_Status * status)
+static inline int MPID_Iprobe(int source,
+                              int tag,
+                              MPIR_Comm * comm, int context_offset, int *flag, MPI_Status * status)
 {
 
     int mpi_errno;

--- a/src/mpid/ch4/src/ch4_proc.h
+++ b/src/mpid/ch4/src/ch4_proc.h
@@ -17,7 +17,7 @@
 #define FUNCNAME MPIDI_CH4_rank_is_local
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4_rank_is_local(int rank, MPIR_Comm * comm)
+static inline int MPIDI_CH4_rank_is_local(int rank, MPIR_Comm * comm)
 {
     int ret;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4_RANK_IS_LOCAL);
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4_rank_is_local(int rank, MPIR_Comm * comm)
 #define FUNCNAME MPIDI_av_is_local
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av)
+static inline int MPIDI_av_is_local(MPIDI_av_entry_t * av)
 {
     int ret;
 

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -30,7 +30,7 @@
 #define FUNCNAME MPIDI_Progress_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
+static inline int MPIDI_Progress_test(int flags)
 {
     int mpi_errno, made_progress, i;
 
@@ -79,12 +79,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 #define FUNCNAME MPID_Progress_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
+static inline int MPID_Progress_test(void)
 {
     return MPIDI_Progress_test(MPIDI_PROGRESS_ALL);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_poke(void)
+static inline int MPID_Progress_poke(void)
 {
     int ret;
 
@@ -97,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_poke(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPID_Progress_start(MPID_Progress_state * state)
+static inline void MPID_Progress_start(MPID_Progress_state * state)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROGRESS_START);
@@ -106,7 +106,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Progress_start(MPID_Progress_state * state)
     return;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state * state)
+static inline void MPID_Progress_end(MPID_Progress_state * state)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_END);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROGRESS_END);
@@ -115,7 +115,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state * state)
     return;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_wait(MPID_Progress_state * state)
+static inline int MPID_Progress_wait(MPID_Progress_state * state)
 {
     int ret;
 
@@ -133,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_wait(MPID_Progress_state * state)
 #define FUNCNAME MPID_Progress_register
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_register(int (*progress_fn) (int *), int *id)
+static inline int MPID_Progress_register(int (*progress_fn) (int *), int *id)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_register(int (*progress_fn) (int *), 
 #define FUNCNAME MPID_Progress_deregister
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_deregister(int id)
+static inline int MPID_Progress_deregister(int id)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_DEREGISTER);
@@ -194,7 +194,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deregister(int id)
 #define FUNCNAME MPID_Progress_activate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_activate(int id)
+static inline int MPID_Progress_activate(int id)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_ACTIVATE);
@@ -216,7 +216,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_activate(int id)
 #define FUNCNAME MPID_Progress_deactivate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
+static inline int MPID_Progress_deactivate(int id)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_DEACTIVATE);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -17,14 +17,13 @@
 #define FUNCNAME MPID_Recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
-                                       MPI_Aint count,
-                                       MPI_Datatype datatype,
-                                       int rank,
-                                       int tag,
-                                       MPIR_Comm * comm,
-                                       int context_offset, MPI_Status * status,
-                                       MPIR_Request ** request)
+static inline int MPID_Recv(void *buf,
+                            MPI_Aint count,
+                            MPI_Datatype datatype,
+                            int rank,
+                            int tag,
+                            MPIR_Comm * comm,
+                            int context_offset, MPI_Status * status, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -109,13 +108,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
 #define FUNCNAME MPID_Recv_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
-                                            int count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag,
-                                            MPIR_Comm * comm, int context_offset,
-                                            MPIR_Request ** request)
+static inline int MPID_Recv_init(void *buf,
+                                 int count,
+                                 MPI_Datatype datatype,
+                                 int rank,
+                                 int tag,
+                                 MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -178,10 +176,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
 #define FUNCNAME MPID_Mrecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
-                                        MPI_Aint count,
-                                        MPI_Datatype datatype, MPIR_Request * message,
-                                        MPI_Status * status)
+static inline int MPID_Mrecv(void *buf,
+                             MPI_Aint count,
+                             MPI_Datatype datatype, MPIR_Request * message, MPI_Status * status)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_MRECV);
@@ -226,10 +223,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
 #define FUNCNAME MPID_Imrecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
-                                         MPI_Aint count,
-                                         MPI_Datatype datatype,
-                                         MPIR_Request * message, MPIR_Request ** rreqp)
+static inline int MPID_Imrecv(void *buf,
+                              MPI_Aint count,
+                              MPI_Datatype datatype, MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IMRECV);
@@ -261,13 +257,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
 #define FUNCNAME MPID_Irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
-                                        MPI_Aint count,
-                                        MPI_Datatype datatype,
-                                        int rank,
-                                        int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+static inline int MPID_Irecv(void *buf,
+                             MPI_Aint count,
+                             MPI_Datatype datatype,
+                             int rank,
+                             int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -339,7 +333,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
 #define FUNCNAME MPIDI_Cancel_Recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request * rreq)
+static inline int MPID_Cancel_recv(MPIR_Request * rreq)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CANCEL_RECV);

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -14,7 +14,7 @@
 #include "ch4_impl.h"
 #include "ch4r_buf.h"
 
-MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request * req)
+static inline int MPID_Request_is_anysource(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_IS_ANYSOURCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_IS_ANYSOURCE);
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Request_is_pending_failure(MPIR_Request * req)
+static inline int MPID_Request_is_pending_failure(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_IS_PENDING_FAILURE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_IS_PENDING_FAILURE);
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_is_pending_failure(MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPID_Request_set_completed(MPIR_Request * req)
+static inline void MPID_Request_set_completed(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_SET_COMPLETED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_SET_COMPLETED);
@@ -82,7 +82,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_set_completed(MPIR_Request * req)
 #define FUNCNAME MPIDI_request_complete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request * req)
+static inline int MPID_Request_complete(MPIR_Request * req)
 {
     int incomplete, notify_counter;
 

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -17,13 +17,12 @@
 #define FUNCNAME MPID_Put
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
-                                      int origin_count,
-                                      MPI_Datatype origin_datatype,
-                                      int target_rank,
-                                      MPI_Aint target_disp,
-                                      int target_count, MPI_Datatype target_datatype,
-                                      MPIR_Win * win)
+static inline int MPID_Put(const void *origin_addr,
+                           int origin_count,
+                           MPI_Datatype origin_datatype,
+                           int target_rank,
+                           MPI_Aint target_disp,
+                           int target_count, MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PUT);
@@ -45,13 +44,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
 #define FUNCNAME MPID_Get
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
-                                      int origin_count,
-                                      MPI_Datatype origin_datatype,
-                                      int target_rank,
-                                      MPI_Aint target_disp,
-                                      int target_count, MPI_Datatype target_datatype,
-                                      MPIR_Win * win)
+static inline int MPID_Get(void *origin_addr,
+                           int origin_count,
+                           MPI_Datatype origin_datatype,
+                           int target_rank,
+                           MPI_Aint target_disp,
+                           int target_count, MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET);
@@ -73,14 +71,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
 #define FUNCNAME MPID_Accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *origin_addr,
-                                             int origin_count,
-                                             MPI_Datatype origin_datatype,
-                                             int target_rank,
-                                             MPI_Aint target_disp,
-                                             int target_count,
-                                             MPI_Datatype target_datatype, MPI_Op op,
-                                             MPIR_Win * win)
+static inline int MPID_Accumulate(const void *origin_addr,
+                                  int origin_count,
+                                  MPI_Datatype origin_datatype,
+                                  int target_rank,
+                                  MPI_Aint target_disp,
+                                  int target_count,
+                                  MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ACCUMULATE);
@@ -102,12 +99,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *origin_addr,
 #define FUNCNAME MPID_Compare_and_swap
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *origin_addr,
-                                                   const void *compare_addr,
-                                                   void *result_addr,
-                                                   MPI_Datatype datatype,
-                                                   int target_rank, MPI_Aint target_disp,
-                                                   MPIR_Win * win)
+static inline int MPID_Compare_and_swap(const void *origin_addr,
+                                        const void *compare_addr,
+                                        void *result_addr,
+                                        MPI_Datatype datatype,
+                                        int target_rank, MPI_Aint target_disp, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMPARE_AND_SWAP);
@@ -128,14 +124,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *origin_addr,
 #define FUNCNAME MPID_Raccumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
-                                              int origin_count,
-                                              MPI_Datatype origin_datatype,
-                                              int target_rank,
-                                              MPI_Aint target_disp,
-                                              int target_count,
-                                              MPI_Datatype target_datatype,
-                                              MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
+static inline int MPID_Raccumulate(const void *origin_addr,
+                                   int origin_count,
+                                   MPI_Datatype origin_datatype,
+                                   int target_rank,
+                                   MPI_Aint target_disp,
+                                   int target_count,
+                                   MPI_Datatype target_datatype,
+                                   MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RACCUMULATE);
@@ -157,18 +153,17 @@ MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
 #define FUNCNAME MPID_Rget_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *origin_addr,
-                                                  int origin_count,
-                                                  MPI_Datatype origin_datatype,
-                                                  void *result_addr,
-                                                  int result_count,
-                                                  MPI_Datatype result_datatype,
-                                                  int target_rank,
-                                                  MPI_Aint target_disp,
-                                                  int target_count,
-                                                  MPI_Datatype target_datatype,
-                                                  MPI_Op op, MPIR_Win * win,
-                                                  MPIR_Request ** request)
+static inline int MPID_Rget_accumulate(const void *origin_addr,
+                                       int origin_count,
+                                       MPI_Datatype origin_datatype,
+                                       void *result_addr,
+                                       int result_count,
+                                       MPI_Datatype result_datatype,
+                                       int target_rank,
+                                       MPI_Aint target_disp,
+                                       int target_count,
+                                       MPI_Datatype target_datatype,
+                                       MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RGET_ACCUMULATE);
@@ -191,11 +186,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *origin_addr,
 #define FUNCNAME MPID_Fetch_and_op
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *origin_addr,
-                                               void *result_addr,
-                                               MPI_Datatype datatype,
-                                               int target_rank,
-                                               MPI_Aint target_disp, MPI_Op op, MPIR_Win * win)
+static inline int MPID_Fetch_and_op(const void *origin_addr,
+                                    void *result_addr,
+                                    MPI_Datatype datatype,
+                                    int target_rank,
+                                    MPI_Aint target_disp, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_FETCH_AND_OP);
@@ -217,14 +212,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *origin_addr,
 #define FUNCNAME MPID_Rget
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
-                                       int origin_count,
-                                       MPI_Datatype origin_datatype,
-                                       int target_rank,
-                                       MPI_Aint target_disp,
-                                       int target_count,
-                                       MPI_Datatype target_datatype, MPIR_Win * win,
-                                       MPIR_Request ** request)
+static inline int MPID_Rget(void *origin_addr,
+                            int origin_count,
+                            MPI_Datatype origin_datatype,
+                            int target_rank,
+                            MPI_Aint target_disp,
+                            int target_count,
+                            MPI_Datatype target_datatype, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RGET);
@@ -246,14 +240,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
 #define FUNCNAME MPID_Rput
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
-                                       int origin_count,
-                                       MPI_Datatype origin_datatype,
-                                       int target_rank,
-                                       MPI_Aint target_disp,
-                                       int target_count,
-                                       MPI_Datatype target_datatype, MPIR_Win * win,
-                                       MPIR_Request ** request)
+static inline int MPID_Rput(const void *origin_addr,
+                            int origin_count,
+                            MPI_Datatype origin_datatype,
+                            int target_rank,
+                            MPI_Aint target_disp,
+                            int target_count,
+                            MPI_Datatype target_datatype, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RPUT);
@@ -275,17 +268,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
 #define FUNCNAME MPID_Get_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *origin_addr,
-                                                 int origin_count,
-                                                 MPI_Datatype origin_datatype,
-                                                 void *result_addr,
-                                                 int result_count,
-                                                 MPI_Datatype result_datatype,
-                                                 int target_rank,
-                                                 MPI_Aint target_disp,
-                                                 int target_count,
-                                                 MPI_Datatype target_datatype, MPI_Op op,
-                                                 MPIR_Win * win)
+static inline int MPID_Get_accumulate(const void *origin_addr,
+                                      int origin_count,
+                                      MPI_Datatype origin_datatype,
+                                      void *result_addr,
+                                      int result_count,
+                                      MPI_Datatype result_datatype,
+                                      int target_rank,
+                                      MPI_Aint target_disp,
+                                      int target_count,
+                                      MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_GET_ACCUMULATE);

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -17,13 +17,11 @@
 #define FUNCNAME MPID_Send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
-                                       MPI_Aint count,
-                                       MPI_Datatype datatype,
-                                       int rank,
-                                       int tag,
-                                       MPIR_Comm * comm, int context_offset,
-                                       MPIR_Request ** request)
+static inline int MPID_Send(const void *buf,
+                            MPI_Aint count,
+                            MPI_Datatype datatype,
+                            int rank,
+                            int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -68,13 +66,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
 #define FUNCNAME MPID_Isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
-                                        MPI_Aint count,
-                                        MPI_Datatype datatype,
-                                        int rank,
-                                        int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+static inline int MPID_Isend(const void *buf,
+                             MPI_Aint count,
+                             MPI_Datatype datatype,
+                             int rank,
+                             int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -120,13 +116,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
 #define FUNCNAME MPID_Rsend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
-                                        MPI_Aint count,
-                                        MPI_Datatype datatype,
-                                        int rank,
-                                        int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+static inline int MPID_Rsend(const void *buf,
+                             MPI_Aint count,
+                             MPI_Datatype datatype,
+                             int rank,
+                             int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -172,13 +166,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
 #define FUNCNAME MPID_Irsend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
-                                         MPI_Aint count,
-                                         MPI_Datatype datatype,
-                                         int rank,
-                                         int tag,
-                                         MPIR_Comm * comm, int context_offset,
-                                         MPIR_Request ** request)
+static inline int MPID_Irsend(const void *buf,
+                              MPI_Aint count,
+                              MPI_Datatype datatype,
+                              int rank,
+                              int tag,
+                              MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -223,13 +216,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
 #define FUNCNAME MPID_Ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
-                                        MPI_Aint count,
-                                        MPI_Datatype datatype,
-                                        int rank,
-                                        int tag,
-                                        MPIR_Comm * comm, int context_offset,
-                                        MPIR_Request ** request)
+static inline int MPID_Ssend(const void *buf,
+                             MPI_Aint count,
+                             MPI_Datatype datatype,
+                             int rank,
+                             int tag, MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -274,13 +265,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
 #define FUNCNAME MPID_Issend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
-                                         MPI_Aint count,
-                                         MPI_Datatype datatype,
-                                         int rank,
-                                         int tag,
-                                         MPIR_Comm * comm, int context_offset,
-                                         MPIR_Request ** request)
+static inline int MPID_Issend(const void *buf,
+                              MPI_Aint count,
+                              MPI_Datatype datatype,
+                              int rank,
+                              int tag,
+                              MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -325,13 +315,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
 #define FUNCNAME MPID_Send_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
-                                            int count,
-                                            MPI_Datatype datatype,
-                                            int rank,
-                                            int tag,
-                                            MPIR_Comm * comm, int context_offset,
-                                            MPIR_Request ** request)
+static inline int MPID_Send_init(const void *buf,
+                                 int count,
+                                 MPI_Datatype datatype,
+                                 int rank,
+                                 int tag,
+                                 MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -367,13 +356,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
 #define FUNCNAME MPID_Ssend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
-                                             int count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+static inline int MPID_Ssend_init(const void *buf,
+                                  int count,
+                                  MPI_Datatype datatype,
+                                  int rank,
+                                  int tag,
+                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -410,13 +398,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
 #define FUNCNAME MPID_Bsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
-                                             int count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+static inline int MPID_Bsend_init(const void *buf,
+                                  int count,
+                                  MPI_Datatype datatype,
+                                  int rank,
+                                  int tag,
+                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -453,13 +440,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
 #define FUNCNAME MPID_Rsend_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
-                                             int count,
-                                             MPI_Datatype datatype,
-                                             int rank,
-                                             int tag,
-                                             MPIR_Comm * comm, int context_offset,
-                                             MPIR_Request ** request)
+static inline int MPID_Rsend_init(const void *buf,
+                                  int count,
+                                  MPI_Datatype datatype,
+                                  int rank,
+                                  int tag,
+                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIDI_av_entry_t *av = NULL;
@@ -497,7 +483,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
 #define FUNCNAME MPID_Cancel_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request * sreq)
+static inline int MPID_Cancel_send(MPIR_Request * sreq)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CANCEL_SEND);

--- a/src/mpid/ch4/src/ch4_spawn.h
+++ b/src/mpid/ch4/src/ch4_spawn.h
@@ -100,14 +100,14 @@ static inline void MPIDI_free_pmi_keyvals(PMI_keyval_t ** kv, int size, int *cou
 #define FUNCNAME MPID_Comm_spawn_multiple
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_spawn_multiple(int count,
-                                                      char *commands[],
-                                                      char **argvs[],
-                                                      const int maxprocs[],
-                                                      MPIR_Info * info_ptrs[],
-                                                      int root,
-                                                      MPIR_Comm * comm_ptr,
-                                                      MPIR_Comm ** intercomm, int errcodes[])
+static inline int MPID_Comm_spawn_multiple(int count,
+                                           char *commands[],
+                                           char **argvs[],
+                                           const int maxprocs[],
+                                           MPIR_Info * info_ptrs[],
+                                           int root,
+                                           MPIR_Comm * comm_ptr,
+                                           MPIR_Comm ** intercomm, int errcodes[])
 {
     char port_name[MPI_MAX_PORT_NAME];
     int *info_keyval_sizes = 0, i, mpi_errno = MPI_SUCCESS;
@@ -237,9 +237,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_spawn_multiple(int count,
 #define FUNCNAME MPID_Comm_connect
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_connect(const char *port_name,
-                                               MPIR_Info * info,
-                                               int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
+static inline int MPID_Comm_connect(const char *port_name,
+                                    MPIR_Info * info,
+                                    int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     int timeout = MPIR_CVAR_CH4_COMM_CONNECT_TIMEOUT;
@@ -271,7 +271,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_connect(const char *port_name,
 #define FUNCNAME MPID_Comm_disconnect
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_disconnect(MPIR_Comm * comm_ptr)
+static inline int MPID_Comm_disconnect(MPIR_Comm * comm_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_DISCONNECT);
@@ -293,7 +293,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_disconnect(MPIR_Comm * comm_ptr)
 #define FUNCNAME MPID_Open_port
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Open_port(MPIR_Info * info_ptr, char *port_name)
+static inline int MPID_Open_port(MPIR_Info * info_ptr, char *port_name)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_OPEN_PORT);
@@ -315,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Open_port(MPIR_Info * info_ptr, char *port_nam
 #define FUNCNAME MPID_Close_port
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Close_port(const char *port_name)
+static inline int MPID_Close_port(const char *port_name)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CLOSE_PORT);
@@ -337,9 +337,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Close_port(const char *port_name)
 #define FUNCNAME MPID_Comm_accept
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Comm_accept(const char *port_name,
-                                              MPIR_Info * info,
-                                              int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
+static inline int MPID_Comm_accept(const char *port_name,
+                                   MPIR_Info * info,
+                                   int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COMM_ACCEPT);

--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -17,7 +17,7 @@
 #define FUNCNAME MPID_Startall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Startall(int count, MPIR_Request * requests[])
+static inline int MPID_Startall(int count, MPIR_Request * requests[])
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_STARTALL);

--- a/src/mpid/ch4/src/ch4_win.h
+++ b/src/mpid/ch4/src/ch4_win.h
@@ -17,7 +17,7 @@
 #define FUNCNAME MPID_Win_set_info
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
+static inline int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SET_INFO);
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
 #define FUNCNAME MPID_Win_start
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPID_Win_start(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_START);
@@ -57,7 +57,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
 #define FUNCNAME MPID_Win_complete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
+static inline int MPID_Win_complete(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_COMPLETE);
@@ -77,7 +77,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
 #define FUNCNAME MPID_Win_post
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_Win * win)
+static inline int MPID_Win_post(MPIR_Group * group, int assert, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_POST);
@@ -97,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
 #define FUNCNAME MPID_Win_wait
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
+static inline int MPID_Win_wait(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_WAIT);
@@ -118,7 +118,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
 #define FUNCNAME MPID_Win_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
+static inline int MPID_Win_test(MPIR_Win * win, int *flag)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_TEST);
@@ -138,7 +138,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
 #define FUNCNAME MPID_Win_lock
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, MPIR_Win * win)
+static inline int MPID_Win_lock(int lock_type, int rank, int assert, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK);
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
 #define FUNCNAME MPID_Win_unlock
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
+static inline int MPID_Win_unlock(int rank, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK);
@@ -178,7 +178,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
 #define FUNCNAME MPID_Win_get_info
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
+static inline int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_GET_INFO);
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info
 #define FUNCNAME MPID_Win_free
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_free(MPIR_Win ** win_ptr)
+static inline int MPID_Win_free(MPIR_Win ** win_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FREE);
@@ -218,7 +218,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_free(MPIR_Win ** win_ptr)
 #define FUNCNAME MPID_Win_fence
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
+static inline int MPID_Win_fence(int assert, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FENCE);
@@ -238,11 +238,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
 #define FUNCNAME MPID_Win_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_create(void *base,
-                                             MPI_Aint length,
-                                             int disp_unit,
-                                             MPIR_Info * info, MPIR_Comm * comm_ptr,
-                                             MPIR_Win ** win_ptr)
+static inline int MPID_Win_create(void *base,
+                                  MPI_Aint length,
+                                  int disp_unit,
+                                  MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_CREATE);
@@ -262,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_create(void *base,
 #define FUNCNAME MPID_Win_attach
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_attach(MPIR_Win * win, void *base, MPI_Aint size)
+static inline int MPID_Win_attach(MPIR_Win * win, void *base, MPI_Aint size)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_ATTACH);
@@ -282,11 +281,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_attach(MPIR_Win * win, void *base, MPI_Ain
 #define FUNCNAME MPID_Win_allocate_shared
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_allocate_shared(MPI_Aint size,
-                                                      int disp_unit,
-                                                      MPIR_Info * info_ptr,
-                                                      MPIR_Comm * comm_ptr,
-                                                      void **base_ptr, MPIR_Win ** win_ptr)
+static inline int MPID_Win_allocate_shared(MPI_Aint size,
+                                           int disp_unit,
+                                           MPIR_Info * info_ptr,
+                                           MPIR_Comm * comm_ptr,
+                                           void **base_ptr, MPIR_Win ** win_ptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_ALLOCATE_SHARED);
@@ -307,7 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_allocate_shared(MPI_Aint size,
 #define FUNCNAME MPID_Win_flush_local
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
+static inline int MPID_Win_flush_local(int rank, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
@@ -327,7 +326,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
 #define FUNCNAME MPID_Win_detach
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_detach(MPIR_Win * win, const void *base)
+static inline int MPID_Win_detach(MPIR_Win * win, const void *base)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_DETACH);
@@ -348,9 +347,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_detach(MPIR_Win * win, const void *base)
 #define FUNCNAME MPID_Win_shared_query
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_shared_query(MPIR_Win * win,
-                                                   int rank, MPI_Aint * size, int *disp_unit,
-                                                   void *baseptr)
+static inline int MPID_Win_shared_query(MPIR_Win * win,
+                                        int rank, MPI_Aint * size, int *disp_unit, void *baseptr)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SHARED_QUERY);
@@ -370,10 +368,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_shared_query(MPIR_Win * win,
 #define FUNCNAME MPID_Win_allocate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_allocate(MPI_Aint size,
-                                               int disp_unit,
-                                               MPIR_Info * info,
-                                               MPIR_Comm * comm, void *baseptr, MPIR_Win ** win)
+static inline int MPID_Win_allocate(MPI_Aint size,
+                                    int disp_unit,
+                                    MPIR_Info * info,
+                                    MPIR_Comm * comm, void *baseptr, MPIR_Win ** win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_ALLOCATE);
@@ -393,7 +391,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_allocate(MPI_Aint size,
 #define FUNCNAME MPID_Win_flush
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
+static inline int MPID_Win_flush(int rank, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH);
@@ -413,7 +411,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
 #define FUNCNAME MPID_Win_flush_local_all
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
+static inline int MPID_Win_flush_local_all(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
@@ -433,7 +431,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
 #define FUNCNAME MPID_Win_unlock_all
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
+static inline int MPID_Win_unlock_all(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK_ALL);
@@ -453,8 +451,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
 #define FUNCNAME MPID_Win_create_dynamic
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm,
-                                                     MPIR_Win ** win)
+static inline int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_CREATE_DYNAMIC);
@@ -474,7 +471,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm
 #define FUNCNAME MPID_Win_sync
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
+static inline int MPID_Win_sync(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SYNC);
@@ -494,7 +491,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
 #define FUNCNAME MPID_Win_flush_all
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
+static inline int MPID_Win_flush_all(MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_ALL);
@@ -514,7 +511,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
 #define FUNCNAME MPID_Win_lock_all
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
+static inline int MPID_Win_lock_all(int assert, MPIR_Win * win)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK_ALL);

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -872,7 +872,7 @@ static inline int MPIDI_set_map(MPIDI_rank_map_t * src_rmap,
 #define FUNCNAME MPIDI_comm_create_rank_map
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
+static inline int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm_map_t *mapper;
@@ -1067,8 +1067,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
 #define FUNCNAME MPIDI_check_disjoint_lupids
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_check_disjoint_lupids(int lupids1[], int n1,
-                                                         int lupids2[], int n2)
+static inline int MPIDI_check_disjoint_lupids(int lupids1[], int n1, int lupids2[], int n2)
 {
     int i, mask_size, idx, bit, maxlupid = -1;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_comm.h
+++ b/src/mpid/ch4/src/ch4r_comm.h
@@ -18,10 +18,10 @@
 #define FUNCNAME MPIDIU_upids_to_lupids
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIU_upids_to_lupids(int size,
-                                                    size_t * remote_upid_size,
-                                                    char *remote_upids,
-                                                    int **remote_lupids, int *remote_node_ids)
+static inline int MPIDIU_upids_to_lupids(int size,
+                                         size_t * remote_upid_size,
+                                         char *remote_upids,
+                                         int **remote_lupids, int *remote_node_ids)
 {
     int mpi_errno = MPI_SUCCESS, i;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_UPIDS_TO_LUPIDS);
@@ -71,15 +71,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_upids_to_lupids(int size,
 #define FUNCNAME MPIDIU_Intercomm_map_bcast_intra
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm,
-                                                              int local_leader,
-                                                              int *remote_size,
-                                                              int *is_low_group,
-                                                              int pure_intracomm,
-                                                              size_t * remote_upid_size,
-                                                              char *remote_upids,
-                                                              int **remote_lupids,
-                                                              int *remote_node_ids)
+static inline int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm,
+                                                   int local_leader,
+                                                   int *remote_size,
+                                                   int *is_low_group,
+                                                   int pure_intracomm,
+                                                   size_t * remote_upid_size,
+                                                   char *remote_upids,
+                                                   int **remote_lupids, int *remote_node_ids)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -24,7 +24,7 @@
 #define FUNCNAME MPIDI_CH4U_init_comm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_init_comm(MPIR_Comm * comm)
+static inline int MPIDI_CH4U_init_comm(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS, comm_idx, subcomm_type, is_localcomm;
     MPIDI_CH4U_rreq_t **uelist;
@@ -77,7 +77,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_init_comm(MPIR_Comm * comm)
 #define FUNCNAME MPIDI_CH4U_destroy_comm
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_destroy_comm(MPIR_Comm * comm)
+static inline int MPIDI_CH4U_destroy_comm(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS, comm_idx, subcomm_type, is_localcomm;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DESTROY_COMM);
@@ -110,8 +110,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_destroy_comm(MPIR_Comm * comm)
 #define FUNCNAME MPIDI_CH4U_mpi_alloc_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
-                                                        MPL_memory_class class)
+static inline void *MPIDI_CH4U_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
+                                             MPL_memory_class class)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_ALLOC_MEM);
@@ -125,7 +125,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_mpi_alloc_mem(size_t size, MPIR_Info *
 #define FUNCNAME MPIDI_CH4U_mpi_free_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_free_mem(void *ptr)
+static inline int MPIDI_CH4U_mpi_free_mem(void *ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_FREE_MEM);

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -17,11 +17,10 @@
 #define FUNCNAME MPIDI_CH4U_mpi_iprobe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
-                                                   int tag,
-                                                   MPIR_Comm * comm,
-                                                   int context_offset, int *flag,
-                                                   MPI_Status * status)
+static inline int MPIDI_CH4U_mpi_iprobe(int source,
+                                        int tag,
+                                        MPIR_Comm * comm,
+                                        int context_offset, int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *root_comm;
@@ -72,12 +71,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
 #define FUNCNAME MPIDI_CH4U_mpi_improbe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
-                                                    int tag,
-                                                    MPIR_Comm * comm,
-                                                    int context_offset,
-                                                    int *flag, MPIR_Request ** message,
-                                                    MPI_Status * status)
+static inline int MPIDI_CH4U_mpi_improbe(int source,
+                                         int tag,
+                                         MPIR_Comm * comm,
+                                         int context_offset,
+                                         int *flag, MPIR_Request ** message, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *root_comm;
@@ -138,11 +136,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
 #define FUNCNAME MPIDI_CH4U_mprobe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mprobe(int source,
-                                               int tag,
-                                               MPIR_Comm * comm,
-                                               int context_offset,
-                                               MPIR_Request ** message, MPI_Status * status)
+static inline int MPIDI_CH4U_mprobe(int source,
+                                    int tag,
+                                    MPIR_Comm * comm,
+                                    int context_offset,
+                                    MPIR_Request ** message, MPI_Status * status)
 {
     int mpi_errno, flag = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPROBE);

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -22,8 +22,7 @@
 #define FUNCNAME MPIDIU_comm_rank_to_pid
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank, int *index,
-                                                     int *avtid)
+static inline int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank, int *index, int *avtid)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_COMM_RANK_TO_PID);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_COMM_RANK_TO_PID);
@@ -91,7 +90,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank,
 #define FUNCNAME MPIDIU_comm_rank_to_av
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIDI_av_entry_t *MPIDIU_comm_rank_to_av(MPIR_Comm * comm, int rank)
+static inline MPIDI_av_entry_t *MPIDIU_comm_rank_to_av(MPIR_Comm * comm, int rank)
 {
     MPIDI_av_entry_t *ret = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_COMM_RANK_TO_AV);
@@ -166,8 +165,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_av_entry_t *MPIDIU_comm_rank_to_av(MPIR_Comm * co
 #define FUNCNAME MPIDIU_comm_rank_to_pid_local
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid_local(MPIR_Comm * comm, int rank, int *index,
-                                                           int *avtid)
+static inline int MPIDIU_comm_rank_to_pid_local(MPIR_Comm * comm, int rank, int *index, int *avtid)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_COMM_RANK_TO_PID_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_COMM_RANK_TO_PID_LOCAL);
@@ -212,7 +210,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid_local(MPIR_Comm * comm, int
     return *index;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_rank_is_local(int rank, MPIR_Comm * comm)
+static inline int MPIDI_CH4U_rank_is_local(int rank, MPIR_Comm * comm)
 {
     int ret = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_RANK_IS_LOCAL);
@@ -228,7 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_rank_is_local(int rank, MPIR_Comm * comm
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_av_is_local(MPIDI_av_entry_t * av)
+static inline int MPIDI_CH4U_av_is_local(MPIDI_av_entry_t * av)
 {
     int ret = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_AV_IS_LOCAL);
@@ -244,7 +242,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_av_is_local(MPIDI_av_entry_t * av)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_rank_to_lpid(int rank, MPIR_Comm * comm)
+static inline int MPIDI_CH4U_rank_to_lpid(int rank, MPIR_Comm * comm)
 {
     int ret;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_RANK_TO_LPID);

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -27,7 +27,7 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_time_matching_unexpectedq ATTRIBUTE((unuse
 #define FUNCNAME MPIDI_CH4U_Recvq_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_Recvq_init(void)
+static inline int MPIDI_CH4U_Recvq_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_T_PVAR_LEVEL_REGISTER_STATIC(RECVQ, MPI_UNSIGNED, posted_recvq_length, 0,      /* init value */
@@ -65,8 +65,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_Recvq_init(void)
 #define FUNCNAME MPIDI_CH4U_enqueue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
-                                                        MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_enqueue_posted(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
@@ -80,8 +79,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
 #define FUNCNAME MPIDI_CH4U_enqueue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
-                                                       MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
@@ -95,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
 #define FUNCNAME MPIDI_CH4U_delete_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
@@ -108,9 +106,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp_strict
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
-                                                                       uint64_t ignore,
-                                                                       MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
+                                                            uint64_t ignore,
+                                                            MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -138,8 +136,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
-                                                                MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
+                                                     MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -166,8 +164,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
 #define FUNCNAME MPIDI_CH4U_find_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
-                                                             MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
+                                                  MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -192,8 +190,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
 #define FUNCNAME MPIDI_CH4U_dequeue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
-                                                                 MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -223,8 +220,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
 #define FUNCNAME MPIDI_CH4U_delete_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req,
-                                                      MPIDI_CH4U_rreq_t ** list)
+static inline int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req, MPIDI_CH4U_rreq_t ** list)
 {
     int found = 0;
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -255,8 +251,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req,
 #define FUNCNAME MPIDI_CH4U_enqueue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
-                                                        MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_enqueue_posted(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
@@ -270,8 +265,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
 #define FUNCNAME MPIDI_CH4U_enqueue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
-                                                       MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
@@ -285,7 +279,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
 #define FUNCNAME MPIDI_CH4U_delete_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
+static inline void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
@@ -298,9 +292,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp_strict
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
-                                                                       uint64_t ignore,
-                                                                       MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
+                                                            uint64_t ignore,
+                                                            MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -328,8 +322,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
-                                                                MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
+                                                     MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -356,8 +350,8 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
 #define FUNCNAME MPIDI_CH4U_find_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
-                                                             MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
+                                                  MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
     MPIR_Request *req = NULL;
@@ -382,8 +376,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
 #define FUNCNAME MPIDI_CH4U_dequeue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
-                                                                 MPIDI_CH4U_rreq_t ** list)
+static inline MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag, MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -413,8 +406,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
 #define FUNCNAME MPIDI_CH4U_delete_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req,
-                                                      MPIDI_CH4U_rreq_t ** list)
+static inline int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req, MPIDI_CH4U_rreq_t ** list)
 {
     int found = 0;
     MPIDI_CH4U_rreq_t *curr, *tmp;

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -278,15 +278,14 @@ static inline int MPIDI_do_get(void *origin_addr,
 #define FUNCNAME MPIDI_do_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
-                                                 int origin_count,
-                                                 MPI_Datatype origin_datatype,
-                                                 int target_rank,
-                                                 MPI_Aint target_disp,
-                                                 int target_count,
-                                                 MPI_Datatype target_datatype,
-                                                 MPI_Op op, MPIR_Win * win,
-                                                 MPIR_Request ** sreq_ptr)
+static inline int MPIDI_do_accumulate(const void *origin_addr,
+                                      int origin_count,
+                                      MPI_Datatype origin_datatype,
+                                      int target_rank,
+                                      MPI_Aint target_disp,
+                                      int target_count,
+                                      MPI_Datatype target_datatype,
+                                      MPI_Op op, MPIR_Win * win, MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c, n_iov;
     MPIR_Request *sreq = NULL;
@@ -426,18 +425,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
 #define FUNCNAME MPIDI_do_get_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
-                                                     int origin_count,
-                                                     MPI_Datatype origin_datatype,
-                                                     void *result_addr,
-                                                     int result_count,
-                                                     MPI_Datatype result_datatype,
-                                                     int target_rank,
-                                                     MPI_Aint target_disp,
-                                                     int target_count,
-                                                     MPI_Datatype target_datatype,
-                                                     MPI_Op op, MPIR_Win * win,
-                                                     MPIR_Request ** sreq_ptr)
+static inline int MPIDI_do_get_accumulate(const void *origin_addr,
+                                          int origin_count,
+                                          MPI_Datatype origin_datatype,
+                                          void *result_addr,
+                                          int result_count,
+                                          MPI_Datatype result_datatype,
+                                          int target_rank,
+                                          MPI_Aint target_disp,
+                                          int target_count,
+                                          MPI_Datatype target_datatype,
+                                          MPI_Op op, MPIR_Win * win, MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, c, n_iov;
     MPIR_Request *sreq = NULL;
@@ -587,13 +585,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_put
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_put(const void *origin_addr,
-                                                int origin_count,
-                                                MPI_Datatype origin_datatype,
-                                                int target_rank,
-                                                MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
-                                                MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_put(const void *origin_addr,
+                                     int origin_count,
+                                     MPI_Datatype origin_datatype,
+                                     int target_rank,
+                                     MPI_Aint target_disp,
+                                     int target_count, MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -620,14 +617,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_put(const void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_rput
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rput(const void *origin_addr,
-                                                 int origin_count,
-                                                 MPI_Datatype origin_datatype,
-                                                 int target_rank,
-                                                 MPI_Aint target_disp,
-                                                 int target_count,
-                                                 MPI_Datatype target_datatype,
-                                                 MPIR_Win * win, MPIR_Request ** request)
+static inline int MPIDI_CH4U_mpi_rput(const void *origin_addr,
+                                      int origin_count,
+                                      MPI_Datatype origin_datatype,
+                                      int target_rank,
+                                      MPI_Aint target_disp,
+                                      int target_count,
+                                      MPI_Datatype target_datatype,
+                                      MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -661,13 +658,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rput(const void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_get
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_get(void *origin_addr,
-                                                int origin_count,
-                                                MPI_Datatype origin_datatype,
-                                                int target_rank,
-                                                MPI_Aint target_disp,
-                                                int target_count, MPI_Datatype target_datatype,
-                                                MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_get(void *origin_addr,
+                                     int origin_count,
+                                     MPI_Datatype origin_datatype,
+                                     int target_rank,
+                                     MPI_Aint target_disp,
+                                     int target_count, MPI_Datatype target_datatype, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -694,14 +690,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_get(void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_rget
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget(void *origin_addr,
-                                                 int origin_count,
-                                                 MPI_Datatype origin_datatype,
-                                                 int target_rank,
-                                                 MPI_Aint target_disp,
-                                                 int target_count,
-                                                 MPI_Datatype target_datatype,
-                                                 MPIR_Win * win, MPIR_Request ** request)
+static inline int MPIDI_CH4U_mpi_rget(void *origin_addr,
+                                      int origin_count,
+                                      MPI_Datatype origin_datatype,
+                                      int target_rank,
+                                      MPI_Aint target_disp,
+                                      int target_count,
+                                      MPI_Datatype target_datatype,
+                                      MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -735,15 +731,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget(void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_raccumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_raccumulate(const void *origin_addr,
-                                                        int origin_count,
-                                                        MPI_Datatype origin_datatype,
-                                                        int target_rank,
-                                                        MPI_Aint target_disp,
-                                                        int target_count,
-                                                        MPI_Datatype target_datatype,
-                                                        MPI_Op op, MPIR_Win * win,
-                                                        MPIR_Request ** request)
+static inline int MPIDI_CH4U_mpi_raccumulate(const void *origin_addr,
+                                             int origin_count,
+                                             MPI_Datatype origin_datatype,
+                                             int target_rank,
+                                             MPI_Aint target_disp,
+                                             int target_count,
+                                             MPI_Datatype target_datatype,
+                                             MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -777,14 +772,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_raccumulate(const void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_accumulate(const void *origin_addr,
-                                                       int origin_count,
-                                                       MPI_Datatype origin_datatype,
-                                                       int target_rank,
-                                                       MPI_Aint target_disp,
-                                                       int target_count,
-                                                       MPI_Datatype target_datatype, MPI_Op op,
-                                                       MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_accumulate(const void *origin_addr,
+                                            int origin_count,
+                                            MPI_Datatype origin_datatype,
+                                            int target_rank,
+                                            MPI_Aint target_disp,
+                                            int target_count,
+                                            MPI_Datatype target_datatype, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -813,18 +807,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_accumulate(const void *origin_addr,
 #define FUNCNAME MPIDI_CH4U_mpi_rget_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget_accumulate(const void *origin_addr,
-                                                            int origin_count,
-                                                            MPI_Datatype origin_datatype,
-                                                            void *result_addr,
-                                                            int result_count,
-                                                            MPI_Datatype result_datatype,
-                                                            int target_rank,
-                                                            MPI_Aint target_disp,
-                                                            int target_count,
-                                                            MPI_Datatype target_datatype,
-                                                            MPI_Op op, MPIR_Win * win,
-                                                            MPIR_Request ** request)
+static inline int MPIDI_CH4U_mpi_rget_accumulate(const void *origin_addr,
+                                                 int origin_count,
+                                                 MPI_Datatype origin_datatype,
+                                                 void *result_addr,
+                                                 int result_count,
+                                                 MPI_Datatype result_datatype,
+                                                 int target_rank,
+                                                 MPI_Aint target_disp,
+                                                 int target_count,
+                                                 MPI_Datatype target_datatype,
+                                                 MPI_Op op, MPIR_Win * win, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -859,17 +852,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget_accumulate(const void *origin_a
 #define FUNCNAME MPIDI_CH4U_mpi_get_accumulate
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_get_accumulate(const void *origin_addr,
-                                                           int origin_count,
-                                                           MPI_Datatype origin_datatype,
-                                                           void *result_addr,
-                                                           int result_count,
-                                                           MPI_Datatype result_datatype,
-                                                           int target_rank,
-                                                           MPI_Aint target_disp,
-                                                           int target_count,
-                                                           MPI_Datatype target_datatype,
-                                                           MPI_Op op, MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_get_accumulate(const void *origin_addr,
+                                                int origin_count,
+                                                MPI_Datatype origin_datatype,
+                                                void *result_addr,
+                                                int result_count,
+                                                MPI_Datatype result_datatype,
+                                                int target_rank,
+                                                MPI_Aint target_disp,
+                                                int target_count,
+                                                MPI_Datatype target_datatype,
+                                                MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -898,12 +891,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_get_accumulate(const void *origin_ad
 #define FUNCNAME MPIDI_CH4U_mpi_compare_and_swap
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_addr,
-                                                             const void *compare_addr,
-                                                             void *result_addr,
-                                                             MPI_Datatype datatype,
-                                                             int target_rank,
-                                                             MPI_Aint target_disp, MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_addr,
+                                                  const void *compare_addr,
+                                                  void *result_addr,
+                                                  MPI_Datatype datatype,
+                                                  int target_rank,
+                                                  MPI_Aint target_disp, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
@@ -970,12 +963,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
 #define FUNCNAME MPIDI_CH4U_mpi_fetch_and_op
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_fetch_and_op(const void *origin_addr,
-                                                         void *result_addr,
-                                                         MPI_Datatype datatype,
-                                                         int target_rank,
-                                                         MPI_Aint target_disp, MPI_Op op,
-                                                         MPIR_Win * win)
+static inline int MPIDI_CH4U_mpi_fetch_and_op(const void *origin_addr,
+                                              void *result_addr,
+                                              MPI_Datatype datatype,
+                                              int target_rank,
+                                              MPI_Aint target_disp, MPI_Op op, MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_FETCH_AND_OP);

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -53,7 +53,6 @@
 #endif /* ATTRIBUTE */
 
 #define MPL_UNUSED ATTRIBUTE((unused))
-#define MPL_STATIC_INLINE_PREFIX ATTRIBUTE((always_inline)) static inline
 
 #ifdef MPL_HAVE_FUNC_ATTRIBUTE_FALLTHROUGH
 #define MPL_FALLTHROUGH ATTRIBUTE((fallthrough))

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -54,7 +54,6 @@
 
 #define MPL_UNUSED ATTRIBUTE((unused))
 #define MPL_STATIC_INLINE_PREFIX ATTRIBUTE((always_inline)) static inline
-#define MPL_STATIC_INLINE_SUFFIX ATTRIBUTE((always_inline))
 
 #ifdef MPL_HAVE_FUNC_ATTRIBUTE_FALLTHROUGH
 #define MPL_FALLTHROUGH ATTRIBUTE((fallthrough))

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -243,7 +243,7 @@ typedef struct {
 #define MPL_munmap(a,b,c)  munmap((void *)(a),(size_t)(b))
 
 #ifdef MPL_DEFINE_ALIGNED_ALLOC
-MPL_STATIC_INLINE_PREFIX void *MPL_aligned_alloc(size_t alignment, size_t size,
+static inline void *MPL_aligned_alloc(size_t alignment, size_t size,
                                                  MPL_memory_class class)
 {
 #if defined (MPL_HAVE_ALIGNED_ALLOC)

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -283,7 +283,7 @@ void MPL_trconfig(int rank, int need_thread_safety)
   Validate given alignment.
   Invoked only when memory tracing is enabled.
  */
-MPL_STATIC_INLINE_PREFIX int is_valid_alignment(size_t a)
+static inline int is_valid_alignment(size_t a)
 {
     /* No alignment constraints - okay */
     if (a == 0)


### PR DESCRIPTION
The static inline attributes are an overkill for inlining.  Regular language-based `static inline` is good enough when the function is available in a header and can be inlined easily by the compiler.