### PR TITLE
CH4/generic: Initialize global struct

### DIFF
--- a/src/mpid/ch4/generic/mpidig_globals.c
+++ b/src/mpid/ch4/generic/mpidig_globals.c
@@ -12,4 +12,4 @@
 #include "mpidimpl.h"
 #include "mpidig.h"
 
-MPIDIG_global_t MPIDIG_global;
+MPIDIG_global_t MPIDIG_global = { 0 };


### PR DESCRIPTION
Builds with weak symbol support disabled broke with commit ad7a404dd5bd.
Initializing this global struct makes linking MPI/PMPI statically happy
again in these configurations.