### PR TITLE
CH4: Namespace MPIDI_NM_mpi_probe

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_probe.h
@@ -13,7 +13,7 @@
 
 #include "ofi_impl.h"
 
-static inline int MPIDI_NM_probe(int source,
+static inline int MPIDI_NM_mpi_probe(int source,
                                  int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
 {
     return MPIDI_CH4U_probe(source, tag, comm, context_offset, status);

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -97,15 +97,15 @@ static inline int MPIDI_OFI_do_iprobe(int source,
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_NM_probe
+#define FUNCNAME MPIDI_NM_mpi_probe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_probe(int source,
-                                 int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
+static inline int MPIDI_NM_mpi_probe(int source,
+                                     int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS, flag = 0;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROBE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROBE);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_PROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PROBE);
 
     while (!flag) {
         mpi_errno = MPIDI_Iprobe(source, tag, comm, context_offset, &flag, status);
@@ -117,7 +117,7 @@ static inline int MPIDI_NM_probe(int source,
     }
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROBE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_PROBE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/portals4/ptl_probe.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_probe.h
@@ -13,7 +13,7 @@
 
 #include "ptl_impl.h"
 
-static inline int MPIDI_NM_probe(int source,
+static inline int MPIDI_NM_mpi_probe(int source,
                                  int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
 {
     return MPIDI_CH4U_probe(source, tag, comm, context_offset, status);

--- a/src/mpid/ch4/netmod/stubnm/stubnm_probe.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_probe.h
@@ -13,8 +13,8 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_probe(int source,
-                                 int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
+static inline int MPIDI_NM_mpi_probe(int source,
+                                     int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
 {
     return MPIDI_CH4U_probe(source, tag, comm, context_offset, status);
 }


### PR DESCRIPTION
The MPIDI_NM_probe function was missed in the big namespace. Add the
_mpi_ to the name.