### PR TITLE
CH4/OFI:  Add Cray PMI support

### DIFF
--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -119,6 +119,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPIDI_CH4_DBG_MEMORY = MPL_dbg_class_alloc("CH4_MEMORY", "ch4_memory");
 #endif
     MPIDI_choose_netmod();
+#ifdef USE_CRAYPMI_API
+    pmi_errno = PMI2_Init(&has_parent, &size, &rank, &appnum);
+
+    if (pmi_errno != PMI_SUCCESS) {
+        MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmi_init", "**pmi_init %d", pmi_errno);
+    }
+#else
     pmi_errno = PMI_Init(&has_parent);
 
     if (pmi_errno != PMI_SUCCESS) {
@@ -145,6 +152,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
         MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmi_get_appnum",
                              "**pmi_get_appnum %d", pmi_errno);
     }
+#endif
 
     MPID_Thread_mutex_create(&MPIDI_CH4I_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);

--- a/src/pmi/craypmi/subconfigure.m4
+++ b/src/pmi/craypmi/subconfigure.m4
@@ -1,0 +1,28 @@
+[#] start of __file__
+
+AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+])
+
+AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+
+AM_CONDITIONAL([BUILD_PMI_CRAY],[test "x$pmi_name" = "xcraypmi"])
+AM_COND_IF([BUILD_PMI_CRAY],[
+
+# sets CPPFLAGS and LDFLAGS
+PAC_SET_HEADER_LIB_PATH([pmi])
+
+AC_CHECK_HEADER([pmi.h], [], [AC_MSG_ERROR([could not find pmi.h.  Configure aborted])])
+AC_DEFINE(USE_CRAYPMI_API, 1, [Define if Cray PMI API must be used])
+AC_CHECK_LIB([pmi], [PMI_Init],
+             [
+              PAC_PREPEND_FLAG([$CRAY_PMI_POST_LINK_OPTS -lpmi], [WRAPPER_LIBS])
+              PAC_PREPEND_FLAG([$CRAY_PMI_POST_LINK_OPTS -lpmi],[LIBS])
+              PAC_PREPEND_FLAG([-Wl,-rpath=${with_pmi_lib},--enable-new-dtags], [WRAPPER_LIBS])
+             ],
+             [AC_MSG_ERROR([could not find the cray libpmi.  Configure aborted])])
+
+])dnl end COND_IF
+
+])dnl end BODY macro
+
+[#] end of __file__


### PR DESCRIPTION
Cray PMI is a mix of PMI ver 1 and ver 2. The new code to support Cray PMI
is now under macro USE_CRAYPMI_API.
New option 'craypmi' is added to configure support it: --enable-pmi=craypmi.