### PR TITLE
CH4/OFI: fixed windows startup issue: type mismatch

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1398,7 +1398,7 @@ static inline int MPIDI_OFI_application_hints(int rank)
         MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_get_size",
                              "**pmi_get_size %d", mpi_errno);
     }
-    if (world_size > (1UL << MPIDI_OFI_MAX_RANK_BITS)) {
+    if (MPIDI_OFI_MAX_RANK_BITS < 32 && world_size > (1 << MPIDI_OFI_MAX_RANK_BITS)) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**ch4|too_many_ranks");
     }
 


### PR DESCRIPTION
- on LLP64 platforms (for example Windows) "long int" type
  is 4 bytes data type, due to this limitation comparing
  of (int) and (long << 32) works incorrectly (different
  from Linux systems), there is overflow of value.
  Fix: add additional condition for shift-bits are less
  than 32
