### PR TITLE
CH4/OFI: Support unknown provider name

### DIFF
--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -17,6 +17,22 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
  * ofi_capability_sets.h so we can refer to it if we want to preload a
  * capability set at runtime */
 {
+    { /* minimal required capability */
+        .enable_data               = MPIDI_OFI_ENABLE_DATA_MINIMAL,
+        .enable_av_table           = MPIDI_OFI_ENABLE_AV_TABLE_MINIMAL,
+        .enable_scalable_endpoints = MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS_MINIMAL,
+        .enable_stx_rma            = MPIDI_OFI_ENABLE_STX_RMA_MINIMAL,
+        .enable_mr_scalable        = MPIDI_OFI_ENABLE_MR_SCALABLE_MINIMAL,
+        .enable_tagged             = MPIDI_OFI_ENABLE_TAGGED_MINIMAL,
+        .enable_am                 = MPIDI_OFI_ENABLE_AM_MINIMAL,
+        .enable_rma                = MPIDI_OFI_ENABLE_RMA_MINIMAL,
+        .enable_atomics            = MPIDI_OFI_ENABLE_ATOMICS_MINIMAL,
+        .max_endpoints             = MPIDI_OFI_MAX_ENDPOINTS_MINIMAL,
+        .max_endpoints_bits        = MPIDI_OFI_MAX_ENDPOINTS_BITS_MINIMAL,
+        .context_bits              = MPIDI_OFI_CONTEXT_BITS_MINIMAL,
+        .source_bits               = MPIDI_OFI_SOURCE_BITS_MINIMAL,
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_MINIMAL
+    },
     { /* psm */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_PSM,
         .enable_av_table           = MPIDI_OFI_ENABLE_AV_TABLE_PSM,

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -15,7 +15,8 @@
 #define MPIDI_OFI_ON      1
 
 enum {
-    MPIDI_OFI_SET_NUMBER_PSM = 0,
+    MPIDI_OFI_SET_NUMBER_UNKNOWN = 0,
+    MPIDI_OFI_SET_NUMBER_PSM,
     MPIDI_OFI_SET_NUMBER_PSM2,
     MPIDI_OFI_SET_NUMBER_GNI,
     MPIDI_OFI_SET_NUMBER_SOCKETS,
@@ -45,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
     } else if (!strcmp("verbs", set_name)) {
         return MPIDI_OFI_SET_NUMBER_VERBS;
     } else {
-        return -1;
+        return MPIDI_OFI_SET_NUMBER_UNKNOWN;
     }
 }
 
@@ -348,6 +349,29 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_VERBS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_VERBS
 #endif
+
+/* capability set for default provider (to request the minimal supported capability) */
+#define MPIDI_OFI_ENABLE_DATA_MINIMAL               MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_AV_TABLE_MINIMAL           MPIDI_OFI_ON
+#define MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS_MINIMAL MPIDI_OFI_OFF
+#define MPIDI_OFI_MAX_ENDPOINTS_MINIMAL             MPIDI_OFI_MAX_ENDPOINTS_REGULAR
+#define MPIDI_OFI_MAX_ENDPOINTS_BITS_MINIMAL        MPIDI_OFI_MAX_ENDPOINTS_BITS_REGULAR
+#define MPIDI_OFI_ENABLE_STX_RMA_MINIMAL            MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_MR_SCALABLE_MINIMAL        MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_TAGGED_MINIMAL             MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_AM_MINIMAL                 MPIDI_OFI_ON
+#define MPIDI_OFI_ENABLE_RMA_MINIMAL                MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_ATOMICS_MINIMAL            MPIDI_OFI_ENABLE_RMA_MINIMAL
+#define MPIDI_OFI_FETCH_ATOMIC_IOVECS_MINIMAL       1
+#define MPIDI_OFI_ENABLE_DATA_AUTO_PROGRESS_MINIMAL MPIDI_OFI_OFF
+#define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_MINIMAL  MPIDI_OFI_OFF
+#define MPIDI_OFI_CONTEXT_MASK_MINIMAL              (0x0FFFF00000000000ULL)
+#define MPIDI_OFI_SOURCE_MASK_MINIMAL               (0x00000FFFFFF00000ULL) /* assume that provider does not support immediate data
+                                                                             * so this field needs to be available */
+#define MPIDI_OFI_TAG_MASK_MINIMAL                  (0x00000000000FFFFFULL)
+#define MPIDI_OFI_CONTEXT_BITS_MINIMAL              (16)
+#define MPIDI_OFI_SOURCE_BITS_MINIMAL               (24)
+#define MPIDI_OFI_TAG_BITS_MINIMAL                  (20)
 
 #ifdef MPIDI_CH4_OFI_USE_SET_RUNTIME
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     1


### PR DESCRIPTION
- added support of provider not listed in predefined
  providers caps (minimal capability are required for such
  providers)
- fixed incorrect memory access on wrong provider
  name specified via MPIR_CVAR_OFI_USE_PROVIDER variable:
  if user set non-existing provider name then initialization
  function is trying to access to array of predefined caps
  by index -1. In most of cases this is not critical, but
  potentially may cause crash

Change-Id: I95e8571643e8e0451a72d19e01c668e195983b57