### PR TITLE
CH4/OFI: Fix the runtime check for FI_EP_RDM

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -354,7 +354,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                 continue;
 
             /* Check that the provider has all of the requirements of MPICH */
-            } else if (prov_use->ep_attr->type == FI_EP_RDM) {
+            } else if (prov_use->ep_attr->type != FI_EP_RDM) {
                 MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "Provider doesn't support RDM"));
                 fprintf(stderr, "Doesn't support RDM\n");
                 prov = prov_use->next;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -356,7 +356,6 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
             /* Check that the provider has all of the requirements of MPICH */
             } else if (prov_use->ep_attr->type != FI_EP_RDM) {
                 MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "Provider doesn't support RDM"));
-                fprintf(stderr, "Doesn't support RDM\n");
                 prov = prov_use->next;
                 continue;
             }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -349,7 +349,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                 prov = prov_use->next;
                 continue;
             } else if (MPIDI_OFI_ENABLE_RMA && 0ULL == (prov_use->caps & (FI_RMA | FI_ATOMICS))) {
-                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "Providerdoesn't support RMA"));
+                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "Provider doesn't support RMA"));
                 prov = prov_use->next;
                 continue;
 


### PR DESCRIPTION
Somehow this check hasn't caused problems up to now. We should be
checking that the provider supports FI_EP_RDM, not the opposite.