### PR TITLE
CH4/UCX: Remove ucp_request pointer in MPIR_Request

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -26,10 +26,7 @@ typedef struct {
 } MPIDI_UCX_dt_t;
 
 typedef struct {
-    union {
-        ucp_tag_message_h message_handler;
-        MPIDI_UCX_ucp_request_t *ucp_request;
-    } a;
+    ucp_tag_message_h message_handler;
 } MPIDI_UCX_request_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -69,7 +69,7 @@ static inline int MPIDI_NM_mpi_improbe(int source,
     *flag = 1;
     req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
     MPIR_Assert(req);
-    MPIDI_UCX_REQ(req).a.message_handler = message_handler;
+    MPIDI_UCX_REQ(req).message_handler = message_handler;
     if (status == MPI_STATUS_IGNORE)
         goto fn_exit;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -39,14 +39,12 @@ MPL_STATIC_INLINE_PREFIX int ucx_irecv_continous(void *buf,
     if (ucp_request->req == NULL) {
         req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
         MPIR_Request_add_ref(req);
-        MPIDI_UCX_REQ(req).a.ucp_request = ucp_request;
         ucp_request->req = req;
         ucp_request_release(ucp_request);
     }
     else {
         req = ucp_request->req;
         ucp_request->req = NULL;
-        MPIDI_UCX_REQ(req).a.ucp_request = NULL;
         ucp_request_release(ucp_request);
     }
   fn_exit:
@@ -87,13 +85,11 @@ MPL_STATIC_INLINE_PREFIX int ucx_irecv_non_continous(void *buf,
         req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
-        MPIDI_UCX_REQ(req).a.ucp_request = ucp_request;
         ucp_request_release(ucp_request);
     }
     else {
         req = ucp_request->req;
 
-        MPIDI_UCX_REQ(req).a.ucp_request = NULL;
         ucp_request->req = NULL;
         ucp_request_release(ucp_request);
     }
@@ -180,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
         goto fn_exit;
     }
 
-    message_handler = MPIDI_UCX_REQ(message).a.message_handler;
+    message_handler = MPIDI_UCX_REQ(message).message_handler;
     if (dt_contig)
         ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
                                                                       (char *) buf + dt_true_lb,
@@ -236,8 +232,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
 static inline int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
 {
 
-    if (MPIDI_UCX_REQ(rreq).a.ucp_request) {
-        ucp_request_cancel(MPIDI_UCX_global.worker, MPIDI_UCX_REQ(rreq).a.ucp_request);
+    if (!MPIR_Request_is_complete(rreq)) {
+        ucp_request_cancel(MPIDI_UCX_global.worker, MPL_container_of(rreq, MPIDI_UCX_ucp_request_t, req));
     }
 
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -98,11 +98,9 @@ static inline int MPIDI_UCX_send(const void *buf,
         req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
-        MPIDI_UCX_REQ(req).a.ucp_request = ucp_request;
     } else if (have_request) {
         req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
         MPIR_cc_set(&req->cc, 0);
-        MPIDI_UCX_REQ(req).a.ucp_request = NULL;
     }
     *request = req;
 
@@ -273,9 +271,8 @@ static inline int MPIDI_NM_mpi_issend(const void *buf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
 {
-    if (MPIDI_UCX_REQ(sreq).a.ucp_request) {
-        ucp_request_cancel(MPIDI_UCX_global.worker, MPIDI_UCX_REQ(sreq).a.ucp_request);
-        ucp_request_release(MPIDI_UCX_REQ(sreq).a.ucp_request);
+    if (!MPIR_Request_is_complete(sreq)) {
+        ucp_request_cancel(MPIDI_UCX_global.worker, MPL_container_of(sreq, MPIDI_UCX_ucp_request_t, req));
     }
 }
 


### PR DESCRIPTION
This pointer is not necessary. It can be inferred using the
MPL_container_of macro and completion status of the MPIR_Request.