### PR TITLE
CH4/UCX: Fix potential memory leak

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -256,8 +256,6 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
         ucp_request_release(pending[i]);
     }
 
-    MPL_free(pending);
-
     pmi_errno = PMI_Barrier();
     MPIDI_UCX_PMI_ERROR(pmi_errno);
 
@@ -279,6 +277,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     PMI_Finalize();
 
   fn_exit:
+    MPL_free(pending);
     return mpi_errno;
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
An error condition could cause the array of pending disconnect
requests to leak. Free it at fn_exit to be safe.

Fixes CID #158203.

No reviewer.