### PR TITLE
xfail issendselfcancel

### DIFF
--- a/test/mpi/pt2pt/testlist
+++ b/test/mpi/pt2pt/testlist
@@ -16,7 +16,7 @@ bsend5 4
 bsendalign 2
 bsendpending 2
 isendself 1
-issendselfcancel 1
+issendselfcancel 1 xfail=ticket2276
 isendirecv 10
 bsendfrag 2
 icsend 4


### PR DESCRIPTION
The `pt2pt/issendselfcancel` test fails due to some leaked requests between the netmod and shmod. We could fix this, but given that it's getting deprecated (https://github.com/mpi-forum/mpi-issues/issues/26) and potentially removed (https://github.com/mpi-forum/mpi-issues/issues/27), it's probably not worth putting a lot more effort into this.