### PR TITLE
mpid/common/shm: Remove *_ptr_t typedefs

### DIFF
--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -167,7 +167,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 #endif /* MEM_REGION_IN_HEAP */
 
     MPID_nem_mem_region.num_seg        = 7;
-    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.seg, MPIDU_shm_seg_info_ptr_t, MPID_nem_mem_region.num_seg * sizeof(MPIDU_shm_seg_info_t), mpi_errno, "mem_region segments");
+    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.seg, MPIDU_shm_seg_info_t *, MPID_nem_mem_region.num_seg * sizeof(MPIDU_shm_seg_info_t), mpi_errno, "mem_region segments");
     MPID_nem_mem_region.rank           = pg_rank;
     MPID_nem_mem_region.num_local      = num_local;
     MPID_nem_mem_region.num_procs      = num_procs;

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -42,7 +42,7 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_INIT);
 
     MPIDI_POSIX_mem_region.num_seg = 1;
-    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.seg, MPIDU_shm_seg_info_ptr_t,
+    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.seg, MPIDU_shm_seg_info_t *,
                         MPIDI_POSIX_mem_region.num_seg * sizeof(MPIDU_shm_seg_info_t), mpi_errno,
                         "mem_region segments");
     MPIR_CHKPMEM_MALLOC(local_procs, int *, size * sizeof(int), mpi_errno,

--- a/src/mpid/common/shm/mpidu_shm.h
+++ b/src/mpid/common/shm/mpidu_shm.h
@@ -15,7 +15,7 @@ typedef struct MPIDU_shm_barrier
 {
     OPA_int_t val;
     OPA_int_t wait;
-} MPIDU_shm_barrier_t, *MPIDU_shm_barrier_ptr_t;
+} MPIDU_shm_barrier_t;
 
 typedef struct MPIDU_shm_seg
 {
@@ -28,21 +28,21 @@ typedef struct MPIDU_shm_seg
     char  file_name[MPIDU_SHM_MAX_FNAME_LEN];
     int   base_descs;
     int   symmetrical;
-} MPIDU_shm_seg_t, *MPIDU_shm_seg_ptr_t;
+} MPIDU_shm_seg_t;
 
 typedef struct MPIDU_shm_seg_info
 {
     size_t size;
     char *addr;
-} MPIDU_shm_seg_info_t, *MPIDU_shm_seg_info_ptr_t;
+} MPIDU_shm_seg_info_t;
 
 int MPIDU_shm_seg_alloc(size_t len, void **ptr_p);
-int MPIDU_shm_seg_commit(MPIDU_shm_seg_ptr_t memory, MPIDU_shm_barrier_ptr_t *barrier,
+int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
                      int num_local, int local_rank, int local_procs_0, int rank);
-int MPIDU_shm_seg_destroy(MPIDU_shm_seg_ptr_t memory, int num_local);
+int MPIDU_shm_seg_destroy(MPIDU_shm_seg_t *memory, int num_local);
 
 int MPIDU_shm_barrier_init(MPIDU_shm_barrier_t *barrier_region,
-                           MPIDU_shm_barrier_ptr_t *barrier, int init_values);
+                           MPIDU_shm_barrier_t **barrier, int init_values);
 int MPIDU_shm_barrier(MPIDU_shm_barrier_t *barrier, int num_local);
 
 #endif /* MPIDU_SHM_H */

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -38,7 +38,7 @@ typedef struct alloc_elem {
 
 static struct { alloc_elem_t *head, *tail; } allocq = {0};
 
-static int check_alloc(MPIDU_shm_seg_ptr_t memory, MPIDU_shm_barrier_ptr_t barrier,
+static int check_alloc(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t *barrier,
                        int num_local, int local_rank);
 
 #define ALLOCQ_HEAD() GENERIC_Q_HEAD(allocq)
@@ -127,7 +127,7 @@ int MPIDU_shm_seg_alloc(size_t len, void **ptr_p)
 #define FUNCNAME MPIDU_shm_seg_commit
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_shm_seg_commit(MPIDU_shm_seg_ptr_t memory, MPIDU_shm_barrier_ptr_t *barrier,
+int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
                      int num_local, int local_rank, int local_procs_0, int rank)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -457,7 +457,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_ptr_t memory, MPIDU_shm_barrier_ptr_t *ba
 #define FUNCNAME MPIDU_shm_seg_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_shm_seg_destroy(MPIDU_shm_seg_ptr_t memory, int num_local)
+int MPIDU_shm_seg_destroy(MPIDU_shm_seg_t *memory, int num_local)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SHM_SEG_DESTROY);
@@ -488,7 +488,7 @@ int MPIDU_shm_seg_destroy(MPIDU_shm_seg_ptr_t memory, int num_local)
 #define FUNCNAME check_alloc
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int check_alloc(MPIDU_shm_seg_ptr_t memory, MPIDU_shm_barrier_ptr_t barrier,
+static int check_alloc(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t *barrier,
                        int num_local, int local_rank)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/common/shm/mpidu_shm_barrier.c
+++ b/src/mpid/common/shm/mpidu_shm_barrier.c
@@ -14,7 +14,7 @@ static int barrier_init = 0;
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIDU_shm_barrier_init(MPIDU_shm_barrier_t *barrier_region,
-                           MPIDU_shm_barrier_ptr_t *barrier, int init_values)
+                           MPIDU_shm_barrier_t **barrier, int init_values)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SHM_BARRIER_INIT);
 


### PR DESCRIPTION
There is no need for an additional ptr type for these structs. They just
lead to confusion.