### PR TITLE
Expose VNI through NM/SHM APIs

### DIFF
--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -33,8 +33,7 @@ extern MPIDIG_global_t MPIDIG_global;
 
 int MPIDIG_am_reg_cb(int handler_id,
                      MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                int num_contexts, void **netmod_contexts);
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self);
 void MPIDIG_finalize(void);
 
 #endif /* MPIDIG_H_INCLUDED */

--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -33,7 +33,7 @@ extern MPIDIG_global_t MPIDIG_global;
 
 int MPIDIG_am_reg_cb(int handler_id,
                      MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self);
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vnis);
 void MPIDIG_finalize(void);
 
 #endif /* MPIDIG_H_INCLUDED */

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -35,7 +35,7 @@ int MPIDIG_am_reg_cb(int handler_id,
 #define FUNCNAME MPIDIG_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vnis)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT);

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -35,8 +35,7 @@ int MPIDIG_am_reg_cb(int handler_id,
 #define FUNCNAME MPIDIG_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                int num_contexts, void **netmod_contexts)
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT);

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -57,13 +57,13 @@ static inline int MPIDI_am_isend(const void *buf, int count, MPI_Datatype dataty
 
         mpi_errno = MPIDI_NM_am_isend(rank, comm, MPIDI_CH4U_SSEND_REQ,
                                       &ssend_req, sizeof(ssend_req),
-                                      buf, count, datatype, sreq, NULL);
+                                      buf, count, datatype, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
     else {
         mpi_errno = MPIDI_NM_am_isend(rank, comm, MPIDI_CH4U_SEND,
-                                      &am_hdr, sizeof(am_hdr), buf, count, datatype, sreq, NULL);
+                                      &am_hdr, sizeof(am_hdr), buf, count, datatype, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -17,10 +17,9 @@
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_ub,
-                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
-                                    int num_contexts, void **netmod_contexts);
+                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_progress_t) (void *netmod_context, int blocking);
+typedef int (*MPIDI_NM_progress_t) (int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_NM_mpi_comm_disconnect_t) (MPIR_Comm * comm_ptr);
@@ -29,15 +28,13 @@ typedef int (*MPIDI_NM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_NM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info, int root,
                                            MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_NM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz, void *netmod_context);
+                                       const void *am_hdr, size_t am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
                                     size_t am_hdr_sz, const void *data, MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq,
-                                    void *netmod_context);
+                                    MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_NM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
                                      struct iovec * am_hdrs, size_t iov_len, const void *data,
-                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq,
-                                     void *netmod_context);
+                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_NM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
                                              int handler_id, const void *am_hdr, size_t am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
@@ -491,12 +488,10 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int num_contexts,
-                                                    void **netmod_contexts)
+                                                    int spawned)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(void *netmod_context,
-                                               int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,
                                                        MPIR_Comm * comm, MPIR_Comm **
@@ -512,18 +507,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPI
                                                       MPIR_Comm **
                                                       newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz,
-                                                  void *netmod_context) MPL_STATIC_INLINE_SUFFIX;
+                                                  const void *am_hdr,
+                                                  size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq,
-                                               void *netmod_context) MPL_STATIC_INLINE_SUFFIX;
+                                               MPI_Datatype datatype,
+                                               MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq,
-                                                void *netmod_context) MPL_STATIC_INLINE_SUFFIX;
+                                                MPI_Datatype datatype,
+                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                         int handler_id, const void *am_hdr,
                                                         size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -17,9 +17,11 @@
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_ub,
-                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned);
+                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
+                                    int *n_vnis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_progress_t) (int blocking);
+typedef int (*MPIDI_NM_get_vni_attr_t)(int vni);
+typedef int (*MPIDI_NM_progress_t) (int vni, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_NM_mpi_comm_disconnect_t) (MPIR_Comm * comm_ptr);
@@ -344,6 +346,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
+    MPIDI_NM_get_vni_attr_t get_vni_attr;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -488,10 +491,11 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned)
+                                                    int spawned, int *n_vnis_provided)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,
                                                        MPIR_Comm * comm, MPIR_Comm **

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -18,16 +18,14 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int num_contexts,
-                                                    void **netmod_contexts)
+                                                    int spawned)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
-    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_ub, comm_world, comm_self, spawned,
-                                  num_contexts, netmod_contexts);
+    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_ub, comm_world, comm_self, spawned);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     return ret;
@@ -46,14 +44,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(void *netmod_context, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
-    ret = MPIDI_NM_func->progress(netmod_context, blocking);
+    ret = MPIDI_NM_func->progress(blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROGRESS);
     return ret;
@@ -129,15 +127,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_accept(const char *port_name, MPI
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz,
-                                                  void *netmod_context)
+                                                  const void *am_hdr, size_t am_hdr_sz)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
 
-    ret = MPIDI_NM_func->am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz, netmod_context);
+    ret = MPIDI_NM_func->am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     return ret;
@@ -146,8 +143,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq,
-                                               void *netmod_context)
+                                               MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -155,7 +151,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
     ret = MPIDI_NM_func->am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count, datatype,
-                                  sreq, netmod_context);
+                                  sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
     return ret;
@@ -164,8 +160,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq,
-                                                void *netmod_context)
+                                                MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -173,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
 
     ret = MPIDI_NM_func->am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count, datatype,
-                                   sreq, netmod_context);
+                                   sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISENDV);
     return ret;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -18,14 +18,15 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned)
+                                                    int spawned, int *n_vnis_provided)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
-    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_ub, comm_world, comm_self, spawned);
+    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_ub, comm_world, comm_self, spawned,
+                                  n_vnis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     return ret;
@@ -44,14 +45,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vni_attr(int vni)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VNI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VNI);
+
+    ret = MPIDI_NM_func->get_vni_attr(vni);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VNI);
+    return ret;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
-    ret = MPIDI_NM_func->progress(blocking);
+    ret = MPIDI_NM_func->progress(vni, blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROGRESS);
     return ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -14,7 +14,7 @@
 #include "ofi_am_impl.h"
 #include "ofi_am_events.h"
 
-static inline int MPIDI_OFI_progress_do_queue(void *netmod_context);
+static inline int MPIDI_OFI_progress_do_queue(void);
 
 static inline void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
@@ -37,8 +37,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     size_t am_hdr_sz,
                                     const void *data,
                                     MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq,
-                                    void *netmod_context)
+                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_SEND_AM);
@@ -66,7 +65,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      const void *data,
                                      MPI_Count count,
                                      MPI_Datatype datatype,
-                                     MPIR_Request * sreq, void *netmod_context)
+                                     MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
     size_t am_hdr_sz = 0, i;
@@ -97,7 +96,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
     }
 
     mpi_errno = MPIDI_NM_am_isend(rank, comm, handler_id, am_hdr_buf, am_hdr_sz,
-                                  data, count, datatype, sreq, netmod_context);
+                                  data, count, datatype, sreq);
 
     if (is_allocated)
         MPL_free(am_hdr_buf);
@@ -151,14 +150,14 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz, void *netmod_context)
+                                       const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
     mpi_errno = MPIDI_OFI_do_inject(rank, comm,
                                     handler_id, am_hdr, am_hdr_sz,
-                                    netmod_context, FALSE, TRUE, TRUE);
+                                    FALSE, TRUE, TRUE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -180,7 +179,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR_REPLY);
 
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDI_CH4U_context_id_to_comm(context_id),
-                                    handler_id, am_hdr, am_hdr_sz, NULL, TRUE, TRUE, FALSE);
+                                    handler_id, am_hdr, am_hdr_sz, TRUE, TRUE, FALSE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -403,7 +403,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_OFI_dispatch_ack(int rank,
                                          int context_id,
-                                         uint64_t sreq_ptr, int am_type, void *netmod_context)
+                                         uint64_t sreq_ptr, int am_type)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_ack_msg_t msg;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -13,7 +13,7 @@
 
 #include "ofi_impl.h"
 
-static inline int MPIDI_OFI_progress_do_queue(void *netmod_context);
+static inline int MPIDI_OFI_progress_do_queue(void);
 
 /*
   Per-object lock for OFI
@@ -43,7 +43,7 @@ static inline int MPIDI_OFI_progress_do_queue(void *netmod_context);
                                    FCNAME,                              \
                                    fi_strerror(-_ret));                 \
             if (LOCK) MPID_THREAD_CS_ENTER(POBJ,MPIDI_OFI_THREAD_FI_MUTEX); \
-            mpi_errno = MPIDI_OFI_progress_do_queue(NULL);      \
+            mpi_errno = MPIDI_OFI_progress_do_queue();                  \
             if (LOCK) MPID_THREAD_CS_EXIT(POBJ,MPIDI_OFI_THREAD_FI_MUTEX); \
             if (mpi_errno != MPI_SUCCESS)                                \
                 MPIR_ERR_POP(mpi_errno);                                \
@@ -142,7 +142,7 @@ static inline int MPIDI_OFI_repost_buffer(void *buf, MPIR_Request * req)
 #define FUNCNAME MPIDI_OFI_progress_do_queue
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_OFI_progress_do_queue(void *netmod_context)
+static inline int MPIDI_OFI_progress_do_queue(void)
 {
     int mpi_errno = MPI_SUCCESS, ret;
     struct fi_cq_tagged_entry cq_entry;
@@ -433,7 +433,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).msg_tag = lreq_hdr.hdr.msg_tag;
         MPIDI_CH4U_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDI_CH4U_SEND_LONG_REQ,
-                                         &lreq_hdr, sizeof(lreq_hdr), NULL);
+                                         &lreq_hdr, sizeof(lreq_hdr));
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -494,7 +494,6 @@ static inline int MPIDI_OFI_do_inject(int rank,
                                       int handler_id,
                                       const void *am_hdr,
                                       size_t am_hdr_sz,
-                                      void *netmod_context,
                                       int is_reply, int use_comm_table, int need_lock)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -31,7 +31,7 @@ static inline int MPIDI_OFI_do_control_win(MPIDI_OFI_win_control_t * control,
                                     win->comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
                                     (void *) control,
-                                    sizeof(*control), NULL, FALSE, use_comm, use_lock);
+                                    sizeof(*control), FALSE, use_comm, use_lock);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_WIN);
     return mpi_errno;
@@ -62,7 +62,7 @@ static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
     mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
                                     (void *) control,
-                                    sizeof(*control), NULL, FALSE, TRUE, need_lock);
+                                    sizeof(*control), FALSE, TRUE, need_lock);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -613,7 +613,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_read_event(struct fi_cq_tagged_entry *
                                                      MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
-    void *netmod_context = NULL;
     MPIR_Request *rreq;
     MPIDI_OFI_am_request_t *ofi_req;
 
@@ -630,7 +629,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_read_event(struct fi_cq_tagged_entry *
     mpi_errno = MPIDI_OFI_dispatch_ack(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).src_rank,
                                        MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).context_id,
                                        MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).sreq_ptr,
-                                       MPIDI_AMTYPE_LMT_ACK, netmod_context);
+                                       MPIDI_AMTYPE_LMT_ACK);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -338,7 +338,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned)
+                                         int spawned,
+                                         int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS, pmi_errno, i, fi_version;
     int thr_err = 0, str_errno, maxlen;
@@ -707,6 +708,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         }
     }
 
+    *n_vnis_provided = 1;
+
     /* ------------------------------------------------------------------------ */
     /* Create a transport level communication endpoint.  To use the endpoint,   */
     /* it must be bound to completion counters or event queues and enabled,     */
@@ -835,7 +838,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIR_Assert(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE <= MPIDI_Global.max_send);
         MPIDI_Global.am_buf_pool =
             MPIDI_CH4U_create_buf_pool(MPIDI_OFI_BUF_POOL_NUM, MPIDI_OFI_BUF_POOL_SIZE);
-        mpi_errno = MPIDIG_init(comm_world, comm_self);
+        mpi_errno = MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
 
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1006,6 +1009,12 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+static inline int MPIDI_NM_get_vni_attr(int vni)
+{
+    MPIR_Assert(0 <= vni && vni < 1);
+    return MPIDI_VNI_TX | MPIDI_VNI_RX;
 }
 
 static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -338,7 +338,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned, int num_contexts, void **netmod_contexts)
+                                         int spawned)
 {
     int mpi_errno = MPI_SUCCESS, pmi_errno, i, fi_version;
     int thr_err = 0, str_errno, maxlen;
@@ -835,7 +835,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIR_Assert(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE <= MPIDI_Global.max_send);
         MPIDI_Global.am_buf_pool =
             MPIDI_CH4U_create_buf_pool(MPIDI_OFI_BUF_POOL_NUM, MPIDI_OFI_BUF_POOL_SIZE);
-        mpi_errno = MPIDIG_init(comm_world, comm_self, num_contexts, netmod_contexts);
+        mpi_errno = MPIDIG_init(comm_world, comm_self);
 
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(void *netmod_context, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     if (ret == 0) {
         while ((!MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) && (!MPIR_cc_is_complete(&rreq->cc))) {
             if ((mpi_errno =
-                 MPIDI_NM_progress(&MPIDI_OFI_REQUEST(rreq, context), 0)) != MPI_SUCCESS)
+                 MPIDI_NM_progress(0)) != MPI_SUCCESS)
                 goto fn_exit;
         }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     if (ret == 0) {
         while ((!MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) && (!MPIR_cc_is_complete(&rreq->cc))) {
             if ((mpi_errno =
-                 MPIDI_NM_progress(0)) != MPI_SUCCESS)
+                 MPIDI_NM_progress(0, 0)) != MPI_SUCCESS)
                 goto fn_exit;
         }
 

--- a/src/mpid/ch4/netmod/portals4/ptl_am.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_am.h
@@ -20,8 +20,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     size_t am_hdr_sz,
                                     const void *data,
                                     MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq,
-                                    void *netmod_context)
+                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, ret, c;
     size_t data_sz;
@@ -117,7 +116,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      const void *data,
                                      MPI_Count count,
                                      MPI_Datatype datatype,
-                                     MPIR_Request * sreq, void *netmod_context)
+                                     MPIR_Request * sreq)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -214,7 +213,7 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz, void *netmod_context)
+                                       const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS, ret, c;
     ptl_hdr_data_t ptl_hdr;

--- a/src/mpid/ch4/netmod/portals4/ptl_init.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_init.h
@@ -49,7 +49,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned)
+                                         int spawned,
+                                         int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
     int ret;
@@ -69,6 +70,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_Assert(((void *) &(((ptl_iovec_t *) 0)->iov_len)) ==
                 ((void *) &(((MPL_IOV *) 0)->MPL_IOV_LEN)));
     MPIR_Assert(sizeof(((ptl_iovec_t *) 0)->iov_len) == sizeof(((MPL_IOV *) 0)->MPL_IOV_LEN));
+
+    *n_vnis_provided = 1;
 
     /* init portals */
     ret = PtlInit();
@@ -163,7 +166,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     }
 
     /* Setup CH4R Active Messages */
-    MPIDIG_init(comm_world, comm_self);
+    MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
     for (i = 0; i < MPIDI_PTL_NUM_OVERFLOW_BUFFERS; i++) {
         MPIDI_PTL_global.overflow_bufs[i] = MPL_malloc(MPIDI_PTL_OVERFLOW_BUFFER_SZ);
         MPIDI_PTL_append_overflow(i);
@@ -211,6 +214,11 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
+static inline int MPIDI_NM_get_vni_attr(int vni)
+{
+    MPIR_Assert(0 <= vni && vni < 1);
+    return MPIDI_VNI_TX | MPIDI_VNI_RX;
+}
 
 static inline int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr,
                                          int idx, int *lpid_ptr, MPL_bool is_remote)

--- a/src/mpid/ch4/netmod/portals4/ptl_init.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_init.h
@@ -49,7 +49,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned, int num_contexts, void **netmod_contexts)
+                                         int spawned)
 {
     int mpi_errno = MPI_SUCCESS;
     int ret;
@@ -163,7 +163,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     }
 
     /* Setup CH4R Active Messages */
-    MPIDIG_init(comm_world, comm_self, num_contexts, netmod_contexts);
+    MPIDIG_init(comm_world, comm_self);
     for (i = 0; i < MPIDI_PTL_NUM_OVERFLOW_BUFFERS; i++) {
         MPIDI_PTL_global.overflow_bufs[i] = MPL_malloc(MPIDI_PTL_OVERFLOW_BUFFER_SZ);
         MPIDI_PTL_append_overflow(i);

--- a/src/mpid/ch4/netmod/portals4/ptl_progress.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_progress.h
@@ -84,7 +84,7 @@ static inline int MPIDI_PTL_am_handler(ptl_event_t * e)
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_progress(int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     ptl_event_t e;
     unsigned int which;

--- a/src/mpid/ch4/netmod/portals4/ptl_progress.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_progress.h
@@ -84,7 +84,7 @@ static inline int MPIDI_PTL_am_handler(ptl_event_t * e)
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_progress(void *netmod_context, int blocking)
+static inline int MPIDI_NM_progress(int blocking)
 {
     ptl_event_t e;
     unsigned int which;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -20,8 +20,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     size_t am_hdr_sz,
                                     const void *data,
                                     MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq,
-                                    void *netmod_context)
+                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -35,7 +34,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      const void *data,
                                      MPI_Count count,
                                      MPI_Datatype datatype,
-                                     MPIR_Request * sreq, void *netmod_context)
+                                     MPIR_Request * sreq)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -62,7 +61,7 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz, void *netmod_context)
+                                       const void *am_hdr, size_t am_hdr_sz)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -19,7 +19,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned)
+                                         int spawned,
+                                         int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -35,6 +36,11 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
+static inline int MPIDI_NM_get_vni_attr(int vni)
+{
+    MPIR_Assert(0);
+    return 0;
+}
 
 static inline int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr,
                                          int idx, int *lpid_ptr, MPL_bool is_remote)

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -19,7 +19,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned, int num_contexts, void **netmod_contexts)
+                                         int spawned)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
@@ -13,7 +13,7 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_progress(int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
@@ -13,7 +13,7 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_progress(void *netmod_context, int blocking)
+static inline int MPIDI_NM_progress(int blocking)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -62,8 +62,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     size_t am_hdr_sz,
                                     const void *data,
                                     MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq,
-                                    void *netmod_context)
+                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;
@@ -94,7 +93,7 @@ static inline int MPIDI_NM_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).msg_tag = lreq_hdr.hdr.msg_tag;
         MPIDI_CH4U_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDI_CH4U_SEND_LONG_REQ,
-                                         &lreq_hdr, sizeof(lreq_hdr), NULL);
+                                         &lreq_hdr, sizeof(lreq_hdr));
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -171,7 +170,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      const void *data,
                                      MPI_Count count,
                                      MPI_Datatype datatype,
-                                     MPIR_Request * sreq, void *netmod_context)
+                                     MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t am_hdr_sz = 0, i;
@@ -352,7 +351,7 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz, void *netmod_context)
+                                       const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -24,7 +24,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned)
+                                         int spawned,
+                                         int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS, pmi_errno;
     int str_errno = MPL_STR_SUCCESS;
@@ -54,6 +55,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_INIT);
+
+    *n_vnis_provided = 1;
 
     ucx_status = ucp_config_read(NULL, NULL, &config);
     MPIDI_UCX_CHK_STATUS(ucx_status);
@@ -215,7 +218,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIDI_UCX_CHK_STATUS(ucx_status);
     }
 
-    MPIDIG_init(comm_world, comm_self);
+    MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
@@ -294,6 +297,12 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
   fn_fail:
     goto fn_exit;
 
+}
+
+static inline int MPIDI_NM_get_vni_attr(int vni)
+{
+    MPIR_Assert(0 <= vni && vni < 1);
+    return MPIDI_VNI_TX | MPIDI_VNI_RX;
 }
 
 static inline int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr,

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -24,7 +24,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int *tag_ub,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self,
-                                         int spawned, int num_contexts, void **netmod_contexts)
+                                         int spawned)
 {
     int mpi_errno = MPI_SUCCESS, pmi_errno;
     int str_errno = MPL_STR_SUCCESS;
@@ -215,7 +215,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIDI_UCX_CHK_STATUS(ucx_status);
     }
 
-    MPIDIG_init(comm_world, comm_self, num_contexts, netmod_contexts);
+    MPIDIG_init(comm_world, comm_self);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -103,7 +103,7 @@ static inline void MPIDI_UCX_Handle_am_recv(void *request, ucs_status_t status,
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_progress(int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_tag_recv_info_t info;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -103,7 +103,7 @@ static inline void MPIDI_UCX_Handle_am_recv(void *request, ucs_status_t status,
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_progress(void *netmod_context, int blocking)
+static inline int MPIDI_NM_progress(int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_tag_recv_info_t info;

--- a/src/mpid/ch4/shm/glue/shm_am.h
+++ b/src/mpid/ch4/shm/glue/shm_am.h
@@ -13,14 +13,14 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
                                                    int handler_id, const void *am_hdr,
-                                                   size_t am_hdr_sz, void *shm_context)
+                                                   size_t am_hdr_sz)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
 
-    ret = MPIDI_POSIX_am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz, shm_context);
+    ret = MPIDI_POSIX_am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
     return ret;
@@ -29,8 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq,
-                                                void *shm_context)
+                                                MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -38,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND);
 
     ret = MPIDI_POSIX_am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count,
-                               datatype, sreq, shm_context);
+                               datatype, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     return ret;
@@ -47,8 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq,
-                                                 void *shm_context)
+                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int ret;
 
@@ -56,7 +54,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISENDV);
 
     ret = MPIDI_POSIX_am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count,
-                                datatype, sreq, shm_context);
+                                datatype, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_AM_ISENDV);
     return ret;

--- a/src/mpid/ch4/shm/glue/shm_init.h
+++ b/src/mpid/ch4/shm/glue/shm_init.h
@@ -11,14 +11,14 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
 
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size);
+    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vnis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     return ret;
@@ -37,7 +37,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int blocking)
+static inline int MPIDI_SHM_get_vni_attr(int vni)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_QUERY_VNI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_QUERY_VNI);
+
+    ret = MPIDI_POSIX_get_vni_attr(vni);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_QUERY_VNI);
+    return ret;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -32,18 +32,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_accept(const char *port_name, MP
                                                        MPIR_Comm **
                                                        newcomm_ptr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr, size_t am_hdr_sz,
-                                                   void *shm_context) MPL_STATIC_INLINE_SUFFIX;
+                                                   const void *am_hdr,
+                                                   size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq,
-                                                void *shm_context) MPL_STATIC_INLINE_SUFFIX;
+                                                MPI_Datatype datatype,
+                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq,
-                                                 void *shm_context) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPI_Datatype datatype,
+                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                          int handler_id, const void *am_hdr,
                                                          size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -14,9 +14,11 @@
 
 #include <mpidimpl.h>
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
+                                                     int *n_vnis_provided) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,
                                                         MPIR_Comm **

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -19,7 +19,7 @@ static inline int MPIDI_POSIX_am_isend(int rank,
                                      size_t am_hdr_sz,
                                      const void *data,
                                      MPI_Count count,
-                                     MPI_Datatype datatype, MPIR_Request * sreq, void *shm_context)
+                                     MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND);
@@ -37,7 +37,7 @@ static inline int MPIDI_POSIX_am_isendv(int rank,
                                       size_t iov_len,
                                       const void *data,
                                       MPI_Count count,
-                                      MPI_Datatype datatype, MPIR_Request * sreq, void *shm_context)
+                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISENDV);
@@ -79,7 +79,7 @@ static inline size_t MPIDI_POSIX_am_hdr_max_sz(void)
 static inline int MPIDI_POSIX_am_send_hdr(int rank,
                                         MPIR_Comm * comm,
                                         int handler_id,
-                                        const void *am_hdr, size_t am_hdr_sz, void *shm_context)
+                                        const void *am_hdr, size_t am_hdr_sz)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_SEND_HDR);

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -23,7 +23,7 @@ extern char *MPIDI_POSIX_asym_base_addr;
 
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_mpi_init_hook)
-static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size)
+static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
     int num_local = 0;
@@ -40,6 +40,8 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_INIT);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_INIT);
+
+    *n_vnis_provided = 1;
 
     MPIDI_POSIX_mem_region.num_seg = 1;
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.seg, MPIDU_shm_seg_info_t *,
@@ -262,6 +264,12 @@ static inline int MPIDI_POSIX_mpi_finalize_hook(void)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+static inline int MPIDI_POSIX_get_vni_attr(int vni)
+{
+    MPIR_Assert(0 <= vni && vni < 1);
+    return MPIDI_VNI_TX | MPIDI_VNI_RX;
 }
 
 static inline void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/shm/stubshm/stubshm_am.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_am.h
@@ -19,7 +19,7 @@ static inline int MPIDI_STUBSHM_am_isend(int rank,
                                      size_t am_hdr_sz,
                                      const void *data,
                                      MPI_Count count,
-                                     MPI_Datatype datatype, MPIR_Request * sreq, void *shm_context)
+                                     MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_ISEND);
@@ -37,7 +37,7 @@ static inline int MPIDI_STUBSHM_am_isendv(int rank,
                                       size_t iov_len,
                                       const void *data,
                                       MPI_Count count,
-                                      MPI_Datatype datatype, MPIR_Request * sreq, void *shm_context)
+                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_ISENDV);
@@ -79,7 +79,7 @@ static inline size_t MPIDI_STUBSHM_am_hdr_max_sz(void)
 static inline int MPIDI_STUBSHM_am_send_hdr(int rank,
                                         MPIR_Comm * comm,
                                         int handler_id,
-                                        const void *am_hdr, size_t am_hdr_sz, void *shm_context)
+                                        const void *am_hdr, size_t am_hdr_sz)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR);

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.h
@@ -13,7 +13,7 @@
 
 #include "stubshm_impl.h"
 
-static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size)
+static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vnis_provided)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
@@ -22,6 +22,19 @@ static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size)
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
     return MPI_SUCCESS;
+}
+
+static inline int MPIDI_STUBSHM_get_vni_attr(int vni)
+{
+    int ret = 0;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VNI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VNI);
+
+    MPIR_Assert(0);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_QUERY_VNI);
+    return ret;
 }
 
 static inline int MPIDI_STUBSHM_mpi_finalize_hook(void)

--- a/src/mpid/ch4/shm/stubshm/stubshm_progress.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_progress.h
@@ -35,7 +35,7 @@ static inline int MPIDI_STUBSHM_do_progress_send(int blocking, int *completion_c
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_STUBSHM_progress(int blocking)
+static inline int MPIDI_STUBSHM_progress(int vni, int blocking)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_PROGRESS);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -108,6 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 {
     int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
     int avtid;
+    int n_vnis_provided;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
 
@@ -246,7 +247,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 
     mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &MPIR_Process.attrs.tag_ub,
                                        MPIR_Process.comm_world,
-                                       MPIR_Process.comm_self, has_parent);
+                                       MPIR_Process.comm_self, has_parent,
+                                       &n_nm_vnis_provided);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POPFATAL(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -108,7 +108,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 {
     int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
     int avtid;
-    int n_vnis_provided;
+    int n_nm_vnis_provided;
+#ifdef MPIDI_BUILD_CH4_SHM
+    int n_shm_vnis_provided;
+#endif
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
 
@@ -238,7 +242,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 #endif
 
 #ifdef MPIDI_BUILD_CH4_SHM
-    mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size);
+    mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vnis_provided);
 
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POPFATAL(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -107,7 +107,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
                                         int requested, int *provided, int *has_args, int *has_env)
 {
     int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
-    void *netmod_contexts;
     int avtid;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
@@ -247,7 +246,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 
     mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &MPIR_Process.attrs.tag_ub,
                                        MPIR_Process.comm_world,
-                                       MPIR_Process.comm_self, has_parent, 1, &netmod_contexts);
+                                       MPIR_Process.comm_self, has_parent);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POPFATAL(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
         MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_PROGRESS_MUTEX);
     }
     /* todo: progress unexp_list */
-    mpi_errno = MPIDI_NM_progress(0);
+    mpi_errno = MPIDI_NM_progress(0, 0);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -44,7 +44,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
         MPIR_ERR_POP(mpi_errno);
     }
 #ifdef MPIDI_CH4_EXCLUSIVE_SHM
-    mpi_errno = MPIDI_SHM_progress(0);
+    mpi_errno = MPIDI_SHM_progress(0, 0);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
         MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_PROGRESS_MUTEX);
     }
     /* todo: progress unexp_list */
-    mpi_errno = MPIDI_NM_progress(MPIDI_CH4_Global.netmod_context[0], 0);
+    mpi_errno = MPIDI_NM_progress(0);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -39,6 +39,12 @@
 
 #define MAX_PROGRESS_HOOKS 4
 
+/* VNI attributes */
+enum {
+    MPIDI_VNI_TX = 0x1, /* Can send */
+    MPIDI_VNI_RX = 0x2, /* Can receive */
+};
+
 #define MPIDI_CH4I_BUF_POOL_NUM (1024)
 #define MPIDI_CH4I_BUF_POOL_SZ (256)
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -37,7 +37,6 @@
 
 #define MPIDI_CH4I_MAP_NOT_FOUND      ((void*)(-1UL))
 
-#define MAX_NETMOD_CONTEXTS 8
 #define MAX_PROGRESS_HOOKS 4
 
 #define MPIDI_CH4I_BUF_POOL_NUM (1024)
@@ -275,7 +274,6 @@ typedef struct MPIDI_CH4_Global_t {
     MPIDI_CH4U_req_ext_t *cmpl_list;
     OPA_int_t exp_seq_no;
     OPA_int_t nxt_seq_no;
-    void *netmod_context[8];
     MPIU_buf_pool_t *buf_pool;
 } MPIDI_CH4_Global_t;
 extern MPIDI_CH4_Global_t MPIDI_CH4_Global;

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -84,7 +84,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_PUT_REQ,
                                       &am_hdr, sizeof(am_hdr), origin_addr,
-                                      origin_count, origin_datatype, sreq, NULL);
+                                      origin_count, origin_datatype, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -119,7 +119,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDI_CH4U_PUT_REQ,
                                        &am_iov[0], 2, origin_addr, origin_count, origin_datatype,
-                                       sreq, NULL);
+                                       sreq);
     }
     else {
         MPIDI_CH4U_REQUEST(sreq, req->preq.origin_addr) = (void *) origin_addr;
@@ -130,7 +130,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_PUT_IOV_REQ,
                                       &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                      am_iov[1].iov_len, MPI_BYTE, sreq, NULL);
+                                      am_iov[1].iov_len, MPI_BYTE, sreq);
     }
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -218,7 +218,7 @@ static inline int MPIDI_do_get(void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr,
                                       MPIDI_CH4U_GET_REQ, &am_hdr, sizeof(am_hdr),
-                                      NULL, 0, MPI_DATATYPE_NULL, sreq, NULL);
+                                      NULL, 0, MPI_DATATYPE_NULL, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -245,7 +245,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     /* FIXIME: we need to choose between NM and SHM */
     mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_GET_REQ,
                                   &am_hdr, sizeof(am_hdr), dt_iov,
-                                  sizeof(struct iovec) * am_hdr.n_iov, MPI_BYTE, sreq, NULL);
+                                  sizeof(struct iovec) * am_hdr.n_iov, MPI_BYTE, sreq);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -338,7 +338,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_ACC_REQ,
                                       &am_hdr, sizeof(am_hdr), origin_addr,
                                       (op == MPI_NO_OP) ? 0 : origin_count,
-                                      origin_datatype, sreq, NULL);
+                                      origin_datatype, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -378,7 +378,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
         mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDI_CH4U_ACC_REQ,
                                        &am_iov[0], 2, origin_addr,
                                        (op == MPI_NO_OP) ? 0 : origin_count,
-                                       origin_datatype, sreq, NULL);
+                                       origin_datatype, sreq);
     }
     else {
         MPIDI_CH4U_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
@@ -389,7 +389,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_ACC_IOV_REQ,
                                       &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                      am_iov[1].iov_len, MPI_BYTE, sreq, NULL);
+                                      am_iov[1].iov_len, MPI_BYTE, sreq);
     }
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -495,7 +495,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_GET_ACC_REQ,
                                       &am_hdr, sizeof(am_hdr), origin_addr,
                                       (op == MPI_NO_OP) ? 0 : origin_count,
-                                      origin_datatype, sreq, NULL);
+                                      origin_datatype, sreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         goto fn_exit;
@@ -535,7 +535,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
         mpi_errno = MPIDI_NM_am_isendv(target_rank, win->comm_ptr, MPIDI_CH4U_GET_ACC_REQ,
                                        &am_iov[0], 2, origin_addr,
                                        (op == MPI_NO_OP) ? 0 : origin_count,
-                                       origin_datatype, sreq, NULL);
+                                       origin_datatype, sreq);
     }
     else {
         MPIDI_CH4U_REQUEST(sreq, req->areq.origin_addr) = (void *) origin_addr;
@@ -546,7 +546,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
         /* FIXIME: we need to choose between NM and SHM */
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_GET_ACC_IOV_REQ,
                                       &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                      am_iov[1].iov_len, MPI_BYTE, sreq, NULL);
+                                      am_iov[1].iov_len, MPI_BYTE, sreq);
     }
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -926,8 +926,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
 
     /* FIXIME: we need to choose between NM and SHM */
     mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_CSWAP_REQ,
-                                  &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq,
-                                  NULL);
+                                  &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
   fn_exit:

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -294,7 +294,7 @@ static inline int MPIDI_CH4R_mpi_win_complete(MPIR_Win * win)
     for (index = 0; index < group->size; ++index) {
         peer = ranks_in_win_grp[index];
         mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                         MPIDI_CH4U_WIN_COMPLETE, &msg, sizeof(msg), NULL);
+                                         MPIDI_CH4U_WIN_COMPLETE, &msg, sizeof(msg));
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
@@ -347,7 +347,7 @@ static inline int MPIDI_CH4R_mpi_win_post(MPIR_Group * group, int assert, MPIR_W
     for (index = 0; index < group->size; ++index) {
         peer = ranks_in_win_grp[index];
         mpi_errno = MPIDI_NM_am_send_hdr(peer, win->comm_ptr,
-                                         MPIDI_CH4U_WIN_POST, &msg, sizeof(msg), NULL);
+                                         MPIDI_CH4U_WIN_POST, &msg, sizeof(msg));
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     }
@@ -448,7 +448,7 @@ static inline int MPIDI_CH4R_mpi_win_lock(int lock_type, int rank, int assert, M
 
     locked = slock->remote.locked + 1;
     mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
-                                     MPIDI_CH4U_WIN_LOCK, &msg, sizeof(msg), NULL);
+                                     MPIDI_CH4U_WIN_LOCK, &msg, sizeof(msg));
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
     MPIDI_CH4R_PROGRESS_WHILE(slock->remote.locked != locked);
@@ -489,7 +489,7 @@ static inline int MPIDI_CH4R_mpi_win_unlock(int rank, MPIR_Win * win)
     unlocked = MPIDI_CH4U_WIN(win, sync).lock.remote.locked - 1;
 
     mpi_errno = MPIDI_NM_am_send_hdr(rank, win->comm_ptr,
-                                     MPIDI_CH4U_WIN_UNLOCK, &msg, sizeof(msg), NULL);
+                                     MPIDI_CH4U_WIN_UNLOCK, &msg, sizeof(msg));
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
 
@@ -1110,7 +1110,7 @@ static inline int MPIDI_CH4R_mpi_win_unlock_all(MPIR_Win * win)
         lockQ[i].win = win;
 
         mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                         MPIDI_CH4U_WIN_UNLOCKALL, &msg, sizeof(msg), NULL);
+                                         MPIDI_CH4U_WIN_UNLOCKALL, &msg, sizeof(msg));
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
 
@@ -1276,7 +1276,7 @@ static inline int MPIDI_CH4R_mpi_win_lock_all(int assert, MPIR_Win * win)
         lockQ[i].lock_type = MPI_LOCK_SHARED;
 
         mpi_errno = MPIDI_NM_am_send_hdr(i, win->comm_ptr,
-                                         MPIDI_CH4U_WIN_LOCKALL, &msg, sizeof(msg), NULL);
+                                         MPIDI_CH4U_WIN_LOCKALL, &msg, sizeof(msg));
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_RMA_SYNC, goto fn_fail, "**rmasync");
 


### PR DESCRIPTION
These patches are to expose "VNI" (virtual network interface) concepts through netmod/shmmod APIs. VNIs are what used to be called "CH4 Endpoints" in #2391.

Basically VNI is an abstraction of multiple network resources in
the underlying network fabric, for example multiple hardware queues.
Expectation is that different VNIs can be simultaneously accessed
by different threads without taking locks.

This patch defines an interface for netmod to tell CH4 about available
VNIs. VNI is identified through an integer index.
Netmod returns the number of available VNIs through
`NM_mpi_init_hook`. CH4 can then call `NM_get_vni_attr` to query
what each VNI is capable of.

CH4 does not control how many VNIs are created. It depends on netmod.
Netmod can expose a CVAR for instance, so users can have a control
on how many VNIs to use.

Each VNI is expected to have its own progress. So the VNI parameter
is added to `NM_progress`.

This PR also applies the same change for SHM API. Also it removes `netmod/shm_context` parameters from the function signatures. They were originally introduced for a similar goal as VNI (exposing multiple network resources).
