### PR TITLE
util/nodemap: fix out_sz for one process case.

### DIFF
--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -356,8 +356,8 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
     MPL_env2int("PMI_SUBVERSION", &pmi_subversion);
 
     if (sz == 1) {
-        out_nodemap[0] = ++g_max_node_id;
-        *out_sz = g_max_node_id;
+        out_nodemap[0] = 0;
+        *out_sz = 1;
         goto fn_exit;
     }
 


### PR DESCRIPTION
The special case for one process incorrectly sets out_sz to 0. This
patch fix it.

This is a low priority patch.