### PR TITLE
CH4 Set Win-Info after initilalization

### DIFF
--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -140,10 +140,6 @@ static inline int MPIDI_CH4R_win_init(MPI_Aint length,
     win->copyDispUnit = 0;
     win->copySize = 0;
     MPIDI_CH4U_WIN(win, shared_table) = NULL;
-    if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
-        mpi_errno = MPIDI_CH4R_mpi_win_set_info(win, info);
-        MPIR_Assert(mpi_errno == 0);
-    }
 
     /* Initialize the info (hint) flags per window */
     MPIDI_CH4U_WIN(win, info_args).no_locks = 0;
@@ -154,6 +150,13 @@ static inline int MPIDI_CH4R_win_init(MPI_Aint length,
     MPIDI_CH4U_WIN(win, info_args).accumulate_ops = MPIDI_CH4I_ACCU_SAME_OP_NO_OP;
     MPIDI_CH4U_WIN(win, info_args).same_size = 0;
     MPIDI_CH4U_WIN(win, info_args).alloc_shared_noncontig = 0;
+
+    if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
+        mpi_errno = MPIDI_CH4R_mpi_win_set_info(win, info);
+        MPIR_Assert(mpi_errno == 0);
+    }
+
+
     MPIDI_CH4U_WIN(win, mmap_sz) = 0;
     MPIDI_CH4U_WIN(win, mmap_addr) = NULL;
 

--- a/test/mpi/rma/win_info.c
+++ b/test/mpi/rma/win_info.c
@@ -28,9 +28,34 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
+    /* Test#1: setting a valid key at window-create time */
+
+    MPI_Info_create(&info_in);
+    MPI_Info_set(info_in, "no_locks", "true");
+
+    MPI_Win_allocate(sizeof(int), sizeof(int), info_in, MPI_COMM_WORLD, &base, &win);
+
+    MPI_Win_get_info(win, &info_out);
+
+    MPI_Info_get(info_out, "no_locks", MPI_MAX_INFO_VAL, buf, &flag);
+    if (!flag || strncmp(buf, "true", strlen("true")) != 0) {
+        if (!flag)
+            printf("%d: no_locks is not defined\n", rank);
+        else
+            printf("%d: no_locks = %s, expected true\n", rank, buf);
+        errors++;
+    }
+
+    MPI_Info_free(&info_in);
+    MPI_Info_free(&info_out);
+
+    /* We create a new window with no info argument for the next text to ensure that we have the
+     * default settings */
+
+    MPI_Win_free(&win);
     MPI_Win_allocate(sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &base, &win);
 
-    /* Test#1: setting and getting invalid key */
+    /* Test#2: setting and getting invalid key */
 
     MPI_Info_create(&info_in);
     MPI_Info_set(info_in, invalid_key, "true");
@@ -52,7 +77,7 @@ int main(int argc, char **argv)
     MPI_Info_free(&info_in);
     MPI_Info_free(&info_out);
 
-    /* Test#2: setting info key "no_lock" to false and getting the key */
+    /* Test#3: setting info key "no_lock" to false and getting the key */
 
     MPI_Info_create(&info_in);
     MPI_Info_set(info_in, "no_locks", "false");
@@ -74,7 +99,7 @@ int main(int argc, char **argv)
     MPI_Info_free(&info_in);
     MPI_Info_free(&info_out);
 
-    /* Test#3: setting info key "no_lock" to true and getting the key */
+    /* Test#4: setting info key "no_lock" to true and getting the key */
 
     MPI_Info_create(&info_in);
     MPI_Info_set(info_in, "no_locks", "true");


### PR DESCRIPTION
Move MPIDI_CH4R_mpi_win_set_info after the initialization of the info-objects, otherwise the info
arguments are overwritten