### PR TITLE
CH4/OFI: updated runtime check for RMA calls

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -577,7 +577,7 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
     MPI_Aint origin_true_lb, target_true_lb;
     size_t offset;
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_put(origin_addr, origin_count, origin_datatype,
                                        target_rank, target_disp, target_count,
                                        target_datatype, win);
@@ -738,7 +738,7 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_get(origin_addr, origin_count, origin_datatype,
                                        target_rank, target_disp, target_count,
                                        target_datatype, win);
@@ -821,7 +821,7 @@ static inline int MPIDI_NM_mpi_rput(const void *origin_addr,
     size_t origin_bytes;
     size_t offset;
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_rput(origin_addr, origin_count, origin_datatype,
                                         target_rank, target_disp, target_count,
                                         target_datatype, win, request);
@@ -881,7 +881,7 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     struct fi_rma_ioc targetv;
     struct fi_msg_atomic msg;
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_compare_and_swap(origin_addr, compare_addr,
                                                     result_addr, datatype,
                                                     target_rank, target_disp,
@@ -1031,7 +1031,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) goto am_fallback;
+    if (!MPIDI_OFI_ENABLE_ATOMICS) goto am_fallback;
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
@@ -1160,7 +1160,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) goto am_fallback;
+    if (!MPIDI_OFI_ENABLE_ATOMICS) goto am_fallback;
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
@@ -1308,7 +1308,7 @@ static inline int MPIDI_NM_mpi_raccumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_raccumulate(origin_addr, origin_count, origin_datatype,
                                                target_rank, target_disp, target_count,
                                                target_datatype, op, win, request);
@@ -1350,7 +1350,7 @@ static inline int MPIDI_NM_mpi_rget_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RGET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET_ACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype,
                                                    result_addr, result_count, result_datatype,
                                                    target_rank, target_disp, target_count,
@@ -1381,7 +1381,7 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_fetch_and_op(origin_addr, result_addr, datatype,
                                                 target_rank, target_disp, op, win);
         goto fn_exit;
@@ -1419,7 +1419,7 @@ static inline int MPIDI_NM_mpi_rget(void *origin_addr,
     size_t origin_bytes;
     size_t offset;
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_rget(origin_addr, origin_count, origin_datatype,
                                         target_rank, target_disp, target_count, target_datatype, win,
                                         request);
@@ -1479,7 +1479,7 @@ static inline int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_get_accumulate(origin_addr, origin_count, origin_datatype,
                                                   result_addr, result_count, result_datatype,
                                                   target_rank, target_disp, target_count,
@@ -1513,7 +1513,7 @@ static inline int MPIDI_NM_mpi_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ACCUMULATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_ATOMICS) {
         mpi_errno = MPIDI_CH4U_mpi_accumulate(origin_addr, origin_count, origin_datatype,
                                               target_rank, target_disp, target_count, target_datatype, op,
                                               win);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -336,7 +336,7 @@ static inline int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Wi
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_START);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_start(group, assert, win);
         goto fn_exit;
     }
@@ -424,7 +424,7 @@ static inline int MPIDI_NM_mpi_win_complete(MPIR_Win * win)
 
     MPIR_CHKLMEM_DECL(1);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_complete(win);
         goto fn_exit;
     }
@@ -490,7 +490,7 @@ static inline int MPIDI_NM_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_POST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_POST);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_post(group, assert, win);
         goto fn_exit;
     }
@@ -534,7 +534,7 @@ static inline int MPIDI_NM_mpi_win_wait(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_WAIT);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_wait(win);
         goto fn_exit;
     }
@@ -571,7 +571,7 @@ static inline int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_TEST);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_test(win, flag);
         goto fn_exit;
     }
@@ -611,7 +611,7 @@ static inline int MPIDI_NM_mpi_win_lock(int lock_type, int rank, int assert, MPI
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_LOCK);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_lock(lock_type, rank, assert, win);
         goto fn_exit;
     }
@@ -654,7 +654,7 @@ static inline int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_UNLOCK);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_unlock(rank, win);
         goto fn_exit;
     }
@@ -699,7 +699,7 @@ static inline int MPIDI_NM_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_GET_INFO);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_GET_INFO);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_get_info(win, info_p_p);
         goto fn_exit;
     }
@@ -729,7 +729,7 @@ static inline int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FREE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FREE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_free(win_ptr);
         goto fn_fail;
     }
@@ -777,7 +777,7 @@ static inline int MPIDI_NM_mpi_win_fence(int massert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FENCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FENCE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_fence(massert, win);
         goto fn_exit;
     }
@@ -831,7 +831,7 @@ static inline int MPIDI_NM_mpi_win_create(void *base,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_CREATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_create(base, length, disp_unit, info, comm_ptr, win_ptr);
         goto fn_exit;
     }
@@ -873,7 +873,7 @@ static inline int MPIDI_NM_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint s
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_ATTACH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_ATTACH);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_attach(win, base, size);
         goto fn_exit;
     }
@@ -910,7 +910,7 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE_SHARED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE_SHARED);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_allocate_shared(size, disp_unit, info_ptr, comm_ptr, base_ptr, win_ptr);
         goto fn_exit;
     }
@@ -1064,7 +1064,7 @@ static inline int MPIDI_NM_mpi_win_detach(MPIR_Win * win, const void *base)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_DETACH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_DETACH);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_detach(win, base);
         goto fn_exit;
     }
@@ -1094,7 +1094,7 @@ static inline int MPIDI_NM_mpi_win_shared_query(MPIR_Win * win,
     int i;
     uintptr_t base = (uintptr_t) MPIDI_CH4U_WIN(win, mmap_addr);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_shared_query(win, rank, size, disp_unit, baseptr);
         goto fn_exit;
     }
@@ -1137,7 +1137,7 @@ static inline int MPIDI_NM_mpi_win_allocate(MPI_Aint size,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_allocate(size, disp_unit, info, comm, baseptr, win_ptr);
         goto fn_exit;
     }
@@ -1183,7 +1183,7 @@ static inline int MPIDI_NM_mpi_win_flush(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_flush(rank, win);
         goto fn_exit;
     }
@@ -1212,7 +1212,7 @@ static inline int MPIDI_NM_mpi_win_flush_local_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_LOCAL_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_LOCAL_ALL);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_flush_local_all(win);
         goto fn_exit;
     }
@@ -1243,7 +1243,7 @@ static inline int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win)
     int i;
     MPIDI_CH4U_win_lock_info *lockQ;
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_unlock_all(win);
         goto fn_exit;
     }
@@ -1300,7 +1300,7 @@ static inline int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_CREATE_DYNAMIC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_CREATE_DYNAMIC);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_create_dynamic(info, comm, win_ptr);
         goto fn_exit;
     }
@@ -1338,7 +1338,7 @@ static inline int MPIDI_NM_mpi_win_flush_local(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_LOCAL);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_flush_local(rank, win);
         goto fn_exit;
     }
@@ -1368,7 +1368,7 @@ static inline int MPIDI_NM_mpi_win_sync(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_SYNC);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_sync(win);
         goto fn_exit;
     }
@@ -1394,7 +1394,7 @@ static inline int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_ALL);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_flush_all(win);
         goto fn_exit;
     }
@@ -1425,7 +1425,7 @@ static inline int MPIDI_NM_mpi_win_lock_all(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_LOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_LOCK_ALL);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
+    if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4R_mpi_win_lock_all(assert, win);
         goto fn_exit;
     }


### PR DESCRIPTION
fixes csr/mpich-ofi#489

- runtime checks for RMA implementation now is based on
  RMA and ATOMICS variables (instead of TAGGED) which is
  more correct/flexible
