### PR TITLE
Hierarchy support in hydra process manager

### DIFF
--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -337,6 +337,7 @@ struct HYD_node {
     int active_processes;
 
     int node_id;
+    int pmi_level;
 
     /* Username */
     char *user;
@@ -403,6 +404,7 @@ struct HYD_user_global {
     int usize;
 
     int auto_cleanup;
+    int branch_count;
 
     struct HYD_env_global global_env;
 };

--- a/src/pm/hydra/include/hydra_server.h
+++ b/src/pm/hydra/include/hydra_server.h
@@ -41,6 +41,7 @@ struct HYD_server_info_s {
     /* Cleanup */
     int cmd_pipe[2];
 
+    char **nodes_lists;
 #if defined ENABLE_PROFILING
     int enable_profiling;
     int num_pmi_calls;

--- a/src/pm/hydra/pm/pmiserv/common.h
+++ b/src/pm/hydra/pm/pmiserv/common.h
@@ -46,7 +46,10 @@ struct HYD_pmcd_hdr {
         PMI_CMD,
         STDOUT,
         STDERR,
-        PROCESS_TERMINATED
+        PROCESS_TERMINATED,
+        LAUNCH_CHILD_PROXY,
+        SEND_EXEC,
+        PIDS_INFO
     } cmd;
 
     /* Generic */

--- a/src/pm/hydra/pm/pmiserv/pmi_v2_common.c
+++ b/src/pm/hydra/pm/pmiserv/pmi_v2_common.c
@@ -9,7 +9,7 @@
 #include "pmiserv_pmi.h"
 #include "pmi_v2_common.h"
 
-HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], char *key,
+HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, int rank, char *args[], char *key,
                                      struct HYD_pmcd_pmi_v2_reqs **pending_reqs)
 {
     struct HYD_pmcd_pmi_v2_reqs *req, *tmp;
@@ -20,6 +20,7 @@ HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], ch
     req->fd = fd;
     req->pid = pid;
     req->pgid = pgid;
+    req->rank = rank;
     req->prev = NULL;
     req->next = NULL;
 

--- a/src/pm/hydra/pm/pmiserv/pmi_v2_common.h
+++ b/src/pm/hydra/pm/pmiserv/pmi_v2_common.h
@@ -13,6 +13,7 @@ struct HYD_pmcd_pmi_v2_reqs {
     int fd;
     int pid;
     int pgid;
+    int rank;
     char *thrid;
     char **args;
     char *key;
@@ -21,7 +22,7 @@ struct HYD_pmcd_pmi_v2_reqs {
     struct HYD_pmcd_pmi_v2_reqs *next;
 };
 
-HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, char *args[], char *key,
+HYD_status HYD_pmcd_pmi_v2_queue_req(int fd, int pid, int pgid, int rank, char *args[], char *key,
                                      struct HYD_pmcd_pmi_v2_reqs **pending_reqs);
 void HYD_pmcd_pmi_v2_print_req_list(struct HYD_pmcd_pmi_v2_reqs *pending_reqs);
 

--- a/src/pm/hydra/pm/pmiserv/pmip.c
+++ b/src/pm/hydra/pm/pmiserv/pmip.c
@@ -192,6 +192,8 @@ int main(int argc, char **argv)
 
     /* See if HYDI_CONTROL_FD is set before trying to connect upstream */
     ret = MPL_env2int("HYDI_CONTROL_FD", &HYD_pmcd_pmip.upstream.control);
+    unsetenv("HYDI_CONTROL_FD");
+
     if (ret < 0) {
         HYDU_ERR_POP(status, "error reading HYDI_CONTROL_FD environment\n");
     }

--- a/src/pm/hydra/pm/pmiserv/pmip.h
+++ b/src/pm/hydra/pm/pmiserv/pmip.h
@@ -18,6 +18,7 @@ struct HYD_pmcd_pmip_map {
 };
 
 struct HYD_pmcd_pmip_s {
+    char *base_path;
     struct HYD_user_global user_global;
 
     struct {
@@ -68,6 +69,7 @@ struct HYD_pmcd_pmip_s {
     struct {
         int id;
         int pgid;
+        int parent_id;
         char *iface_ip_env_name;
         char *hostname;
 
@@ -82,9 +84,27 @@ struct HYD_pmcd_pmip_s {
         int retries;
     } local;
 
+    /* Child proxy */
+    struct {
+        int num;
+        int *pid;
+        int *exited;
+        int *proxy_id;
+        int *proxy_fd;
+    } children;
+    char **nodes_lists;
+
     /* Process segmentation information for this proxy */
     struct HYD_exec *exec_list;
+
+    int *pid_to_fd;
 };
+
+typedef struct HYD_pmi_ranks2fds {
+    int rank;
+    int fd;
+    struct HYD_pmi_ranks2fds *next;
+} HYD_pmi_ranks2fds;
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
 extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
@@ -92,5 +112,13 @@ extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
 HYD_status HYD_pmcd_pmip_get_params(char **t_argv);
 void HYD_pmcd_pmip_send_signal(int sig);
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp);
+HYD_status HYD_pmcd_pmi_fill_in_child_proxy_args(struct HYD_string_stash *proxy_stash, char *control_port, int pgid, int start_node_id);
+HYD_status HYDU_send_procinfo_request(void);
+HYD_status HYD_pmci_wait_for_children_completion(void);
+
+HYD_status HYDU_free_fd_list(struct HYD_pmi_ranks2fds **r2f_list);
+HYD_status HYDU_add_pmi_r2f(struct HYD_pmi_ranks2fds **r2f_list, int rank, int fd);
+int HYDU_get_fd_by_rank(struct HYD_pmi_ranks2fds **r2f_list, int rank);
+int HYDU_get_rank_by_fd(struct HYD_pmi_ranks2fds **r2f_list, int fd);
 
 #endif /* PMIP_H_INCLUDED */

--- a/src/pm/hydra/pm/pmiserv/pmip_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_cb.c
@@ -11,10 +11,16 @@
 #include "demux.h"
 #include "topo.h"
 
+static HYD_status control_cb(int fd, HYD_event_t events, void *userp);
+HYD_status HYD_pmci_launch_child_procs(char *nodes);
+
 struct HYD_pmcd_pmip_pmi_handle *HYD_pmcd_pmip_pmi_handle = { 0 };
 
 static int pmi_storage_len = 0;
 static char pmi_storage[HYD_TMPBUF_SIZE], *sptr = pmi_storage, r[HYD_TMPBUF_SIZE];
+static int using_pmi_port = 0;
+
+extern struct HYD_pmi_ranks2fds *r2f_table;
 
 static HYD_status stdoe_cb(int fd, HYD_event_t events, void *userp)
 {
@@ -213,6 +219,11 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     HYDU_FUNC_ENTER();
 
     HYD_pmcd_init_header(&hdr);
+    if(HYD_pmcd_pmip.user_global.branch_count != -1) {
+        hdr.pid = HYD_pmcd_pmip.local.id;
+    } else {
+        hdr.pid = fd;
+    }
 
     /* Try to find the PMI FD */
     for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
@@ -271,6 +282,7 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
 
                 hdr.cmd = PROCESS_TERMINATED;
                 hdr.pid = HYD_pmcd_pmip.downstream.pmi_rank[pid];
+                hdr.buflen = 0;
                 status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr),
                                          &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
                 HYDU_ERR_POP(status, "unable to send PMI header upstream\n");
@@ -315,11 +327,26 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
         HYDU_dump(stdout, "got pmi command (from %d): %s\n", fd, pmi_cmd);
         HYDU_print_strlist(args);
     }
+    hdr.buflen = strlen(buf);
+    if (using_pmi_port) {
+        if (!strcmp(pmi_cmd, "initack")){
+            /* Get rank from initack PMI request (buf is 'cmd=initack pmiid=<rank>') */
+            hdr.rank = atoi(buf+18);
+            HYDU_add_pmi_r2f(&r2f_table, hdr.rank, fd);
+        } else {
+            /* Get rank from r2f table */
+            hdr.rank = HYDU_get_rank_by_fd(&r2f_table, fd);
+        }
+    } else {
+        /* Get rank from r2f table */
+        hdr.rank = HYDU_get_rank_by_fd(&r2f_table, fd);
+    }
 
     h = HYD_pmcd_pmip_pmi_handle;
+    hdr.cmd = PMI_CMD;
     while (h->handler) {
         if (!strcmp(pmi_cmd, h->cmd)) {
-            status = h->handler(fd, args);
+            status = h->handler(fd, args, &hdr);
             HYDU_ERR_POP(status, "PMI handler returned error\n");
             goto fn_exit;
         }
@@ -331,9 +358,6 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
     }
 
     /* We don't understand the command; forward it upstream */
-    hdr.cmd = PMI_CMD;
-    hdr.pid = fd;
-    hdr.buflen = strlen(buf);
     status =
         HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
                         HYDU_SOCK_COMM_MSGWAIT);
@@ -393,7 +417,7 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
     h = HYD_pmcd_pmip_pmi_handle;
     while (h->handler) {
         if (!strcmp(pmi_cmd, h->cmd)) {
-            status = h->handler(fd, args);
+            status = h->handler(fd, args, &hdr);
             HYDU_ERR_POP(status, "PMI handler returned error\n");
             goto fn_exit;
         }
@@ -404,7 +428,13 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
         HYDU_dump(stdout, "we don't understand the response %s; forwarding downstream\n", pmi_cmd);
     }
 
-    status = HYDU_sock_write(hdr.pid, buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    if (HYD_pmcd_pmip.user_global.branch_count != -1 && hdr.pid != HYD_pmcd_pmip.local.id) {
+        status = HYDU_sock_write(HYD_pmcd_pmip.pid_to_fd[hdr.pid], &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to sent PMI_RESPONSE header to proxy\n");
+        status = HYDU_sock_write(HYD_pmcd_pmip.pid_to_fd[hdr.pid], buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    } else {
+        status = HYDU_sock_write(HYDU_get_fd_by_rank(&r2f_table, hdr.rank), buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    }
     HYDU_ERR_POP(status, "unable to forward PMI response to MPI process\n");
 
     if (HYD_pmcd_pmip.user_global.auto_cleanup) {
@@ -429,6 +459,91 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
   fn_fail:
     goto fn_exit;
 }
+
+static HYD_status handle_pmi_command(int fd, struct HYD_pmcd_hdr hdr)
+{
+    int count, closed, sent;
+    char *buf = NULL, *pmi_cmd = NULL, *args[MAX_PMI_INTERNAL_ARGS] = { 0 };
+    struct HYD_pmcd_pmip_pmi_handle *h;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen + 1, status);
+
+    status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to read PMI command from proxy\n");
+    HYDU_ASSERT(!closed, status);
+
+    buf[hdr.buflen] = 0;
+
+    status = HYD_pmcd_pmi_parse_pmi_cmd(buf, hdr.pmi_version, &pmi_cmd, args);
+    HYDU_ERR_POP(status, "unable to parse PMI command\n");
+
+    h = HYD_pmcd_pmip_pmi_handle;
+    while (h->handler) {
+        if (!strcmp(pmi_cmd, h->cmd)) {
+            status = h->handler(fd, args, &hdr);
+            HYDU_ERR_POP(status, "PMI handler returned error\n");
+            goto fn_exit;
+        }
+        h++;
+    }
+
+    if (HYD_pmcd_pmip.user_global.debug) {
+        HYDU_dump(stdout, "we don't understand the %s; forwarding upstream\n", pmi_cmd);
+    }
+
+    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to forward PMI command upstream\n");
+
+    if (HYD_pmcd_pmip.user_global.auto_cleanup) {
+        HYDU_ASSERT(!closed, status);
+    }
+    else {
+        /* Ignore the error and drop the PMI response */
+    }
+
+  fn_exit:
+    if (pmi_cmd)
+        MPL_free(pmi_cmd);
+    HYDU_free_strlist(args);
+    if (buf)
+        MPL_free(buf);
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+HYD_status handle_launch_children(int fd, struct HYD_pmcd_hdr *hdr)
+{
+    int count, closed;
+    char *buf=NULL;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    HYDU_MALLOC_OR_JUMP(buf, char *, hdr->buflen + 1, status);
+    status = HYDU_sock_read(fd, buf, hdr->buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to read PMI response from proxy\n");
+    HYDU_ASSERT(!closed, status);
+
+    buf[hdr->buflen] = 0;
+    status = HYD_pmci_launch_child_procs(buf);
+    HYDU_ERR_POP(status, "unable to launch child proxy\n");
+
+  fn_exit:
+    if (buf)
+        MPL_free(buf);
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 
 static HYD_status pmi_listen_cb(int fd, HYD_event_t events, void *userp)
 {
@@ -472,7 +587,6 @@ static int local_to_global_id(int local_id)
 static HYD_status launch_procs(void)
 {
     int i, j, process_id, dummy;
-    int using_pmi_port = 0;
     char *str, *envstr, *list, *pmi_port;
     struct HYD_string_stash stash;
     struct HYD_env *env, *force_env = NULL;
@@ -692,6 +806,8 @@ static HYD_status launch_procs(void)
                 status = HYDU_append_env_to_list("PMI_SIZE", str, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
                 MPL_free(str);
+
+                HYDU_add_pmi_r2f(&r2f_table, HYD_pmcd_pmip.downstream.pmi_rank[process_id], pmi_fds[0]);
             }
 
             HYD_STRING_STASH_INIT(stash);
@@ -737,6 +853,12 @@ static HYD_status launch_procs(void)
     /* Send the PID list upstream */
     HYD_pmcd_init_header(&hdr);
     hdr.cmd = PID_LIST;
+    if (HYD_pmcd_pmip.user_global.branch_count != -1) {
+        hdr.pid = HYD_pmcd_pmip.local.id;
+        hdr.pmi_version = 1;
+        hdr.buflen = HYD_pmcd_pmip.local.proxy_process_count * sizeof(int);
+        hdr.rank = 0;
+    }
     status =
         HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
                         HYDU_SOCK_COMM_MSGWAIT);
@@ -877,6 +999,71 @@ static HYD_status procinfo(int fd)
     goto fn_exit;
 }
 
+static HYD_status send_procinfo_downstream(int in_fd, int out_fd, int proxy_id)
+{
+    struct HYD_pmcd_hdr hdr;
+    char *string = NULL;
+    int num_strings, str_len, recvd, i, curr_alloc = 0;
+    int sent, closed;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    HYD_pmcd_init_header(&hdr);
+    hdr.cmd = PROC_INFO;
+    status = HYDU_sock_write(out_fd, &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to write data to proxy\n");
+    HYDU_ASSERT(!closed, status);
+
+    status = HYDU_sock_write(out_fd, &proxy_id, sizeof(int), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to write data to proxy\n");
+    HYDU_ASSERT(!closed, status);
+
+    /* Read information about the application to launch into a string
+     * the proxy handle. */
+    status = HYDU_sock_read(in_fd, &num_strings, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "error reading data from upstream\n");
+    HYDU_ASSERT(!closed, status);
+
+    status = HYDU_sock_write(out_fd, &num_strings, sizeof(int), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "error writing data to downstream\n");
+    HYDU_ASSERT(!closed, status);
+
+    for (i = 0; i < num_strings; i++) {
+        status = HYDU_sock_read(in_fd, &str_len, sizeof(int), &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error reading data from upstream\n");
+        HYDU_ASSERT(!closed, status);
+        status = HYDU_sock_write(out_fd, &str_len, sizeof(int), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error writing data to downstream\n");
+        HYDU_ASSERT(!closed, status);
+
+        if (curr_alloc < str_len) {
+            if (string)
+                MPL_free(string);
+               HYDU_MALLOC_OR_JUMP(string, char *, str_len, status);
+            curr_alloc = str_len;
+        }
+
+        status = HYDU_sock_read(in_fd, string, str_len, &recvd, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error reading data from upstream\n");
+        HYDU_ASSERT(!closed, status);
+        status = HYDU_sock_write(out_fd, string, str_len, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "error writing data to downstream\n");
+        HYDU_ASSERT(!closed, status);
+    }
+
+
+  fn_exit:
+    if(string)
+        MPL_free(string);
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+
 HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
 {
     int cmd_len, closed;
@@ -892,6 +1079,20 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
     HYDU_ASSERT(!closed, status);
 
     if (hdr.cmd == PROC_INFO) {
+        if(HYD_pmcd_pmip.user_global.branch_count != -1) {
+            int proxy_id;
+
+            status = HYDU_sock_read(fd, &proxy_id, sizeof(int), &cmd_len, &closed, HYDU_SOCK_COMM_MSGWAIT);
+            HYDU_ERR_POP(status, "error reading command from launcher\n");
+            HYDU_ASSERT(!closed, status);
+            if(proxy_id != HYD_pmcd_pmip.local.id) {
+                /* transfer to child */
+                status = send_procinfo_downstream(fd, HYD_pmcd_pmip.pid_to_fd[proxy_id], proxy_id);
+                HYDU_ERR_POP(status, "error sending procinfo downstream\n");
+                goto fn_exit;
+            }
+        }
+
         status = procinfo(fd);
         HYDU_ERR_POP(status, "error parsing process info\n");
 
@@ -956,6 +1157,10 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
             HYD_pmcd_pmip.downstream.in = HYD_FD_CLOSED;
         }
     }
+    else if ( hdr.cmd == LAUNCH_CHILD_PROXY ) {
+        status = handle_launch_children(fd, &hdr);
+        HYDU_ERR_POP(status, "unable to handle launch children\n");
+    }
     else {
         status = HYD_INTERNAL_ERROR;
     }
@@ -963,6 +1168,291 @@ HYD_status HYD_pmcd_pmip_control_cmd_cb(int fd, HYD_event_t events, void *userp)
     HYDU_ERR_POP(status, "error handling proxy command\n");
 
   fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *userp)
+{
+    int accept_fd, proxy_id, count, pgid, closed;
+    HYD_status status = HYD_SUCCESS;
+    int i;
+
+    HYDU_FUNC_ENTER();
+
+    /* We got a control socket connection */
+    status = HYDU_sock_accept(fd, &accept_fd);
+    HYDU_ERR_POP(status, "accept error\n");
+
+    /* Get the PGID of the connection */
+    pgid = ((int) (size_t) userp);
+
+    /* Read the proxy ID */
+    status = HYDU_sock_read(accept_fd, &proxy_id, sizeof(int), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "sock read returned error\n");
+    HYDU_ASSERT(!closed, status);
+
+    /* Find the proxy */
+    for (i = 0; i < HYD_pmcd_pmip.children.num; i++) {
+        if (HYD_pmcd_pmip.children.proxy_id[i] == proxy_id) {
+            break;
+        }
+    }
+    if (i == HYD_pmcd_pmip.children.num)
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
+                             "cannot find proxy with ID %d\n", proxy_id);
+
+    /* This will be the control socket for this proxy */
+    HYD_pmcd_pmip.children.proxy_fd[i] = accept_fd;
+
+    /* Ask to start children if necessary */
+    if(HYD_pmcd_pmip.nodes_lists != NULL && HYD_pmcd_pmip.nodes_lists[i] != NULL) {
+        HYDU_send_start_children(accept_fd, HYD_pmcd_pmip.nodes_lists[i], proxy_id);
+    }
+
+    status = HYDT_dmx_register_fd(1, &accept_fd, HYD_POLLIN, &i, control_cb);
+    HYDU_ERR_POP(status, "unable to register fd\n");
+
+    HYD_pmcd_pmip.pid_to_fd[proxy_id] = accept_fd;
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+
+HYD_status HYD_pmci_launch_child_procs(char *nodes)
+{
+    struct HYD_node *node_list = NULL, *node, *tnode;
+    struct HYD_string_stash proxy_stash;
+    char *control_port = NULL;
+    char *pmi_port = NULL;
+    int pmi_id = -1, ret;
+    HYD_status status = HYD_SUCCESS;
+    char *node_point;
+    int num_nodes = 0, i, size, num_child;
+    int max_nodeid = 0;
+    int enable_stdin;
+    int *control_fd;
+    HYDU_FUNC_ENTER();
+
+    /* Initialize PMI */
+    ret = MPL_env2str("PMI_PORT", (const char **) &pmi_port);
+    if (ret) {  /* PMI_PORT already set */
+        pmi_port = MPL_strdup(pmi_port);
+
+        ret = MPL_env2int("PMI_ID", &pmi_id);
+        if (!ret)
+            HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "PMI_PORT set but not PMI_ID\n");
+    }
+    else {
+        pmi_id = -1;
+    }
+    if (HYD_pmcd_pmip.user_global.debug == 1)
+        HYDU_dump(stdout, "PMI port: %s; PMI ID: %d\n", pmi_port, pmi_id);
+
+    /* Copy the host list to pass to the bootstrap server */
+    node_list = NULL;
+    tnode = NULL;
+    node_point = strtok(nodes, ",");
+    for (num_nodes = 0, i = 0; node_point; ) {
+        HYDU_alloc_node(&node);
+        node->hostname = MPL_strdup(node_point);
+        node_point = strtok(NULL, ",");
+        node->core_count = atoi(node_point);
+        node_point = strtok(NULL, ",");
+        node->node_id = atoi(node_point);
+        node_point = strtok(NULL, ",");
+        node->next = NULL;
+        if(node->node_id > max_nodeid) {
+            max_nodeid = node->node_id;
+        }
+
+        if (node_list == NULL) {
+            node_list = node;
+        } else {
+            tnode->next = node;
+        }
+        tnode = node;
+        num_nodes++;
+    }
+
+
+    status = HYDU_sock_create_and_listen_portstr(HYD_pmcd_pmip.user_global.iface,
+                                                 NULL, NULL, &control_port,
+                                                 HYD_pmcd_pmiserv_control_listen_cb,
+                                                 (void *) (size_t) 0);
+    HYDU_ERR_POP(status, "unable to create PMI port\n");
+    if (HYD_pmcd_pmip.user_global.debug == 1)
+        HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
+
+    status = HYD_pmcd_pmi_fill_in_child_proxy_args(&proxy_stash, control_port, 0, node_list->node_id);
+    HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
+
+    if(num_nodes > HYD_pmcd_pmip.user_global.branch_count) {
+        int i;
+        node = node_list;
+        for(i = 1; i < HYD_pmcd_pmip.user_global.branch_count; i++) {
+            node = node->next;
+        }
+        tnode = node->next;
+        node->next = NULL;
+        num_child = HYD_pmcd_pmip.user_global.branch_count;
+        i = (num_nodes - 1) / HYD_pmcd_pmip.user_global.branch_count;
+        HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.nodes_lists, char **, HYD_pmcd_pmip.user_global.branch_count * sizeof (char *), status);
+        memset(HYD_pmcd_pmip.nodes_lists, 0, HYD_pmcd_pmip.user_global.branch_count * sizeof (char *));
+        node_list_to_strings(tnode, i, HYD_pmcd_pmip.nodes_lists);
+    } else {
+        num_child = num_nodes;
+    }
+    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.children.exited, int *, num_child* sizeof (int), status);
+    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.children.proxy_id, int *, num_child * sizeof (int), status);
+    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.children.proxy_fd, int *, num_child * sizeof (int), status);
+    HYDU_MALLOC_OR_JUMP(HYD_pmcd_pmip.pid_to_fd, int *, (max_nodeid + 1) * sizeof (int), status);
+    HYDU_MALLOC_OR_JUMP(control_fd, int *, num_child * sizeof(int), status);
+
+    node = node_list;
+    for(i = 0 ; i < num_child; i++) {
+        HYD_pmcd_pmip.children.proxy_id[i] = node->node_id;
+        HYD_pmcd_pmip.children.exited[i] = 0;
+        node = node->next;
+        control_fd[i] = HYD_FD_UNSET;
+    }
+    HYD_pmcd_pmip.children.num = num_child;
+
+    status = HYDT_bsci_launch_procs(proxy_stash.strlist, NULL, node_list, HYD_FALSE, control_fd);
+    HYDU_ERR_POP(status, "launcher server cannot launch processes\n");
+
+  fn_exit:
+    if (pmi_port)
+        MPL_free(pmi_port);
+    if (control_port)
+        MPL_free(control_port);
+    HYD_STRING_STASH_FREE(proxy_stash);
+    HYDU_free_node_list(node_list);
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
+{
+    char *buf = NULL, *pmi_cmd = NULL, *args[MAX_PMI_ARGS] = { 0 };
+    int sent, closed, repeat;
+    struct HYD_pmcd_hdr hdr;
+    struct HYD_pmcd_pmip_pmi_handle *h;
+    HYD_status status = HYD_SUCCESS;
+    int count;
+
+    HYDU_FUNC_ENTER();
+
+    HYD_pmcd_init_header(&hdr);
+    status = HYDU_sock_read(fd, &hdr, sizeof(hdr), &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to read PMI header from proxy\n");
+    HYDU_ASSERT(!closed, status)
+
+    /* Signal propagation */
+    if (hdr.cmd == SIGNAL) {
+        int i;
+
+        /* Send signal upstream */
+        status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to send SIGNAL command to proxy\n");
+        HYDU_ASSERT(!closed, status);
+
+        /* Send signal downstream except child proxy which sent this signal */
+        for( i = 0; i < HYD_pmcd_pmip.children.num; i++ ) {
+            if (fd == HYD_pmcd_pmip.children.proxy_fd[i])
+                continue;
+
+            status = HYDU_sock_write(HYD_pmcd_pmip.children.proxy_fd[i], &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+            HYDU_ERR_POP(status, "unable to send SIGNAL command to proxy\n");
+            HYDU_ASSERT(!closed, status);
+        }
+
+        status = HYD_SUCCESS;
+        goto fn_exit;
+    }
+
+    if (hdr.buflen != 0) {
+        HYDU_MALLOC_OR_JUMP(buf, char *, hdr.buflen + 1, status);
+        status = HYDU_sock_read(fd, buf, hdr.buflen, &count, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to read PMI command\n");
+        HYDU_ASSERT(!closed, status);
+        buf[hdr.buflen] = 0;
+    }
+
+    /* Handle exit_status */
+    if(hdr.cmd == EXIT_STATUS) {
+        int i;
+
+        for(i = 0; i < HYD_pmcd_pmip.children.num; i++) {
+            if(HYD_pmcd_pmip.children.proxy_id[i] == hdr.pid) {
+                HYD_pmcd_pmip.children.exited[i] = 1;
+                break;
+            }
+        }
+
+        /* Check the hdr.rank, in this case the lower level lets us know to close this socket, */
+        /* because lower level child proxies already has sent EXIT_STATUS */
+        if (hdr.rank == 1) {
+            status = HYDT_dmx_deregister_fd(fd);
+            HYDU_ERR_POP(status, "error deregistering fd\n");
+            close(fd);
+        }
+        hdr.rank = 0;
+    } else {
+        if (hdr.pid > 0) {
+            HYD_pmcd_pmip.pid_to_fd[hdr.pid] = fd;
+        }
+    }
+
+
+    /* Handle barrier_in */
+    if ( hdr.cmd == PMI_CMD) {
+        if (hdr.pmi_version == 1)
+            h = HYD_pmcd_pmip_pmi_v1;
+        else
+            h = HYD_pmcd_pmip_pmi_v2;
+        status = HYD_pmcd_pmi_parse_pmi_cmd(buf, hdr.pmi_version, &pmi_cmd, args);
+        HYDU_ERR_POP(status, "unable to parse PMI command\n");
+
+        if ( pmi_cmd && !strncmp(pmi_cmd, "barrier_in", 10) ) {
+            while (h->handler) {
+                if (!strcmp(pmi_cmd, h->cmd)) {
+                    status = h->handler(fd, NULL, &hdr);
+                    HYDU_ERR_POP(status, "PMI handler returned error\n");
+                    goto fn_exit;
+                }
+                h++;
+            }
+        }
+    }
+
+    /* Forward PMI command upstream */
+    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+    HYDU_ERR_POP(status, "unable to send PMI header upstream\n");
+    HYDU_ASSERT(!closed, status);
+
+    if (hdr.buflen != 0) {
+        status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, hdr.buflen, &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to send PMI command upstream\n");
+        HYDU_ASSERT(!closed, status);
+    }
+
+  fn_exit:
+    if (pmi_cmd)
+        MPL_free(pmi_cmd);
+    if (buf)
+        MPL_free(buf);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi.h
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi.h
@@ -18,7 +18,7 @@ extern struct HYD_pmcd_pmip_pmi_handle *HYD_pmcd_pmip_pmi_v2;
 
 struct HYD_pmcd_pmip_pmi_handle {
     const char *cmd;
-     HYD_status(*handler) (int fd, char *args[]);
+     HYD_status(*handler) (int fd, char *args[], struct HYD_pmcd_hdr *hdr);
 };
 
 extern struct HYD_pmcd_pmip_pmi_handle *HYD_pmcd_pmip_pmi_handle;

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -34,7 +34,7 @@ static struct {
     int keyval_len;
 } cache_get;
 
-static HYD_status send_cmd_upstream(const char *start, int fd, int num_args, char *args[])
+static HYD_status send_cmd_upstream(const char *start, int fd, int num_args, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int i, j, sent, closed;
     char **tmp, *buf;
@@ -62,20 +62,17 @@ static HYD_status send_cmd_upstream(const char *start, int fd, int num_args, cha
     HYDU_free_strlist(tmp);
     MPL_free(tmp);
 
-    HYD_pmcd_init_header(&hdr);
-    hdr.cmd = PMI_CMD;
-    hdr.pid = fd;
-    hdr.buflen = strlen(buf);
-    hdr.pmi_version = 1;
+    cmd_hdr->pmi_version = 1;
+    cmd_hdr->buflen = strlen(buf);
     status =
-        HYDU_sock_write(HYD_pmcd_pmip.upstream.control, &hdr, sizeof(hdr), &sent, &closed,
+        HYDU_sock_write(HYD_pmcd_pmip.upstream.control, cmd_hdr, sizeof(*cmd_hdr), &sent, &closed,
                         HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to send PMI header upstream\n");
     HYDU_ASSERT(!closed, status);
 
     debug("forwarding command (%s) upstream\n", buf);
 
-    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, hdr.buflen, &sent, &closed,
+    status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control, buf, cmd_hdr->buflen, &sent, &closed,
                              HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to send PMI command upstream\n");
     HYDU_ASSERT(!closed, status);
@@ -118,6 +115,7 @@ static HYD_status cache_put_flush(int fd)
 {
     int i;
     HYD_status status = HYD_SUCCESS;
+    struct HYD_pmcd_hdr hdr;
 
     HYDU_FUNC_ENTER();
 
@@ -126,7 +124,14 @@ static HYD_status cache_put_flush(int fd)
 
     debug("flushing %d put command(s) out\n", cache_put.keyval_len);
 
-    status = send_cmd_upstream("cmd=put ", fd, cache_put.keyval_len, cache_put.keyval);
+    HYD_pmcd_init_header(&hdr);
+    hdr.cmd = PMI_CMD;
+    if (HYD_pmcd_pmip.user_global.branch_count != -1)
+        hdr.pid = HYD_pmcd_pmip.local.id;
+    else
+        hdr.pid = fd;
+
+    status = send_cmd_upstream("cmd=put ", fd, cache_put.keyval_len, cache_put.keyval, &hdr);
     HYDU_ERR_POP(status, "error sending command upstream\n");
 
     for (i = 0; i < cache_put.keyval_len; i++)
@@ -141,7 +146,7 @@ static HYD_status cache_put_flush(int fd)
     goto fn_exit;
 }
 
-static HYD_status fn_init(int fd, char *args[])
+static HYD_status fn_init(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int pmi_version, pmi_subversion, i;
     char *tmp = NULL;
@@ -185,7 +190,7 @@ static HYD_status fn_init(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_initack(int fd, char *args[])
+static HYD_status fn_initack(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int id, i;
     char *val, *cmd;
@@ -240,7 +245,7 @@ static HYD_status fn_initack(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get_maxes(int fd, char *args[])
+static HYD_status fn_get_maxes(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd;
@@ -271,7 +276,7 @@ static HYD_status fn_get_maxes(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get_appnum(int fd, char *args[])
+static HYD_status fn_get_appnum(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int i, idx;
     struct HYD_exec *exec;
@@ -314,7 +319,7 @@ static HYD_status fn_get_appnum(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get_my_kvsname(int fd, char *args[])
+static HYD_status fn_get_my_kvsname(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd;
@@ -341,7 +346,7 @@ static HYD_status fn_get_my_kvsname(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get_usize(int fd, char *args[])
+static HYD_status fn_get_usize(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd;
@@ -375,7 +380,7 @@ static HYD_status fn_get_usize(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get(int fd, char *args[])
+static HYD_status fn_get(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd, *key, *val;
@@ -428,7 +433,7 @@ static HYD_status fn_get(int fd, char *args[])
         }
         else {
             /* if we can't find the key locally, ask upstream */
-            status = send_cmd_upstream("cmd=get ", fd, token_count, args);
+            status = send_cmd_upstream("cmd=get ", fd, token_count, args, cmd_hdr);
             HYDU_ERR_POP(status, "error sending command upstream\n");
         }
     }
@@ -442,7 +447,7 @@ static HYD_status fn_get(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_put(int fd, char *args[])
+static HYD_status fn_put(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd;
@@ -489,10 +494,11 @@ static HYD_status fn_put(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_keyval_cache(int fd, char *args[])
+static HYD_status fn_keyval_cache(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_pmcd_token *tokens;
-    int token_count, i;
+    int token_count, i, j, sent, closed;
+    char **tmp = NULL, *cmd = NULL;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -513,7 +519,37 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
     }
     cache_get.keyval_len += token_count;
 
+    if (HYD_pmcd_pmip.children.num > 0) {
+        /* allocate space for command (tokens + EOL + spaces + null) */
+        HYDU_MALLOC_OR_JUMP(tmp, char **, (2 * token_count + 3) * sizeof(char *), status);
+        j = 0;
+        tmp[j++] = MPL_strdup("cmd=keyval_cache ");
+        for (i = 0; i < token_count; i++) {
+            tmp[j++] = MPL_strdup(args[i]);
+            tmp[j++] = MPL_strdup(" ");
+        }
+        tmp[j++] = MPL_strdup("\n");
+        tmp[j] = NULL;
+
+        status = HYDU_str_alloc_and_join(tmp, &cmd);
+        HYDU_ERR_POP(status, "unable to join strings\n");
+        for(i = 0; i < HYD_pmcd_pmip.children.num; i++) {
+            status = HYDU_sock_write(HYD_pmcd_pmip.children.proxy_fd[i], cmd_hdr, sizeof(*cmd_hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+            HYDU_ERR_POP(status, "unable to sent PMI header to proxy\n");
+            HYDU_ASSERT(!closed, status);
+
+            status = send_cmd_downstream(HYD_pmcd_pmip.children.proxy_fd[i], cmd);
+            HYDU_ERR_POP(status, "unable to send keyval_cache to proxy\n");
+        }
+    }
+
   fn_exit:
+    if (tmp) {
+        HYDU_free_strlist(tmp);
+        MPL_free(tmp);
+    }
+    if (cmd)
+        MPL_free(cmd);
     HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYDU_FUNC_EXIT();
     return status;
@@ -522,7 +558,7 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_barrier_in(int fd, char *args[])
+static HYD_status fn_barrier_in(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     static int barrier_count = 0;
     HYD_status status = HYD_SUCCESS;
@@ -530,12 +566,12 @@ static HYD_status fn_barrier_in(int fd, char *args[])
     HYDU_FUNC_ENTER();
 
     barrier_count++;
-    if (barrier_count == HYD_pmcd_pmip.local.proxy_process_count) {
+    if (barrier_count == HYD_pmcd_pmip.local.proxy_process_count + HYD_pmcd_pmip.children.num) {
         barrier_count = 0;
 
         cache_put_flush(fd);
 
-        status = send_cmd_upstream("cmd=barrier_in", fd, 0, args);
+        status = send_cmd_upstream("cmd=barrier_in", fd, 0, args, cmd_hdr);
         HYDU_ERR_POP(status, "error sending command upstream\n");
     }
 
@@ -547,15 +583,25 @@ static HYD_status fn_barrier_in(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_barrier_out(int fd, char *args[])
+static HYD_status fn_barrier_out(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     char *cmd;
-    int i;
+    int i, sent, closed;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
     cmd = MPL_strdup("cmd=barrier_out\n");
+
+    for( i = 0; i < HYD_pmcd_pmip.children.num; i++ ){
+        cmd_hdr->cmd = PMI_RESPONSE;
+        status = HYDU_sock_write(HYD_pmcd_pmip.children.proxy_fd[i], cmd_hdr, sizeof(*cmd_hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
+        HYDU_ERR_POP(status, "unable to send PMI_RESPONSE header to proxy\n");
+        HYDU_ASSERT(!closed, status);
+
+        status = send_cmd_downstream(HYD_pmcd_pmip.children.proxy_fd[i], cmd);
+        HYDU_ERR_POP(status, "error sending PMI response\n");
+    }
 
     for (i = 0; i < HYD_pmcd_pmip.local.proxy_process_count; i++) {
         status = send_cmd_downstream(HYD_pmcd_pmip.downstream.pmi_fd[i], cmd);
@@ -572,7 +618,7 @@ static HYD_status fn_barrier_out(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_finalize(int fd, char *args[])
+static HYD_status fn_finalize(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     char *cmd;
     int i;

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
@@ -11,7 +11,7 @@
 #include "topo.h"
 #include "pmi_v2_common.h"
 
-static HYD_status fn_info_getnodeattr(int fd, char *args[]);
+static HYD_status fn_info_getnodeattr(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr);
 
 static struct HYD_pmcd_pmi_v2_reqs *pending_reqs = NULL;
 
@@ -127,7 +127,7 @@ static HYD_status poke_progress(char *key)
             }
         }
         else {
-            status = fn_info_getnodeattr(req->fd, req->args);
+            status = fn_info_getnodeattr(req->fd, req->args, NULL);
             HYDU_ERR_POP(status, "getnodeattr returned error\n");
 
             /* Free the dequeued request */
@@ -148,7 +148,7 @@ static HYD_status poke_progress(char *key)
     goto fn_exit;
 }
 
-static HYD_status fn_fullinit(int fd, char *args[])
+static HYD_status fn_fullinit(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int id, i;
     char *rank_str;
@@ -214,7 +214,7 @@ static HYD_status fn_fullinit(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_job_getid(int fd, char *args[])
+static HYD_status fn_job_getid(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd, *thrid;
@@ -255,7 +255,7 @@ static HYD_status fn_job_getid(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_info_putnodeattr(int fd, char *args[])
+static HYD_status fn_info_putnodeattr(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *key, *val, *thrid, *cmd;
@@ -315,7 +315,7 @@ static HYD_status fn_info_putnodeattr(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_info_getnodeattr(int fd, char *args[])
+static HYD_status fn_info_getnodeattr(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     int found;
     struct HYD_pmcd_pmi_kvs_pair *run;
@@ -367,7 +367,7 @@ static HYD_status fn_info_getnodeattr(int fd, char *args[])
     }
     else if (waitval && !strcmp(waitval, "TRUE")) {
         /* The client wants to wait for a response; queue up the request */
-        status = HYD_pmcd_pmi_v2_queue_req(fd, -1, -1, args, key, &pending_reqs);
+        status = HYD_pmcd_pmi_v2_queue_req(fd, -1, -1, -1, args, key, &pending_reqs);
         HYDU_ERR_POP(status, "unable to queue request\n");
 
         goto fn_exit;
@@ -399,7 +399,7 @@ static HYD_status fn_info_getnodeattr(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_info_getjobattr(int fd, char *args[])
+static HYD_status fn_info_getjobattr(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     struct HYD_string_stash stash;
     char *cmd, *key, *thrid;
@@ -449,7 +449,7 @@ static HYD_status fn_info_getjobattr(int fd, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_finalize(int fd, char *args[])
+static HYD_status fn_finalize(int fd, char *args[], struct HYD_pmcd_hdr *cmd_hdr)
 {
     char *thrid;
     struct HYD_string_stash stash;

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi.h
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi.h
@@ -62,7 +62,7 @@ HYD_status HYD_pmcd_pmi_lookup(char *name, char **value);
 
 struct HYD_pmcd_pmi_handle {
     const char *cmd;
-     HYD_status(*handler) (int fd, int pid, int pgid, char *args[]);
+     HYD_status(*handler) (int fd, int pid, int pgid, char *args[], int rank);
 };
 
 extern struct HYD_pmcd_pmi_handle *HYD_pmcd_pmi_handle;

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v1.c
@@ -11,7 +11,7 @@
 #include "pmiserv_pmi.h"
 #include "pmiserv_utils.h"
 
-static HYD_status cmd_response(int fd, int pid, const char *cmd)
+static HYD_status cmd_response(int fd, int pid, const char *cmd, int rank)
 {
     struct HYD_pmcd_hdr hdr;
     int sent, closed;
@@ -24,6 +24,7 @@ static HYD_status cmd_response(int fd, int pid, const char *cmd)
     hdr.pid = pid;
     hdr.pmi_version = 1;
     hdr.buflen = strlen(cmd);
+    hdr.rank = rank;
     status = HYDU_sock_write(fd, &hdr, sizeof(hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);
     HYDU_ERR_POP(status, "unable to send PMI_RESPONSE header to proxy\n");
     HYDU_ASSERT(!closed, status);
@@ -44,7 +45,7 @@ static HYD_status cmd_response(int fd, int pid, const char *cmd)
     goto fn_exit;
 }
 
-static HYD_status bcast_keyvals(int fd, int pid)
+static HYD_status bcast_keyvals(int fd, int pid, int rank)
 {
     int keyval_count, arg_count, i, j;
     char **tmp = NULL, *cmd;
@@ -96,8 +97,11 @@ static HYD_status bcast_keyvals(int fd, int pid)
 
                 pg_scratch->keyval_dist_count += (arg_count - 1);
                 for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-                    status = cmd_response(tproxy->control_fd, pid, cmd);
-                    HYDU_ERR_POP(status, "error writing PMI line\n");
+                    if (tproxy->node->pmi_level == 1 || tproxy->pg->pgid) {
+                        /* we do not support hierarchy for spawned processes yet */
+                        status = cmd_response(tproxy->control_fd, pid, cmd, rank);
+                        HYDU_ERR_POP(status, "error writing PMI line\n");
+                    }
                 }
                 MPL_free(cmd);
 
@@ -115,8 +119,11 @@ static HYD_status bcast_keyvals(int fd, int pid)
 
             pg_scratch->keyval_dist_count += (arg_count - 1);
             for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-                status = cmd_response(tproxy->control_fd, pid, cmd);
-                HYDU_ERR_POP(status, "error writing PMI line\n");
+                if (tproxy->node->pmi_level == 1 || tproxy->pg->pgid) {
+                    /* we do not support hierarchy for spawned processes yet */
+                    status = cmd_response(tproxy->control_fd, pid, cmd, rank);
+                    HYDU_ERR_POP(status, "error writing PMI line\n");
+                }
             }
             MPL_free(cmd);
         }
@@ -133,7 +140,7 @@ static HYD_status bcast_keyvals(int fd, int pid)
     goto fn_exit;
 }
 
-static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_proxy *proxy, *tproxy;
     int proxy_count;
@@ -149,14 +156,22 @@ static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
         proxy_count++;
 
     proxy->pg->barrier_count++;
+
+    if (HYD_server_info.user_global.branch_count != -1 && proxy_count > HYD_server_info.user_global.branch_count && pgid == 0) {
+        proxy_count = HYD_server_info.user_global.branch_count;
+    }
+
     if (proxy->pg->barrier_count == proxy_count) {
         proxy->pg->barrier_count = 0;
 
-        bcast_keyvals(fd, pid);
+        bcast_keyvals(fd, pid, rank);
 
         for (tproxy = proxy->pg->proxy_list; tproxy; tproxy = tproxy->next) {
-            status = cmd_response(tproxy->control_fd, pid, "cmd=barrier_out\n");
-            HYDU_ERR_POP(status, "error writing PMI line\n");
+            if (tproxy->node->pmi_level == 1 || tproxy->pg->pgid) {
+                /* we do not support hierarchy for spawned processes yet */
+                status = cmd_response(tproxy->control_fd, pid, "cmd=barrier_out\n", rank);
+                HYDU_ERR_POP(status, "error writing PMI line\n");
+            }
         }
     }
 
@@ -168,7 +183,7 @@ static HYD_status fn_barrier_in(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_put(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_put(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_proxy *proxy;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
@@ -199,7 +214,7 @@ static HYD_status fn_put(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_get(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_get(int fd, int pid, int pgid, char *args[], int rank)
 {
     int i;
     struct HYD_proxy *proxy;
@@ -266,7 +281,7 @@ static HYD_status fn_get(int fd, int pid, int pgid, char *args[])
     HYDU_ERR_POP(status, "unable to join strings\n");
     HYDU_free_strlist(tmp);
 
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, cmd, rank);
     HYDU_ERR_POP(status, "error writing PMI line\n");
     MPL_free(cmd);
 
@@ -304,7 +319,7 @@ static void segment_tokens(struct HYD_pmcd_token *tokens, int token_count,
     *num_segments = j + 1;
 }
 
-static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_pg *pg;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
@@ -592,7 +607,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");
 
-    status = HYDT_bsci_launch_procs(proxy_stash.strlist, pg->proxy_list, HYD_FALSE, NULL);
+    status = HYDT_bsci_launch_procs(proxy_stash.strlist, pg->proxy_list, pg->user_node_list, HYD_FALSE, NULL);
     HYDU_ERR_POP(status, "launcher cannot launch processes\n");
 
     {
@@ -604,14 +619,14 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
 
         HYD_STRING_SPIT(stash, cmd, status);
 
-        status = cmd_response(fd, pid, cmd);
+        status = cmd_response(fd, pid, cmd, rank);
         HYDU_ERR_POP(status, "error writing PMI line\n");
         MPL_free(cmd);
     }
 
     /* Cache the pre-initialized keyvals on the new proxies */
     if (preput_num)
-        bcast_keyvals(fd, pid);
+        bcast_keyvals(fd, pid, rank);
 
   fn_exit:
     HYD_pmcd_pmi_free_tokens(tokens, token_count);
@@ -625,7 +640,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_string_stash stash;
     char *cmd, *val;
@@ -662,7 +677,7 @@ static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[])
 
     HYD_STRING_SPIT(stash, cmd, status);
 
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, cmd, rank);
     HYDU_ERR_POP(status, "send command failed\n");
     MPL_free(cmd);
 
@@ -681,7 +696,7 @@ static HYD_status fn_publish_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_string_stash stash;
     char *cmd, *name;
@@ -712,7 +727,7 @@ static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[])
 
     HYD_STRING_SPIT(stash, cmd, status);
 
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, cmd, rank);
     HYDU_ERR_POP(status, "send command failed\n");
     MPL_free(cmd);
 
@@ -726,7 +741,7 @@ static HYD_status fn_unpublish_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[], int rank)
 {
     struct HYD_string_stash stash;
     char *cmd, *name, *value = NULL;
@@ -758,7 +773,7 @@ static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[])
 
     HYD_STRING_SPIT(stash, cmd, status);
 
-    status = cmd_response(fd, pid, cmd);
+    status = cmd_response(fd, pid, cmd, rank);
     HYDU_ERR_POP(status, "send command failed\n");
     MPL_free(cmd);
 
@@ -774,7 +789,7 @@ static HYD_status fn_lookup_name(int fd, int pid, int pgid, char *args[])
     goto fn_exit;
 }
 
-static HYD_status fn_abort(int fd, int pid, int pgid, char *args[])
+static HYD_status fn_abort(int fd, int pid, int pgid, char *args[], int rank)
 {
     int token_count;
     struct HYD_pmcd_token *tokens;
@@ -794,7 +809,7 @@ static HYD_status fn_abort(int fd, int pid, int pgid, char *args[])
 
   fn_exit:
     /* clean everything up and exit */
-    status = HYDT_bsci_wait_for_completion(0);
+    status = HYDT_bsci_wait_for_completion(0, NULL, NULL, NULL);
     exit(exitcode);
 
     /* never get here */

--- a/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
@@ -59,6 +59,11 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     if (HYD_server_info.user_global.debug)
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--debug"), status);
 
+    if (HYD_server_info.user_global.branch_count != -1) {
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup("--branch-count"), status);
+        HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(HYD_server_info.user_global.branch_count), status);
+    }
+
     if (HYDT_bsci_info.rmk) {
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--rmk"), status);
         HYD_STRING_STASH(*proxy_stash, MPL_strdup(HYDT_bsci_info.rmk), status);

--- a/src/pm/hydra/tools/bootstrap/external/common.h
+++ b/src/pm/hydra/tools/bootstrap/external/common.h
@@ -20,6 +20,6 @@ int HYDTI_bscd_env_is_avail(const char *env_name);
 int HYDTI_bscd_in_env_list(const char *env_name, const char *env_list[]);
 
 HYD_status HYDT_bscd_common_launch_procs(char **args, struct HYD_proxy *proxy_list,
-                                         int use_rmk, int *control_fd);
+                                         struct HYD_node *node_list, int use_rmk, int *control_fd);
 
 #endif /* COMMON_H_INCLUDED */

--- a/src/pm/hydra/tools/bootstrap/external/ll.h
+++ b/src/pm/hydra/tools/bootstrap/external/ll.h
@@ -11,8 +11,8 @@
 
 HYD_status HYDTI_bscd_ll_query_node_count(int *count);
 
-HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                     int *control_fd);
+HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list,
+                                     struct HYD_node *node_list, int use_rmk, int *control_fd);
 HYD_status HYDT_bscd_ll_query_proxy_id(int *proxy_id);
 HYD_status HYDT_bscd_ll_query_native_int(int *ret);
 HYD_status HYDT_bscd_ll_query_node_list(struct HYD_node **node_list);

--- a/src/pm/hydra/tools/bootstrap/external/ll_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/ll_launch.c
@@ -12,8 +12,8 @@
 
 static int fd_stdout, fd_stderr;
 
-HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                     int *control_fd)
+HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list,
+                                     struct HYD_node *node_list, int use_rmk, int *control_fd)
 {
     int idx, i, total_procs, node_count;
     int *pid, *fd_list, exec_idx;

--- a/src/pm/hydra/tools/bootstrap/external/pbs.h
+++ b/src/pm/hydra/tools/bootstrap/external/pbs.h
@@ -20,8 +20,8 @@ struct HYDT_bscd_pbs_sys_s {
 
 extern struct HYDT_bscd_pbs_sys_s *HYDT_bscd_pbs_sys;
 
-HYD_status HYDT_bscd_pbs_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                      int *control_fd);
+HYD_status HYDT_bscd_pbs_launch_procs(char **args, struct HYD_proxy *proxy_list, struct HYD_node *node_list,
+                                      int use_rmk, int *control_fd);
 HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *ret);
 HYD_status HYDT_bscd_pbs_wait_for_completion(int timeout);
 HYD_status HYDT_bscd_pbs_launcher_finalize(void);

--- a/src/pm/hydra/tools/bootstrap/external/pbs_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/pbs_launch.c
@@ -35,8 +35,8 @@ static HYD_status find_pbs_node_id(const char *hostname, int *node_id)
     goto fn_exit;
 }
 
-HYD_status HYDT_bscd_pbs_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                      int *control_fd)
+HYD_status HYDT_bscd_pbs_launch_procs(char **args, struct HYD_proxy *proxy_list,
+                                      struct HYD_node *node_list, int use_rmk, int *control_fd)
 {
     int proxy_count, i, args_count, err, hostid;
     struct HYD_proxy *proxy;

--- a/src/pm/hydra/tools/bootstrap/external/slurm.h
+++ b/src/pm/hydra/tools/bootstrap/external/slurm.h
@@ -9,8 +9,8 @@
 
 #include "hydra.h"
 
-HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                        int *control_fd);
+HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_list,
+                                        struct HYD_node *node_list, int use_rmk, int *control_fd);
 HYD_status HYDT_bscd_slurm_query_proxy_id(int *proxy_id);
 HYD_status HYDT_bscd_slurm_query_native_int(int *ret);
 HYD_status HYDT_bscd_slurm_query_node_list(struct HYD_node **node_list);

--- a/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
@@ -59,8 +59,8 @@ static HYD_status proxy_list_to_node_str(struct HYD_proxy *proxy_list, char **no
     goto fn_exit;
 }
 
-HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                        int *control_fd)
+HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_list,
+                                        struct HYD_node *node_list, int use_rmk, int *control_fd)
 {
     int num_hosts, idx, i;
     int *pid, *fd_list;

--- a/src/pm/hydra/tools/bootstrap/include/bsci.h
+++ b/src/pm/hydra/tools/bootstrap/include/bsci.h
@@ -51,14 +51,13 @@ struct HYDT_bsci_fns {
 
     /* Launcher functions */
     /** \brief Launch processes */
-    HYD_status(*launch_procs) (char **args, struct HYD_proxy * proxy_list, int use_rmk,
-                               int *control_fd);
+    HYD_status(*launch_procs) (char **args, struct HYD_proxy * proxy_list, struct HYD_node * node_list, int use_rmk, int *control_fd);
 
     /** \brief Finalize the bootstrap control device */
     HYD_status(*launcher_finalize) (void);
 
     /** \brief Wait for launched processes to complete */
-    HYD_status(*wait_for_completion) (int timeout);
+    HYD_status(*wait_for_completion) (int timeout, int *ncompleted, int **pids, int **exit_statuses);
 
     /** \brief Query the ID of a proxy */
     HYD_status(*query_proxy_id) (int *proxy_id);
@@ -95,6 +94,7 @@ HYD_status HYDT_bsci_init(const char *rmk, const char *launcher,
  *
  * \param[in]   args            Arguments to be used for the launched processes
  * \param[in]   proxy_list      List of proxies to launch
+ * \param[in]   node_list       List of nodes to launch
  * \param[in]   use_rmk         Force not to use RMK if HYD_FALSE
  * \param[out]  control_fd      Control socket to communicate with the launched process
  *
@@ -128,8 +128,7 @@ HYD_status HYDT_bsci_init(const char *rmk, const char *launcher,
  * process.  On the other hand, if it is HYD_FALSE, we force not to
  * use RMK.  HYD_FALSE is passed in PMI spawn functions.
  */
-HYD_status HYDT_bsci_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                  int *control_fd);
+HYD_status HYDT_bsci_launch_procs(char **args, struct HYD_proxy *proxy_list, struct HYD_node *node_list, int use_rmk, int *control_fd);
 
 
 /**
@@ -146,13 +145,19 @@ HYD_status HYDT_bsci_finalize(void);
  *
  * \param[in]  timeout        Time to wait for
  *
+ * \param[out] ncompleted     Number of completed processes
+ *
+ * \param[out] pids           Pids of the completed processes
+ *
+ * \param[out] exit_statuses  Exit statuses of the completed processes
+ *
  * \param[ret] status         HYD_TIMED_OUT if the timer expired
  *
  * This function waits for all processes it launched to finish. The
  * launcher should keep track of the processes it is launching and
  * wait for their completion.
  */
-HYD_status HYDT_bsci_wait_for_completion(int timeout);
+HYD_status HYDT_bsci_wait_for_completion(int timeout, int *ncompleted, int **pids, int **exit_statuses);
 
 
 /**

--- a/src/pm/hydra/tools/bootstrap/persist/persist_client.h
+++ b/src/pm/hydra/tools/bootstrap/persist/persist_client.h
@@ -12,8 +12,8 @@
 #include "persist.h"
 
 HYD_status HYDT_bscd_persist_launch_procs(char **args, struct HYD_proxy *proxy_list,
-                                          int use_rmk, int *control_fd);
-HYD_status HYDT_bscd_persist_wait_for_completion(int timeout);
+                                          struct HYD_node *node_list, int use_rmk, int *control_fd);
+HYD_status HYDT_bscd_persist_wait_for_completion(int timeout, int *, int **, int **);
 
 extern int *HYDT_bscd_persist_control_fd;
 extern int HYDT_bscd_persist_node_count;

--- a/src/pm/hydra/tools/bootstrap/persist/persist_launch.c
+++ b/src/pm/hydra/tools/bootstrap/persist/persist_launch.c
@@ -59,7 +59,7 @@ static HYD_status persist_cb(int fd, HYD_event_t events, void *userp)
 }
 
 HYD_status HYDT_bscd_persist_launch_procs(char **args, struct HYD_proxy *proxy_list,
-                                          int use_rmk, int *control_fd)
+                                          struct HYD_node *node_list, int use_rmk, int *control_fd)
 {
     struct HYD_proxy *proxy;
     int idx, i;

--- a/src/pm/hydra/tools/bootstrap/persist/persist_wait.c
+++ b/src/pm/hydra/tools/bootstrap/persist/persist_wait.c
@@ -8,7 +8,7 @@
 #include "bsci.h"
 #include "persist_client.h"
 
-HYD_status HYDT_bscd_persist_wait_for_completion(int timeout)
+HYD_status HYDT_bscd_persist_wait_for_completion(int timeout, int *ncompleted, int **procs, int **exit_statuses)
 {
     int ret, i, all_done;
     HYD_status status = HYD_SUCCESS;

--- a/src/pm/hydra/tools/bootstrap/src/bsci_launch.c
+++ b/src/pm/hydra/tools/bootstrap/src/bsci_launch.c
@@ -7,14 +7,13 @@
 #include "hydra.h"
 #include "bsci.h"
 
-HYD_status HYDT_bsci_launch_procs(char **args, struct HYD_proxy *proxy_list, int use_rmk,
-                                  int *control_fd)
+HYD_status HYDT_bsci_launch_procs(char **args, struct HYD_proxy *proxy_list, struct HYD_node *node_list, int use_rmk, int *control_fd)
 {
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    status = HYDT_bsci_fns.launch_procs(args, proxy_list, use_rmk, control_fd);
+    status = HYDT_bsci_fns.launch_procs(args, proxy_list, node_list, use_rmk, control_fd);
     HYDU_ERR_POP(status, "launcher returned error while launching processes\n");
 
   fn_exit:

--- a/src/pm/hydra/tools/bootstrap/src/bsci_wait.c
+++ b/src/pm/hydra/tools/bootstrap/src/bsci_wait.c
@@ -8,17 +8,17 @@
 #include "bsci.h"
 #include "bscu.h"
 
-HYD_status HYDT_bsci_wait_for_completion(int timeout)
+HYD_status HYDT_bsci_wait_for_completion(int timeout, int *ncompleted, int **procs, int **exit_statuses)
 {
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
     if (HYDT_bsci_fns.wait_for_completion) {
-        status = HYDT_bsci_fns.wait_for_completion(timeout);
+        status = HYDT_bsci_fns.wait_for_completion(timeout, ncompleted, procs, exit_statuses);
     }
     else {
-        status = HYDT_bscu_wait_for_completion(timeout);
+        status = HYDT_bscu_wait_for_completion(timeout, ncompleted, procs, exit_statuses);
     }
     HYDU_ERR_POP(status, "launcher returned error waiting for completion\n");
 

--- a/src/pm/hydra/tools/bootstrap/utils/bscu.h
+++ b/src/pm/hydra/tools/bootstrap/utils/bscu.h
@@ -15,7 +15,7 @@ extern int HYD_bscu_fd_count;
 extern int *HYD_bscu_pid_list;
 extern int HYD_bscu_pid_count;
 
-HYD_status HYDT_bscu_wait_for_completion(int timeout);
+HYD_status HYDT_bscu_wait_for_completion(int timeout, int *ncompleted, int **procs, int **exit_statuses);
 HYD_status HYDT_bscu_stdio_cb(int fd, HYD_event_t events, void *userp);
 
 #endif /* BSCU_H_INCLUDED */

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -619,6 +619,27 @@ static HYD_status config_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
+static void branch_count_help_fn(void)
+{
+    printf("\n");
+    printf("-branch-count: number of child proxies in tree\n");
+}
+
+static HYD_status branch_count_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    status = HYDU_set_int(arg, &HYD_server_info.user_global.branch_count, atoi(**argv));
+    HYDU_ERR_POP(status, "error setting branch count\n");
+
+  fn_exit:
+    (*argv)++;
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 static void env_help_fn(void)
 {
     printf("\n");
@@ -1533,6 +1554,14 @@ static HYD_status set_default_values(void)
     if (hostname_propagation == -1)
         MPL_env2bool("HYDRA_HOSTNAME_PROPAGATION", &hostname_propagation);
 
+    if (HYD_server_info.user_global.branch_count == -1) {
+        if (MPL_env2str("HYDRA_BRANCH_COUNT", (const char **) &tmp) != 0)
+            HYD_server_info.user_global.branch_count = atoi(tmp);
+        tmp = NULL;
+    }
+    if (HYD_server_info.user_global.branch_count < 1)
+        HYD_server_info.user_global.branch_count = -1;
+
     /* If an interface is provided, set that */
     if (HYD_server_info.user_global.iface) {
         if (hostname_propagation == 1) {
@@ -1790,6 +1819,7 @@ static struct HYD_arg_match_table match_table[] = {
     {"errfile", errfile_pattern_fn, errfile_pattern_help_fn},
     {"wdir", wdir_fn, wdir_help_fn},
     {"configfile", config_fn, config_help_fn},
+    {"branch-count", branch_count_fn, branch_count_help_fn},
 
     /* Local environment options */
     {"env", env_fn, env_help_fn},

--- a/src/pm/hydra/ui/utils/uiu.c
+++ b/src/pm/hydra/ui/utils/uiu.c
@@ -52,6 +52,14 @@ void HYD_uiu_init_params(void)
 void HYD_uiu_free_params(void)
 {
     struct stdoe_fd *tmp, *run;
+    int i;
+
+    if (HYD_server_info.nodes_lists) {
+        for(i = 0; i < HYD_server_info.user_global.branch_count; i++) {
+            MPL_free(HYD_server_info.nodes_lists[i]);
+        }
+        MPL_free(HYD_server_info.nodes_lists);
+    }
 
     HYDU_finalize_user_global(&HYD_server_info.user_global);
 

--- a/src/pm/hydra/utils/alloc/alloc.c
+++ b/src/pm/hydra/utils/alloc/alloc.c
@@ -25,6 +25,7 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
     user_global->enablex = -1;
     user_global->debug = -1;
     user_global->usize = HYD_USIZE_UNSET;
+    user_global->branch_count = -1;
 
     user_global->auto_cleanup = -1;
 
@@ -99,6 +100,7 @@ HYD_status HYDU_alloc_node(struct HYD_node **node)
     (*node)->node_id = -1;
     (*node)->user = NULL;
     (*node)->local_binding = NULL;
+    (*node)->pmi_level = 1;
     (*node)->next = NULL;
 
   fn_exit:


### PR DESCRIPTION
Hierarchy support includes options parsing, tree-based application process startup, hydra, and pmi commands propagation.
Added new "-branch-count <num>" Hydra's option to restrict the number of child management processes launched by the Hydra PM, or by each pmi_proxy management process.

Tree-based startup currently is not supported for spawned processes.