### PR TITLE
Fixed CH4 lock synchronization.

### DIFF
--- a/src/mpi/coll/ired_scat.c
+++ b/src/mpi/coll/ired_scat.c
@@ -1070,10 +1070,8 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
                         MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i;
     MPIR_Comm *comm_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IREDUCE_SCATTER);
-    i = 0;
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IREDUCE_SCATTER);
@@ -1101,6 +1099,8 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
     {
         MPID_BEGIN_ERROR_CHECKS
         {
+            int i = 0;
+
             MPIR_Comm_valid_ptr( comm_ptr, mpi_errno, FALSE );
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 

--- a/src/mpi/pt2pt/testall.c
+++ b/src/mpi/pt2pt/testall.c
@@ -233,7 +233,6 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
 		MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
-    int i;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -246,6 +245,8 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
+        int i = 0;
+
 	    MPIR_ERRTEST_COUNT(count, mpi_errno);
 
 	    if (count != 0) {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -262,15 +262,14 @@ typedef struct MPIDI_CH4U_win_sync_pscw {
 } MPIDI_CH4U_win_sync_pscw_t;
 
 typedef struct MPIDI_CH4U_win_target_sync {
-    int origin_epoch_type;      /* NONE, LOCK. */
+    int access_epoch_type;      /* NONE, LOCK. */
     MPIDI_CH4U_win_target_sync_lock_t lock;
 } MPIDI_CH4U_win_target_sync_t;
 
 typedef struct MPIDI_CH4U_win_sync {
-    /* TODO: replace with access/exposure */
-    int origin_epoch_type;      /* NONE, FENCE, LOCKALL, START,
+    int access_epoch_type;      /* NONE, FENCE, LOCKALL, START,
                                  * LOCK (refer to target_sync). */
-    int target_epoch_type;      /* NONE, FENCE, POST. */
+    int exposure_epoch_type;    /* NONE, FENCE, POST. */
 
     /* access epochs */
     /* TODO: Can we put access epochs in union,

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -284,8 +284,11 @@ typedef struct MPIDI_CH4U_win_sync {
 } MPIDI_CH4U_win_sync_t;
 
 typedef struct MPIDI_CH4U_win_target {
-    MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */
-    MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
+    /* NOTE: use volatile to avoid compiler optimization which keeps reading
+     * register value when no dependency or function pointer is found in fully
+     * inlined code. MPIR_cc_t does not include volatile for global lock. */
+    volatile MPIR_cc_t local_cmpl_cnts; /* increase at OP issuing, decrease at local completion */
+    volatile MPIR_cc_t remote_cmpl_cnts;        /* increase at OP issuing, decrease at remote completion */
     MPIDI_CH4U_win_target_sync_t sync;
 } MPIDI_CH4U_win_target_t;
 
@@ -295,8 +298,12 @@ typedef struct MPIDI_CH4U_win_t {
     int64_t mmap_sz;
 
     /* per-window OP completion for fence */
-    MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */
-    MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
+
+    /* NOTE: use volatile to avoid compiler optimization which keeps reading
+     * register value when no dependency or function pointer is found in fully
+     * inlined code. MPIR_cc_t does not include volatile for global lock.*/
+    volatile MPIR_cc_t local_cmpl_cnts; /* increase at OP issuing, decrease at local completion */
+    volatile MPIR_cc_t remote_cmpl_cnts;        /* increase at OP issuing, decrease at remote completion */
 
     MPI_Aint *sizes;
     MPIDI_CH4U_win_sync_t sync;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -441,7 +441,7 @@ static inline int MPIDI_NM_mpi_win_complete(MPIR_Win * win)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
 
-    MPIDI_CH4U_EPOCH_TARGET_EVENT(win);
+    MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
 
     MPIR_Group_release(MPIDI_CH4U_WIN(win, sync).sc.group);
     MPIDI_CH4U_WIN(win, sync).sc.group = NULL;
@@ -527,7 +527,7 @@ static inline int MPIDI_NM_mpi_win_wait(MPIR_Win * win)
 
     MPIR_Group_release(group);
 
-    MPIDI_CH4U_EPOCH_ORIGIN_EVENT(win);
+    MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_WIN_WAIT);
@@ -562,7 +562,7 @@ static inline int MPIDI_NM_mpi_win_test(MPIR_Win * win, int *flag)
         MPIDI_CH4U_WIN(win, sync).pw.group = NULL;
         *flag = 1;
         MPIR_Group_release(group);
-        MPIDI_CH4U_EPOCH_ORIGIN_EVENT(win);
+        MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     }
     else {
         MPIDI_OFI_PROGRESS();
@@ -679,7 +679,6 @@ static inline int MPIDI_NM_mpi_win_unlock(int rank, MPIR_Win * win, MPIDI_av_ent
     /* Reset window epoch only when all per-target lock epochs are closed.*/
     if (MPIDI_CH4U_WIN(win, sync).lock.count == 0) {
       MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
-      MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     }
 
   fn_exit:
@@ -1276,7 +1275,6 @@ static inline int MPIDI_NM_mpi_win_unlock_all(MPIR_Win * win)
     MPIDI_OFI_PROGRESS_WHILE(MPIDI_CH4U_WIN(win, sync).lockall.allLocked);
 
     MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
-    MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_WIN_UNLOCK_ALL);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -340,8 +340,9 @@ static inline void MPIDI_OFI_win_unlock_done_proc(const MPIDI_OFI_win_control_t 
         MPIR_Assert((int) MPIDI_CH4U_WIN(win, sync).lockall.allLocked > 0);
         MPIDI_CH4U_WIN(win, sync).lockall.allLocked -= 1;
     }
-    else
+    else {
         MPIR_Assert(0);
+    }
 
 }
 

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -330,13 +330,13 @@ static inline void MPIDI_OFI_win_post_proc(const MPIDI_OFI_win_control_t * info,
 static inline void MPIDI_OFI_win_unlock_done_proc(const MPIDI_OFI_win_control_t * info,
                                                   MPIR_Win * win, unsigned peer)
 {
-    if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK) {
+    if (MPIDI_CH4U_WIN(win, sync).access_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK) {
         MPIDI_CH4U_win_target_t *target_ptr = &MPIDI_CH4U_WIN(win, targets)[info->origin_rank];
 
         MPIR_Assert((int ) target_ptr->sync.lock.locked == 1);
         target_ptr->sync.lock.locked = 0;
     }
-    else if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK_ALL) {
+    else if (MPIDI_CH4U_WIN(win, sync).access_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK_ALL) {
         MPIR_Assert((int) MPIDI_CH4U_WIN(win, sync).lockall.allLocked > 0);
         MPIDI_CH4U_WIN(win, sync).lockall.allLocked -= 1;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -26,7 +26,7 @@ static inline int MPIDI_UCX_contig_put(const void *origin_addr,
     MPIR_Comm *comm = win->comm_ptr;
     ucp_ep_h ep = MPIDI_UCX_COMM_TO_EP(comm, target_rank);
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
 
@@ -71,7 +71,7 @@ static inline int MPIDI_UCX_noncontig_put(const void *origin_addr,
     MPIDU_Segment_pack(segment_ptr, segment_first, &last, buffer);
     MPIDU_Segment_free(segment_ptr);
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
     /* We use the blocking put here - should be faster than send/recv - ucp_put returns when it is
@@ -102,7 +102,7 @@ static inline int MPIDI_UCX_contig_get(void *origin_addr,
     ucp_ep_h ep = MPIDI_UCX_COMM_TO_EP(comm, target_rank);
 
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -242,7 +242,10 @@ static inline int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
     int mpi_errno = MPI_SUCCESS;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Win *win = *win_ptr;
-    MPIDI_CH4U_EPOCH_FREE_CHECK(win, mpi_errno, return mpi_errno);
+
+    MPIDI_CH4U_ACCESS_EPOCH_CHECK_NONE(win, mpi_errno, return mpi_errno);
+    MPIDI_CH4U_EXPOSURE_EPOCH_CHECK_NONE(win, mpi_errno, return mpi_errno);
+
     mpi_errno = MPIR_Barrier_impl(win->comm_ptr, &errflag);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -59,8 +59,9 @@ static inline int MPIDI_POSIX_mpi_improbe(int source,
 
             if (MPIDI_POSIX_ENVELOPE_MATCH
                 (MPIDI_POSIX_REQUEST(req), source, tag, comm->recvcontext_id + context_offset)) {
-                if (mqueue.head == NULL)
+                if (mqueue.head == NULL) {
                     MPIR_Assert(req == matched_req);
+                }
 
                 count += MPIR_STATUS_GET_COUNT(req->status);
                 MPIDI_POSIX_REQUEST_DEQUEUE(&req, prev_req, MPIDI_POSIX_recvq_unexpected);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -432,8 +432,8 @@ static inline int MPIDI_CH4I_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_G
 #define MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, stmt)               \
     do {                                                                \
         MPID_BEGIN_ERROR_CHECKS;                                        \
-        if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_WIN(win, sync).target_epoch_type && \
-           MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_REFENCE) \
+        if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_REFENCE && \
+           MPIDI_CH4U_WIN(win, sync).target_epoch_type == MPIDI_CH4U_EPOTYPE_REFENCE) \
         {                                                               \
             MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_FENCE; \
             MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_FENCE; \
@@ -497,13 +497,12 @@ static inline int MPIDI_CH4I_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_G
 #define MPIDI_CH4U_EPOCH_FENCE_CHECK(win,mpi_errno,stmt)                \
     do {                                                                \
         MPID_BEGIN_ERROR_CHECKS;                                        \
-        if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_WIN(win, sync).target_epoch_type) \
-            MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC,            \
-                                stmt, "**rmasync");                     \
-        if (!(massert & MPI_MODE_NOPRECEDE) &&                          \
-            MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_FENCE && \
+        if ((MPIDI_CH4U_WIN(win, sync).target_epoch_type != MPIDI_CH4U_EPOTYPE_FENCE && \
+            MPIDI_CH4U_WIN(win, sync).target_epoch_type != MPIDI_CH4U_EPOTYPE_REFENCE && \
+            MPIDI_CH4U_WIN(win, sync).target_epoch_type != MPIDI_CH4U_EPOTYPE_NONE) || \
+            (MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_FENCE && \
             MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_REFENCE && \
-            MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_NONE) \
+            MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_NONE)) \
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC,            \
                                 stmt, "**rmasync");                     \
         MPID_END_ERROR_CHECKS;                                          \
@@ -543,7 +542,8 @@ do {                                                                  \
 #define MPIDI_CH4U_EPOCH_FREE_CHECK(win,mpi_errno,stmt)                 \
     do {                                                                \
         MPID_BEGIN_ERROR_CHECKS;                                        \
-        if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_WIN(win, sync).target_epoch_type || \
+        if ((MPIDI_CH4U_WIN(win, sync).target_epoch_type != MPIDI_CH4U_EPOTYPE_NONE &&  \
+            MPIDI_CH4U_WIN(win, sync).target_epoch_type != MPIDI_CH4U_EPOTYPE_REFENCE) || \
            (MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_NONE && \
             MPIDI_CH4U_WIN(win, sync).origin_epoch_type != MPIDI_CH4U_EPOTYPE_REFENCE)) \
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, stmt, "**rmasync"); \
@@ -605,22 +605,6 @@ do {                                                                  \
             MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_REFENCE; \
             MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_REFENCE; \
         }                                                               \
-    } while (0)
-
-#define MPIDI_CH4U_EPOCH_TARGET_EVENT(win)                              \
-    do {                                                            \
-        if (MPIDI_CH4U_WIN(win, sync).target_epoch_type == MPIDI_CH4U_EPOTYPE_REFENCE) \
-            MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_REFENCE; \
-        else                                                            \
-            MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE; \
-    } while (0)
-
-#define MPIDI_CH4U_EPOCH_ORIGIN_EVENT(Win)                              \
-    do {                                                                \
-        if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_REFENCE) \
-            MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_REFENCE; \
-        else                                                            \
-            MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE; \
     } while (0)
 
 /*

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -882,13 +882,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
 
     /* do some sanity checks */
     MPL_LL_FOREACH(comm->mapper_head, mapper) {
-        if (mapper->src_comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+        if (mapper->src_comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
             MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
                         mapper->dir == MPIR_COMM_MAP_DIR__L2R);
+        }
 
-        if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+        if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
             MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
                         mapper->dir == MPIR_COMM_MAP_DIR__R2L);
+        }
     }
 
     /* First, handle all the mappers that contribute to the local part

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -39,6 +39,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_PUT);
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
@@ -63,7 +64,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIR_Assert(sreq);
     MPIDI_CH4U_REQUEST(sreq, req->preq.win_ptr) = win;
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
     am_hdr.src_rank = win->comm_ptr->rank;
     am_hdr.target_disp = target_disp;
@@ -170,6 +171,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_GET);
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
@@ -198,7 +200,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->greq.datatype) = origin_datatype;
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
@@ -287,6 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_ACCUMULATE);
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -302,7 +305,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIR_Assert(sreq);
     MPIDI_CH4U_REQUEST(sreq, req->areq.win_ptr) = win;
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     am_hdr.req_ptr = (uint64_t) sreq;
@@ -434,6 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_GET_ACCUMULATE);
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -456,7 +460,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->areq.result_datatype) = result_datatype;
     dtype_add_ref_if_not_builtin(result_datatype);
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     /* TODO: have common routine for accumulate/get_accumulate */
@@ -892,6 +896,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_COMPARE_AND_SWAP);
 
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
     MPIDI_Datatype_check_size(datatype, 1, data_sz);
     if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
@@ -913,7 +918,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIDI_CH4U_REQUEST(sreq, req->creq.data) = p_data;
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
 
-    MPIDI_CH4U_EPOCH_START_CHECK(win, mpi_errno, goto fn_fail);
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     am_hdr.target_disp = target_disp;

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -41,10 +41,14 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
-    MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
-    if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
+    /* Check target sync status for any target_rank except PROC_NULL. */
+    if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    }
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
+
+    MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
+    if (data_sz == 0)
+        goto fn_exit;
 
     if (target_rank == win->comm_ptr->rank) {
         offset = win->disp_unit * target_disp;
@@ -64,7 +68,6 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIR_Assert(sreq);
     MPIDI_CH4U_REQUEST(sreq, req->preq.win_ptr) = win;
 
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
     am_hdr.src_rank = win->comm_ptr->rank;
     am_hdr.target_disp = target_disp;
@@ -173,10 +176,14 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
-    MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
-    if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
+    /* Check target sync status for any target_rank except PROC_NULL. */
+    if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    }
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
+
+    MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
+    if (data_sz == 0)
+        goto fn_exit;
 
     if (target_rank == win->comm_ptr->rank) {
         offset = win->disp_unit * target_disp;
@@ -200,7 +207,6 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->greq.datatype) = origin_datatype;
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
 
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
@@ -291,10 +297,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
+    /* Check target sync status for any target_rank except PROC_NULL. */
+    if (target_rank == MPI_PROC_NULL)
+        goto fn_exit;
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
+
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
-
-    if (data_sz == 0 || target_rank == MPI_PROC_NULL || target_data_sz == 0) {
+    if (data_sz == 0 || target_data_sz == 0) {
         goto fn_exit;
     }
 
@@ -304,8 +314,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     sreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 2);
     MPIR_Assert(sreq);
     MPIDI_CH4U_REQUEST(sreq, req->areq.win_ptr) = win;
-
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     am_hdr.req_ptr = (uint64_t) sreq;
@@ -439,12 +447,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
+    /* Check target sync status for any target_rank except PROC_NULL. */
+    if (target_rank == MPI_PROC_NULL)
+        goto fn_exit;
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
+
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
     MPIDI_Datatype_check_size(result_datatype, result_count, result_data_sz);
 
-    if (target_rank == MPI_PROC_NULL || target_data_sz == 0 ||
-        (data_sz == 0 && result_data_sz == 0)) {
+    if (target_data_sz == 0 || (data_sz == 0 && result_data_sz == 0)) {
         goto fn_exit;
     }
 
@@ -459,8 +471,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->areq.result_count) = result_count;
     MPIDI_CH4U_REQUEST(sreq, req->areq.result_datatype) = result_datatype;
     dtype_add_ref_if_not_builtin(result_datatype);
-
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     /* TODO: have common routine for accumulate/get_accumulate */
@@ -898,10 +908,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
     MPIDI_CH4U_EPOCH_OP_REFENCE(win);
 
-    MPIDI_Datatype_check_size(datatype, 1, data_sz);
-    if (data_sz == 0 || target_rank == MPI_PROC_NULL) {
+    /* Check target sync status for any target_rank except PROC_NULL. */
+    if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    }
+    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
+
+    MPIDI_Datatype_check_size(datatype, 1, data_sz);
+    if (data_sz == 0)
+        goto fn_exit;
 
     p_data = MPL_malloc(data_sz * 2);
     MPIR_Assert(p_data);
@@ -917,8 +931,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIDI_CH4U_REQUEST(sreq, req->creq.result_addr) = result_addr;
     MPIDI_CH4U_REQUEST(sreq, req->creq.data) = p_data;
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
-
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     am_hdr.target_disp = target_disp;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -320,13 +320,13 @@ static inline void MPIDI_win_unlock_done(const MPIDI_CH4U_win_cntrl_msg_t * info
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_WIN_UNLOCK_DONE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_WIN_UNLOCK_DONE);
 
-    if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK) {
+    if (MPIDI_CH4U_WIN(win, sync).access_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK) {
         MPIDI_CH4U_win_target_t *target_ptr = &MPIDI_CH4U_WIN(win, targets)[info->origin_rank];
 
         MPIR_Assert((int) target_ptr->sync.lock.locked == 1);
         target_ptr->sync.lock.locked = 0;
     }
-    else if (MPIDI_CH4U_WIN(win, sync).origin_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK_ALL) {
+    else if (MPIDI_CH4U_WIN(win, sync).access_epoch_type == MPIDI_CH4U_EPOTYPE_LOCK_ALL) {
         MPIR_Assert((int) MPIDI_CH4U_WIN(win, sync).lockall.allLocked > 0);
         MPIDI_CH4U_WIN(win, sync).lockall.allLocked -= 1;
     }

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -323,7 +323,7 @@ static inline int MPIDI_CH4R_mpi_win_complete(MPIR_Win * win)
     }
 
     MPL_free(ranks_in_win_grp);
-    MPIDI_CH4U_EPOCH_TARGET_EVENT(win);
+    MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     MPIR_Group_release(MPIDI_CH4U_WIN(win, sync).sc.group);
     MPIDI_CH4U_WIN(win, sync).sc.group = NULL;
 
@@ -403,7 +403,7 @@ static inline int MPIDI_CH4R_mpi_win_wait(MPIR_Win * win)
     MPIDI_CH4U_WIN(win, sync).sc.count = 0;
     MPIDI_CH4U_WIN(win, sync).pw.group = NULL;
     MPIR_Group_release(group);
-    MPIDI_CH4U_EPOCH_ORIGIN_EVENT(win);
+    MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_MPI_WIN_WAIT);
@@ -433,7 +433,7 @@ static inline int MPIDI_CH4R_mpi_win_test(MPIR_Win * win, int *flag)
         MPIDI_CH4U_WIN(win, sync).pw.group = NULL;
         *flag = 1;
         MPIR_Group_release(group);
-        MPIDI_CH4U_EPOCH_ORIGIN_EVENT(win);
+        MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     }
     else {
         MPIDI_CH4R_PROGRESS();
@@ -544,7 +544,6 @@ static inline int MPIDI_CH4R_mpi_win_unlock(int rank, MPIR_Win * win)
     /* Reset window epoch only when all per-target lock epochs are closed. */
     if (MPIDI_CH4U_WIN(win, sync).lock.count == 0) {
         MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
-        MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     }
 
   fn_exit:
@@ -1164,7 +1163,6 @@ static inline int MPIDI_CH4R_mpi_win_unlock_all(MPIR_Win * win)
     MPIDI_CH4R_PROGRESS_WHILE(MPIDI_CH4U_WIN(win, sync).lockall.allLocked);
 
     MPIDI_CH4U_WIN(win, sync).origin_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
-    MPIDI_CH4U_WIN(win, sync).target_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_MPI_WIN_UNLOCK_ALL);


### PR DESCRIPTION
The previous code managed lock epochs per window, thus did not support
simultaneous lock epochs on the same window but targeting to different
processes. This patch redesigned the RMA synchronization structure to
support per-target lock synchronization.