### PR TITLE
CH4 Cancel Cleanup

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -113,9 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
             MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(rreq)) = NULL;
             MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(rreq) = NULL;
         }
-
-        if (!continue_matching)
-            goto fn_exit;
+        MPIR_Request_free(rreq);
     }
 
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -42,8 +42,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_IRECV);
 
-    if (mode == MPIDI_OFI_ON_HEAP)      /* Branch should compile out */
+    if (mode == MPIDI_OFI_ON_HEAP) {    /* Branch should compile out */
         MPIDI_OFI_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__RECV);
+        /* Need to set the source to UNDEFINED for anysource matching */
+        rreq->status.MPI_SOURCE = MPI_UNDEFINED;
+    }
     else if (mode == MPIDI_OFI_USE_EXISTING) {
         rreq = *request;
         rreq->kind = MPIR_REQUEST_KIND__RECV;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -279,15 +279,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
         goto fn_exit;
     }
 
-#ifndef MPIDI_BUILD_CH4_SHM
-    MPIDI_OFI_PROGRESS();
-#endif /* MPIDI_BUILD_CH4_SHM */
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
     ret = fi_cancel((fid_t) MPIDI_OFI_EP_RX_TAG(0), &(MPIDI_OFI_REQUEST(rreq, context)));
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
 
     if (ret == 0) {
         while ((!MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) && (!MPIR_cc_is_complete(&rreq->cc))) {
+            /* The cancel is local and must complete, so only poll this device (not global progress) */
             if ((mpi_errno =
                  MPIDI_NM_progress(0, 0)) != MPI_SUCCESS)
                 goto fn_exit;


### PR DESCRIPTION
Locks were being unnecessary cycled in the CH4 netmod/shmemod layers. This moves all of that up to the CH4 layer so things are consistent. The original authors are @charlesarcher and @zhenggb72.

The changes in #2369 sit on top of this PR.