### PR TITLE
timers: fix and make optional the PPC64 cycle counter

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -258,26 +258,6 @@ AC_ARG_ENABLE(timer-type,
 
 ## The user did not specify a timer type.  Try to find a sane option
 ## that is supported by the platform.
-dnl Check first for the ppc64 timebase cycle counter, so we would use this
-dnl instead of a timer function.  In a cross-compile environment the timer
-dnl functions may compile but there is no way to check if they are actually
-dnl implemented.
-if test -z "$timer_type" ; then
-dnl First see if the ppc64 timebase asm works
-    AC_CACHE_CHECK([that ppc64 timebase cycle counter is available],
-                pac_cv_ppc64_cycle,[
-    AC_TRY_COMPILE([
-    ],[
-        unsigned temp;
-        asm volatile ("mfspr %0,%1" : "=r" (temp)        : "i" (0x10D));
-    ],pac_cv_ppc64_cycle=yes,
-    pac_cv_ppc64_cycle=no)
-    ])
-    if test "$pac_cv_ppc64_cycle" = "yes" ; then
-        timer_type=ppc64_cycle
-    fi
-fi
-dnl If the ppc64 timebase cycle counter is not found then check the timer funcs
 if test -z "$timer_type" ; then
     # Try to pick a timer based on what is available
     AC_CHECK_FUNCS(clock_gettime clock_getres gethrtime mach_absolute_time gettimeofday)
@@ -527,6 +507,18 @@ pac_cv_ia64_cycle,[
     ;;
 
     ppc64_cycle)
+    AC_CACHE_CHECK([that ppc64 timebase cycle counter is available],
+                pac_cv_ppc64_cycle,[
+    AC_TRY_COMPILE([
+    ],[
+        unsigned temp;
+        asm volatile ("mfspr %0,%1" : "=r" (temp)        : "i" (0x10D));
+    ],pac_cv_ppc64_cycle=yes,
+    pac_cv_ppc64_cycle=no)
+    ])
+    if test "pac_cv_ppc64_cycle" != "yes" ; then
+        AC_MSG_ERROR([The PPC64 cycle counter is not available on this system and or with the $CC compiler])
+    fi
     MPL_TIMER_TYPE="uint64_t"
     ;;
     *)


### PR DESCRIPTION
If the user selects the PPC64 cycle counter, configure does not test
for it properly and fail gracefully. Furthermore, testing for this
counter is always performed by default (when the user did not ask
explicitly for a timer type). One certain platforms (e.g., Intel
compilers on OSX), this mandatory check breaks subsequent configure
tests unintentionally. This patch makes this cycle counter a
user-supplied option only (consistent with the other cycle counters)
and fails gracefully when configure cannot compile the corresponding
assembly.  It also avoids the default check.