### PR TITLE
Fixed packet data length bug in LMT in commit bcc8a81.

### DIFF
--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -557,6 +557,8 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
                     cell_buf    += buflen;
                     payload_len -= buflen;
 
+                    MPIR_Assert(payload_len >= 0);
+
                     mpi_errno = MPID_nem_handle_pkt(vc, cell_buf, payload_len);
                     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
                     MPID_nem_mpich_release_fbox(cell);
@@ -783,6 +785,9 @@ int MPID_nem_handle_pkt(MPIDI_VC_t *vc, char *buf, intptr_t buflen)
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
                 buflen -= len;
                 buf    += len;
+
+                MPIR_Assert(buflen >= 0);
+
                 MPL_DBG_STMT(MPIDI_CH3_DBG_CHANNEL, VERBOSE, if (!rreq) MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "...completed immediately"));
             }
             while (!rreq && buflen >= sizeof(MPIDI_CH3_Pkt_t));
@@ -848,6 +853,7 @@ int MPID_nem_handle_pkt(MPIDI_VC_t *vc, char *buf, intptr_t buflen)
         /* copy data into user buffer described by iov in rreq */
         MPIR_Assert(rreq);
         MPIR_Assert(rreq->dev.iov_count > 0 && rreq->dev.iov[rreq->dev.iov_offset].MPL_IOV_LEN > 0);
+        MPIR_Assert(buflen >= 0);
 
         MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "    copying into user buffer from IOV");
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
@@ -509,7 +509,7 @@ static int pkt_COOKIE_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, 
         mpi_errno = vc->ch.lmt_handle_cookie(vc, req, cookie);
         MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        *buflen = sizeof(MPIDI_CH3_Pkt_t);
+        *buflen = 0;
         *rreqp = NULL;
     }
 


### PR DESCRIPTION
Commit bcc8a81 changed the buffer length adjustment in all packet
handlers. But it missed pkt_COOKIE_handler in nemesis LMT routine,
thus resulted in negative buflen in progress engine.

This patch fixed it and added assert to check buflen never goes into
negative in progress engine.

Thanks Steven Oyanagi for the bug report.