### PR TITLE
Bgq romio ch4 enablement

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -18,7 +18,7 @@
 #include "ad_gpfs_aggrs.h"
 
 #ifdef BGQPLATFORM
-#include <mpix.h>
+#include "bg/ad_bg_pset.h"
 #endif
 
 #ifdef AGGREGATION_PROFILE
@@ -583,7 +583,7 @@ static int gpfs_find_access_for_ion(ADIO_File fd,
 	ADIO_Offset *fd_start, ADIO_Offset *fd_end,
 	ADIO_Offset *start, ADIO_Offset *end)
 {
-    int my_ionode = MPIX_IO_node_id();
+    int my_ionode = BGQ_IO_node_id();
     int *rank_to_ionode;
     int i, nprocs, rank;
     ADIO_Offset group_start=LLONG_MAX, group_end=0;

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
@@ -281,6 +281,14 @@ ADIOI_BG_compute_agg_ranklist_serial_do (const ADIOI_BG_ConfInfo_t *confInfo,
           }
         }
         currentNumHops++;
+        /* Handle the case where the numAggs is more than exists starting
+         * at gpfsmpio_bridgeringagg hops, wrap back and restart at 0 to
+         * assign the overrun - it is up to the user to realize this
+         * situation and adjust numAggs and gpfsmpio_bridgeringagg
+         * accordingly.
+         */
+        if (currentNumHops > 16)
+          currentNumHops = 0;
         /* If 3 rounds go by without selecting an agg abort to avoid
            infinite loop.
         */

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_aggrs.c
@@ -428,7 +428,7 @@ ADIOI_BG_compute_agg_ranklist_serial ( ADIO_File fd,
 
 #   if AGG_DEBUG
     for (i=0; i<confInfo->nProcs; i++) {
-      DBG_FPRINTF(stderr, "\tcpuid %1d, rank = %6d\n", all_procInfo[i].coreID, all_procInfo[i].rank );
+      DBG_FPRINTF(stderr, "\trank = %6d\n", all_procInfo[i].rank );
     }
 #   endif
 
@@ -437,14 +437,13 @@ ADIOI_BG_compute_agg_ranklist_serial ( ADIO_File fd,
 
 #   define VERIFY 1
 #   if VERIFY
-    DBG_FPRINTF(stderr, "\tconfInfo = min: %3d, max: %3d, naggrs: %3d, bridge: %3d, nprocs: %3d, vpset: %3d, tsize: %3d, ratio: %.4f; naggs = %d\n", 
+    DBG_FPRINTF(stderr, "\tconfInfo = min: %3d, max: %3d, naggrs: %3d, bridge: %3d, nprocs: %3d, vpset: %3d, ratio: %.4f; naggs = %d\n",
 	    confInfo->ioMinSize        ,
 	    confInfo->ioMaxSize        ,
 	    confInfo->nAggrs           ,
 	    confInfo->numBridgeRanks ,
 	    confInfo->nProcs          ,
 	    confInfo->ioMaxSize /*virtualPsetSize*/          ,
-      confInfo->cpuIDsize,
 	    confInfo->aggRatio        ,
 	    naggs );
 #   endif

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_pset.h
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_pset.h
@@ -17,9 +17,6 @@
 #ifndef AD_BG_PSET_H_
 #define AD_BG_PSET_H_
 
-#ifdef HAVE_MPIX_H
-#include <mpix.h>
-#endif
 
 /* Keeps specific information to each process, will be exchanged among processes */
 typedef struct {
@@ -28,7 +25,6 @@ typedef struct {
    int ionID;  /* ion id this cn is using */
 /*   int myCoords[5]; */
    int bridgeRank; /* my bridge node (or proxy) rank */
-   unsigned char coreID;
    unsigned char threadID; /* unlikely to be useful but better than just padding */
    unsigned char __cpad[2];
    int myIOSize;  /* number of ranks sharing my bridge/IO
@@ -70,6 +66,7 @@ typedef struct {
 
 
 /* public funcs for a pair of ADIOI_BG_ConfInfo_t and ADIOI_BG_ProcInfo_t objects */
+    int BGQ_IO_node_id ();
     void ADIOI_BG_persInfo_init( ADIOI_BG_ConfInfo_t *conf,
 				  ADIOI_BG_ProcInfo_t *proc,
 				  int s, int r, int n_aggrs, MPI_Comm comm);

--- a/src/mpi/romio/adio/common/ad_close.c
+++ b/src/mpi/romio/adio/common/ad_close.c
@@ -61,7 +61,7 @@ void ADIO_Close(ADIO_File fd, int *error_code)
     }
 
     if (fd->hints) ADIOI_Free(fd->hints->ranklist);
-    if (fd->hints) ADIOI_Free(fd->hints->cb_config_list);
+    if (fd->hints && fd->hints->cb_config_list) ADIOI_Free(fd->hints->cb_config_list);
 
     /* This BlueGene platform-specific free must be done in the common code
      * because the malloc's for these hint data structures are done at the
@@ -71,10 +71,8 @@ void ADIO_Close(ADIO_File fd, int *error_code)
      * ADIOI_GPFS_Close and re-open via ADIOI_GPFS_Open are done which results
      * in a double-free - ADIOI_GPFS_Open does not redo the SetInfo...  */
 #ifdef BGQPLATFORM
-    if (fd->hints)
-      ADIOI_Free(fd->hints->fs_hints.bg.bridgelist);
-    if (fd->hints)
-      ADIOI_Free(fd->hints->fs_hints.bg.bridgelistnum);
+    if (fd->hints && fd->hints->fs_hints.bg.bridgelist) ADIOI_Free(fd->hints->fs_hints.bg.bridgelist);
+    if (fd->hints && fd->hints->fs_hints.bg.bridgelistnum) ADIOI_Free(fd->hints->fs_hints.bg.bridgelistnum);
 #endif
 
     /* Persistent File Realms */


### PR DESCRIPTION
There was pamid-specific (MPIX) code in the BGQ ROMIO files that needed to be replaced with SPI calls.  There were also some bugs in BGQ ROMIO exposed by running CH4 that needed to be fixed.
