### PR TITLE
CH4: Check for errors when building locality

### DIFF
--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -225,10 +225,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
         MPIDI_av_table0->table[i].is_local = 0;
     }
-    MPIDI_CH4U_build_nodemap(MPIR_Process.comm_world->rank,
-                             MPIR_Process.comm_world,
-                             MPIR_Process.comm_world->local_size,
-                             MPIDI_CH4_Global.node_map[0], &MPIDI_CH4_Global.max_node_id);
+    mpi_errno = MPIDI_CH4U_build_nodemap(MPIR_Process.comm_world->rank,
+                                         MPIR_Process.comm_world,
+                                         MPIR_Process.comm_world->local_size,
+                                         MPIDI_CH4_Global.node_map[0], &MPIDI_CH4_Global.max_node_id);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
         MPIDI_av_table0->table[i].is_local =


### PR DESCRIPTION
We should abort if we are unable to build locality info, otherwise we
will almost certainly crash later.