### PR TITLE
Get jobid

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -408,7 +408,6 @@ typedef struct {
     /* Process management and PMI globals */
     int pname_set;
     int pname_len;
-    int jobid;
     char addrname[FI_NAME_MAX];
     size_t addrnamelen;
     char kvsname[MPIDI_KVSAPPSTRLEN];

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -963,12 +963,12 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
         goto fn_fail;
 
     shm_key = (char *) MPL_malloc(sizeof(char));
-    shm_key_size = snprintf(shm_key, 1, "/mpi-%X-%X-%" PRIx64,
-                            MPIDI_Global.jobid, root_rank,
+    shm_key_size = snprintf(shm_key, 1, "/mpi-%s-%X-%" PRIx64,
+                            MPIDI_CH4_Global.jobid, root_rank,
                             MPIDI_OFI_WIN(win).win_id);
     shm_key = (char *) MPL_realloc(shm_key, shm_key_size);
-    snprintf(shm_key, shm_key_size, "/mpi-%X-%X-%" PRIx64,
-             MPIDI_Global.jobid, root_rank, MPIDI_OFI_WIN(win).win_id);
+    snprintf(shm_key, shm_key_size, "/mpi-%s-%X-%" PRIx64,
+             MPIDI_CH4_Global.jobid, root_rank, MPIDI_OFI_WIN(win).win_id);
 
     rc = shm_open(shm_key, O_CREAT | O_EXCL | O_RDWR, 0600);
     first = (rc != -1);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -272,7 +272,7 @@ typedef struct MPIDI_CH4_Global_t {
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
     MPID_Thread_mutex_t m[2];
     MPIR_Win *win_hash;
-    int jobid;
+    char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDI_CH4U_rreq_t *posted_list;
     MPIDI_CH4U_rreq_t *unexp_list;

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -888,11 +888,11 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
         goto fn_fail;
 
     shm_key = (char *) MPL_malloc(sizeof(char));
-    shm_key_size = snprintf(shm_key, 1, "/mpi-%X-%X-%" PRIx64,
+    shm_key_size = snprintf(shm_key, 1, "/mpi-%s-%X-%" PRIx64,
                             MPIDI_CH4_Global.jobid, root_rank,
                             MPIDI_CH4U_WIN(win, win_id));
     shm_key = (char *) MPL_realloc(shm_key, shm_key_size);
-    snprintf(shm_key, shm_key_size, "/mpi-%X-%X-%" PRIx64,
+    snprintf(shm_key, shm_key_size, "/mpi-%s-%X-%" PRIx64,
              MPIDI_CH4_Global.jobid, root_rank, MPIDI_CH4U_WIN(win, win_id));
 
     rc = shm_open(shm_key, O_CREAT | O_EXCL | O_RDWR, 0600);

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -832,14 +832,14 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
                                                      MPIR_Comm * comm_ptr,
                                                      void **base_ptr, MPIR_Win ** win_ptr)
 {
-    int i = 0, fd = -1, rc, first = 0, mpi_errno = MPI_SUCCESS;
+    int i = 0, fd = -1, rc, first = 0, mpi_errno = MPI_SUCCESS, shm_key_size;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     void *baseP = NULL;
     MPIR_Win *win = NULL;
     ssize_t total_size = 0LL;
     MPI_Aint size_out = 0;
     MPIDI_CH4U_win_shared_info_t *shared_table = NULL;
-    char shm_key[64];
+    char *shm_key = NULL;
     void *map_ptr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4R_MPI_WIN_ALLOCATE_SHARED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4R_MPI_WIN_ALLOCATE_SHARED);
@@ -887,8 +887,13 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
-    sprintf(shm_key, "/mpi-%X-%X-%" PRIx64, MPIDI_CH4_Global.jobid, root_rank,
-            MPIDI_CH4U_WIN(win, win_id));
+    shm_key = (char *) MPL_malloc(sizeof(char));
+    shm_key_size = snprintf(shm_key, 1, "/mpi-%X-%X-%" PRIx64,
+                            MPIDI_CH4_Global.jobid, root_rank,
+                            MPIDI_CH4U_WIN(win, win_id));
+    shm_key = (char *) MPL_realloc(shm_key, shm_key_size);
+    snprintf(shm_key, shm_key_size, "/mpi-%X-%X-%" PRIx64,
+             MPIDI_CH4_Global.jobid, root_rank, MPIDI_CH4U_WIN(win, win_id));
 
     rc = shm_open(shm_key, O_CREAT | O_EXCL | O_RDWR, 0600);
     first = (rc != -1);
@@ -985,6 +990,8 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
         shm_unlink(shm_key);
 
   fn_exit:
+    if (shm_key != NULL)
+        MPL_free(shm_key);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_MPI_WIN_ALLOCATE_SHARED);
     return mpi_errno;
   fn_fail:

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -40,3 +40,5 @@
 **pmi_get_clique_ranks %d:PMI_Get_clique_ranks returned %d
 **pmi_invalid_clique_size:PMI_Get_clique_ranks returned an invalid size
 **pmi_invalid_clique_size %d:PMI_Get_clique_ranks returned an invalid size %d
+**pmi_job_getid:PMI2_Job_GetId failed
+**pmi_job_getid %d:PMI2_Job_GetId returned %d


### PR DESCRIPTION
`jobid` was never initialized in global CH4/OFI structures. Changed
`jobid` to be a string, since PMI considers `jobid` a string rather
than an integer. Also, removed duplication of `jobid` in OFI global's
structure.

I decided to include the initialization in generic `MPIDIG_init`
rather than CH4's `MPID_Init` because several other variables in
`MPIDI_CH4_Global` are being initialized in the former. We can easily
move it into `MPID_Init` if it makes more sense.