### PR TITLE
CH3: fixed compilation issue

### DIFF
--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -28,6 +28,8 @@ char *MPIDI_DBG_parent_str = "?";
 #include "pmi.h"
 #endif
 
+#include "datatype.h"
+
 int MPIDI_Use_pmi2_api = 0;
 
 static int init_pg( int *argc_p, char ***argv_p,


### PR DESCRIPTION
- MPIR_Datatype_init is declared implicitly which is not
  allowed in -Werror mode. Added header where this function
  is declared
