### PR TITLE
Fix crash in Nemesis shared memory barrier

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_defs.h
@@ -67,9 +67,18 @@ static inline MPID_nem_cell_rel_ptr_t MPID_NEM_ABS_TO_REL (MPID_nem_cell_ptr_t a
 #define MPID_NEM_LOCAL_RANK(grank) (MPID_nem_mem_region.local_ranks[grank])
 
 #define MPID_NEM_NUM_BARRIER_VARS 16
+
+enum MPIDI_CH3I_nem_barrier_var_occupation {
+    MPIDI_CH3I_NEM_BARRIER_VAR_EMPTY = 0,
+    MPIDI_CH3I_NEM_BARRIER_VAR_OCCUPIED,
+};
+
 typedef struct MPID_nem_barrier_vars
 {
-    OPA_int_t context_id;
+/* Represents if this slot is occupied, by a value of with type
+   enum MPIDI_CH3I_nem_barrier_var_occupation.
+   FIXME: essentially a one-bit information. Opportunity for packing? */
+    OPA_int_t occupied;
     OPA_int_t usage_cnt;
     OPA_int_t cnt;
 #if MPID_NEM_CACHE_LINE_LEN != SIZEOF_INT

--- a/src/mpid/ch3/channels/nemesis/src/ch3i_comm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3i_comm.c
@@ -208,6 +208,13 @@ static int barrier(MPIR_Comm *comm_ptr, MPIR_Errflag_t *errflag)
 
     barrier_vars = comm_ptr->dev.ch.barrier_vars;
 
+    /*
+      Perform the barrier, based on the centralized sense-reversing barrier [1]
+
+      [1] John M. Mellor-Crummey and Michael L. Scott. 1991. Algorithms for
+      scalable synchronization on shared-memory multiprocessors. ACM
+      Trans. Comput. Syst. 9, 1 (February 1991), 21-65.
+    */
     sense = OPA_load_int(&barrier_vars->sig);
     OPA_read_barrier();
 

--- a/src/mpid/ch3/src/mpid_finalize.c
+++ b/src/mpid/ch3/src/mpid_finalize.c
@@ -111,11 +111,6 @@ int MPID_Finalize(void)
     if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 #endif
 
-    /* Note that the CH3I_Progress_finalize call has been removed; the
-       CH3_Finalize routine should call it */
-    mpi_errno = MPIDI_CH3_Finalize();
-    if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
-
 #ifdef MPID_NEEDS_ICOMM_WORLD
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.icomm_world);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -126,6 +121,11 @@ int MPID_Finalize(void)
 
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_world);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+
+    /* Note that the CH3I_Progress_finalize call has been removed; the
+       CH3_Finalize routine should call it */
+    mpi_errno = MPIDI_CH3_Finalize();
+    if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 
     /* Tell the process group code that we're done with the process groups.
        This will notify PMI (with PMI_Finalize) if necessary.  It


### PR DESCRIPTION
There has been an option to turn on the Nemesis shared memory collectives but it has never worked (#2476) because its barrier implementation was incomplete. This PR addresses several issues around the shared memory barrier.

This has been reviewed by @pavanbalaji. I think I have addressed all of his comments so far.

Fixes #2476.
