### PR TITLE
CH3: Add missing header in init

### DIFF
--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -5,6 +5,7 @@
  */
 
 #include "mpidimpl.h"
+#include "datatype.h"
 
 #define MAX_JOBID_LEN 1024
 


### PR DESCRIPTION
Commit [f5e80c8f088b] broke strict builds for ch3 because of an implicit
function definition. Fixed by adding the missing datatype header.

No reviewer.