### PR TITLE
Make version strings public

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -48,15 +48,15 @@ typedef enum MPIR_Lang_t {
 #endif
 } MPIR_Lang_t;
 
-extern const char MPII_Version_string[];
-extern const char MPII_Version_date[];
-extern const char MPII_Version_configure[];
-extern const char MPII_Version_device[];
-extern const char MPII_Version_CC[];
-extern const char MPII_Version_CXX[];
-extern const char MPII_Version_F77[];
-extern const char MPII_Version_FC[];
-extern const char MPII_Version_custom[];
+extern const char MPII_Version_string[] MPICH_API_PUBLIC;
+extern const char MPII_Version_date[] MPICH_API_PUBLIC;
+extern const char MPII_Version_configure[] MPICH_API_PUBLIC;
+extern const char MPII_Version_device[] MPICH_API_PUBLIC;
+extern const char MPII_Version_CC[] MPICH_API_PUBLIC;
+extern const char MPII_Version_CXX[] MPICH_API_PUBLIC;
+extern const char MPII_Version_F77[] MPICH_API_PUBLIC;
+extern const char MPII_Version_FC[] MPICH_API_PUBLIC;
+extern const char MPII_Version_custom[] MPICH_API_PUBLIC;
 
 int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype);

--- a/src/mpi/init/initinfo.c
+++ b/src/mpi/init/initinfo.c
@@ -4,7 +4,7 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include "mpi.h"
+#include "mpiimpl.h"
 #include "mpichinfo.h"
 /* 
    Global definitions of variables that hold information about the


### PR DESCRIPTION
Version strings are needed by the mpichversion binary, therefore need to
be externally visible. Fixes #2471