### PR TITLE
CH4/OFI: Remove unused labels

### DIFF
--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -26,7 +26,7 @@ int MPIDIG_am_reg_cb(int handler_id,
 
     MPIDIG_global.target_msg_cbs[handler_id] = target_msg_cb;
     MPIDIG_global.origin_cbs[handler_id] = origin_cb;
-  fn_exit:
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_AM_REG_CB);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -1326,7 +1326,6 @@ static inline int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
                                             request);
     }
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RACCUMULATE);
     return mpi_errno;
 }
@@ -1364,7 +1363,6 @@ static inline int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
                                                 target_datatype, op, win, request);
     }
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RGET_ACCUMULATE);
     return mpi_errno;
 }


### PR DESCRIPTION
Squash warnings related to unused fn_exit labels