### PR TITLE
mtest: avoid destroying uninitialized thread barriers

### DIFF
--- a/test/mpi/threads/pt2pt/multisend2.c
+++ b/test/mpi/threads/pt2pt/multisend2.c
@@ -84,22 +84,22 @@ int main(int argc, char **argv)
         MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
-    err = MTest_thread_barrier_init();
-    if (err) {
-        fprintf(stderr, "Could not create thread barrier\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
     MPI_Barrier(MPI_COMM_WORLD);
     if (rank == 0) {
         nthreads = nprocs - 1;
+        err = MTest_thread_barrier_init();
+        if (err) {
+            fprintf(stderr, "Could not create thread barrier\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
         for (i = 1; i < nprocs; i++)
             MTest_Start_thread(run_test_send, (void *) (long) i);
         MTest_Join_threads();
+        MTest_thread_barrier_free();
     }
     else {
         run_test_recv();
     }
-    MTest_thread_barrier_free();
 
     MTest_Finalize(errs);
 

--- a/test/mpi/threads/pt2pt/multisend3.c
+++ b/test/mpi/threads/pt2pt/multisend3.c
@@ -114,23 +114,23 @@ int main(int argc, char **argv)
     if (nprocs > MAX_NTHREAD)
         nprocs = MAX_NTHREAD;
 
-    err = MTest_thread_barrier_init();
-    if (err) {
-        fprintf(stderr, "Could not create thread barrier\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
-    }
     MPI_Barrier(MPI_COMM_WORLD);
     if (rank == 0) {
+        err = MTest_thread_barrier_init();
+        if (err) {
+            fprintf(stderr, "Could not create thread barrier\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
         nthreads = nprocs - 1;
         for (i = 1; i < nprocs; i++)
             MTest_Start_thread(run_test_send, (void *) (long) i);
 
         MTest_Join_threads();
+        MTest_thread_barrier_free();
     }
     else if (rank < MAX_NTHREAD) {
         run_test_recv();
     }
-    MTest_thread_barrier_free();
 
     MTest_Finalize(errs);
 


### PR DESCRIPTION
In MTest, thread barriers are initialized lazily when first reaching
the barrier. Some tests never reach the barrier but still try
to destroy it despite being uninitialized. By the POSIX standard, this
results in undefined behavior. This patch removes barrier-related
operations on receivers because they do not need them.