### PR TITLE
CH4: fixed crash on multi-netmod init

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -460,11 +460,6 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
     MPII_COMML_REMEMBER( MPIR_Process.comm_world );
     MPII_COMML_REMEMBER( MPIR_Process.comm_self );
 
-    /* Call any and all MPID_Init type functions */
-    MPIR_Err_init();
-    MPIR_Datatype_init();
-    MPIR_Group_init();
-
     /* MPIU_Timer_pre_init(); */
 
     /* Wait for debugger to attach if requested. */

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -115,6 +115,11 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
 
+    /* Call any and all MPID_Init type functions */
+    MPIR_Err_init();
+    MPIR_Datatype_init();
+    MPIR_Group_init();
+
     /* initialization routine for ch3u_comm.c */
     mpi_errno = MPIDI_CH3I_Comm_init();
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -15,6 +15,7 @@
 #include "ch4r_proc.h"
 #include "ch4i_comm.h"
 #include "strings.h"
+#include "datatype.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -198,6 +199,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 
     MPIR_Process.attrs.tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
     /* discuss */
+
+    /* Call any and all MPID_Init type functions */
+    MPIR_Err_init();
+    MPIR_Datatype_init();
+    MPIR_Group_init();
 
     mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &MPIR_Process.attrs.tag_ub,
                                        MPIR_Process.comm_world,


### PR DESCRIPTION
fixes csr/mpich-ofi#475

there is an issue in initialization, in MPIR_Init_thread:
function MPIR_Datatype_init is called too early, in stack deeper
there is call by native call table.

fix: shift some MPIR_* initialization into device