### PR TITLE
CH4: Fix builds with multiple netmods

### DIFF
--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -11,6 +11,7 @@
 
 #include "mpidimpl.h"
 #include "mpidig.h"
+#include "mpidch4r.h"
 
 #undef FUNCNAME
 #define FUNCNAME MPIDIG_am_reg_cb


### PR DESCRIPTION
The MPIDIG path is missing an include for the CH4R callbacks. This shows
up when building with multiple netmods. Add the include to the
appropriate file.

Fix pmodels/mpich#2433