### PR TITLE
CH4: Remove unnecessary netmod functions

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -94,39 +94,6 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     goto fn_exit;
 }
 
-
-#undef FUNCNAME
-#define FUNCNAME MPIDI_NM_probe
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_probe(int source,
-                                 int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
-{
-    int mpi_errno = MPI_SUCCESS, flag = 0;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROBE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROBE);
-
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDI_CH4U_probe(source, tag, comm, context_offset, status);
-        goto fn_exit;
-    }
-
-    while (!flag) {
-        mpi_errno = MPIDI_Iprobe(source, tag, comm, context_offset, &flag, status);
-
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-
-        MPIDI_OFI_PROGRESS();
-    }
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROBE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 #undef FUNCNAME
 #define FUNCNAME MPIDI_NM_mpi_improbe
 #undef FCNAME

--- a/src/mpid/ch4/netmod/portals4/ptl_probe.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_probe.h
@@ -13,12 +13,6 @@
 
 #include "ptl_impl.h"
 
-static inline int MPIDI_NM_probe(int source,
-                                 int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
-{
-    return MPIDI_CH4U_probe(source, tag, comm, context_offset, status);
-}
-
 static inline int MPIDI_NM_mpi_improbe(int source,
                                        int tag,
                                        MPIR_Comm * comm,

--- a/src/mpid/ch4/netmod/portals4/ptl_send.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_send.h
@@ -23,28 +23,6 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
     return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
-static inline int MPIDI_NM_rsend(const void *buf,
-                                 int count,
-                                 MPI_Datatype datatype,
-                                 int rank,
-                                 int tag,
-                                 MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_rsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
-
-
-static inline int MPIDI_NM_irsend(const void *buf,
-                                  int count,
-                                  MPI_Datatype datatype,
-                                  int rank,
-                                  int tag,
-                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_irsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
 static inline int MPIDI_NM_mpi_ssend(const void *buf,
                                      int count,
                                      MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_probe.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_probe.h
@@ -13,12 +13,6 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_probe(int source,
-                                 int tag, MPIR_Comm * comm, int context_offset, MPI_Status * status)
-{
-    return MPIDI_CH4U_probe(source, tag, comm, context_offset, status);
-}
-
 static inline int MPIDI_NM_mpi_improbe(int source,
                                        int tag,
                                        MPIR_Comm * comm,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_send.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_send.h
@@ -23,28 +23,6 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
     return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
-static inline int MPIDI_NM_rsend(const void *buf,
-                                 int count,
-                                 MPI_Datatype datatype,
-                                 int rank,
-                                 int tag,
-                                 MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_rsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
-
-
-static inline int MPIDI_NM_irsend(const void *buf,
-                                  int count,
-                                  MPI_Datatype datatype,
-                                  int rank,
-                                  int tag,
-                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_irsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
 static inline int MPIDI_NM_mpi_ssend(const void *buf,
                                      int count,
                                      MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/ucx/ucx_am_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_send.h
@@ -23,28 +23,6 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
     return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, request);
 }
 
-static inline int MPIDI_NM_rsend(const void *buf,
-                                 int count,
-                                 MPI_Datatype datatype,
-                                 int rank,
-                                 int tag,
-                                 MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_rsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
-
-
-static inline int MPIDI_NM_irsend(const void *buf,
-                                  int count,
-                                  MPI_Datatype datatype,
-                                  int rank,
-                                  int tag,
-                                  MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDIG_mpi_irsend(buf, count, datatype, rank, tag, comm, context_offset, request);
-}
-
 static inline int MPIDI_NM_mpi_ssend(const void *buf,
                                      int count,
                                      MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -128,35 +128,6 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_NM_mpi_rsend
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_mpi_rsend(const void *buf,
-                                     int count,
-                                     MPI_Datatype datatype,
-                                     int rank,
-                                     int tag,
-                                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset, request, 0, 0);
-}
-
-
-#undef FUNCNAME
-#define FUNCNAME MPIDI_NM_mpi_irsend
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_mpi_irsend(const void *buf,
-                                      int count,
-                                      MPI_Datatype datatype,
-                                      int rank,
-                                      int tag,
-                                      MPIR_Comm * comm, int context_offset, MPIR_Request ** request)
-{
-    return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0);
-}
-
-#undef FUNCNAME
 #define FUNCNAME MPIDI_NM_mpi_ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -67,32 +67,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_Probe
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_probe(int source,
-                                              int tag,
-                                              MPIR_Comm * comm, int context_offset,
-                                              MPI_Status * status)
-{
-    int mpi_errno, flag = 0;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_PROBE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_PROBE);
-
-    while (!flag) {
-        mpi_errno = MPIDI_CH4U_mpi_iprobe(source, tag, comm, context_offset, &flag, status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-    }
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_PROBE);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-#undef FUNCNAME
 #define FUNCNAME MPIDI_CH4U_mpi_improbe
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)


### PR DESCRIPTION
Three netmod functions were never used and had been left behind with
previous namespace changes. Remove them to avoid confusion:

MPIDI_NM_probe
MPIDI_NM_rsend
MPIDI_NM_irsend