### PR TITLE
CH4/OFI: Fixup [ae7878565f96]

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -311,7 +311,7 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int 
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, rank));
-        int ep_num = MPIDI_OFI_Av_to_ep(av);
+        int ep_num = MPIDI_OFI_av_to_ep(av);
         int offset = MPIDI_Global.ctx[ep_num].ctx_offset;
         int rx_idx = offset + ep_family;
         return fi_rx_addr(MPIDI_OFI_AV_TO_PHYS(av), rx_idx, MPIDI_OFI_MAX_ENDPOINTS_BITS);


### PR DESCRIPTION
Fix typo in function name.

No reviewer.