### PR TITLE
CH4: Define MPID_Node_id_t as signed type

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -391,7 +391,7 @@ typedef struct MPIDI_Devcomm_t {
 
 
 #define MPID_USE_NODE_IDS
-typedef uint16_t MPID_Node_id_t;
+typedef int16_t MPID_Node_id_t;
 
 typedef struct {
     union {


### PR DESCRIPTION
This type should be signed so that proper error checking can be done by
the upper layer.