### PR TITLE
CH4/UCX Remove old mutex code

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -136,8 +136,6 @@ static inline int MPIDI_NM_progress(void *netmod_context, int blocking)
 
     ucp_worker_progress(MPIDI_UCX_global.worker);
 
-    MPID_THREAD_CS_EXIT(POBJ, MPIDI_THREAD_WORKER_MUTEX);
-
   fn_exit:
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION
UCX currently only supports coarse grain threading
.
The deleted line is a remnant  from old copy/paste and will break
some builds