### PR TITLE
config: Use relative path to embedded OPA source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1239,7 +1239,7 @@ AC_SUBST([opalib])
 
 if test "$with_openpa_prefix" = "embedded" ; then
     if test -e "${use_top_srcdir}/src/openpa" ; then
-        opasrcdir="${master_top_builddir}/src/openpa"
+        opasrcdir="src/openpa"
         opalib="src/openpa/src/lib${OPALIBNAME}.la"
         PAC_APPEND_FLAG([-I${use_top_srcdir}/src/openpa/src],[CPPFLAGS])
         PAC_APPEND_FLAG([-I${master_top_builddir}/src/openpa/src],[CPPFLAGS])


### PR DESCRIPTION
Specifying the full path to an embedded OpenPA confused the TAGS target
provided by automake. Use a relative path like we do with MPL.