### PR TITLE
mpl/thread/solaris: Fix compilation issues

### DIFF
--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -13,6 +13,7 @@
 typedef mutex_t MPL_thread_mutex_t;
 typedef cond_t MPL_thread_cond_t;
 typedef thread_t MPL_thread_id_t;
+typedef thread_key_t MPL_thread_tls_t;
 
 typedef void (*MPL_thread_func_t) (void *data);
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id, int *err);
@@ -43,12 +44,15 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
  *    Mutexes
  */
 
-#define MPL_thread_mutex_create(mutex_ptr_, err_ptr_)	\
-    do {                                                \
-        *(mutex_ptr_) = DEFAULTMUTEX;			\
-        if ((err_ptr_) == NULL) {                       \
-            *(err_ptr_) = MPL_THREAD_SUCCESS;		\
-        }                                               \
+#define MPL_thread_mutex_create(mutex_ptr_, err_ptr_)                   \
+    do {                                                                \
+        if ((err_ptr_) == NULL) {                                       \
+            mutex_init(mutex_ptr_, USYNC_THREAD, NULL);                 \
+        }                                                               \
+        else {                                                          \
+            *(err_ptr_) = mutex_init(mutex_ptr_, USYNC_THREAD, NULL);   \
+            /* FIXME: convert error to an MPL_THREAD_ERR value */       \
+        }                                                               \
     } while (0)
 
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_)                 \
@@ -89,12 +93,15 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
  * Condition Variables
  */
 
-#define MPL_thread_cond_create(cond_ptr_, err_ptr_)	\
-    do {                                                \
-        *(cond_ptr_) = DEFAULTCV;                       \
-        if ((err_ptr_) == NULL) {                       \
-            *(err_ptr_) = MPL_THREAD_SUCCESS;		\
-        }                                               \
+#define MPL_thread_cond_create(cond_ptr_, err_ptr_)                     \
+    do {                                                                \
+        if ((err_ptr_) == NULL) {                                       \
+            cond_init(cond_ptr_, NULL, NULL);                           \
+        }                                                               \
+        else {                                                          \
+            *(err_ptr_) == cond_init(cond_ptr_, NULL, NULL);            \
+            /* FIXME: convert error to an MPL_THREAD_ERR value */	\
+        }                                                               \
     } while (0)
 
 #define MPL_thread_cond_destroy(cond_ptr_, err_ptr_)                   \
@@ -148,11 +155,11 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
 #define MPL_thread_tls_create(exit_func_ptr_, tls_ptr_, err_ptr_)	\
     do {                                                                \
         if ((err_ptr_) == NULL) {                                       \
-            thr_keycreate((tls_ptr), (exit_func_ptr));			\
+            thr_keycreate((tls_ptr_), (exit_func_ptr_));                \
         }                                                               \
         else {								\
-            *(err_ptr_) = thr_keycreate((tls_ptr), (exit_func_ptr));	\
-            /* FIXME: convert error to a MPL_THREAD_ERR value */       \
+            *(err_ptr_) = thr_keycreate((tls_ptr_), (exit_func_ptr_));	\
+            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
         }                                                               \
     } while (0)
 
@@ -166,29 +173,29 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
          * have shutdown from continuing to receive callbacks.          \
          */                                                             \
         if ((err_ptr_) != NULL) {                                       \
-            *(err_ptr) = MPL_THREAD_SUCCESS;                           \
+            *(err_ptr_) = MPL_THREAD_SUCCESS;                           \
         }                                                               \
     } while (0)
 
-#define MPL_thread_tls_set(tls_ptr, value_)                            \
+#define MPL_thread_tls_set(tls_ptr_, value_, err_ptr_)                  \
     do {                                                                \
         if ((err_ptr_) == NULL) {                                       \
-            thr_setspecific(*(tls_ptr), (value_));			\
+            thr_setspecific(*(tls_ptr_), (value_));			\
         }								\
         else {                                                          \
-            *(err_ptr_) = thr_setspecific(*(tls_ptr), (value_));	\
+            *(err_ptr_) = thr_setspecific(*(tls_ptr_), (value_));	\
             /* FIXME: convert error to a MPL_THREAD_ERR value */	\
         }								\
     } while (0)
 
-#define MPL_thread_tls_get(tls_ptr, value_ptr_)                        \
+#define MPL_thread_tls_get(tls_ptr_, value_ptr_, err_ptr_)              \
     do {                                                                \
         if ((err_ptr_) == NULL) {                                       \
-            thr_setspecific(*(tls_ptr), (value_ptr_));			\
+            thr_setspecific(*(tls_ptr_), (value_ptr_));			\
         }                                                               \
         else {								\
-            *(err_ptr_) = thr_setspecific(*(tls_ptr), (value_ptr_));	\
-            /* FIXME: convert error to a MPL_THREAD_ERR value */       \
+            *(err_ptr_) = thr_setspecific(*(tls_ptr_), (value_ptr_));	\
+            /* FIXME: convert error to a MPL_THREAD_ERR value */        \
         }                                                               \
     } while (0)
 


### PR DESCRIPTION
There was some missing functionality, mismatched variable names, and
outright wrong code in the Solaris thread support header. This should
get things back to a buildable state.