### PR TITLE
CH4 OFI:  Obey the FI_ASYNC_IOV mode flag that is asserted by netmod

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -105,6 +105,8 @@ typedef struct {
     uint8_t pad[6];
     MPIDI_OFI_am_header_t msg_hdr;
     uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE];
+    /* FI_ASYNC_IOV requires an iov storage to be alive until a request completes */
+    struct iovec iov[3];
 } MPIDI_OFI_am_request_header_t;
 
 typedef struct {


### PR DESCRIPTION
 Calculate and allocate the number of iovecs that will be used
 by the iovec state machine to generate the put/get/accumulate lists.

 Currently, we are setting the FI_ASYNC_IOV mode bit, which tells libfabric
 that we (netmod) will provide the storage for all the iovec operations.
 However, we currently do not provide that storage, and some providers
 appear to be providing the storage for iovecs anyways, so we have a
 "double bug" that makes this problem rarely manifest.

 There are a couple ways to fix this:
 1) Disable FI_ASYNC_IOV.  Probably not an optimal option.  We want to avoid
    internal allocations if possible.  If allocations are required anywhere
    in the stack, probably the best place is in the netmod because
    we have the highest level of datatype metadata.  I think what we really
    want to ask libfabric is if a memory copy of the iovec is required.
    In this case, we can allocate it.  If the hardware is going to copy the
    iovec as part of the command, we can use a "per-op" allocation and bypass
    this calculation entirely.
 2) Use a "per-op" allocation of the iovec, and use fi_context to complete.
    This will probably be slow, as injection should be message rate bound
    on fast networks.  By using completions instead of counters, we avoid
    allocation/free of per element storage and the associated overhead.
    The current scheme only uses 1 allocation.
 3) Allocate the required iovecs up front.

 This implements #3, but with some optimizations.  To count the total iovecs
 that will be required, some estimates are used:
 * We scan two elements from each source datatype and
   extraplate the total iovec count from that.
 * We sum the iovec lists as an upper bound, rather than calculate the
   exact use.  We'll calculate this in an exact manner when we replace
   the existing iovec expansion with direct processing of the datatype.
   We should only be using iovecs we actually touch, so in practice
   this shouldn't be a problem.

Fixes csr/mpich-opa#409