### PR TITLE
CH4/OFI: Add FUNCNAME/FCNAME for do_inject

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -485,6 +485,10 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
     goto fn_exit;
 }
 
+#undef FUNCNAME
+#define FUNCNAME MPIDI_OFI_do_inject
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_OFI_do_inject(int rank,
                                       MPIR_Comm * comm,
                                       int handler_id,


### PR DESCRIPTION
This patch adds missing FUNCNAME/FCNAME declarations for
MPIDI_OFI_do_inject, which causes confusion during debugging.