### PR TITLE
Fix init debug msg

### DIFF
--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -636,6 +636,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
             comm->node_roots_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
             comm->node_roots_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS;
             comm->node_roots_comm->local_comm = NULL;
+            MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_roots_comm=%p\n", comm->node_roots_comm);
 
             comm->node_roots_comm->local_size = num_external;
             comm->node_roots_comm->remote_size = num_external;

--- a/src/mpi/comm/intercomm_merge.c
+++ b/src/mpi/comm/intercomm_merge.c
@@ -98,6 +98,9 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm *comm_ptr, int high, MPIR_Comm **new_int
 
         /* If local_high and remote_high are the same, then order is arbitrary.
            we use the is_low_group in the intercomm in this case. */
+        MPL_DBG_MSG_FMT(MPIR_DBG_COMM,VERBOSE,
+                        (MPL_DBG_FDEST, "local_high=%d remote_high=%d is_low_group=%d",
+                         local_high, remote_high, comm_ptr->is_low_group));
         if (local_high == remote_high) {
             local_high = !(comm_ptr->is_low_group);
         }

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -234,6 +234,15 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPIDI_COMM(MPIR_Process.comm_self, local_map).mode = MPIDI_RANK_MAP_NONE;
     MPIDIU_avt_add_ref(0);
 
+#ifdef MPL_USE_DBG_LOGGING
+    int counter_;
+    if (size < 16) {
+        for (counter_ = 0; counter_ < size; ++counter_) {
+            MPIDIU_comm_rank_to_av(MPIR_Process.comm_world, counter_);
+        }
+    }
+#endif
+
     MPIR_Process.attrs.tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
     /* discuss */
 

--- a/src/mpid/ch4/src/ch4_spawn.h
+++ b/src/mpid/ch4/src/ch4_spawn.h
@@ -93,7 +93,7 @@ static inline void MPIDI_free_pmi_keyvals(PMI_keyval_t ** kv, int size, int *cou
             MPL_free(kv[i]);
     }
 
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FREE_PMI_KEYVALS);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FREE_PMI_KEYVALS);
 }
 
 #undef FUNCNAME

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -1051,6 +1051,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
         MPIDI_COMM(comm, local_map).mode = MPIDI_RANK_MAP_NONE;
     }
 
+#ifdef MPL_USE_DBG_LOGGING
+    int rank_;
+    int avtid_, lpid_;
+    if (comm->remote_size < 16) {
+        for (rank_ = 0; rank_ < comm->remote_size; ++rank_) {
+            MPIDIU_comm_rank_to_pid(comm, rank_, &lpid_, &avtid_);
+            MPIDIU_comm_rank_to_av(comm, rank_);
+        }
+    }
+    if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM && comm->local_size < 16) {
+        for (rank_ = 0; rank_ < comm->local_size; ++rank_) {
+            MPIDIU_comm_rank_to_pid_local(comm, rank_, &lpid_, &avtid_);
+        }
+    }
+#endif
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMM_CREATE_RANK_MAP);
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -26,6 +26,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_COMM_RANK_TO_PID);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_COMM_RANK_TO_PID);
 
+    *avtid = 0;
+
     switch (MPIDI_COMM(comm, map).mode) {
     case MPIDI_RANK_MAP_DIRECT:
         *avtid = MPIDI_COMM(comm, map).avtid;


### PR DESCRIPTION
1. Added new debug messages for MPIR_Comm_commmit and MPIR_Intercomm_merge_impl.
2. Fixed the mismatched FUNC_ENTER/FUNC_EXIT in CH4
3. Added debug message to print the entire rank-address mapping for COMMs with less than 16 ranks.
4. Fixed uninitialized avtid in the rank-address translation.