### PR TITLE
Export the pmi client code into a new external library: libpmi

### DIFF
--- a/src/pmi/simple/Makefile.mk
+++ b/src/pmi/simple/Makefile.mk
@@ -16,5 +16,10 @@ noinst_HEADERS +=                   \
 
 AM_CPPFLAGS += -I$(top_srcdir)/src/pmi/simple
 
+lib_LTLIBRARIES += libpmi.la
+libpmi_la_SOURCES = src/pmi/simple/simple_pmiutil.c src/pmi/simple/simple_pmi.c
+libpmi_la_CPPFLAGS = -DEXTERNAL_PMI_LIBRARY -I$(top_srcdir)/src/include
+libpmi_la_LIBADD = @mpllib@
+
 endif BUILD_PMI_SIMPLE
 

--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -57,6 +57,16 @@
 #include "simple_pmiutil.h"
 #include "mpi.h"		/* to get MPI_MAX_PORT_NAME */
 
+#if defined(EXTERNAL_PMI_LIBRARY)
+#if defined(HAVE_VISIBILITY)
+#define PMI_API_PUBLIC __attribute__((visibility ("default")))
+#else
+#define PMI_API_PUBLIC
+#endif
+#else
+#define PMI_API_PUBLIC
+#endif
+
 /* 
    These are global variable used *ONLY* in this file, and are hence
    declared static.
@@ -110,7 +120,7 @@ static char singinit_kvsname[256];
 
 /******************************** Group functions *************************/
 
-int PMI_Init( int *spawned )
+PMI_API_PUBLIC int PMI_Init( int *spawned )
 {
     char *p;
     int notset = 1;
@@ -218,7 +228,7 @@ int PMI_Init( int *spawned )
     return PMI_SUCCESS;
 }
 
-int PMI_Initialized( int *initialized )
+PMI_API_PUBLIC int PMI_Initialized( int *initialized )
 {
     /* Turn this into a logical value (1 or 0) .  This allows us
        to use PMI_initialized to distinguish between initialized with
@@ -228,7 +238,7 @@ int PMI_Initialized( int *initialized )
     return PMI_SUCCESS;
 }
 
-int PMI_Get_size( int *size )
+PMI_API_PUBLIC int PMI_Get_size( int *size )
 {
     if ( PMI_initialized )
 	*size = PMI_size;
@@ -237,7 +247,7 @@ int PMI_Get_size( int *size )
     return PMI_SUCCESS;
 }
 
-int PMI_Get_rank( int *rank )
+PMI_API_PUBLIC int PMI_Get_rank( int *rank )
 {
     if ( PMI_initialized )
 	*rank = PMI_rank;
@@ -252,7 +262,7 @@ int PMI_Get_rank( int *rank )
  * we first need to connect to the process manager and acquire the 
  * needed information.
  */
-int PMI_Get_universe_size( int *size)
+PMI_API_PUBLIC int PMI_Get_universe_size( int *size)
 {
     int  err;
     char size_c[PMIU_MAXLINE];
@@ -274,7 +284,7 @@ int PMI_Get_universe_size( int *size)
     return PMI_SUCCESS;
 }
 
-int PMI_Get_appnum( int *appnum )
+PMI_API_PUBLIC int PMI_Get_appnum( int *appnum )
 {
     int  err;
     char appnum_c[PMIU_MAXLINE];
@@ -295,7 +305,7 @@ int PMI_Get_appnum( int *appnum )
     return PMI_SUCCESS;
 }
 
-int PMI_Barrier( void )
+PMI_API_PUBLIC int PMI_Barrier( void )
 {
     int err = PMI_SUCCESS;
 
@@ -307,7 +317,7 @@ int PMI_Barrier( void )
 }
 
 /* Inform the process manager that we're in finalize */
-int PMI_Finalize( void )
+PMI_API_PUBLIC int PMI_Finalize( void )
 {
     int err = PMI_SUCCESS;
 
@@ -320,7 +330,7 @@ int PMI_Finalize( void )
     return err;
 }
 
-int PMI_Abort(int exit_code, const char error_msg[])
+PMI_API_PUBLIC int PMI_Abort(int exit_code, const char error_msg[])
 {
     char buf[PMIU_MAXLINE];
 
@@ -340,7 +350,7 @@ int PMI_Abort(int exit_code, const char error_msg[])
   truncated because it is larger than length */
 /* FIXME: My name should be cached rather than re-acquired, as it is
    unchanging (after singleton init) */
-int PMI_KVS_Get_my_name( char kvsname[], int length )
+PMI_API_PUBLIC int PMI_KVS_Get_my_name( char kvsname[], int length )
 {
     int err;
 
@@ -358,7 +368,7 @@ int PMI_KVS_Get_my_name( char kvsname[], int length )
     return err;
 }
 
-int PMI_KVS_Get_name_length_max( int *maxlen )
+PMI_API_PUBLIC int PMI_KVS_Get_name_length_max( int *maxlen )
 {
     if (maxlen == NULL)
 	return PMI_ERR_INVALID_ARG;
@@ -366,7 +376,7 @@ int PMI_KVS_Get_name_length_max( int *maxlen )
     return PMI_SUCCESS;
 }
 
-int PMI_KVS_Get_key_length_max( int *maxlen )
+PMI_API_PUBLIC int PMI_KVS_Get_key_length_max( int *maxlen )
 {
     if (maxlen == NULL)
 	return PMI_ERR_INVALID_ARG;
@@ -374,7 +384,7 @@ int PMI_KVS_Get_key_length_max( int *maxlen )
     return PMI_SUCCESS;
 }
 
-int PMI_KVS_Get_value_length_max( int *maxlen )
+PMI_API_PUBLIC int PMI_KVS_Get_value_length_max( int *maxlen )
 {
     if (maxlen == NULL)
 	return PMI_ERR_INVALID_ARG;
@@ -382,7 +392,7 @@ int PMI_KVS_Get_value_length_max( int *maxlen )
     return PMI_SUCCESS;
 }
 
-int PMI_KVS_Put( const char kvsname[], const char key[], const char value[] )
+PMI_API_PUBLIC int PMI_KVS_Put( const char kvsname[], const char key[], const char value[] )
 {
     char buf[PMIU_MAXLINE];
     int  err = PMI_SUCCESS;
@@ -408,7 +418,7 @@ int PMI_KVS_Put( const char kvsname[], const char key[], const char value[] )
     return err;
 }
 
-int PMI_KVS_Commit( const char kvsname[] ATTRIBUTE((unused)))
+PMI_API_PUBLIC int PMI_KVS_Commit( const char kvsname[] ATTRIBUTE((unused)))
 {
     /* no-op in this implementation */
     return PMI_SUCCESS;
@@ -416,7 +426,7 @@ int PMI_KVS_Commit( const char kvsname[] ATTRIBUTE((unused)))
 
 /*FIXME: need to return an error if the value returned is truncated
   because it is larger than length */
-int PMI_KVS_Get( const char kvsname[], const char key[], char value[], 
+PMI_API_PUBLIC int PMI_KVS_Get( const char kvsname[], const char key[], char value[], 
 		 int length)
 {
     char buf[PMIU_MAXLINE];
@@ -451,7 +461,7 @@ int PMI_KVS_Get( const char kvsname[], const char key[], char value[],
 
 /*************************** Name Publishing functions **********************/
 
-int PMI_Publish_name( const char service_name[], const char port[] )
+PMI_API_PUBLIC int PMI_Publish_name( const char service_name[], const char port[] )
 {
     char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
     int err;
@@ -480,7 +490,7 @@ int PMI_Publish_name( const char service_name[], const char port[] )
     return PMI_SUCCESS;
 }
 
-int PMI_Unpublish_name( const char service_name[] )
+PMI_API_PUBLIC int PMI_Unpublish_name( const char service_name[] )
 {
     char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
     int err = PMI_SUCCESS;
@@ -508,7 +518,7 @@ int PMI_Unpublish_name( const char service_name[] )
     return PMI_SUCCESS;
 }
 
-int PMI_Lookup_name( const char service_name[], char port[] )
+PMI_API_PUBLIC int PMI_Lookup_name( const char service_name[], char port[] )
 {
     char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
     int err;
@@ -540,7 +550,7 @@ int PMI_Lookup_name( const char service_name[], char port[] )
 
 /************************** Process Creation functions **********************/
 
-int PMI_Spawn_multiple(int count,
+PMI_API_PUBLIC int PMI_Spawn_multiple(int count,
                        const char * cmds[],
                        const char ** argvs[],
                        const int maxprocs[],


### PR DESCRIPTION
This pmi client library allows external projects to use hydra as a generic (non-MPI) job launch mechanism.