### PR TITLE
Fix huge message transfer protocol

### DIFF
--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -11,6 +11,12 @@
 #include <mpidimpl.h>
 #include "ofi_impl.h"
 MPIDI_OFI_global_t MPIDI_Global = { 0 };
+
+MPIDI_OFI_huge_recv_t *MPIDI_unexp_huge_recv_head = NULL;
+MPIDI_OFI_huge_recv_t *MPIDI_unexp_huge_recv_tail = NULL;
+MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_head = NULL;
+MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_tail = NULL;
+
 MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
 
 /* Initialize a runtime version of all of the capability sets defined in

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -177,6 +177,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_RECV_HUGE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_RECV_HUGE_EVENT);
 
+    /* Check that the sender didn't underflow the message by sending less than
+     * the huge message threshold. */
+    if (wc->len < MPIDI_Global.max_send) {
+        return MPIDI_OFI_recv_event(wc, rreq);
+    }
+
     comm_ptr = MPIDI_OFI_REQUEST(rreq, util_comm);
 
     /* Check to see if the tracker is already in the unexpected list.

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1313,7 +1313,7 @@ static inline int MPIDI_OFI_choose_provider(struct fi_info *prov, struct fi_info
 
 static inline int MPIDI_OFI_application_hints(int rank)
 {
-    int rank_bits, world_size, mpi_errno;
+    int world_size, mpi_errno;
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "MPIDI_OFI_ENABLE_DATA: %d", MPIDI_OFI_ENABLE_DATA));
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "MPIDI_OFI_ENABLE_AV_TABLE: %d", MPIDI_OFI_ENABLE_AV_TABLE));
@@ -1329,8 +1329,6 @@ static inline int MPIDI_OFI_application_hints(int rank)
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "MPIDI_OFI_CONTEXT_BITS: %d", MPIDI_OFI_CONTEXT_BITS));
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "MPIDI_OFI_SOURCE_BITS: %d", MPIDI_OFI_SOURCE_BITS));
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL,VERBOSE,(MPL_DBG_FDEST, "MPIDI_OFI_TAG_BITS: %d", MPIDI_OFI_TAG_BITS));
-
-    rank_bits = MPIDI_OFI_SOURCE_BITS ? MPIDI_OFI_SOURCE_BITS : 32;
 
     if (MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG && rank == 0) {
         fprintf(stdout, "==== Capability set configuration ====\n");
@@ -1353,7 +1351,7 @@ static inline int MPIDI_OFI_application_hints(int rank)
         /* Discover the maximum number of ranks. If the source shift is not
          * defined, there are 32 bits in use due to the uint32_t used in
          * ofi_send.h */
-        fprintf(stdout, "MAXIMUM SUPPORTED RANKS: %ld\n", (long int) 1 << rank_bits);
+        fprintf(stdout, "MAXIMUM SUPPORTED RANKS: %ld\n", (long int) 1 << MPIDI_OFI_MAX_RANK_BITS);
 
         /* Discover the tag_ub */
         fprintf(stdout, "MAXIMUM TAG: %" PRIu64 "\n", 1UL << MPIDI_OFI_TAG_BITS);
@@ -1366,7 +1364,7 @@ static inline int MPIDI_OFI_application_hints(int rank)
         MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_get_size",
                              "**pmi_get_size %d", mpi_errno);
     }
-    if (world_size > (1UL << rank_bits)) {
+    if (world_size > (1UL << MPIDI_OFI_MAX_RANK_BITS)) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**ch4|too_many_ranks");
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -50,10 +50,22 @@
 #define MPIDI_OFI_CONTEXT_MASK       (((1ULL << MPIDI_OFI_CONTEXT_BITS) - 1) << (MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SOURCE_MASK        (((1ULL << MPIDI_OFI_SOURCE_BITS) - 1) << MPIDI_OFI_TAG_BITS)
 #define MPIDI_OFI_TAG_MASK           ((1ULL << MPIDI_OFI_TAG_BITS) - 1)
+/* This value comes from the fact that we use a uint32_t in
+ * MPIDI_OFI_send_handler to define the dest and that is the size we expect
+ * from the OFI provider for its immediate data field. */
+#define MPIDI_OFI_MAX_RANK_BITS      (MPIDI_OFI_SOURCE_BITS > 0 ? MPIDI_OFI_SOURCE_BITS : 32)
 #else
 #define MPIDI_OFI_CONTEXT_MASK       MPIDI_OFI_CONTEXT_MASK_CAPSET
 #define MPIDI_OFI_SOURCE_MASK        MPIDI_OFI_SOURCE_MASK_CAPSET
 #define MPIDI_OFI_TAG_MASK           MPIDI_OFI_TAG_MASK_CAPSET
+#if MPIDI_OFI_SOURCE_BITS == 0
+/* This value comes from the fact that we use a uint32_t in
+ * MPIDI_OFI_send_handler to define the dest and that is the size we expect
+ * from the OFI provider for its immediate data field. */
+#define MPIDI_OFI_MAX_RANK_BITS      32
+#else
+#define MPIDI_OFI_MAX_RANK_BITS      MPIDI_OFI_SOURCE_BITS
+#endif
 #endif
 
 /* RMA Key Space division

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -56,6 +56,7 @@ noinst_PROGRAMS =  \
     big_count_status	\
     many_isend     \
     manylmt        \
+    huge_underflow \
     dtype_send		 \
     recv_any		\
     irecv_any

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -57,6 +57,7 @@ noinst_PROGRAMS =  \
     many_isend     \
     manylmt        \
     huge_underflow \
+    huge_anysrc    \
     dtype_send		 \
     recv_any		\
     irecv_any

--- a/test/mpi/pt2pt/huge_anysrc.c
+++ b/test/mpi/pt2pt/huge_anysrc.c
@@ -1,0 +1,60 @@
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ *
+ *  This program checks if MPICH can correctly handle many outstanding large
+ *  message transfers which use wildcard receives.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+#include <mpi.h>
+
+#define N_TRY 32
+#define BLKSIZE (10*1024*1024)
+
+int main(int argc, char *argv[])
+{
+    int size, rank;
+    int dest;
+    int i;
+    char *buff;
+    MPI_Request reqs[N_TRY];
+
+    MPI_Init(&argc, &argv);
+
+    buff = malloc(N_TRY * BLKSIZE);
+    memset(buff, -1, N_TRY * BLKSIZE);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    dest = size - 1;
+
+    if (rank == 0) {
+        for (i = 0; i < N_TRY; i++)
+            MPI_Isend(buff + BLKSIZE*i, BLKSIZE, MPI_BYTE, dest, 0, MPI_COMM_WORLD, &reqs[i]);
+        MPI_Waitall(N_TRY, reqs, MPI_STATUSES_IGNORE);
+    }
+    else if (rank == dest) {
+        for (i = 0; i < N_TRY; i++)
+            MPI_Irecv(buff + BLKSIZE*i, BLKSIZE, MPI_BYTE, MPI_ANY_SOURCE, 0, MPI_COMM_WORLD, &reqs[i]);
+        MPI_Waitall(N_TRY, reqs, MPI_STATUSES_IGNORE);
+    }
+
+    free(buff);
+
+    if (rank == 0)
+        puts(" No Errors");
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/mpi/pt2pt/huge_underflow.c
+++ b/test/mpi/pt2pt/huge_underflow.c
@@ -1,0 +1,57 @@
+
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ *
+ *  This program checks if MPICH can correctly handle a huge message receive
+ *  when the sender underflows by sending a much smaller message
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+#include <mpi.h>
+
+#define HUGE_SIZE (10*1024*1024)
+
+int main(int argc, char *argv[])
+{
+    int size, rank;
+    int dest;
+    char *buff;
+
+    MPI_Init(&argc, &argv);
+
+    buff = malloc(HUGE_SIZE);
+    buff[0] = 0;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    dest = size - 1;
+
+    /* Try testing underflow to make sure things work if we try to send 1 byte
+     * when receiving a huge message */
+    if (rank == 0) {
+        MPI_Send(buff, 1, MPI_BYTE, dest, 0, MPI_COMM_WORLD);
+    } else if (rank == dest) {
+        MPI_Recv(buff, HUGE_SIZE, MPI_BYTE, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    }
+
+    free(buff);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0)
+        puts(" No Errors");
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/mpi/pt2pt/testlist
+++ b/test/mpi/pt2pt/testlist
@@ -44,6 +44,7 @@ mprobe 2 mpiversion=3.0
 big_count_status 1 mpiversion=3.0
 many_isend 3
 manylmt 2
+huge_underflow 2
 dtype_send 2
 recv_any 2
 irecv_any 2

--- a/test/mpi/pt2pt/testlist
+++ b/test/mpi/pt2pt/testlist
@@ -45,6 +45,7 @@ big_count_status 1 mpiversion=3.0
 many_isend 3
 manylmt 2
 huge_underflow 2
+huge_anysrc 2
 dtype_send 2
 recv_any 2
 irecv_any 2


### PR DESCRIPTION
The huge message transfer protocol didn't handle multiple outstanding messages at once. This changes that protocol to hash on something that is less specific. It also adds some tests for corner cases that were also failing.