### PR TITLE
Disable overflow check if types are same size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4741,6 +4741,11 @@ if test "$ac_cv_sizeof_int" = "$aint_size" ; then
     AC_DEFINE(SIZEOF_INT_IS_AINT,1,[define if sizeof(int) = sizeof(MPI_Aint)])
 fi
 
+# If sizeof(mpi_aint) = sizeof(int), set this value
+if test "$ac_cv_sizeof_void_p" = "$aint_size" ; then
+    AC_DEFINE(SIZEOF_PTR_IS_AINT,1,[define if sizeof(void *) = sizeof(MPI_Aint)])
+fi
+
 # ----------------------------------------------------------------------------
 # MPI_AINT datatype
 # ----------------------------------------------------------------------------

--- a/src/include/mpir_pointers.h
+++ b/src/include/mpir_pointers.h
@@ -73,7 +73,11 @@
  *
  * \param[in]  aint  Variable of type MPI_Aint
  */
+#ifndef SIZEOF_PTR_IS_AINT
 #define MPIR_Ensure_Aint_fits_in_pointer(aint) \
   MPIR_Assert((aint) == (MPI_Aint)(uintptr_t) MPIR_AINT_CAST_TO_VOID_PTR(aint));
+#else
+#define MPIR_Ensure_Aint_fits_in_pointer(aint) do {} while(0)
+#endif
 
 #endif /* MPIR_POINTERS_H_INCLUDED */


### PR DESCRIPTION
On platforms where MPI_Aint is the same size as a pointer, squash
warnings for "-Wtautological-compare".