### PR TITLE
mpl/bt: Include header when checking for decls

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -843,7 +843,7 @@ AC_CHECK_FUNCS(backtrace_symbols)
 AC_CHECK_LIB(backtrace, backtrace_create_state)
 AC_CHECK_LIB(unwind, unw_backtrace)
 
-AC_CHECK_DECLS([backtrace_create_state, backtrace_print])
+AC_CHECK_DECLS([backtrace_create_state, backtrace_print], [], [], [[#include <backtrace.h>]])
 
 dnl Check for ATTRIBUTE
 PAC_C_GNU_ATTRIBUTE


### PR DESCRIPTION
Checking for backtrace symbols will always fail if we do not include the
backtrace.h header. This could lead to duplicate definition compile
error during strict build.