### PR TITLE
Add hook for non-continues loc-datatypes

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -81,8 +81,12 @@ static inline ucs_status_t MPIDI_UCX_Unpack(void *state, size_t offset, const vo
 
     struct MPIDI_UCX_pack_state *pack_state = (struct MPIDI_UCX_pack_state *) state;
     size_t last = MPL_MIN(pack_state->packsize, offset + count);
+    size_t last_pack = last;
 
     MPID_Segment_unpack(pack_state->segment_ptr, offset, &last, (void *) src);
+    if (unlikely(last != last_pack)) {
+        return UCS_ERR_MESSAGE_TRUNCATED;
+    }
 
     return UCS_OK;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -37,6 +37,8 @@ static inline void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t status,
 
     if (unlikely(status == UCS_ERR_CANCELED)) {
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
+    } else if (unlikely(status == UCS_ERR_MESSAGE_TRUNCATED)) {
+        rreq->status.MPI_ERROR = MPI_ERR_TRUNCATE;
     } else {
         MPI_Aint count = info->length;
         rreq->status.MPI_ERROR = MPI_SUCCESS;

--- a/src/mpid/common/datatype/mpidu_type_create_pairtype.c
+++ b/src/mpid/common/datatype/mpidu_type_create_pairtype.c
@@ -207,6 +207,12 @@ int MPIDU_Type_create_pairtype(MPI_Datatype type,
 					    MPIDU_DATALOOP_HETEROGENEOUS);
     }
 
+#ifdef MPID_Type_commit_hook
+    if (!err) {
+        err =  MPID_Type_commit_hook(new_dtp);
+    }
+#endif /* MPID_Type_commit_hook */
+
     /* --BEGIN ERROR HANDLING-- */
     if (err) {
 	mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,


### PR DESCRIPTION
Some of the loc-datatypes (used for MAXLOC and MINLOC in allreduce) are non-continues. We need to
init these types for UCX to get correct results

This is an initial draft for the proof of concept.
Need a cleaner solution before merging!  