### PR TITLE
Avoid overwriting cached value in simple-pmi

### DIFF
--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -103,6 +103,7 @@ static int PMI_totalview = 0;
 #endif
 static int PMIi_InitIfSingleton(void);
 static int accept_one_connection(int);
+static int cached_singinit_inuse = 0;
 static char cached_singinit_key[PMIU_MAXLINE];
 static char cached_singinit_val[PMIU_MAXLINE];
 static char singinit_kvsname[256];
@@ -389,10 +390,13 @@ int PMI_KVS_Put( const char kvsname[], const char key[], const char value[] )
 
     /* This is a special hack to support singleton initialization */
     if (PMI_initialized == SINGLETON_INIT_BUT_NO_PM) {
+        if (cached_singinit_inuse)
+            return PMI_FAIL;
 	rc = MPL_strncpy(cached_singinit_key,key,PMI_keylen_max);
 	if (rc != 0) return PMI_FAIL;
 	rc = MPL_strncpy(cached_singinit_val,value,PMI_vallen_max);
 	if (rc != 0) return PMI_FAIL;
+        cached_singinit_inuse = 1;
 	return PMI_SUCCESS;
     }
     


### PR DESCRIPTION
In a singleton init without PM, multiple calls to PMI_KVS_Put will
overwrite a cached value without adding it to a KVS.  This patch returns
an error rather than overwriting the cached value.

Signed-off-by: James Dinan <james.dinan@intel.com>