### PR TITLE
Improve memory profiling by adding a class to the allocation routines

### DIFF
--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -1831,7 +1831,7 @@ sub unweighted_in_ftoc {
     }
     else {
         int li;
-        l$count = (int *)$malloc( $Array_size * sizeof(int) );
+        l$count = (int *)$malloc( $Array_size * sizeof(int), MPL_MEM_OTHER );
         for (li=0; li<$Array_size; li++) l$count\[li\] = (int)v$count\[li\];
     }
 EOT
@@ -1854,7 +1854,7 @@ sub unweighted_out_ftoc {
         l$count = MPI_WEIGHTS_EMPTY;
     }
     else {
-        l$count = (int *)$malloc( $Array_size * sizeof(int) );
+        l$count = (int *)$malloc( $Array_size * sizeof(int), MPL_MEM_OTHER );
     }
 EOT
         $clean_up .= "    if (l$count != MPI_UNWEIGHTED && l$count != MPI_WEIGHTS_EMPTY) {$free(l$count);}\n";
@@ -1967,7 +1967,7 @@ sub logical_array_in_ftoc {
     }
     print $OUTFD "\
     if ($ActSize) {int li;
-     l$count = (int *)$malloc($ActSize * sizeof(int));
+     l$count = (int *)$malloc($ActSize * sizeof(int), MPL_MEM_OTHER);
      for (li=0; li<$ActSize; li++) {
         l$count\[li\] = MPII_FROM_FLOG(v$count\[li\]);
      }
@@ -2010,7 +2010,7 @@ sub logical_array_out_ctof {
 sub logical_array_out_decl {
     my $count = $_[0];
     if ($within_fint) {
-	print $OUTFD "    int *l$count = (int *)$malloc($Array_size * sizeof(int));\n";
+	print $OUTFD "    int *l$count = (int *)$malloc($Array_size * sizeof(int), MPL_MEM_OTHER);\n";
 	$clean_up .= "    $free( l$count );\n";
     }
     else {
@@ -2054,7 +2054,7 @@ sub index_array_ftoc {
 sub index_array_out_ftoc {
     my $count = $_[0];
     if ($within_fint) {
-	print $OUTFD "    l$count = (int *)$malloc( $Array_size * sizeof(int) );\n";
+	print $OUTFD "    l$count = (int *)$malloc( $Array_size * sizeof(int), MPL_MEM_OTHER );\n";
     }
 }
 sub index_array_ctof {
@@ -2205,7 +2205,7 @@ sub handle_array_in_ftoc {
 	print $OUTFD "\
      /* handle_array_ftoc( $count ); */
     {int li;
-     $cvar = ($nativeType *)$malloc( $asize * sizeof($nativeType) );
+     $cvar = ($nativeType *)$malloc( $asize * sizeof($nativeType), MPL_MEM_OTHER );
      for (li=0; li<$asize; li++) {
         $cvar\[li\] = $convfunc( $fvar\[li\] );
      }
@@ -2243,7 +2243,7 @@ sub handle_array_out_ftoc {
 	}
 	print $OUTFD "\
      /* handle_array_ftoc( $count ); */
-     $cvar = ($nativeType *)$malloc( $asize * sizeof($nativeType) );
+     $cvar = ($nativeType *)$malloc( $asize * sizeof($nativeType), MPL_MEM_OTHER );
 ";
 	$clean_up .= "    $free( $cvar );\n";
     }
@@ -2589,7 +2589,7 @@ sub errcodesignore_out_ftoc {
 	}
 	print $OUTFD "\
     if ($coutvar != MPI_ERRCODES_IGNORE) {
-         $coutvar = (int *)$malloc( $asize * sizeof(int) );
+         $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
     }
 ";
         $clean_up .= "     $free( $coutvar );\n";
@@ -2655,7 +2655,7 @@ sub status_array_out_ftoc {
 	print $OUTFD "\
     if (l$count != MPI_STATUSES_IGNORE) { 
         int li;
-        l$count = (MPI_Status*)$malloc($Array_size * sizeof(MPI_Status)); 
+        l$count = (MPI_Status*)$malloc($Array_size * sizeof(MPI_Status), MPL_MEM_OTHER);
         for (li=0; li<$Array_size; li++) 
             l$count\[li].MPI_ERROR = ((MPI_Status*)(void*)v$count)[li].MPI_ERROR;
     }\n";
@@ -2814,7 +2814,7 @@ sub fint2int_array_in_ftoc {
 	}
 	print $OUTFD "\
     if ($extraCondition$asize > 0) {int li;
-     $coutvar = (int *)$malloc( $asize * sizeof(int) );
+     $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
      for (li=0; li<$asize; li++) {
         $coutvar\[li\] = (int)$outvar\[li\];
      }
@@ -2849,7 +2849,7 @@ sub fint2int_array_out_ftoc {
 	}
 
 	print $OUTFD "\
-    $coutvar = (int *)$malloc( $asize * sizeof(int) );
+    $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
 ";
         $clean_up .= "     if ($coutvar) { $free( $coutvar ); }\n";
     }
@@ -2992,7 +2992,7 @@ sub fint2intinplace_array_in_ftoc {
 	}
 	print $OUTFD "\
     if ($extraCondition$asize > 0 && v1 != MPI_IN_PLACE) {int li;
-     $coutvar = (int *)$malloc( $asize * sizeof(int) );
+     $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
      for (li=0; li<$asize; li++) {
         $coutvar\[li\] = (int)$outvar\[li\];
      }
@@ -3045,7 +3045,7 @@ sub fint2int_rangearray_in_ftoc {
 	}
 	print $OUTFD "\
     if ($extraCondition$asize > 0) {int li;
-     $coutvar = (int *)$malloc( $asize * sizeof(int) );
+     $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
      for (li=0; li<$asize; li++) {
         $coutvar\[li\] = (int)$outvar\[li\];
      }
@@ -3143,7 +3143,7 @@ sub blankpad_out_ftoc {
 
     # Allocate space to hold the C version of the output
     $strlen = "d$count";
-    print $OUTFD "    p$count = (char *)$malloc( $strlen + 1 );\n";
+    print $OUTFD "    p$count = (char *)$malloc( $strlen + 1, MPL_MEM_OTHER );\n";
 }
 sub blankpad_ctof {
     my $coutvar = $_[0];
@@ -3185,7 +3185,7 @@ sub blankpadonflag_out_ftoc {
 
     # Allocate space to hold the C version of the output
     $strlen = "d$count";
-    print $OUTFD "    p$count = (char *)$malloc( $strlen + 1 );\n";
+    print $OUTFD "    p$count = (char *)$malloc( $strlen + 1, MPL_MEM_OTHER );\n";
 }
 sub blankpadonflag_ctof {
     my $coutvar = $_[0];
@@ -3233,7 +3233,7 @@ sub addnull_ftoc {
      int  li;
         while (*p == ' ' && p > v$count) p--;
         p++;
-        p$count = (char *)$malloc( p-v$count + 1 );
+        p$count = (char *)$malloc( p-v$count + 1, MPL_MEM_OTHER );
         for (li=0; li<(p-v$count); li++) { p$count\[li\] = v$count\[li\]; }
         p$count\[li\] = 0; 
     }
@@ -3269,7 +3269,7 @@ sub addnullandtrim_ftoc {
         while (*p == ' ' && p > v$count) p--;
         p++;
         while (*pin == ' ' && pin < p) pin++;
-        p$count = (char *)$malloc( p-pin + 1 );
+        p$count = (char *)$malloc( p-pin + 1, MPL_MEM_OTHER );
         for (li=0; li<(p-pin); li++) { p$count\[li\] = pin\[li\]; }
         p$count\[li\] = 0; 
     }
@@ -3324,8 +3324,8 @@ sub chararray_ftoc {
       }\n";
     }
     print $OUTFD "\
-      p$count = (char **)$malloc( asize$count * sizeof(char *) );
-      if (asize$count-1 > 0) ptmp = (char *)$malloc( asize$count * (d$count + 1) );
+      p$count = (char **)$malloc( asize$count * sizeof(char *), MPL_MEM_OTHER );
+      if (asize$count-1 > 0) ptmp = (char *)$malloc( asize$count * (d$count + 1), MPL_MEM_OTHER );
       for (i=0; i<asize$count-1; i++) {
           char *p = v$count + i * d$count, *pin, *pdest;
           int j;
@@ -3409,7 +3409,7 @@ sub chararray2_ftoc {
       int k;
 
       /* Allocate the array of pointers for the commands */
-      p$count = (char ***)$malloc( $Array_size * sizeof(char **) );
+      p$count = (char ***)$malloc( $Array_size * sizeof(char **), MPL_MEM_OTHER );
 
       for (k=0; k<$Array_size; k++) {
         /* For each command, find the number of command-line arguments.
@@ -3437,8 +3437,8 @@ sub chararray2_ftoc {
 
         /* argcnt is the number of provided arguments.  
            Allocate the necessary elements and copy, null terminating copies */
-        pargs = (char **)$malloc( (argcnt+1)*sizeof(char *) );
-        pdata = (char *)$malloc( arglen );
+        pargs = (char **)$malloc( (argcnt+1)*sizeof(char *), MPL_MEM_OTHER );
+        pdata = (char *)$malloc( arglen, MPL_MEM_OTHER );
         p$count\[k\] = pargs;
         pargs\[argcnt\] = 0;  /* Null terminate end */
         /* Copy each argument to consequtive locations in pdata, 
@@ -3496,7 +3496,7 @@ sub intToAintArr_ftoc {
     print $OUTFD "
     if ($Array_size > 0) {
         int li;
-        l$count = (MPI_Aint *)$malloc( $Array_size * sizeof(MPI_Aint) );
+        l$count = (MPI_Aint *)$malloc( $Array_size * sizeof(MPI_Aint), MPL_MEM_OTHER );
         for (li=0; li<$Array_size; li++) 
             l$count\[li\] = v$count\[li\];
     }

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -54,12 +54,12 @@ int MPIR_Comm_spawn_multiple_c(int count, char* array_of_commands_f,
     if ((char***)array_of_argv_f == MPI_ARGVS_NULL) {
         array_of_argv_c = MPI_ARGVS_NULL;
     } else {
-        array_of_argv_c = (char***) MPL_malloc(sizeof(char**)*count);
+        array_of_argv_c = (char***) MPL_malloc(sizeof(char**)*count, MPL_MEM_BUFFER);
         if (!array_of_argv_c) MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         /* Allocate a temp buf to put args of a command */
         len = 256; /* length of buf. Initialized with an arbitrary value */
-        buf = (char*)MPL_malloc(sizeof(char)*len);
+        buf = (char*)MPL_malloc(sizeof(char)*len, MPL_MEM_BUFFER);
         if (!buf) MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         for (i = 0; i < count; i++) {
@@ -70,7 +70,7 @@ int MPIR_Comm_spawn_multiple_c(int count, char* array_of_commands_f,
             do {
                 if (offset + argv_elem_len > len) { /* Make sure buf is big enough */
                     len = offset + argv_elem_len;
-                    newbuf = (char*)MPL_realloc(buf, len);
+                    newbuf = (char*)MPL_realloc(buf, len, MPL_MEM_BUFFER);
                     if (!newbuf) {
                         MPL_free(buf);
                         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -56,7 +56,7 @@ extern int MPIR_Fortran_array_of_string_f2c(const char* strs_f, char*** strs_c, 
     }
 
     /* Allocate memory for pointers to strings and the strings themself */
-    buf = (char*) MPL_malloc(sizeof(char*) * num_strs + sizeof(char) * (num_chars + num_strs)); /* Add \0 for each string */
+    buf = (char*) MPL_malloc(sizeof(char*) * num_strs + sizeof(char) * (num_chars + num_strs), MPL_MEM_STRINGS); /* Add \0 for each string */
     if (buf == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     }

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -559,7 +559,7 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype *new_dtp,
 
     contents_size = struct_sz + types_sz + ints_sz + aints_sz;
 
-    cp = (MPIR_Datatype_contents *) MPL_malloc(contents_size);
+    cp = (MPIR_Datatype_contents *) MPL_malloc(contents_size, MPL_MEM_DATATYPE);
     /* --BEGIN ERROR HANDLING-- */
     if (cp == NULL) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -134,7 +134,7 @@ static inline void *MPIR_Handle_indirect_init(void *(**indirect)[],
     /* Create the table */
     if (!*indirect) {
         /* printf("Creating indirect table with %d pointers to blocks in it\n", indirect_num_blocks); */
-        *indirect = (void *) MPL_calloc(indirect_num_blocks, sizeof(void *));
+        *indirect = (void *) MPL_calloc(indirect_num_blocks, sizeof(void *), MPL_MEM_OBJECT);
         if (!*indirect) {
             return 0;
         }
@@ -149,7 +149,7 @@ static inline void *MPIR_Handle_indirect_init(void *(**indirect)[],
 
     /* Create the next block */
     /* printf("Creating indirect block number %d with %d objects in it\n", *indirect_size, indirect_num_indices); */
-    block_ptr = (void *) MPL_calloc(indirect_num_indices, obj_size);
+    block_ptr = (void *) MPL_calloc(indirect_num_indices, obj_size, MPL_MEM_OBJECT);
     if (!block_ptr) {
         return 0;
     }

--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -91,6 +91,13 @@ extern MPL_dbg_class MPIR_DBG_STRING;
 #define calloc(a,b)       'Error use MPL_calloc' :::
 #define free(a)           'Error use MPL_free'   :::
 #define realloc(a)        'Error use MPL_realloc' :::
+/* These two functions can't be guarded because we use #include <sys/mman.h>
+ * throughout the code to be able to use other symbols in that header file.
+ * Because we include that header directly, we bypass this guard and cause
+ * compile problems.
+ * #define mmap(a,b,c,d,e,f) 'Error use MPL_mmap'   :::
+ * #define munmap(a,b)       'Error use MPL_munmap' :::
+ */
 #if defined(strdup) || defined(__strdup)
 #undef strdup
 #endif

--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -135,7 +135,7 @@ extern MPL_dbg_class MPIR_DBG_STRING;
    imposed by C) */
 #define MPIR_CHKLMEM_DECL(n_) int dummy_ ATTRIBUTE((unused))
 #define MPIR_CHKLMEM_FREEALL()
-#define MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) \
+#define MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
 {pointer_ = (type_)alloca(nbytes_); \
     if (!(pointer_) && (nbytes_ > 0)) {	   \
     MPIR_CHKMEM_SETERR(rc_,nbytes_,name_); \
@@ -147,8 +147,8 @@ extern MPL_dbg_class MPIR_DBG_STRING;
  int mpiu_chklmem_stk_sp_=0;\
  MPIR_AssertDeclValue(const int mpiu_chklmem_stk_sz_,n_)
 
-#define MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) \
-{pointer_ = (type_)MPL_malloc(nbytes_); \
+#define MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
+{pointer_ = (type_)MPL_malloc(nbytes_,class_); \
 if (pointer_) { \
     MPIR_Assert(mpiu_chklmem_stk_sp_<mpiu_chklmem_stk_sz_);\
     mpiu_chklmem_stk_[mpiu_chklmem_stk_sp_++] = pointer_;\
@@ -160,18 +160,18 @@ if (pointer_) { \
     do { while (mpiu_chklmem_stk_sp_ > 0) {\
        MPL_free( mpiu_chklmem_stk_[--mpiu_chklmem_stk_sp_] ); } } while(0)
 #endif /* HAVE_ALLOCA */
-#define MPIR_CHKLMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)
-#define MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
+#define MPIR_CHKLMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_)
+#define MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,goto fn_fail)
 
 /* Persistent memory that we may want to recover if something goes wrong */
 #define MPIR_CHKPMEM_DECL(n_) \
  void *(mpiu_chkpmem_stk_[n_]) = { NULL };     \
  int mpiu_chkpmem_stk_sp_=0;\
  MPIR_AssertDeclValue(const int mpiu_chkpmem_stk_sz_,n_)
-#define MPIR_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) \
-{pointer_ = (type_)MPL_malloc(nbytes_); \
+#define MPIR_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
+{pointer_ = (type_)MPL_malloc(nbytes_,class_); \
 if (pointer_) { \
     MPIR_Assert(mpiu_chkpmem_stk_sp_<mpiu_chkpmem_stk_sz_);\
     mpiu_chkpmem_stk_[mpiu_chkpmem_stk_sp_++] = pointer_;\
@@ -187,19 +187,19 @@ if (pointer_) { \
        MPL_free( mpiu_chkpmem_stk_[--mpiu_chkpmem_stk_sp_] ); } }
 #define MPIR_CHKPMEM_COMMIT() \
     mpiu_chkpmem_stk_sp_ = 0
-#define MPIR_CHKPMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKPMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)
-#define MPIR_CHKPMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
+#define MPIR_CHKPMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKPMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_)
+#define MPIR_CHKPMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,goto fn_fail)
 
 /* now the CALLOC version for zeroed memory */
-#define MPIR_CHKPMEM_CALLOC(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKPMEM_CALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_)
-#define MPIR_CHKPMEM_CALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_CHKPMEM_CALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
-#define MPIR_CHKPMEM_CALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_) \
+#define MPIR_CHKPMEM_CALLOC(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKPMEM_CALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_)
+#define MPIR_CHKPMEM_CALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_CHKPMEM_CALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,goto fn_fail)
+#define MPIR_CHKPMEM_CALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
     do {                                                                   \
-        pointer_ = (type_)MPL_calloc(1, (nbytes_));                       \
+        pointer_ = (type_)MPL_calloc(1, (nbytes_), (class_));                       \
         if (pointer_) {                                                    \
             MPIR_Assert(mpiu_chkpmem_stk_sp_<mpiu_chkpmem_stk_sz_);        \
             mpiu_chkpmem_stk_[mpiu_chkpmem_stk_sp_++] = pointer_;          \
@@ -211,8 +211,8 @@ if (pointer_) { \
     } while (0)
 
 /* A special version for routines that only allocate one item */
-#define MPIR_CHKPMEM_MALLOC1(pointer_,type_,nbytes_,rc_,name_,stmt_) \
-{pointer_ = (type_)MPL_malloc(nbytes_); \
+#define MPIR_CHKPMEM_MALLOC1(pointer_,type_,nbytes_,rc_,name_,class_,stmt_) \
+{pointer_ = (type_)MPL_malloc(nbytes_,class_); \
     if (!(pointer_) && (nbytes_ > 0)) {	   \
     MPIR_CHKMEM_SETERR(rc_,nbytes_,name_); \
     stmt_;\
@@ -221,8 +221,8 @@ if (pointer_) { \
 /* Provides a easy way to use realloc safely and avoid the temptation to use
  * realloc unsafely (direct ptr assignment).  Zero-size reallocs returning NULL
  * are handled and are not considered an error. */
-#define MPIR_REALLOC_ORJUMP(ptr_,size_,rc_) do { \
-    void *realloc_tmp_ = MPL_realloc((ptr_), (size_)); \
+#define MPIR_REALLOC_ORJUMP(ptr_,size_,class_,rc_) do { \
+    void *realloc_tmp_ = MPL_realloc((ptr_), (size_), (class_)); \
     if (size_) \
         MPIR_ERR_CHKANDJUMP2(!realloc_tmp_,rc_,MPI_ERR_OTHER,"**nomem2","**nomem2 %d %s",(size_),MPL_QUOTE(ptr_)); \
     (ptr_) = realloc_tmp_; \

--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -117,9 +117,9 @@ int MPIR_Sched_cb_free_buf(MPIR_Comm *comm, int tag, void *state);
     int mpir_sched_chkpmem_stk_sp_=0;                             \
     MPIR_AssertDeclValue(const int mpir_sched_chkpmem_stk_sz_,n_)
 
-#define MPIR_SCHED_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,stmt_)  \
+#define MPIR_SCHED_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,stmt_)  \
     do {                                                                          \
-        (pointer_) = (type_)MPL_malloc(nbytes_);                                 \
+        (pointer_) = (type_)MPL_malloc(nbytes_,class_);                           \
         if (pointer_) {                                                           \
             MPIR_Assert(mpir_sched_chkpmem_stk_sp_ < mpir_sched_chkpmem_stk_sz_); \
             mpir_sched_chkpmem_stk_[mpir_sched_chkpmem_stk_sp_++] = (pointer_);   \
@@ -129,8 +129,8 @@ int MPIR_Sched_cb_free_buf(MPIR_Comm *comm, int tag, void *state);
         }                                                                         \
     } while (0)
 
-#define MPIR_SCHED_CHKPMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_) \
-    MPIR_SCHED_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,goto fn_fail)
+#define MPIR_SCHED_CHKPMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_,class_) \
+    MPIR_SCHED_CHKPMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,goto fn_fail)
 
 /* just cleanup, don't add anything to the schedule */
 #define MPIR_SCHED_CHKPMEM_REAP(sched_)                                       \

--- a/src/mpi/coll/allgather.c
+++ b/src/mpi/coll/allgather.c
@@ -316,7 +316,7 @@ int MPIR_Allgather_intra (
             
             MPIR_Pack_size_impl(recvcount*comm_size, recvtype, &tmp_buf_size);
             
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void*, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void*, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
             
             /* calculate the value of nbytes, the number of bytes in packed
                representation that each process contributes. We can't simply divide
@@ -488,7 +488,7 @@ int MPIR_Allgather_intra (
         recvbuf_extent = recvcount * comm_size *
             (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void*, recvbuf_extent, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void*, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
             
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
@@ -678,7 +678,7 @@ int MPIR_Allgather_inter (
         extent = MPL_MAX(send_extent, true_extent);
 
 	MPIR_Ensure_Aint_fits_in_pointer(extent * sendcount * local_size);
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void*, extent*sendcount*local_size, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void*, extent*sendcount*local_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/allgatherv.c
+++ b/src/mpi/coll/allgatherv.c
@@ -148,7 +148,7 @@ int MPIR_Allgatherv_intra (
 
             MPIR_Ensure_Aint_fits_in_pointer(total_count *
                            (MPL_MAX(recvtype_true_extent, recvtype_extent)));
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(recvtype_true_extent,recvtype_extent)), mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(recvtype_true_extent,recvtype_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
             /* adjust for potential negative lower bound in datatype */
             tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
@@ -344,7 +344,7 @@ int MPIR_Allgatherv_intra (
         else {
             /* heterogeneous. need to use temp. buffer. */
             MPIR_Pack_size_impl(total_count, recvtype, &tmp_buf_size);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
             
             /* calculate the value of nbytes, the number of bytes in packed
                representation corresponding to a single recvtype. Since
@@ -541,7 +541,7 @@ int MPIR_Allgatherv_intra (
         recvbuf_extent = total_count *
             (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
             
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);

--- a/src/mpi/coll/allred_group.c
+++ b/src/mpi/coll/allred_group.c
@@ -55,7 +55,7 @@ int MPIR_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -193,8 +193,8 @@ int MPIR_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
                each process receives and the displacement within
                the buffer */
 
-            MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-            MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
+            MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements", MPL_MEM_BUFFER);
 
             for (i=0; i<(pof2-1); i++)
                 cnts[i] = count/pof2;

--- a/src/mpi/coll/allreduce.c
+++ b/src/mpi/coll/allreduce.c
@@ -363,7 +363,7 @@ int MPIR_Allreduce_inter (
          * inside the for loop */
         /* Should MPIR_CHKLMEM_MALLOC do this? */
         MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);
     }
@@ -455,7 +455,7 @@ int MPIR_Allreduce_recursive_doubling(
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -635,7 +635,7 @@ int MPIR_Allreduce_reduce_scatter_allgather(
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -712,8 +712,8 @@ int MPIR_Allreduce_reduce_scatter_allgather(
        using recursive doubling in that case.) */
 
     if (newrank != -1) {
-      MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-      MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
+      MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts", MPL_MEM_BUFFER);
+      MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements", MPL_MEM_BUFFER);
 
       for (i=0; i<pof2; i++)
           cnts[i] = count/pof2;

--- a/src/mpi/coll/alltoall.c
+++ b/src/mpi/coll/alltoall.c
@@ -214,7 +214,7 @@ int MPIR_Alltoall_intra(
 
         /* allocate temporary buffer */
         MPIR_Pack_size_impl(recvcount*comm_size, recvtype, &pack_size);
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, pack_size, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, pack_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* Do Phase 1 of the algorithim. Shift the data blocks on process i
          * upwards by a distance of i blocks. Store the result in recvbuf. */
@@ -238,7 +238,7 @@ int MPIR_Alltoall_intra(
         /* allocate displacements array for indexed datatype used in
            communication */
 
-        MPIR_CHKLMEM_MALLOC(displs, int *, comm_size * sizeof(int), mpi_errno, "displs");
+        MPIR_CHKLMEM_MALLOC(displs, int *, comm_size * sizeof(int), mpi_errno, "displs", MPL_MEM_BUFFER);
 
         pof2 = 1;
         while (pof2 < comm_size) {
@@ -291,7 +291,7 @@ int MPIR_Alltoall_intra(
 
         recvbuf_extent = recvcount * comm_size *
             (MPL_MAX(recvtype_true_extent, recvtype_extent));
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
 
@@ -335,9 +335,9 @@ int MPIR_Alltoall_intra(
         bblock = MPIR_CVAR_ALLTOALL_THROTTLE;
         if (bblock == 0) bblock = comm_size;
 
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, 2*bblock*sizeof(MPIR_Request*), mpi_errno, "reqarray");
+        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, 2*bblock*sizeof(MPIR_Request*), mpi_errno, "reqarray", MPL_MEM_BUFFER);
 
-        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, 2*bblock*sizeof(MPI_Status), mpi_errno, "starray");
+        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, 2*bblock*sizeof(MPI_Status), mpi_errno, "starray", MPL_MEM_BUFFER);
 
         for (ii=0; ii<comm_size; ii+=bblock) {
             ss = comm_size-ii < bblock ? comm_size-ii : bblock;

--- a/src/mpi/coll/alltoallv.c
+++ b/src/mpi/coll/alltoallv.c
@@ -135,8 +135,8 @@ int MPIR_Alltoallv_intra(const void *sendbuf, const int *sendcounts, const int *
 
         MPIR_Datatype_get_extent_macro(sendtype, send_extent);
 
-        MPIR_CHKLMEM_MALLOC(starray,  MPI_Status*,  2*bblock*sizeof(MPI_Status),  mpi_errno, "starray");
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request**, 2*bblock*sizeof(MPIR_Request *), mpi_errno, "reqarray");
+        MPIR_CHKLMEM_MALLOC(starray,  MPI_Status*,  2*bblock*sizeof(MPI_Status),  mpi_errno, "starray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request**, 2*bblock*sizeof(MPIR_Request *), mpi_errno, "reqarray", MPL_MEM_BUFFER);
 
         /* post only bblock isends/irecvs at a time as suggested by Tony Ladd */
         for (ii=0; ii<comm_size; ii+=bblock) {

--- a/src/mpi/coll/alltoallw.c
+++ b/src/mpi/coll/alltoallw.c
@@ -122,8 +122,8 @@ int MPIR_Alltoallw_intra(const void *sendbuf, const int sendcounts[], const int 
         bblock = MPIR_CVAR_ALLTOALL_THROTTLE;
         if (bblock == 0) bblock = comm_size;
 
-        MPIR_CHKLMEM_MALLOC(starray,  MPI_Status*,  2*bblock*sizeof(MPI_Status),  mpi_errno, "starray");
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request**, 2*bblock*sizeof(MPIR_Request *), mpi_errno, "reqarray");
+        MPIR_CHKLMEM_MALLOC(starray,  MPI_Status*,  2*bblock*sizeof(MPI_Status),  mpi_errno, "starray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request**, 2*bblock*sizeof(MPIR_Request *), mpi_errno, "reqarray", MPL_MEM_BUFFER);
 
         /* post only bblock isends/irecvs at a time as suggested by Tony Ladd */
         for (ii=0; ii<comm_size; ii+=bblock) {

--- a/src/mpi/coll/bcast.c
+++ b/src/mpi/coll/bcast.c
@@ -180,7 +180,7 @@ int MPIR_Bcast_binomial(
 
     if (!is_contig || !is_homogeneous)
     {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         position = 0;
@@ -538,7 +538,7 @@ int MPIR_Bcast_scatter_doubling_allgather(
     }
     else
     {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         position = 0;
@@ -842,7 +842,7 @@ int MPIR_Bcast_scatter_ring_allgather(
     }
     else
     {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         position = 0;

--- a/src/mpi/coll/exscan.c
+++ b/src/mpi/coll/exscan.c
@@ -135,12 +135,12 @@ int MPIR_Exscan (
 
     MPIR_Datatype_get_extent_macro( datatype, extent );
 
-    MPIR_CHKLMEM_MALLOC(partial_scan, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "partial_scan");
+    MPIR_CHKLMEM_MALLOC(partial_scan, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "partial_scan", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *)((char*)partial_scan - true_lb);
 
     /* need to allocate temporary buffer to store incoming data*/
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "tmp_buf");
+    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
 

--- a/src/mpi/coll/gather.c
+++ b/src/mpi/coll/gather.c
@@ -172,7 +172,7 @@ int MPIR_Gather_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 	    tmp_buf_size = 0;
 
 	if (tmp_buf_size) {
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 	}
 
         if (rank == root)
@@ -385,7 +385,7 @@ int MPIR_Gather_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         else
             MPIR_Pack_size_impl(sendcount*(comm_size/2), sendtype, &tmp_buf_size);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         position = 0;
         if (sendbuf != MPI_IN_PLACE)
@@ -572,7 +572,7 @@ int MPIR_Gather_inter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
  
 		MPIR_Ensure_Aint_fits_in_pointer(sendcount*local_size*
 						 (MPL_MAX(extent, true_extent)));
-                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, sendcount*local_size*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, sendcount*local_size*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
                 /* adjust for potential negative lower bound in datatype */
                 tmp_buf = (void *)((char*)tmp_buf - true_lb);
             }

--- a/src/mpi/coll/gatherv.c
+++ b/src/mpi/coll/gatherv.c
@@ -110,8 +110,8 @@ int MPIR_Gatherv (
         MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
 					 displs[rank] * extent);
 
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *), mpi_errno, "reqarray");
-        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno, "starray");
+        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *), mpi_errno, "reqarray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno, "starray", MPL_MEM_BUFFER);
 
         reqs = 0;
         for (i = 0; i < comm_size; i++) {

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -132,7 +132,7 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
 	MPIR_Segment rseg;
 	intptr_t rfirst;
 
-        MPIR_CHKLMEM_MALLOC(buf, char *, COPY_BUFFER_SZ, mpi_errno, "buf");
+        MPIR_CHKLMEM_MALLOC(buf, char *, COPY_BUFFER_SZ, mpi_errno, "buf", MPL_MEM_BUFFER);
 
 	MPIR_Segment_init(sendbuf, sendcount, sendtype, &sseg, 0);
 	MPIR_Segment_init(recvbuf, recvcount, recvtype, &rseg, 0);
@@ -558,7 +558,7 @@ int MPIC_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
 
     if (count > 0 && dest != MPI_PROC_NULL) {
         MPIR_Pack_size_impl(count, datatype, &tmpbuf_size);
-        MPIR_CHKLMEM_MALLOC(tmpbuf, void *, tmpbuf_size, mpi_errno, "temporary send buffer");
+        MPIR_CHKLMEM_MALLOC(tmpbuf, void *, tmpbuf_size, mpi_errno, "temporary send buffer", MPL_MEM_BUFFER);
 
         mpi_errno = MPIR_Pack_impl(buf, count, datatype, tmpbuf, tmpbuf_size, &tmpbuf_count);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -747,8 +747,8 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
     }
 
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno, "request pointers");
-        MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno, "status objects");
+        MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno, "request pointers", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno, "status objects", MPL_MEM_BUFFER);
     }
 
     for (i = 0; i < numreq; ++i) {

--- a/src/mpi/coll/iallgather.c
+++ b/src/mpi/coll/iallgather.c
@@ -93,7 +93,7 @@ int MPIR_Iallgather_rec_dbl(const void *sendbuf, int sendcount, MPI_Datatype sen
         MPIR_SCHED_BARRIER(s);
     }
 
-    MPIR_SCHED_CHKPMEM_MALLOC(ss, struct shared_state *, sizeof(struct shared_state), mpi_errno, "ss");
+    MPIR_SCHED_CHKPMEM_MALLOC(ss, struct shared_state *, sizeof(struct shared_state), mpi_errno, "ss", MPL_MEM_BUFFER);
     ss->curr_count = recvcount;
     ss->recvtype = recvtype;
     /* ensure that recvtype doesn't disappear immediately after last _recv but before _cb */
@@ -260,7 +260,7 @@ int MPIR_Iallgather_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendt
 
     recvbuf_extent = recvcount * comm_size * (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void*, recvbuf_extent, mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void*, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
@@ -514,7 +514,7 @@ int MPIR_Iallgather_inter(const void *sendbuf, int sendcount, MPI_Datatype sendt
         extent = MPL_MAX(send_extent, true_extent);
 
         MPIR_Ensure_Aint_fits_in_pointer(extent * sendcount * local_size);
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void*, extent*sendcount*local_size, mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void*, extent*sendcount*local_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv.c
@@ -67,7 +67,7 @@ int MPIR_Iallgatherv_rec_dbl(const void *sendbuf, int sendcount, MPI_Datatype se
         goto fn_exit;
 
     MPIR_Ensure_Aint_fits_in_pointer(total_count*(MPL_MAX(recvtype_true_extent, recvtype_extent)));
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(recvtype_true_extent,recvtype_extent)), mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(recvtype_true_extent,recvtype_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
@@ -305,7 +305,7 @@ int MPIR_Iallgatherv_bruck(const void *sendbuf, int sendcount, MPI_Datatype send
     MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(recvtype_true_extent, recvtype_extent));
     recvbuf_extent = total_count * (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);

--- a/src/mpi/coll/iallreduce.c
+++ b/src/mpi/coll/iallreduce.c
@@ -89,7 +89,7 @@ int MPIR_Iallreduce_redscat_allgather(const void *sendbuf, void *recvbuf, int co
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -153,8 +153,8 @@ int MPIR_Iallreduce_redscat_allgather(const void *sendbuf, void *recvbuf, int co
          * calculated directly during the loop, rather than requiring a less-scalable
          * "2*pof2"-sized memory allocation */
 
-        MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-        MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
+        MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements", MPL_MEM_BUFFER);
 
         MPIR_Assert(count >= pof2); /* the cnts calculations assume this */
         for (i=0; i<(pof2-1); i++)
@@ -310,7 +310,7 @@ int MPIR_Iallreduce_rec_dbl(const void *sendbuf, void *recvbuf, int count, MPI_D
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/ialltoall.c
+++ b/src/mpi/coll/ialltoall.c
@@ -66,7 +66,7 @@ int MPIR_Ialltoall_inplace(const void *sendbuf, int sendcount, MPI_Datatype send
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     nbytes = recvtype_size * recvcount;
 
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     for (i = 0; i < comm_size; ++i) {
         /* start inner loop at i to avoid re-exchanging data */
@@ -137,7 +137,7 @@ int MPIR_Ialltoall_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendty
     /* allocate temporary buffer */
     /* must be same size as entire recvbuf for Phase 3 */
     nbytes = recvtype_size * recvcount * comm_size;
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* Do Phase 1 of the algorithim. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
@@ -160,7 +160,7 @@ int MPIR_Ialltoall_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendty
     /* allocate displacements array for indexed datatype used in
        communication */
 
-    MPIR_CHKLMEM_MALLOC(displs, int *, comm_size * sizeof(int), mpi_errno, "displs");
+    MPIR_CHKLMEM_MALLOC(displs, int *, comm_size * sizeof(int), mpi_errno, "displs", MPL_MEM_BUFFER);
 
     pof2 = 1;
     while (pof2 < comm_size) {
@@ -211,7 +211,7 @@ int MPIR_Ialltoall_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendty
 
     recvbuf_extent = recvcount * comm_size * (MPL_MAX(recvtype_true_extent, recvtype_extent));
     /* not a leak, old tmp_buf value is still tracked by CHKPMEM macros */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - recvtype_true_lb);
 

--- a/src/mpi/coll/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv.c
@@ -77,7 +77,7 @@ int MPIR_Ialltoallv_intra(const void *sendbuf, const int sendcounts[], const int
             max_count = MPL_MAX(max_count, recvcounts[i]);
         }
 
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, max_count*recv_extent, mpi_errno, "Ialltoallv tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, max_count*recv_extent, mpi_errno, "Ialltoallv tmp_buf", MPL_MEM_BUFFER);
 
         for (i = 0; i < comm_size; ++i) {
             /* start inner loop at i to avoid re-exchanging data */

--- a/src/mpi/coll/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw.c
@@ -95,7 +95,7 @@ int MPIR_Ialltoallw_intra(const void *sendbuf, const int sendcounts[], const int
             MPIR_Datatype_get_extent_macro(recvtypes[i], recv_extent);
             max_size = MPL_MAX(max_size, recvcounts[i] * MPL_MAX(recv_extent, true_extent));
         }
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, max_size, mpi_errno, "Ialltoallw tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, max_size, mpi_errno, "Ialltoallw tmp_buf", MPL_MEM_BUFFER);
 
         for (i = 0; i < comm_size; ++i) {
             /* start inner loop at i to avoid re-exchanging data */

--- a/src/mpi/coll/ibarrier.c
+++ b/src/mpi/coll/ibarrier.c
@@ -125,7 +125,7 @@ int MPIR_Ibarrier_inter(MPIR_Comm *comm_ptr, MPIR_Sched_t s)
        have reached the barrier. We do a 1-byte bcast because a 0-byte
        bcast will just return without doing anything. */
 
-    MPIR_SCHED_CHKPMEM_MALLOC(buf, char *, 1, mpi_errno, "bcast buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(buf, char *, 1, mpi_errno, "bcast buf", MPL_MEM_BUFFER);
     buf[0] = 'D'; /* avoid valgrind warnings */
 
     /* first broadcast from left to right group, then from right to

--- a/src/mpi/coll/ibcast.c
+++ b/src/mpi/coll/ibcast.c
@@ -127,7 +127,7 @@ int MPIR_Ibcast_binomial(void *buffer, int count, MPI_Datatype datatype, int roo
         is_homogeneous = 0;
 #endif
     MPIR_SCHED_CHKPMEM_MALLOC(status, struct MPIR_Ibcast_status *,
-                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Stauts");
+                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Stauts", MPL_MEM_BUFFER);
 
 
     /* MPI_Type_size() might not give the accurate size of the packed
@@ -148,7 +148,7 @@ int MPIR_Ibcast_binomial(void *buffer, int count, MPI_Datatype datatype, int roo
 
     if (!is_contig || !is_homogeneous)
     {
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
@@ -416,7 +416,7 @@ int MPIR_Ibcast_scatter_rec_dbl_allgather(void *buffer, int count, MPI_Datatype 
     }
 
     MPIR_SCHED_CHKPMEM_MALLOC(status, struct MPIR_Ibcast_status*,
-                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status");
+                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status", MPL_MEM_BUFFER);
     is_homogeneous = 1;
 #ifdef MPID_HAS_HETERO
     if (comm_ptr->is_hetero)
@@ -436,7 +436,7 @@ int MPIR_Ibcast_scatter_rec_dbl_allgather(void *buffer, int count, MPI_Datatype 
         tmp_buf = (char *)buffer + true_lb;
     }
     else {
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
@@ -674,7 +674,7 @@ int MPIR_Ibcast_scatter_ring_allgather(void *buffer, int count, MPI_Datatype dat
 #endif
     MPIR_Assert(is_homogeneous); /* we don't handle the hetero case yet */
     MPIR_SCHED_CHKPMEM_MALLOC(status, struct MPIR_Ibcast_status*,
-                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status");
+                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status", MPL_MEM_BUFFER);
     MPIR_Datatype_get_size_macro(datatype, type_size);
     nbytes = type_size * count;
     status->n_bytes = nbytes;
@@ -686,7 +686,7 @@ int MPIR_Ibcast_scatter_ring_allgather(void *buffer, int count, MPI_Datatype dat
         tmp_buf = (char *) buffer + true_lb;
     }
     else {
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
@@ -782,7 +782,7 @@ int MPIR_Ibcast_SMP(void *buffer, int count, MPI_Datatype datatype, int root, MP
         MPID_Abort(comm_ptr, MPI_ERR_OTHER, 1, "SMP collectives are disabled!");
     MPIR_Assert(MPIR_Comm_is_node_aware(comm_ptr));
     MPIR_SCHED_CHKPMEM_MALLOC(status, struct MPIR_Ibcast_status*,
-                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status");
+                              sizeof(struct MPIR_Ibcast_status), mpi_errno, "MPI_Status", MPL_MEM_BUFFER);
 
     is_homogeneous = 1;
 #ifdef MPID_HAS_HETERO

--- a/src/mpi/coll/iexscan.c
+++ b/src/mpi/coll/iexscan.c
@@ -97,12 +97,12 @@ int MPIR_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_SCHED_CHKPMEM_MALLOC(partial_scan, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "partial_scan");
+    MPIR_SCHED_CHKPMEM_MALLOC(partial_scan, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "partial_scan", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *)((char*)partial_scan - true_lb);
 
     /* need to allocate temporary buffer to store incoming data*/
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, (count*(MPL_MAX(true_extent,extent))), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
 

--- a/src/mpi/coll/igather.c
+++ b/src/mpi/coll/igather.c
@@ -130,7 +130,7 @@ int MPIR_Igather_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendt
             tmp_buf_size = 0;
 
         if (tmp_buf_size) {
-            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
         }
 
         if (rank == root) {
@@ -465,7 +465,7 @@ int MPIR_Igather_inter(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 
                 MPIR_Ensure_Aint_fits_in_pointer(sendcount*local_size*(MPL_MAX(extent, true_extent)));
                 MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, sendcount*local_size*(MPL_MAX(extent,true_extent)),
-                                          mpi_errno, "tmp_buf");
+                                          mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
                 /* adjust for potential negative lower bound in datatype */
                 tmp_buf = (void *)((char*)tmp_buf - true_lb);
             }

--- a/src/mpi/coll/ired_scat.c
+++ b/src/mpi/coll/ired_scat.c
@@ -59,7 +59,7 @@ int MPIR_Ireduce_scatter_rec_hlv(const void *sendbuf, void *recvbuf, const int r
 
     MPIR_Assert(MPIR_Op_is_commutative(op));
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -74,13 +74,13 @@ int MPIR_Ireduce_scatter_rec_hlv(const void *sendbuf, void *recvbuf, const int r
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
     /* allocate temp. buffer to receive incoming data */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
        results because recvbuf may not be big enough */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -142,8 +142,8 @@ int MPIR_Ireduce_scatter_rec_hlv(const void *sendbuf, void *recvbuf, const int r
            have their result calculated by the process to their
            right (rank+1). */
 
-        MPIR_SCHED_CHKPMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts");
-        MPIR_SCHED_CHKPMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps");
+        MPIR_SCHED_CHKPMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts", MPL_MEM_BUFFER);
+        MPIR_SCHED_CHKPMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps", MPL_MEM_BUFFER);
 
         for (i = 0; i < pof2; i++) {
             /* what does i map to in the old ranking? */
@@ -285,7 +285,7 @@ int MPIR_Ireduce_scatter_pairwise(const void *sendbuf, void *recvbuf, const int 
     is_commutative = MPIR_Op_is_commutative(op);
     MPIR_Assert(is_commutative);
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -310,7 +310,7 @@ int MPIR_Ireduce_scatter_pairwise(const void *sendbuf, void *recvbuf, const int 
     }
 
     /* allocate temporary buffer to store incoming data */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, recvcounts[rank]*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, recvcounts[rank]*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
@@ -424,7 +424,7 @@ int MPIR_Ireduce_scatter_rec_dbl(const void *sendbuf, void *recvbuf, const int r
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     is_commutative = MPIR_Op_is_commutative(op);
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -444,13 +444,13 @@ int MPIR_Ireduce_scatter_rec_dbl(const void *sendbuf, void *recvbuf, const int r
 
 
     /* need to allocate temporary buffer to receive incoming data*/
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
        results */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -702,8 +702,8 @@ static int MPIR_Ireduce_scatter_noncomm(const void *sendbuf, void *recvbuf,
     block_size = recvcounts[0];
     total_count = block_size * comm_size;
 
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0");
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0", MPL_MEM_BUFFER);
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *)((char*)tmp_buf0 - true_lb);
     tmp_buf1 = (void *)((char*)tmp_buf1 - true_lb);
@@ -927,7 +927,7 @@ int MPIR_Ireduce_scatter_inter(const void *sendbuf, void *recvbuf, const int rec
         /* In each group, rank 0 allocates a temp. buffer for the
            reduce */
 
-        MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, local_size*sizeof(int), mpi_errno, "disps");
+        MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, local_size*sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
         total_count = 0;
         for (i=0; i<local_size; i++) {
@@ -938,7 +938,7 @@ int MPIR_Ireduce_scatter_inter(const void *sendbuf, void *recvbuf, const int rec
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/ired_scat_block.c
+++ b/src/mpi/coll/ired_scat_block.c
@@ -58,7 +58,7 @@ int MPIR_Ireduce_scatter_block_rec_hlv(const void *sendbuf, void *recvbuf, int r
 
     MPIR_Assert(MPIR_Op_is_commutative(op));
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -73,13 +73,13 @@ int MPIR_Ireduce_scatter_block_rec_hlv(const void *sendbuf, void *recvbuf, int r
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
     /* allocate temp. buffer to receive incoming data */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
        results because recvbuf may not be big enough */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -141,8 +141,8 @@ int MPIR_Ireduce_scatter_block_rec_hlv(const void *sendbuf, void *recvbuf, int r
            have their result calculated by the process to their
            right (rank+1). */
 
-        MPIR_SCHED_CHKPMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts");
-        MPIR_SCHED_CHKPMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps");
+        MPIR_SCHED_CHKPMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts", MPL_MEM_BUFFER);
+        MPIR_SCHED_CHKPMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps", MPL_MEM_BUFFER);
 
         for (i = 0; i < pof2; i++) {
             /* what does i map to in the old ranking? */
@@ -277,7 +277,7 @@ int MPIR_Ireduce_scatter_block_pairwise(const void *sendbuf, void *recvbuf, int 
     is_commutative = MPIR_Op_is_commutative(op);
     MPIR_Assert(is_commutative);
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -302,7 +302,7 @@ int MPIR_Ireduce_scatter_block_pairwise(const void *sendbuf, void *recvbuf, int 
     }
 
     /* allocate temporary buffer to store incoming data */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, recvcount*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, recvcount*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
@@ -414,7 +414,7 @@ int MPIR_Ireduce_scatter_block_rec_dbl(const void *sendbuf, void *recvbuf, int r
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     is_commutative = MPIR_Op_is_commutative(op);
 
-    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_SCHED_CHKPMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -434,13 +434,13 @@ int MPIR_Ireduce_scatter_block_rec_dbl(const void *sendbuf, void *recvbuf, int r
 
 
     /* need to allocate temporary buffer to receive incoming data*/
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
        results */
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -678,8 +678,8 @@ int MPIR_Ireduce_scatter_block_noncomm(const void *sendbuf, void *recvbuf, int r
     block_size = recvcount;
     total_count = block_size * comm_size;
 
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0");
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0", MPL_MEM_BUFFER);
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *)((char*)tmp_buf0 - true_lb);
     tmp_buf1 = (void *)((char*)tmp_buf1 - true_lb);
@@ -842,7 +842,7 @@ int MPIR_Ireduce_scatter_block_inter(const void *sendbuf, void *recvbuf, int rec
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+        MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/ireduce.c
+++ b/src/mpi/coll/ireduce.c
@@ -73,7 +73,7 @@ int MPIR_Ireduce_binomial(const void *sendbuf, void *recvbuf, int count, MPI_Dat
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                        mpi_errno, "temporary buffer");
+                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
 
@@ -82,7 +82,7 @@ int MPIR_Ireduce_binomial(const void *sendbuf, void *recvbuf, int count, MPI_Dat
     if (rank != root) {
         MPIR_SCHED_CHKPMEM_MALLOC(recvbuf, void *,
                             count*(MPL_MAX(extent,true_extent)),
-                            mpi_errno, "receive buffer");
+                            mpi_errno, "receive buffer", MPL_MEM_BUFFER);
         recvbuf = (void *)((char*)recvbuf - true_lb);
     }
 
@@ -262,7 +262,7 @@ int MPIR_Ireduce_redscat_gather(const void *sendbuf, void *recvbuf, int count, M
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                              mpi_errno, "temporary buffer");
+                              mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
 
@@ -277,7 +277,7 @@ int MPIR_Ireduce_redscat_gather(const void *sendbuf, void *recvbuf, int count, M
        I have to allocate a temporary one */
     if (rank != root) {
         MPIR_SCHED_CHKPMEM_MALLOC(recvbuf, void *, count*(MPL_MAX(extent,true_extent)),
-                                  mpi_errno, "receive buffer");
+                                  mpi_errno, "receive buffer", MPL_MEM_BUFFER);
         recvbuf = (void *)((char*)recvbuf - true_lb);
     }
 
@@ -341,8 +341,8 @@ int MPIR_Ireduce_redscat_gather(const void *sendbuf, void *recvbuf, int count, M
     /* We allocate these arrays on all processes, even if newrank=-1,
        because if root is one of the excluded processes, we will
        need them on the root later on below. */
-    MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-    MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
+    MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements", MPL_MEM_BUFFER);
 
     last_idx = send_idx = 0; /* suppress spurious compiler warnings */
 
@@ -614,7 +614,7 @@ int MPIR_Ireduce_SMP(const void *sendbuf, void *recvbuf, int count, MPI_Datatype
         MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                                  mpi_errno, "temporary buffer");
+                                  mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);
     }
@@ -732,7 +732,7 @@ int MPIR_Ireduce_inter(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
              * inside the for loop */
             /* Should MPIR_SCHED_CHKPMEM_MALLOC do this? */
             MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_buf = (void *)((char*)tmp_buf - true_lb);
         }

--- a/src/mpi/coll/iscan.c
+++ b/src/mpi/coll/iscan.c
@@ -91,7 +91,7 @@ int MPIR_Iscan_rec_dbl(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
-    MPIR_SCHED_CHKPMEM_MALLOC(partial_scan, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "partial_scan");
+    MPIR_SCHED_CHKPMEM_MALLOC(partial_scan, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "partial_scan", MPL_MEM_BUFFER);
 
     /* This eventually gets malloc()ed as a temp buffer, not added to
      * any user buffers */
@@ -101,7 +101,7 @@ int MPIR_Iscan_rec_dbl(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
     partial_scan = (void *)((char*)partial_scan - true_lb);
 
     /* need to allocate temporary buffer to store incoming data*/
-    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+    MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -211,18 +211,18 @@ int MPIR_Iscan_SMP(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_SCHED_CHKPMEM_MALLOC(tempbuf, void *, count*(MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer");
+                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     tempbuf = (void *)((char*)tempbuf - true_lb);
 
     /* Create prefulldata and localfulldata on local roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
         MPIR_SCHED_CHKPMEM_MALLOC(prefulldata, void *, count*(MPL_MAX(extent, true_extent)),
-                            mpi_errno, "prefulldata for scan");
+                            mpi_errno, "prefulldata for scan", MPL_MEM_BUFFER);
         prefulldata = (void *)((char*)prefulldata - true_lb);
 
         if (node_comm != NULL) {
             MPIR_SCHED_CHKPMEM_MALLOC(localfulldata, void *, count*(MPL_MAX(extent, true_extent)),
-                                mpi_errno, "localfulldata for scan");
+                                mpi_errno, "localfulldata for scan", MPL_MEM_BUFFER);
             localfulldata = (void *)((char*)localfulldata - true_lb);
         }
     }

--- a/src/mpi/coll/iscatter.c
+++ b/src/mpi/coll/iscatter.c
@@ -116,7 +116,7 @@ int MPIR_Iscatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
 
 /* Use binomial tree algorithm */
 
-    MPIR_SCHED_CHKPMEM_MALLOC(ss, struct shared_state *, sizeof(struct shared_state), mpi_errno, "shared_state");
+    MPIR_SCHED_CHKPMEM_MALLOC(ss, struct shared_state *, sizeof(struct shared_state), mpi_errno, "shared_state", MPL_MEM_BUFFER);
     ss->sendcount = sendcount;
 
     if (rank == root)
@@ -148,7 +148,7 @@ int MPIR_Iscatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
            receive data of max size (ss->nbytes*comm_size)/2 */
         if (relative_rank && !(relative_rank % 2)) {
             tmp_buf_size = (ss->nbytes*comm_size)/2;
-            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
         }
 
         /* if the root is not rank 0, we reorder the sendbuf in order of
@@ -158,7 +158,7 @@ int MPIR_Iscatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
         if (rank == root) {
             if (root != 0) {
                 tmp_buf_size = ss->nbytes*comm_size;
-                MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+                MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
                 if (recvbuf != MPI_IN_PLACE)
                     mpi_errno = MPIR_Sched_copy(((char *) sendbuf + extent*sendcount*rank),
@@ -291,7 +291,7 @@ int MPIR_Iscatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
         if (rank == root) {
             MPIR_Pack_size_impl(sendcount*comm_size, sendtype, &tmp_buf_size);
 
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
           /* calculate the value of nbytes, the number of bytes in packed
              representation that each process receives. We can't
@@ -346,7 +346,7 @@ int MPIR_Iscatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
         }
         else {
             MPIR_Pack_size_impl(recvcount*(comm_size/2), recvtype, &tmp_buf_size);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
             /* calculate nbytes */
             position = 0;
@@ -490,7 +490,7 @@ int MPIR_Iscatter_inter(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
                                                  sendcount*remote_size*extent);
 
                 MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvcount*local_size*(MPL_MAX(extent,true_extent)),
-                                          mpi_errno, "tmp_buf");
+                                          mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
                 /* adjust for potential negative lower bound in datatype */
                 tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/red_scat.c
+++ b/src/mpi/coll/red_scat.c
@@ -96,8 +96,8 @@ static int MPIR_Reduce_scatter_noncomm(const void *sendbuf, void *recvbuf, const
     block_size = recvcounts[0];
     total_count = block_size * comm_size;
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0");
-    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1");
+    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *)((char*)tmp_buf0 - true_lb);
     tmp_buf1 = (void *)((char*)tmp_buf1 - true_lb);
@@ -286,7 +286,7 @@ int MPIR_Reduce_scatter_intra(const void *sendbuf, void *recvbuf, const int recv
             is_commutative = 1;
     }
 
-    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = 0;
     for (i=0; i<comm_size; i++) {
@@ -309,13 +309,13 @@ int MPIR_Reduce_scatter_intra(const void *sendbuf, void *recvbuf, const int recv
         /* commutative and short. use recursive halving algorithm */
 
         /* allocate temp. buffer to receive incoming data */
-        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
             
         /* need to allocate another temporary buffer to accumulate
            results because recvbuf may not be big enough */
-        MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+        MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_results = (void *)((char*)tmp_results - true_lb);
         
@@ -389,8 +389,8 @@ int MPIR_Reduce_scatter_intra(const void *sendbuf, void *recvbuf, const int recv
                have their result calculated by the process to their
                right (rank+1). */
 
-            MPIR_CHKLMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts");
-            MPIR_CHKLMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps");
+            MPIR_CHKLMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps", MPL_MEM_BUFFER);
             
             for (i=0; i<pof2; i++) {
                 /* what does i map to in the old ranking? */
@@ -542,7 +542,7 @@ int MPIR_Reduce_scatter_intra(const void *sendbuf, void *recvbuf, const int recv
         }
         
         /* allocate temporary buffer to store incoming data */
-        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcounts[rank]*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf");
+        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcounts[rank]*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
         
@@ -655,13 +655,13 @@ int MPIR_Reduce_scatter_intra(const void *sendbuf, void *recvbuf, const int recv
             /* noncommutative and (non-pof2 or block irregular), use recursive doubling. */
 
             /* need to allocate temporary buffer to receive incoming data*/
-            MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+            MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
             /* need to allocate another temporary buffer to accumulate
                results */
-            MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+            MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -934,7 +934,7 @@ int MPIR_Reduce_scatter_inter(const void *sendbuf, void *recvbuf, const int recv
         /* In each group, rank 0 allocates a temp. buffer for the 
            reduce */
         
-        MPIR_CHKLMEM_MALLOC(disps, int *, local_size*sizeof(int), mpi_errno, "disps");
+        MPIR_CHKLMEM_MALLOC(disps, int *, local_size*sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
         total_count = 0;
         for (i=0; i<local_size; i++) {
@@ -945,7 +945,7 @@ int MPIR_Reduce_scatter_inter(const void *sendbuf, void *recvbuf, const int recv
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/red_scat_block.c
+++ b/src/mpi/coll/red_scat_block.c
@@ -88,8 +88,8 @@ static int MPIR_Reduce_scatter_block_noncomm (
     block_size = recvcount;
     total_count = block_size * comm_size;
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0");
-    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1");
+    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *)((char*)tmp_buf0 - true_lb);
     tmp_buf1 = (void *)((char*)tmp_buf1 - true_lb);
@@ -290,7 +290,7 @@ int MPIR_Reduce_scatter_block_intra (
             is_commutative = 1;
     }
 
-    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps");
+    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
 
     total_count = comm_size*recvcount;
     for (i=0; i<comm_size; i++) {
@@ -308,13 +308,13 @@ int MPIR_Reduce_scatter_block_intra (
         /* commutative and short. use recursive halving algorithm */
 
         /* allocate temp. buffer to receive incoming data */
-        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
             
         /* need to allocate another temporary buffer to accumulate
            results because recvbuf may not be big enough */
-        MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+        MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_results = (void *)((char*)tmp_results - true_lb);
         
@@ -388,8 +388,8 @@ int MPIR_Reduce_scatter_block_intra (
                have their result calculated by the process to their
                right (rank+1). */
 
-            MPIR_CHKLMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts");
-            MPIR_CHKLMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps");
+            MPIR_CHKLMEM_MALLOC(newcnts, int *, pof2*sizeof(int), mpi_errno, "newcnts", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(newdisps, int *, pof2*sizeof(int), mpi_errno, "newdisps", MPL_MEM_BUFFER);
             
             for (i=0; i<pof2; i++) {
                 /* what does i map to in the old ranking? */
@@ -528,7 +528,7 @@ int MPIR_Reduce_scatter_block_intra (
         }
         
         /* allocate temporary buffer to store incoming data */
-        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcount*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf");
+        MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcount*(MPL_MAX(true_extent,extent))+1, mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
         
@@ -630,13 +630,13 @@ int MPIR_Reduce_scatter_block_intra (
             /* noncommutative and non-pof2, use recursive doubling. */
 
             /* need to allocate temporary buffer to receive incoming data*/
-            MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf");
+            MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_recvbuf = (void *)((char*)tmp_recvbuf - true_lb);
 
             /* need to allocate another temporary buffer to accumulate
                results */
-            MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results");
+            MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count*(MPL_MAX(true_extent,extent)), mpi_errno, "tmp_results", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_results = (void *)((char*)tmp_results - true_lb);
 
@@ -913,7 +913,7 @@ int MPIR_Reduce_scatter_block_inter (
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/reduce.c
+++ b/src/mpi/coll/reduce.c
@@ -113,7 +113,7 @@ int MPIR_Reduce_binomial (
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                        mpi_errno, "temporary buffer");
+                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
     
@@ -122,7 +122,7 @@ int MPIR_Reduce_binomial (
     if (rank != root) {
         MPIR_CHKLMEM_MALLOC(recvbuf, void *,
                             count*(MPL_MAX(extent,true_extent)), 
-                            mpi_errno, "receive buffer");
+                            mpi_errno, "receive buffer", MPL_MEM_BUFFER);
         recvbuf = (void *)((char*)recvbuf - true_lb);
     }
 
@@ -328,7 +328,7 @@ int MPIR_Reduce_redscat_gather (
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                        mpi_errno, "temporary buffer");
+                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
     
@@ -337,7 +337,7 @@ int MPIR_Reduce_redscat_gather (
     if (rank != root) {
         MPIR_CHKLMEM_MALLOC(recvbuf, void *,
                             count*(MPL_MAX(extent,true_extent)), 
-                            mpi_errno, "receive buffer");
+                            mpi_errno, "receive buffer", MPL_MEM_BUFFER);
         recvbuf = (void *)((char*)recvbuf - true_lb);
     }
 
@@ -420,8 +420,8 @@ int MPIR_Reduce_redscat_gather (
     /* We allocate these arrays on all processes, even if newrank=-1,
        because if root is one of the excluded processes, we will
        need them on the root later on below. */
-    MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-    MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
+    MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements", MPL_MEM_BUFFER);
     
     if (newrank != -1) {
         for (i=0; i<pof2; i++)
@@ -777,7 +777,7 @@ int MPIR_Reduce_intra (
             MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
             MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                                mpi_errno, "temporary buffer");
+                                mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_buf = (void *)((char*)tmp_buf - true_lb);
         }
@@ -974,7 +974,7 @@ int MPIR_Reduce_inter (
 	     * inside the for loop */
 	    /* Should MPIR_CHKLMEM_MALLOC do this? */
 	    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-	    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer");
+	    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */
             tmp_buf = (void *)((char*)tmp_buf - true_lb);
         }

--- a/src/mpi/coll/scan.c
+++ b/src/mpi/coll/scan.c
@@ -119,7 +119,7 @@ static int MPIR_Scan_generic (
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
-    MPIR_CHKLMEM_MALLOC(partial_scan, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "partial_scan");
+    MPIR_CHKLMEM_MALLOC(partial_scan, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "partial_scan", MPL_MEM_BUFFER);
 
     /* This eventually gets malloc()ed as a temp buffer, not added to
      * any user buffers */
@@ -129,7 +129,7 @@ static int MPIR_Scan_generic (
     partial_scan = (void *)((char*)partial_scan - true_lb);
     
     /* need to allocate temporary buffer to store incoming data*/
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
     
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
@@ -266,18 +266,18 @@ int MPIR_Scan(
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_CHKLMEM_MALLOC(tempbuf, void *, count*(MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer");
+                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     tempbuf = (void *)((char*)tempbuf - true_lb);
 
     /* Create prefulldata and localfulldata on local roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
         MPIR_CHKLMEM_MALLOC(prefulldata, void *, count*(MPL_MAX(extent, true_extent)),
-                            mpi_errno, "prefulldata for scan");
+                            mpi_errno, "prefulldata for scan", MPL_MEM_BUFFER);
         prefulldata = (void *)((char*)prefulldata - true_lb);
 
         if (comm_ptr->node_comm != NULL) {
             MPIR_CHKLMEM_MALLOC(localfulldata, void *, count*(MPL_MAX(extent, true_extent)),
-                                mpi_errno, "localfulldata for scan");
+                                mpi_errno, "localfulldata for scan", MPL_MEM_BUFFER);
             localfulldata = (void *)((char*)localfulldata - true_lb);
         }
     }

--- a/src/mpi/coll/scatter.c
+++ b/src/mpi/coll/scatter.c
@@ -132,7 +132,7 @@ int MPIR_Scatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtype
            receive data of max size (nbytes*comm_size)/2 */
         if (relative_rank && !(relative_rank % 2)) {
 	    tmp_buf_size = (nbytes*comm_size)/2;
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
         }
         
         /* if the root is not rank 0, we reorder the sendbuf in order of
@@ -142,7 +142,7 @@ int MPIR_Scatter_intra(const void *sendbuf, int sendcount, MPI_Datatype sendtype
         if (rank == root) {
             if (root != 0) {
 		tmp_buf_size = nbytes*comm_size;
-                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
                 if (recvbuf != MPI_IN_PLACE)
                     mpi_errno = MPIR_Localcopy(((char *) sendbuf + extent*sendcount*rank),
@@ -482,7 +482,7 @@ int MPIR_Scatter_inter(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 		MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
 						 sendcount*remote_size*extent);
 
-                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvcount*local_size*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf");
+                MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvcount*local_size*(MPL_MAX(extent,true_extent)), mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
                 
                 /* adjust for potential negative lower bound in datatype */
                 tmp_buf = (void *)((char*)tmp_buf - true_lb);

--- a/src/mpi/coll/scatterv.c
+++ b/src/mpi/coll/scatterv.c
@@ -84,8 +84,8 @@ int MPIR_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
          * this? */
         MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + extent);
 
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *), mpi_errno, "reqarray");
-        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno, "starray");
+        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *), mpi_errno, "reqarray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno, "starray", MPL_MEM_BUFFER);
 
         reqs = 0;
         for (i = 0; i < comm_size; i++) {

--- a/src/mpi/comm/comm_create.c
+++ b/src/mpi/comm/comm_create.c
@@ -60,7 +60,7 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group  *group_ptr,
     *mapping_comm = comm_ptr;
 
     n = group_ptr->size;
-    MPIR_CHKPMEM_MALLOC(mapping,int*,n*sizeof(int),mpi_errno,"mapping");
+    MPIR_CHKPMEM_MALLOC(mapping,int*,n*sizeof(int),mpi_errno,"mapping",MPL_MEM_ADDRESS);
 
     /* Make sure that the processes for this group are contained within
        the input communicator.  Also identify the mapping from the ranks of
@@ -364,7 +364,7 @@ PMPI_LOCAL int MPIR_Comm_create_inter(MPIR_Comm *comm_ptr, MPIR_Group *group_ptr
 
         MPIR_CHKLMEM_MALLOC(remote_mapping,int*,
                             remote_size*sizeof(int),
-                            mpi_errno,"remote_mapping");
+                            mpi_errno,"remote_mapping",MPL_MEM_ADDRESS);
 
         /* Populate and exchange the ranks */
         mpi_errno = MPIC_Sendrecv( mapping, group_ptr->size, MPI_INT, 0, 0,
@@ -394,7 +394,7 @@ PMPI_LOCAL int MPIR_Comm_create_inter(MPIR_Comm *comm_ptr, MPIR_Group *group_ptr
         remote_size = rinfo[1];
         MPIR_CHKLMEM_MALLOC(remote_mapping,int*,
                             remote_size*sizeof(int),
-                            mpi_errno,"remote_mapping");
+                            mpi_errno,"remote_mapping",MPL_MEM_ADDRESS);
         mpi_errno = MPID_Bcast( remote_mapping, remote_size, MPI_INT, 0,
                                      comm_ptr->local_comm, &errflag);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -147,7 +147,7 @@ int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **ne
 	
     /* Step 1: Find out what color and keys all of the processes have */
     MPIR_CHKLMEM_MALLOC(table,splittype*,size*sizeof(splittype),mpi_errno,
-			"table");
+			"table",MPL_MEM_COMM);
     table[rank].color = color;
     table[rank].key   = key;
 
@@ -202,7 +202,7 @@ int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **ne
 	*/
 	MPIR_CHKLMEM_MALLOC(remotetable,splittype*,
 			    remote_size*sizeof(splittype),mpi_errno,
-			    "remotetable");
+			    "remotetable",MPL_MEM_COMM);
 	/* This is an intercommunicator allgather */
 	
 	/* We must use a local splittype because we've already modified the
@@ -290,7 +290,7 @@ int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **ne
 	   Also, store in the "color" entry the rank in the input communicator
 	   of the entry. */
 	MPIR_CHKLMEM_MALLOC(keytable,sorttype*,new_size*sizeof(sorttype),
-			    mpi_errno,"keytable");
+			    mpi_errno,"keytable",MPL_MEM_COMM);
 	for (i=0; i<new_size; i++) {
 	    keytable[i].key   = table[first_entry].key;
 	    keytable[i].color = first_entry;
@@ -304,7 +304,7 @@ int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **ne
 	if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
 	    MPIR_CHKLMEM_MALLOC(remotekeytable,sorttype*,
 				new_remote_size*sizeof(sorttype),
-				mpi_errno,"remote keytable");
+				mpi_errno,"remote keytable",MPL_MEM_COMM);
 	    for (i=0; i<new_remote_size; i++) {
 		remotekeytable[i].key   = remotetable[first_remote_entry].key;
 		remotekeytable[i].color = first_remote_entry;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -261,7 +261,7 @@ static int init_default_collops(void)
     /* first initialize the intracomms */
     for (i = 0; i < MPIR_COMM_HIERARCHY_KIND__SIZE; ++i) {
         MPIR_CHKPMEM_CALLOC(ops, struct MPIR_Collops *, sizeof(struct MPIR_Collops), mpi_errno,
-                            "default intracomm collops");
+                            "default intracomm collops", MPL_MEM_COMM);
         ops->ref_count = 1;     /* force existence until finalize time */
 
         /* intracomm default defaults... */
@@ -324,7 +324,7 @@ static int init_default_collops(void)
     /* now the intercomm table */
     {
         MPIR_CHKPMEM_CALLOC(ops, struct MPIR_Collops *, sizeof(struct MPIR_Collops), mpi_errno,
-                            "default intercomm collops");
+                            "default intercomm collops", MPL_MEM_COMM);
         ops->ref_count = 1;     /* force existence until finalize time */
 
         /* intercomm defaults */
@@ -425,7 +425,7 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_MAP_TYPE__IRREGULAR);
 
-    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper");
+    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper", MPL_MEM_COMM);
 
     mapper->type = MPIR_COMM_MAP_TYPE__IRREGULAR;
     mapper->src_comm = src_comm;
@@ -438,7 +438,7 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
     }
     else {
         MPIR_CHKPMEM_MALLOC(mapper->src_mapping, int *,
-                            src_mapping_size * sizeof(int), mpi_errno, "mapper mapping");
+                            src_mapping_size * sizeof(int), mpi_errno, "mapper mapping", MPL_MEM_COMM);
         mapper->free_mapping = 1;
     }
 
@@ -471,7 +471,7 @@ int MPIR_Comm_map_dup(MPIR_Comm * newcomm, MPIR_Comm * src_comm, MPIR_Comm_map_d
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_MAP_TYPE__DUP);
 
-    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper");
+    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper", MPL_MEM_COMM);
 
     mapper->type = MPIR_COMM_MAP_TYPE__DUP;
     mapper->src_comm = src_comm;
@@ -1164,12 +1164,12 @@ int MPIR_Comm_register_hint(const char *hint_key, MPIR_Comm_hint_fn_t fn, void *
         MPIR_Add_finalize(free_hint_handles, NULL, MPIR_FINALIZE_CALLBACK_PRIO - 1);
     }
 
-    hint_elt = MPL_malloc(sizeof(struct MPIR_Comm_hint_fn_elt));
+    hint_elt = MPL_malloc(sizeof(struct MPIR_Comm_hint_fn_elt), MPL_MEM_COMM);
     strncpy(hint_elt->name, hint_key, MPI_MAX_INFO_KEY);
     hint_elt->state = state;
     hint_elt->fn = fn;
 
-    HASH_ADD_STR(MPID_hint_fns, name, hint_elt);
+    HASH_ADD_STR(MPID_hint_fns, name, hint_elt, MPL_MEM_COMM);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_REGISTER_HINT);
     return mpi_errno;

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -967,7 +967,7 @@ static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
         context_id_init();
     }
 
-    MPIR_CHKPMEM_MALLOC(st, struct gcn_state *, sizeof(struct gcn_state), mpi_errno, "gcn_state");
+    MPIR_CHKPMEM_MALLOC(st, struct gcn_state *, sizeof(struct gcn_state), mpi_errno, "gcn_state", MPL_MEM_COMM);
     st->ctx0 = ctx0;
     st->ctx1 = ctx1;
     if (gcn_cid_kind == MPIR_COMM_KIND__INTRACOMM) {

--- a/src/mpi/comm/intercomm_merge.c
+++ b/src/mpi/comm/intercomm_merge.c
@@ -142,7 +142,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm *comm_ptr, int high, MPIR_Comm **new_int
         int lupid, i;
 
         MPL_DBG_MSG(MPIR_DBG_COMM,VERBOSE,"Intercomm_merge contextid fastpath");
-        lupids = (int*) MPL_malloc(new_size * sizeof(int));
+        lupids = (int*) MPL_malloc(new_size * sizeof(int),MPL_MEM_COMM);
 
         if (!local_high) {
             for (i = 0; i < comm_ptr->local_size; i++) {

--- a/src/mpi/datatype/dataloop/darray_support.c
+++ b/src/mpi/datatype/dataloop/darray_support.c
@@ -43,7 +43,7 @@ int MPIR_Type_convert_darray(int size,
 
 /* calculate position in Cartesian grid as MPI would (row-major
    ordering) */
-    coords = (int *) DLOOP_Malloc(ndims*sizeof(int));
+    coords = (int *) DLOOP_Malloc(ndims*sizeof(int), MPL_MEM_DATATYPE);
     procs = size;
     tmp_rank = rank;
     for (i=0; i<ndims; i++) {
@@ -52,7 +52,7 @@ int MPIR_Type_convert_darray(int size,
 	tmp_rank = tmp_rank % procs;
     }
 
-    st_offsets = (MPI_Aint *) DLOOP_Malloc(ndims*sizeof(MPI_Aint));
+    st_offsets = (MPI_Aint *) DLOOP_Malloc(ndims*sizeof(MPI_Aint), MPL_MEM_DATATYPE);
     type_old = oldtype;
 
     if (order == MPI_ORDER_FORTRAN) {

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -379,7 +379,7 @@ void MPIR_Dataloop_alloc_and_copy(int kind,
 	extent_sz + old_loop_sz;
 
     /* allocate space */
-    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(new_loop_sz);
+    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(new_loop_sz, MPL_MEM_DATATYPE);
     if (new_loop == NULL) {
 	*new_loop_p = NULL;
 	return;
@@ -560,7 +560,7 @@ void MPIR_Dataloop_struct_alloc(DLOOP_Count count,
 	extent_sz + (basic_ct * basic_sz) + old_loop_sz;
 
     /* allocate space */
-    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(new_loop_sz);
+    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(new_loop_sz, MPL_MEM_DATATYPE);
     if (new_loop == NULL) {
 	*new_loop_p = NULL;
 	return;
@@ -611,7 +611,7 @@ void MPIR_Dataloop_dup(DLOOP_Dataloop *old_loop,
     DLOOP_Assert(old_loop != NULL);
     DLOOP_Assert(old_loop_sz > 0);
 
-    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(old_loop_sz);
+    new_loop = (DLOOP_Dataloop *) DLOOP_Malloc(old_loop_sz, MPL_MEM_DATATYPE);
     if (new_loop == NULL) {
 	*new_loop_p = NULL;
 	return;

--- a/src/mpi/datatype/dataloop/dataloop_create.c
+++ b/src/mpi/datatype/dataloop/dataloop_create.c
@@ -210,7 +210,7 @@ void MPIR_Dataloop_create(MPI_Datatype type,
 							 flag);
 	    break;
 	case MPI_COMBINER_HINDEXED_BLOCK:
-            disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint));
+            disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
             for (i = 0; i < ints[0]; i++)
                 disps[i] = aints[i];
 	    MPIR_Dataloop_create_blockindexed(ints[0] /* count */,
@@ -224,7 +224,7 @@ void MPIR_Dataloop_create(MPI_Datatype type,
             DLOOP_Free(disps);
 	    break;
 	case MPI_COMBINER_INDEXED:
-            blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size));
+            blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size), MPL_MEM_DATATYPE);
             for (i = 0; i < ints[0]; i++)
                 blklen[i] = ints[1+i];
 	    MPIR_Dataloop_create_indexed(ints[0] /* count */,
@@ -239,7 +239,7 @@ void MPIR_Dataloop_create(MPI_Datatype type,
 	case MPI_COMBINER_HINDEXED_INTEGER:
 	case MPI_COMBINER_HINDEXED:
 	    if (combiner == MPI_COMBINER_HINDEXED_INTEGER) {
-		disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint));
+		disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
 
 		for (i=0; i < ints[0]; i++) {
 		    disps[i] = (MPI_Aint) ints[ints[0] + 1 + i];
@@ -249,7 +249,7 @@ void MPIR_Dataloop_create(MPI_Datatype type,
 		disps = aints;
 	    }
 
-	    blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size));
+	    blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size), MPL_MEM_DATATYPE);
 	    for (i=0; i< ints[0]; i++)
 		blklen[i] = (DLOOP_Size) ints[1+i];
 	    MPIR_Dataloop_create_indexed(ints[0] /* count */,
@@ -292,7 +292,7 @@ void MPIR_Dataloop_create(MPI_Datatype type,
 		}
 	    }
 	    if (combiner == MPI_COMBINER_STRUCT_INTEGER) {
-		disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint));
+		disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
 
 		for (i=0; i < ints[0]; i++) {
 		    disps[i] = (MPI_Aint) ints[ints[0] + 1 + i];

--- a/src/mpi/datatype/dataloop/dataloop_create_struct.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_struct.c
@@ -422,7 +422,7 @@ static int DLOOP_Dataloop_create_unique_type_struct(DLOOP_Count count,
     DLOOP_Offset *tmp_disps;
 
     /* count is an upper bound on number of type instances */
-    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(count * sizeof(DLOOP_Size));
+    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(count * sizeof(DLOOP_Size), MPL_MEM_DATATYPE);
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_blklens) {
 	/* TODO: ??? */
@@ -431,7 +431,7 @@ static int DLOOP_Dataloop_create_unique_type_struct(DLOOP_Count count,
     /* --END ERROR HANDLING-- */
 
     tmp_disps = (DLOOP_Offset *)
-	DLOOP_Malloc(count * sizeof(DLOOP_Offset));
+	DLOOP_Malloc(count * sizeof(DLOOP_Offset), MPL_MEM_DATATYPE);
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_disps) {
 	DLOOP_Free(tmp_blklens);
@@ -482,7 +482,7 @@ static int DLOOP_Dataloop_create_basic_all_bytes_struct(
     MPI_Aint *tmp_disps;
 
     /* count is an upper bound on number of type instances */
-    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(count * sizeof(DLOOP_Size));
+    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(count * sizeof(DLOOP_Size), MPL_MEM_DATATYPE);
 
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_blklens)
@@ -491,7 +491,7 @@ static int DLOOP_Dataloop_create_basic_all_bytes_struct(
     }
     /* --END ERROR HANDLING-- */
 
-    tmp_disps = (MPI_Aint *) DLOOP_Malloc(count * sizeof(MPI_Aint));
+    tmp_disps = (MPI_Aint *) DLOOP_Malloc(count * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
 
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_disps)
@@ -617,7 +617,7 @@ static int DLOOP_Dataloop_create_flattened_struct(DLOOP_Count count,
 
     nr_blks += 2; /* safety measure */
 
-    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(nr_blks * sizeof(DLOOP_Size));
+    tmp_blklens = (DLOOP_Size *) DLOOP_Malloc(nr_blks * sizeof(DLOOP_Size), MPL_MEM_DATATYPE);
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_blklens) {
 	MPIR_Segment_free(segp);
@@ -626,7 +626,7 @@ static int DLOOP_Dataloop_create_flattened_struct(DLOOP_Count count,
     /* --END ERROR HANDLING-- */
 
 
-    tmp_disps = (MPI_Aint *) DLOOP_Malloc(nr_blks * sizeof(MPI_Aint));
+    tmp_disps = (MPI_Aint *) DLOOP_Malloc(nr_blks * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
     /* --BEGIN ERROR HANDLING-- */
     if (!tmp_disps) {
 	DLOOP_Free(tmp_blklens);

--- a/src/mpi/datatype/looputil.c
+++ b/src/mpi/datatype/looputil.c
@@ -440,7 +440,7 @@ int MPIR_Segment_init(const DLOOP_Buffer buf,
  */
 struct DLOOP_Segment * MPIR_Segment_alloc(void)
 {
-    return (struct DLOOP_Segment *) DLOOP_Malloc(sizeof(struct DLOOP_Segment));
+    return (struct DLOOP_Segment *) DLOOP_Malloc(sizeof(struct DLOOP_Segment), MPL_MEM_DATATYPE);
 }
 
 /* Segment_free

--- a/src/mpi/datatype/type_create_darray.c
+++ b/src/mpi/datatype/type_create_darray.c
@@ -527,7 +527,7 @@ int MPI_Type_create_darray(int size,
 
 /* calculate position in Cartesian grid as MPI would (row-major
    ordering) */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(coords, int *, ndims * sizeof(int), mpi_errno, "position is Cartesian grid");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(coords, int *, ndims * sizeof(int), mpi_errno, "position is Cartesian grid", MPL_MEM_COMM);
 
     procs = size;
     tmp_rank = rank;
@@ -537,7 +537,7 @@ int MPI_Type_create_darray(int size,
 	tmp_rank = tmp_rank % procs;
     }
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(st_offsets, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno, "st_offsets");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(st_offsets, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno, "st_offsets", MPL_MEM_COMM);
 
     type_old = oldtype;
 
@@ -707,7 +707,7 @@ int MPI_Type_create_darray(int size,
      */
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (4 * ndims + 4) * sizeof(int), mpi_errno, "content description");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (4 * ndims + 4) * sizeof(int), mpi_errno, "content description", MPL_MEM_BUFFER);
 
     ints[0] = size;
     ints[1] = rank;

--- a/src/mpi/datatype/type_create_hindexed.c
+++ b/src/mpi/datatype/type_create_hindexed.c
@@ -113,7 +113,7 @@ int MPI_Type_create_hindexed(int count,
 
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno, "content description");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno, "content description", MPL_MEM_BUFFER);
 
     ints[0] = count;
 

--- a/src/mpi/datatype/type_create_indexed_block.c
+++ b/src/mpi/datatype/type_create_indexed_block.c
@@ -50,7 +50,7 @@ int MPIR_Type_create_indexed_block_impl(int count,
 				       &new_handle);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 2) * sizeof(int), mpi_errno, "content description");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 2) * sizeof(int), mpi_errno, "content description", MPL_MEM_BUFFER);
 
     ints[0] = count;
     ints[1] = blocklength;

--- a/src/mpi/datatype/type_create_struct.c
+++ b/src/mpi/datatype/type_create_struct.c
@@ -52,7 +52,7 @@ int MPIR_Type_create_struct_impl(int count,
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno, "content description");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno, "content description", MPL_MEM_BUFFER);
 
     ints[0] = count;
     for (i=0; i < count; i++)

--- a/src/mpi/datatype/type_create_subarray.c
+++ b/src/mpi/datatype/type_create_subarray.c
@@ -301,7 +301,7 @@ int MPI_Type_create_subarray(int ndims,
      */
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (3 * ndims + 2) * sizeof(int), mpi_errno, "content description");
+    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (3 * ndims + 2) * sizeof(int), mpi_errno, "content description", MPL_MEM_BUFFER);
 
     ints[0] = ndims;
     for (i=0; i < ndims; i++) {

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -539,17 +539,17 @@ void MPII_Datatype_contents_printf(MPI_Datatype type,
 
     if (cp->nr_ints > 0)
     {
-      ints = (int *) MPL_malloc(cp->nr_ints * sizeof(int));
+      ints = (int *) MPL_malloc(cp->nr_ints * sizeof(int), MPL_MEM_DATATYPE);
       MPII_Datatype_get_contents_ints(cp, ints);
     }
 
     if (cp->nr_aints > 0) {
-      aints = (MPI_Aint *) MPL_malloc(cp->nr_aints * sizeof(MPI_Aint));
+      aints = (MPI_Aint *) MPL_malloc(cp->nr_aints * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
       MPII_Datatype_get_contents_aints(cp, aints);
     }
 
     if (cp->nr_types > 0) {
-      types = (MPI_Datatype *) MPL_malloc(cp->nr_types * sizeof(MPI_Datatype));
+      types = (MPI_Datatype *) MPL_malloc(cp->nr_types * sizeof(MPI_Datatype), MPL_MEM_DATATYPE);
       MPII_Datatype_get_contents_types(cp, types);
     }
 

--- a/src/mpi/datatype/type_hindexed.c
+++ b/src/mpi/datatype/type_hindexed.c
@@ -139,7 +139,7 @@ int MPI_Type_hindexed(int count,
 				  &new_handle);
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 
-    MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array");
+    MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array", MPL_MEM_BUFFER);
 
     /* copy ints into temporary buffer (count and blocklengths) */
     ints[0] = count;

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -233,7 +233,7 @@ int MPIR_Type_indexed(int count,
     new_dtp->is_contig = 0;
     if(old_is_contig)
     {
-	MPI_Aint *blklens = MPL_malloc(count *sizeof(MPI_Aint));
+	MPI_Aint *blklens = MPL_malloc(count *sizeof(MPI_Aint), MPL_MEM_DATATYPE);
 	for (i=0; i<count; i++)
 		blklens[i] = blocklength_array[i];
         contig_count = MPIR_Type_indexed_count_contig(count,
@@ -279,7 +279,7 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
     /* copy all integer values into a temporary buffer; this
      * includes the count, the blocklengths, and the displacements.
      */
-    MPIR_CHKLMEM_MALLOC(ints, int *, (2 * count + 1) * sizeof(int), mpi_errno, "contents integer array");
+    MPIR_CHKLMEM_MALLOC(ints, int *, (2 * count + 1) * sizeof(int), mpi_errno, "contents integer array", MPL_MEM_BUFFER);
 
     ints[0] = count;
 

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -477,7 +477,7 @@ int MPIR_Type_struct_impl(int count, const int *array_of_blocklengths,
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 
-    MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array");
+    MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array", MPL_MEM_BUFFER);
 
     ints[0] = count;
     for (i=0; i < count; i++) {

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -211,7 +211,7 @@ void MPII_Wait_for_debugger( void )
 	int  val;
 
 	MPIR_proctable    = (MPIR_PROCDESC *)MPL_malloc(
-					 size * sizeof(MPIR_PROCDESC) );
+					 size * sizeof(MPIR_PROCDESC), MPL_MEM_DEBUG );
 	for (i=0; i<size; i++) {
 	    /* Initialize the proctable */
 	    MPIR_proctable[i].host_name       = 0;
@@ -228,7 +228,7 @@ void MPII_Wait_for_debugger( void )
 	    int msg[2];
 	    PMPI_Recv( msg, 2, MPI_INT, i, 0, MPI_COMM_WORLD,MPI_STATUS_IGNORE);
 	    MPIR_proctable[i].pid = msg[1];
-	    MPIR_proctable[i].host_name = (char *)MPL_malloc( msg[0] + 1 );
+	    MPIR_proctable[i].host_name = (char *)MPL_malloc( msg[0] + 1, MPL_MEM_DEBUG );
 	    PMPI_Recv( MPIR_proctable[i].host_name, msg[0]+1, MPI_CHAR, 
 		       i, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE );
 	    MPIR_proctable[i].host_name[msg[0]] = 0;
@@ -360,7 +360,7 @@ void MPII_Sendq_remember( MPIR_Request *req,
 	pool = p->next;
     }
     else {
-	p = (MPIR_Sendq *)MPL_malloc( sizeof(MPIR_Sendq) );
+	p = (MPIR_Sendq *)MPL_malloc( sizeof(MPIR_Sendq), MPL_MEM_DEBUG );
 	if (!p) {
 	    /* Just ignore it */
             if (MPIR_REQUEST_KIND__SEND == req->kind)
@@ -440,7 +440,7 @@ static void SendqInit( void )
 
     /* Preallocated a few send requests */
     for (i=0; i<10; i++) {
-	p = (MPIR_Sendq *)MPL_malloc( sizeof(MPIR_Sendq) );
+	p = (MPIR_Sendq *)MPL_malloc( sizeof(MPIR_Sendq), MPL_MEM_DEBUG );
 	if (!p) {
 	    /* Just ignore it */
 	    break;

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -139,7 +139,7 @@ int MPIR_Err_set_msg( int code, const char *msg_string )
 
     /* --------------------------------------------------------------------- */
     msg_len = strlen( msg_string );
-    str = (char *)MPL_malloc( msg_len + 1 );
+    str = (char *)MPL_malloc( msg_len + 1, MPL_MEM_BUFFER );
     /* --BEGIN ERROR HANDLING-- */
     if (!str) {
 	return MPIR_Err_create_code( MPI_SUCCESS, MPIR_ERR_RECOVERABLE,

--- a/src/mpi/group/groupdebug.c
+++ b/src/mpi/group/groupdebug.c
@@ -29,7 +29,7 @@ void MPITEST_Group_create( int nproc, int myrank, MPI_Group *new_group )
 	PMPI_Abort( MPI_COMM_WORLD, 1 );
     }
     MPIR_Object_set_ref( new_group_ptr, 1 );
-    new_group_ptr->lrank_to_lpid = (MPII_Group_pmap_t *)MPL_malloc( nproc * sizeof(MPII_Group_pmap_t) );
+    new_group_ptr->lrank_to_lpid = (MPII_Group_pmap_t *)MPL_malloc( nproc * sizeof(MPII_Group_pmap_t), MPL_MEM_DEBUG );
     if (!new_group_ptr->lrank_to_lpid) {
 	fprintf( stderr, "Could not create lrank map for new group\n" );
 	PMPI_Abort( MPI_COMM_WORLD, 1 );

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -71,7 +71,7 @@ int MPIR_Group_create( int nproc, MPIR_Group **new_group_ptr )
     /* --END ERROR HANDLING-- */
     MPIR_Object_set_ref( *new_group_ptr, 1 );
     (*new_group_ptr)->lrank_to_lpid = 
-	(MPII_Group_pmap_t *)MPL_malloc( nproc * sizeof(MPII_Group_pmap_t) );
+	(MPII_Group_pmap_t *)MPL_malloc( nproc * sizeof(MPII_Group_pmap_t), MPL_MEM_GROUP );
     /* --BEGIN ERROR HANDLING-- */
     if (!(*new_group_ptr)->lrank_to_lpid) {
 	MPIR_Handle_obj_free( &MPIR_Group_mem, *new_group_ptr );
@@ -385,7 +385,7 @@ int MPIR_Group_check_subset( MPIR_Group *group_ptr, MPIR_Comm *comm_ptr )
     MPIR_Assert(group_ptr != NULL);
 
     MPIR_CHKLMEM_MALLOC(vmap,MPII_Group_pmap_t*,
-			vsize*sizeof(MPII_Group_pmap_t),mpi_errno, "" );
+			vsize*sizeof(MPII_Group_pmap_t),mpi_errno, "", MPL_MEM_GROUP );
     /* Initialize the vmap */
     for (i=0; i<vsize; i++) {
 	MPID_Comm_get_lpid(comm_ptr, i, &vmap[i].lpid, FALSE);

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -27,6 +27,17 @@ cvars:
         If true, list any memory that was allocated by MPICH and that
         remains allocated when MPI_Finalize completes.
 
+    - name        : MPIR_CVAR_MEM_CATEGORY_INFORMATION
+      category    : DEVELOPER
+      type        : boolean
+      default     : false
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If true, print a summary of memory allocation by category. The category
+        definitions are found in mpl_trmem.h.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -277,6 +288,8 @@ int MPI_Finalize( void )
 	       ignore, if desired, memory leaks in the MPID_Init call */
 	    MPL_trdump( (void *)0, -1 );
 	}
+        if (MPIR_CVAR_MEM_CATEGORY_INFORMATION)
+            MPL_trcategorydump(stderr);
     }
 #endif
 

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -495,7 +495,11 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
     info_ptr->next  = NULL;
     info_ptr->key   = NULL;
     info_ptr->value = NULL;
-    
+
+#ifdef USE_MEMORY_TRACING
+    MPL_trinit();
+#endif
+
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided, 
 			  &has_args, &has_env);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -528,9 +532,9 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
 		    MPIR_Process.comm_world->local_size);
 #ifdef USE_MEMORY_TRACING
 #ifdef MPICH_IS_THREADED
-    MPL_trinit( MPIR_Process.comm_world->rank, MPIR_ThreadInfo.isThreaded );
+    MPL_trconfig( MPIR_Process.comm_world->rank, MPIR_ThreadInfo.isThreaded );
 #else
-    MPL_trinit( MPIR_Process.comm_world->rank, 0 );
+    MPL_trconfig( MPIR_Process.comm_world->rank, 0 );
 #endif
     /* Indicate that we are near the end of the init step; memory 
        allocated already will have an id of zero; this helps 

--- a/src/mpi/pt2pt/greq_start.c
+++ b/src/mpi/pt2pt/greq_start.c
@@ -91,7 +91,7 @@ int MPIR_Grequest_start_impl(MPI_Grequest_query_function *query_fn,
     (*request_ptr)->cc_ptr               = &(*request_ptr)->cc;
     MPIR_cc_set((*request_ptr)->cc_ptr, 1);
     (*request_ptr)->comm                 = NULL;
-    MPIR_CHKPMEM_MALLOC((*request_ptr)->u.ureq.greq_fns, struct MPIR_Grequest_fns *, sizeof(struct MPIR_Grequest_fns), mpi_errno, "greq_fns");
+    MPIR_CHKPMEM_MALLOC((*request_ptr)->u.ureq.greq_fns, struct MPIR_Grequest_fns *, sizeof(struct MPIR_Grequest_fns), mpi_errno, "greq_fns", MPL_MEM_GREQ);
     (*request_ptr)->u.ureq.greq_fns->cancel_fn            = cancel_fn;
     (*request_ptr)->u.ureq.greq_fns->free_fn              = free_fn;
     (*request_ptr)->u.ureq.greq_fns->query_fn             = query_fn;

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -108,7 +108,7 @@ int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest
     MPII_SENDQ_REMEMBER(request_ptr, dest, tag, comm_ptr->context_id);
 
     /* FIXME: use the memory management macros */
-    ibinfo = (ibsend_req_info *)MPL_malloc( sizeof(ibsend_req_info) );
+    ibinfo = (ibsend_req_info *)MPL_malloc( sizeof(ibsend_req_info), MPL_MEM_BUFFER );
     ibinfo->req       = request_ptr;
     ibinfo->cancelled = 0;
     mpi_errno = MPIR_Grequest_start_impl( MPIR_Ibsend_query, MPIR_Ibsend_free,

--- a/src/mpi/pt2pt/mpir_request.c
+++ b/src/mpi/pt2pt/mpir_request.c
@@ -551,7 +551,7 @@ int MPIR_Grequest_progress_poke(int count,
     int made_progress = 0;
     MPIR_CHKLMEM_DECL(1);
 
-    MPIR_CHKLMEM_MALLOC(state_ptrs, void **, sizeof(void*) * count, mpi_errno, "state_ptrs");
+    MPIR_CHKLMEM_MALLOC(state_ptrs, void **, sizeof(void*) * count, mpi_errno, "state_ptrs", MPL_MEM_GREQ);
 
     /* TODO: Implement the class-wise completion optimization described in:
     Latham, Robert, et al. "Extending the MPI-2 generalized request interface."
@@ -601,7 +601,7 @@ int MPIR_Grequest_waitall(int count, MPIR_Request * const * request_ptrs)
     MPID_Progress_state progress_state;
     MPIR_CHKLMEM_DECL(1);
 
-    MPIR_CHKLMEM_MALLOC(state_ptrs, void *, sizeof(void*)*count, mpi_error, "state_ptrs");
+    MPIR_CHKLMEM_MALLOC(state_ptrs, void *, sizeof(void*)*count, mpi_error, "state_ptrs", MPL_MEM_GREQ);
     
         /* DISABLED CODE: The greq wait_fn function returns when ANY
            of the requests completes, rather than all.  Also, once a

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -147,7 +147,7 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
 	{
 	    MPIR_Pack_size_impl(count, datatype, &tmpbuf_size);
 
-	    MPIR_CHKLMEM_MALLOC_ORJUMP(tmpbuf, void *, tmpbuf_size, mpi_errno, "temporary send buffer");
+	    MPIR_CHKLMEM_MALLOC_ORJUMP(tmpbuf, void *, tmpbuf_size, mpi_errno, "temporary send buffer", MPL_MEM_BUFFER);
 
 	    mpi_errno = MPIR_Pack_impl(buf, count, datatype, tmpbuf, tmpbuf_size, &tmpbuf_count);
 	    if (mpi_errno != MPI_SUCCESS) goto fn_fail;

--- a/src/mpi/pt2pt/startall.c
+++ b/src/mpi/pt2pt/startall.c
@@ -92,7 +92,7 @@ int MPI_Startall(int count, MPI_Request array_of_requests[])
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     for (i = 0; i < count; i++)

--- a/src/mpi/pt2pt/testall.c
+++ b/src/mpi/pt2pt/testall.c
@@ -53,7 +53,7 @@ int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **,
-                count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+                count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_completed = 0;

--- a/src/mpi/pt2pt/testany.c
+++ b/src/mpi/pt2pt/testany.c
@@ -111,7 +111,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_inactive = 0;

--- a/src/mpi/pt2pt/testsome.c
+++ b/src/mpi/pt2pt/testsome.c
@@ -117,7 +117,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     /* Convert MPI request handles to a request object pointers */
     if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_inactive = 0;

--- a/src/mpi/pt2pt/waitall.c
+++ b/src/mpi/pt2pt/waitall.c
@@ -89,7 +89,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_greqs = 0;

--- a/src/mpi/pt2pt/waitany.c
+++ b/src/mpi/pt2pt/waitany.c
@@ -110,7 +110,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_inactive = 0;

--- a/src/mpi/pt2pt/waitsome.c
+++ b/src/mpi/pt2pt/waitsome.c
@@ -136,7 +136,7 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     /* Convert MPI request handles to a request object pointers */
     if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
-	MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
     
     n_inactive = 0;

--- a/src/mpi/rma/alloc_mem.c
+++ b/src/mpi/rma/alloc_mem.c
@@ -90,7 +90,7 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
     /* ... body of routine ...  */
 
     MPIR_Ensure_Aint_fits_in_pointer(size);
-    ap = MPID_Alloc_mem(size, info_ptr);
+    ap = MPID_Alloc_mem(size, info_ptr, MPL_MEM_RMA);
 
     /* --BEGIN ERROR HANDLING-- */
     if (!ap)

--- a/src/mpi/romio/adio/common/malloc.c
+++ b/src/mpi/romio/adio/common/malloc.c
@@ -44,7 +44,7 @@ void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname)
 #ifdef ROMIO_XFS
     new = (void *) memalign(XFS_MEMALIGN, size);
 #else
-    new = (void *) MPL_malloc(size);
+    new = (void *) MPL_malloc(size, MPL_MEM_IO);
 #endif
     if (!new && size) {
 	FPRINTF(stderr, "Out of memory in file %s, line %d\n", fname, lineno);
@@ -60,7 +60,7 @@ void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname
 {
     void *new;
 
-    new = (void *) MPL_calloc(nelem, elsize);
+    new = (void *) MPL_calloc(nelem, elsize, MPL_MEM_IO);
     if (!new && nelem) {
 	FPRINTF(stderr, "Out of memory in file %s, line %d\n", fname, lineno);
 	MPI_Abort(MPI_COMM_WORLD, 1);
@@ -74,7 +74,7 @@ void *ADIOI_Realloc_fn(void *ptr, size_t size, int lineno, const char *fname)
 {
     void *new;
 
-    new = (void *) MPL_realloc(ptr, size);
+    new = (void *) MPL_realloc(ptr, size, MPL_MEM_IO);
     if (!new && size) {
 	FPRINTF(stderr, "realloc failed in file %s, line %d\n", fname, lineno);
 	MPI_Abort(MPI_COMM_WORLD, 1);

--- a/src/mpi/romio/mpi-io/mpir_cst_filesys.c
+++ b/src/mpi/romio/mpi-io/mpir_cst_filesys.c
@@ -47,9 +47,9 @@ static int comm_split_filesystem_exhaustive(MPI_Comm comm, int key,
      * a headache for the file system at scale..  don't do this on a
      * large parallel file system! */
 
-    testdirname = MPL_malloc(PATH_MAX);
-    filename = MPL_malloc(PATH_MAX);
-    ranks = MPL_malloc(nprocs*sizeof(int));
+    testdirname = MPL_malloc(PATH_MAX, MPL_MEM_IO);
+    filename = MPL_malloc(PATH_MAX, MPL_MEM_IO);
+    ranks = MPL_malloc(nprocs*sizeof(int), MPL_MEM_IO);
 
     if (rank == 0) {
         /* same algorithim as shared file pointer name */
@@ -138,7 +138,7 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
     /* learn a bit about what groups were created: as a scalable
      * optimization we want to check a file's presence from a group
      * other than which created it */
-    all_ids = MPL_malloc(nprocs * sizeof(*all_ids));
+    all_ids = MPL_malloc(nprocs * sizeof(*all_ids), MPL_MEM_IO);
 
     mpi_errno = MPI_Gather(&id, 1, MPI_INT32_T, all_ids, 1, MPI_INT32_T, 0, comm);
 
@@ -178,7 +178,7 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
      * is a little odd in case we are creating and checking on the same
      * rank  */
 
-    filename = MPL_calloc(PATH_MAX, sizeof(char));
+    filename = MPL_calloc(PATH_MAX, sizeof(char), MPL_MEM_IO);
 
     if (rank == 0) {
         int r, pid;

--- a/src/mpi/spawn/comm_join.c
+++ b/src/mpi/spawn/comm_join.c
@@ -149,8 +149,8 @@ int MPI_Comm_join(int fd, MPI_Comm *intercomm)
 
     /* ... body of routine ...  */
     
-    MPIR_CHKLMEM_MALLOC(local_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "local port name");
-    MPIR_CHKLMEM_MALLOC(remote_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "remote port name");
+    MPIR_CHKLMEM_MALLOC(local_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "local port name", MPL_MEM_DYNAMIC);
+    MPIR_CHKLMEM_MALLOC(remote_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "remote port name", MPL_MEM_DYNAMIC);
 
     MPL_VG_MEM_INIT(local_port, MPI_MAX_PORT_NAME * sizeof(char));
     

--- a/src/mpi/spawn/comm_spawn_multiple.c
+++ b/src/mpi/spawn/comm_spawn_multiple.c
@@ -127,7 +127,7 @@ int MPI_Comm_spawn_multiple(int count, char *array_of_commands[],
     /* ... body of routine ...  */
     
     if (comm_ptr->rank == root) {
-	MPIR_CHKLMEM_MALLOC(array_of_info_ptrs, MPIR_Info **, count * sizeof(MPIR_Info*), mpi_errno, "array of info pointers");
+        MPIR_CHKLMEM_MALLOC(array_of_info_ptrs, MPIR_Info **, count * sizeof(MPIR_Info*), mpi_errno, "array of info pointers", MPL_MEM_BUFFER);
 	for (i=0; i<count; i++)
 	{
 	    MPIR_Info_get_ptr(array_of_info[i], array_of_info_ptrs[i]);

--- a/src/mpi/topo/cart_create.c
+++ b/src/mpi/topo/cart_create.c
@@ -71,7 +71,7 @@ int MPIR_Cart_create( MPIR_Comm *comm_ptr, int ndims, const int dims[],
 	    
 	    /* Create the topology structure */
 	    MPIR_CHKPMEM_MALLOC(cart_ptr,MPIR_Topology*,sizeof(MPIR_Topology),
-				mpi_errno, "cart_ptr" );
+				mpi_errno, "cart_ptr" , MPL_MEM_COMM);
 	    
 	    cart_ptr->kind               = MPI_CART;
 	    cart_ptr->topo.cart.nnodes   = 1;
@@ -81,11 +81,11 @@ int MPIR_Cart_create( MPIR_Comm *comm_ptr, int ndims, const int dims[],
 	       normal free mechanism */
 	    
 	    MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims,int*,sizeof(int),
-				mpi_errno, "cart.dims");
+				mpi_errno, "cart.dims", MPL_MEM_COMM);
 	    MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic,int*,sizeof(int),
-				mpi_errno, "cart.periodic");
+				mpi_errno, "cart.periodic", MPL_MEM_COMM);
 	    MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position,int*,sizeof(int),
-				mpi_errno, "cart.position");
+				mpi_errno, "cart.position", MPL_MEM_COMM);
 	}
 	else {
 	    *comm_cart = MPI_COMM_NULL;
@@ -127,17 +127,17 @@ int MPIR_Cart_create( MPIR_Comm *comm_ptr, int ndims, const int dims[],
 	
 	/* Create the topololgy structure */
 	MPIR_CHKPMEM_MALLOC(cart_ptr,MPIR_Topology*,sizeof(MPIR_Topology),
-			    mpi_errno, "cart_ptr" );
+			    mpi_errno, "cart_ptr", MPL_MEM_COMM );
 	
 	cart_ptr->kind               = MPI_CART;
 	cart_ptr->topo.cart.nnodes   = newsize;
 	cart_ptr->topo.cart.ndims    = ndims;
 	MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims,int*,ndims*sizeof(int),
-			    mpi_errno, "cart.dims");
+			    mpi_errno, "cart.dims", MPL_MEM_COMM);
 	MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic,int*,ndims*sizeof(int),
-			    mpi_errno, "cart.periodic");
+			    mpi_errno, "cart.periodic", MPL_MEM_COMM);
 	MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position,int*,ndims*sizeof(int),
-			    mpi_errno, "cart.position");
+			    mpi_errno, "cart.position", MPL_MEM_COMM);
 	nranks = newsize;
 	for (i=0; i<ndims; i++)
 	{

--- a/src/mpi/topo/cart_sub.c
+++ b/src/mpi/topo/cart_sub.c
@@ -155,18 +155,18 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *newcomm)
 	
 	/* Save the topology of this new communicator */
 	MPIR_CHKPMEM_MALLOC(toponew_ptr,MPIR_Topology*,sizeof(MPIR_Topology),
-			    mpi_errno,"toponew_ptr");
+			    mpi_errno,"toponew_ptr", MPL_MEM_COMM);
 	
 	toponew_ptr->kind		  = MPI_CART;
 	toponew_ptr->topo.cart.ndims  = ndims_in_subcomm;
 	toponew_ptr->topo.cart.nnodes = nnodes_in_subcomm;
 	if (ndims_in_subcomm) {
 	    MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.dims,int*,
-				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.dims");
+				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.dims", MPL_MEM_COMM);
 	    MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.periodic,int*,
-				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.periodic");
+				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.periodic", MPL_MEM_COMM);
 	    MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.position,int*,
-				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.position");
+				ndims_in_subcomm*sizeof(int),mpi_errno,"cart.position", MPL_MEM_COMM);
 	}
 	else {
 	    toponew_ptr->topo.cart.dims     = 0;

--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -326,7 +326,7 @@ static int factor_to_divisors(int nf, Factors *factors, int ndiv, int divs[])
         int *divs2;
         int *restrict d1, *restrict d2;
 
-        MPIR_CHKLMEM_MALLOC(divs2, int *, nd*sizeof(int), mpi_errno, "divs2");
+        MPIR_CHKLMEM_MALLOC(divs2, int *, nd*sizeof(int), mpi_errno, "divs2", MPL_MEM_COMM);
 
         MPIR_T_PVAR_TIMER_START(DIMS, dims_sort);
         /* handling the first set of pairs separately saved about 20%;
@@ -448,7 +448,7 @@ static int optbalance(int n, int idx, int nd, int ndivs, const int divs[],
     if (idx > 1) {
         MPIR_CHKLMEM_DECL(1);
         int *newdivs;
-        MPIR_CHKLMEM_MALLOC(newdivs,int*,ndivs*sizeof(int),mpi_errno,"divs");
+        MPIR_CHKLMEM_MALLOC(newdivs,int*,ndivs*sizeof(int),mpi_errno,"divs", MPL_MEM_COMM);
         if (mpi_errno) return mpi_errno;
 
         /* At least 3 divisors to set (0...idx).  We try all choices
@@ -777,7 +777,7 @@ PMPI_LOCAL int MPIR_Dims_create_impl(int nnodes, int ndims, int dims[])
      * have already trimmed off some large factors */
     /* First, find all of the divisors given by the remaining factors */
     ndivs = ndivisors_from_factor(nf, (const Factors *)f);
-    MPIR_CHKLMEM_MALLOC(divs, int*, (ndivs)*sizeof(int), mpi_errno, "divs");
+    MPIR_CHKLMEM_MALLOC(divs, int*, (ndivs)*sizeof(int), mpi_errno, "divs", MPL_MEM_COMM);
     ndivs = factor_to_divisors(nf, f, ndivs, divs);
     if (MPIR_CVAR_DIMS_VERBOSE) {
         for (i=0; i<ndivs; i++) {

--- a/src/mpi/topo/dist_gr_create_adj.c
+++ b/src/mpi/topo/dist_gr_create_adj.c
@@ -150,7 +150,7 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     /* Create the topology structure */
-    MPIR_CHKPMEM_MALLOC(topo_ptr, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "topo_ptr");
+    MPIR_CHKPMEM_MALLOC(topo_ptr, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "topo_ptr", MPL_MEM_COMM);
     topo_ptr->kind = MPI_DIST_GRAPH;
     dist_graph_ptr = &topo_ptr->topo.dist_graph;
     dist_graph_ptr->indegree = indegree;
@@ -161,14 +161,14 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
     dist_graph_ptr->out_weights = NULL;
     dist_graph_ptr->is_weighted = (sourceweights != MPI_UNWEIGHTED);
 
-    MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in, int *, indegree*sizeof(int), mpi_errno, "dist_graph_ptr->in");
-    MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out, int *, outdegree*sizeof(int), mpi_errno, "dist_graph_ptr->out");
+    MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in, int *, indegree*sizeof(int), mpi_errno, "dist_graph_ptr->in", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out, int *, outdegree*sizeof(int), mpi_errno, "dist_graph_ptr->out", MPL_MEM_COMM);
     MPIR_Memcpy(dist_graph_ptr->in, sources, indegree*sizeof(int));
     MPIR_Memcpy(dist_graph_ptr->out, destinations, outdegree*sizeof(int));
 
     if (dist_graph_ptr->is_weighted) {
-        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in_weights, int *, indegree*sizeof(int), mpi_errno, "dist_graph_ptr->in_weights");
-        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out_weights, int *, outdegree*sizeof(int), mpi_errno, "dist_graph_ptr->out_weights");
+        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in_weights, int *, indegree*sizeof(int), mpi_errno, "dist_graph_ptr->in_weights", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out_weights, int *, outdegree*sizeof(int), mpi_errno, "dist_graph_ptr->out_weights", MPL_MEM_COMM);
         MPIR_Memcpy(dist_graph_ptr->in_weights, sourceweights, indegree*sizeof(int));
         MPIR_Memcpy(dist_graph_ptr->out_weights, destweights, outdegree*sizeof(int));
     }

--- a/src/mpi/topo/graphcreate.c
+++ b/src/mpi/topo/graphcreate.c
@@ -86,15 +86,15 @@ int MPIR_Graph_create( MPIR_Comm *comm_ptr, int nnodes,
 
     nedges = indx[nnodes-1];
     MPIR_CHKPMEM_MALLOC(graph_ptr,MPIR_Topology*,sizeof(MPIR_Topology),
-			mpi_errno,"graph_ptr");
+			mpi_errno,"graph_ptr", MPL_MEM_COMM);
     
     graph_ptr->kind = MPI_GRAPH;
     graph_ptr->topo.graph.nnodes = nnodes;
     graph_ptr->topo.graph.nedges = nedges;
     MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.index,int*,
-			nnodes*sizeof(int),mpi_errno,"graph.index");
+			nnodes*sizeof(int),mpi_errno,"graph.index", MPL_MEM_COMM);
     MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.edges,int*,
-			nedges*sizeof(int),mpi_errno,"graph.edges");
+			nedges*sizeof(int),mpi_errno,"graph.edges", MPL_MEM_COMM);
     for (i=0; i<nnodes; i++) 
 	graph_ptr->topo.graph.index[i] = indx[i];
     for (i=0; i<nedges; i++) 

--- a/src/mpi/topo/inhb_allgather.c
+++ b/src/mpi/topo/inhb_allgather.c
@@ -50,8 +50,8 @@ int MPIR_Ineighbor_allgather_default(const void *sendbuf, int sendcount, MPI_Dat
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs");
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts");
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/topo/inhb_allgatherv.c
+++ b/src/mpi/topo/inhb_allgatherv.c
@@ -54,8 +54,8 @@ int MPIR_Ineighbor_allgatherv_default(const void *sendbuf, int sendcount, MPI_Da
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs");
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts");
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/topo/inhb_alltoall.c
+++ b/src/mpi/topo/inhb_alltoall.c
@@ -54,8 +54,8 @@ int MPIR_Ineighbor_alltoall_default(const void *sendbuf, int sendcount, MPI_Data
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs");
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts");
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/topo/inhb_alltoallv.c
+++ b/src/mpi/topo/inhb_alltoallv.c
@@ -58,8 +58,8 @@ int MPIR_Ineighbor_alltoallv_default(const void *sendbuf, const int sendcounts[]
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs");
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts");
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/topo/inhb_alltoallw.c
+++ b/src/mpi/topo/inhb_alltoallw.c
@@ -43,8 +43,8 @@ int MPIR_Ineighbor_alltoallw_default(const void *sendbuf, const int sendcounts[]
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs");
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts");
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree*sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree*sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -101,7 +101,7 @@ static int *MPIR_Copy_array( int n, const int a[], int *err )
         return NULL;
     }
 
-    new_p = (int *)MPL_malloc( n * sizeof(int) );
+    new_p = (int *)MPL_malloc( n * sizeof(int), MPL_MEM_OTHER );
 
     /* --BEGIN ERROR HANDLING-- */
     if (!new_p) {
@@ -142,7 +142,7 @@ static int MPIR_Topology_copy_fn ( MPI_Comm comm ATTRIBUTE((unused)),
     *flag = 0;
     *(void **)attr_out = NULL;
 
-    MPIR_CHKPMEM_MALLOC(copy_topology, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "copy_topology");
+    MPIR_CHKPMEM_MALLOC(copy_topology, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "copy_topology", MPL_MEM_OTHER);
 
     MPL_VG_MEM_INIT(copy_topology, sizeof(MPIR_Topology));
 

--- a/src/mpi_t/cvar_handle_alloc.c
+++ b/src/mpi_t/cvar_handle_alloc.c
@@ -41,7 +41,7 @@ int MPIR_T_cvar_handle_alloc_impl(int cvar_index, void *obj_handle, MPI_T_cvar_h
     cvar_table_entry_t *cvar = (cvar_table_entry_t *) utarray_eltptr(cvar_table, cvar_index);
 
     /* Allocate handle memory */
-    MPIR_CHKPMEM_MALLOC(hnd, MPIR_T_cvar_handle_t*, sizeof(*hnd), mpi_errno, "control variable handle");
+    MPIR_CHKPMEM_MALLOC(hnd, MPIR_T_cvar_handle_t*, sizeof(*hnd), mpi_errno, "control variable handle", MPL_MEM_MPIT);
 #ifdef HAVE_ERROR_CHECKING
     hnd->kind = MPIR_T_CVAR_HANDLE;
 #endif

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -30,7 +30,7 @@ static inline void MPIR_T_enum_env_init(void)
     static const UT_icd enum_table_entry_icd =
         {sizeof(MPIR_T_enum_t), NULL, NULL, NULL};
 
-    utarray_new(enum_table, &enum_table_entry_icd);
+    utarray_new(enum_table, &enum_table_entry_icd, MPL_MEM_MPIT);
 }
 
 static inline void MPIR_T_cat_env_init(void)
@@ -38,7 +38,7 @@ static inline void MPIR_T_cat_env_init(void)
     static const UT_icd cat_table_entry_icd =
                     {sizeof(cat_table_entry_t), NULL, NULL, NULL};
 
-    utarray_new(cat_table, &cat_table_entry_icd);
+    utarray_new(cat_table, &cat_table_entry_icd, MPL_MEM_MPIT);
     cat_hash = NULL;
     cat_stamp = 0;
 }
@@ -48,7 +48,7 @@ static inline void MPIR_T_cvar_env_init(void)
     static const UT_icd cvar_table_entry_icd =
                     {sizeof(cvar_table_entry_t), NULL, NULL, NULL};
 
-    utarray_new(cvar_table, &cvar_table_entry_icd);
+    utarray_new(cvar_table, &cvar_table_entry_icd, MPL_MEM_MPIT);
     cvar_hash = NULL;
     MPIR_T_cvar_init();
 }
@@ -59,7 +59,7 @@ static inline void MPIR_T_pvar_env_init(void)
     static const UT_icd pvar_table_entry_icd =
                     {sizeof(pvar_table_entry_t), NULL, NULL, NULL};
 
-    utarray_new(pvar_table, &pvar_table_entry_icd);
+    utarray_new(pvar_table, &pvar_table_entry_icd, MPL_MEM_MPIT);
     for (i = 0; i < MPIR_T_PVAR_CLASS_NUMBER; i++) {
         pvar_hashs[i] = NULL;
     }

--- a/src/mpi_t/pvar_handle_alloc.c
+++ b/src/mpi_t/pvar_handle_alloc.c
@@ -81,7 +81,7 @@ int MPIR_T_pvar_handle_alloc_impl(MPI_T_pvar_session session, int pvar_index,
 
     /* Allocate memory and bzero it */
     MPIR_CHKPMEM_CALLOC(hnd, MPIR_T_pvar_handle_t*, sizeof(*hnd) + extra,
-                        mpi_errno, "performance variable handle");
+                        mpi_errno, "performance variable handle", MPL_MEM_MPIT);
 #ifdef HAVE_ERROR_CHECKING
     hnd->kind = MPIR_T_PVAR_HANDLE;
 #endif

--- a/src/mpi_t/pvar_session_create.c
+++ b/src/mpi_t/pvar_session_create.c
@@ -37,7 +37,7 @@ int MPIR_T_pvar_session_create_impl(MPI_T_pvar_session *session)
 
     *session = MPI_T_PVAR_SESSION_NULL;
 
-    MPIR_CHKPMEM_MALLOC(*session, MPI_T_pvar_session, sizeof(**session), mpi_errno, "performance var session");
+    MPIR_CHKPMEM_MALLOC(*session, MPI_T_pvar_session, sizeof(**session), mpi_errno, "performance var session", MPL_MEM_MPIT);
 
     /* essential for utlist to work */
     (*session)->hlist = NULL;

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -216,7 +216,7 @@ static inline int MPIDI_CH3I_SHM_Wins_append(MPIDI_SHM_Wins_list_t * list, MPIR_
 
     /* FIXME: We should use a pool allocator here */
     MPIR_CHKPMEM_MALLOC(tmp_ptr, MPIDI_SHM_Win_t *, sizeof(MPIDI_SHM_Win_t),
-                        mpi_errno, "SHM window entry");
+                        mpi_errno, "SHM window entry", MPL_MEM_SHM);
 
     tmp_ptr->next = NULL;
     tmp_ptr->win = win;

--- a/src/mpid/ch3/channels/nemesis/netmod/llc/llc_poll.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/llc/llc_poll.c
@@ -264,7 +264,7 @@ int MPID_nem_llc_recv_posted(struct MPIDI_VC *vc, struct MPIR_Request *req)
         write_to_buf = (void *) ((char *) req->dev.user_buf + dt_true_lb);
     }
     else {
-        REQ_FIELD(req, pack_buf) = MPL_malloc(data_sz);
+        REQ_FIELD(req, pack_buf) = MPL_malloc(data_sz, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!REQ_FIELD(req, pack_buf), mpi_errno, MPI_ERR_OTHER, "**outofmemory");
         write_to_buf = REQ_FIELD(req, pack_buf);
     }

--- a/src/mpid/ch3/channels/nemesis/netmod/llc/llc_probe.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/llc/llc_probe.c
@@ -178,7 +178,7 @@ int MPID_nem_llc_improbe(MPIDI_VC_t * vc, int source, int tag, MPIR_Comm * comm,
         req->status.MPI_TAG = probe.tag & 0xffffffff;
         req->dev.recv_data_sz = probe.len;
         MPIR_STATUS_SET_COUNT(req->status, req->dev.recv_data_sz);
-        req->dev.tmpbuf = MPL_malloc(req->dev.recv_data_sz);
+        req->dev.tmpbuf = MPL_malloc(req->dev.recv_data_sz, MPL_MEM_BUFFER);
         MPIR_Assert(req->dev.tmpbuf);
 
         /* receive message in req->dev.tmpbuf */

--- a/src/mpid/ch3/channels/nemesis/netmod/llc/llc_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/llc/llc_send.c
@@ -129,7 +129,7 @@ int MPID_nem_llc_isend(struct MPIDI_VC *vc, const void *buf, int count, MPI_Data
         intptr_t segment_size = data_sz;
         intptr_t last = segment_size;
         MPIR_Assert(last > 0);
-        REQ_FIELD(sreq, pack_buf) = MPL_malloc((size_t) data_sz);
+        REQ_FIELD(sreq, pack_buf) = MPL_malloc((size_t) data_sz, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!REQ_FIELD(sreq, pack_buf), mpi_errno, MPI_ERR_OTHER, "**outofmemory");
         MPIR_Segment_pack(segment_ptr, segment_first, &last, (char *) (REQ_FIELD(sreq, pack_buf)));
         MPIR_Assert(last == data_sz);
@@ -363,7 +363,7 @@ int MPID_nem_llc_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr,
 
     data_sz = sreq->dev.segment_size;
     if (data_sz > 0) {
-        REQ_FIELD(sreq, rma_buf) = MPL_malloc((size_t) sreq->dev.segment_size);
+        REQ_FIELD(sreq, rma_buf) = MPL_malloc((size_t) sreq->dev.segment_size, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!REQ_FIELD(sreq, rma_buf), mpi_errno, MPI_ERR_OTHER, "**outofmemory");
         MPIR_Segment_pack(sreq->dev.segment_ptr, sreq->dev.segment_first, &data_sz,
                           (char *) REQ_FIELD(sreq, rma_buf));
@@ -547,14 +547,14 @@ ssize_t llc_writev(void *endpt, uint64_t raddr,
             }
 #ifdef	notdef_hsiz_hack
             if (bsiz > 0) {
-                buff = MPL_malloc(bsiz + sizeof(MPID_nem_llc_netmod_hdr_t));
+                buff = MPL_malloc(bsiz + sizeof(MPID_nem_llc_netmod_hdr_t), MPL_MEM_BUFFER);
                 if (buff == 0) {
                     nw = -1;    /* ENOMEM */
                     goto bad;
                 }
             }
 #else /* notdef_hsiz_hack */
-            buff = MPL_malloc(bsiz + sizeof(MPID_nem_llc_netmod_hdr_t));
+            buff = MPL_malloc(bsiz + sizeof(MPID_nem_llc_netmod_hdr_t), MPL_MEM_BUFFER);
             if (buff == 0) {
                 nw = -1;        /* ENOMEM */
                 goto bad;
@@ -1050,7 +1050,7 @@ int MPID_nem_llc_issend(struct MPIDI_VC *vc, const void *buf, int count, MPI_Dat
         intptr_t segment_size = data_sz;
         intptr_t last = segment_size;
         MPIR_Assert(last > 0);
-        REQ_FIELD(sreq, pack_buf) = MPL_malloc((size_t) data_sz);
+        REQ_FIELD(sreq, pack_buf) = MPL_malloc((size_t) data_sz, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!REQ_FIELD(sreq, pack_buf), mpi_errno, MPI_ERR_OTHER, "**outofmemory");
         MPIR_Segment_pack(segment_ptr, segment_first, &last, (char *) (REQ_FIELD(sreq, pack_buf)));
         MPIR_Assert(last == data_sz);

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_impl.h
@@ -234,7 +234,7 @@ static inline void list_grow_mxm_req(list_head_t * list_head)
     int count = MXM_MPICH_MAX_REQ;
 
     while (count--) {
-        mxm_req = (MPID_nem_mxm_req_t *) MPL_malloc(sizeof(MPID_nem_mxm_req_t));
+        mxm_req = (MPID_nem_mxm_req_t *) MPL_malloc(sizeof(MPID_nem_mxm_req_t), MPL_MEM_OBJECT);
         list_enqueue(list_head, &mxm_req->queue);
     }
 }
@@ -375,7 +375,7 @@ static inline void _dbg_mxm_hexdump(void *ptr, int buflen)
         return;
 
     len = 80 * (buflen / 16 + 1);
-    str = (char *) MPL_malloc(len);
+    str = (char *) MPL_malloc(len, MPL_MEM_STRINGS);
     for (i = 0; i < buflen; i += 16) {
         cur_len += MPL_snprintf(str + cur_len, len - cur_len, "%06x: ", i);
         for (j = 0; j < 16; j++)

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_init.c
@@ -292,7 +292,7 @@ int MPID_nem_mxm_vc_init(MPIDI_VC_t * vc)
             MPIR_ERR_POP(mpi_errno);
 #endif
 
-        business_card = (char *) MPL_malloc(val_max_sz);
+        business_card = (char *) MPL_malloc(val_max_sz, MPL_MEM_ADDRESS);
         mpi_errno = vc->pg->getConnInfo(vc->pg_rank, business_card, val_max_sz, vc->pg);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -423,7 +423,7 @@ static int _mxm_conf(void)
 #if MXM_API >= MXM_VERSION(3,0)
     _mxm_obj.runtime_version = MPL_strdup(mxm_get_version_string());
 #else
-    _mxm_obj.runtime_version = MPL_malloc(sizeof(MXM_VERNO_STRING) + 10);
+    _mxm_obj.runtime_version = MPL_malloc(sizeof(MXM_VERNO_STRING) + 10, MPL_MEM_STRINGS);
     snprintf(_mxm_obj.runtime_version, (sizeof(MXM_VERNO_STRING) + 9),
              "%ld.%ld", (cur_ver >> MXM_MAJOR_BIT) & 0xff, (cur_ver >> MXM_MINOR_BIT) & 0xff);
 #endif
@@ -493,7 +493,7 @@ static int _mxm_init(int rank, int size)
     _mxm_obj.mxm_rank = rank;
     _mxm_obj.mxm_np = size;
     _mxm_obj.endpoint =
-        (MPID_nem_mxm_ep_t *) MPL_malloc(_mxm_obj.mxm_np * sizeof(MPID_nem_mxm_ep_t));
+        (MPID_nem_mxm_ep_t *) MPL_malloc(_mxm_obj.mxm_np * sizeof(MPID_nem_mxm_ep_t), MPL_MEM_ADDRESS);
     memset(_mxm_obj.endpoint, 0, _mxm_obj.mxm_np * sizeof(MPID_nem_mxm_ep_t));
 
     list_init(&_mxm_obj.free_queue);
@@ -639,7 +639,7 @@ static int _mxm_add_comm(MPIR_Comm * comm, void *param)
     MPIR_CHKPMEM_DECL(1);
 
     MPIR_CHKPMEM_MALLOC(mq_h_v, mxm_mq_h *, sizeof(mxm_mq_h) * 2, mpi_errno,
-                        "mxm_mq_h_context_ptr");
+                        "mxm_mq_h_context_ptr", MPL_MEM_COMM);
 
     _dbg_mxm_output(6, "Add COMM comm %p (rank %d type %d context %d | %d size %d | %d) \n",
                     comm, comm->rank, comm->comm_kind,

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_poll.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_poll.c
@@ -303,7 +303,7 @@ static int _mxm_handle_rreq(MPIR_Request * req)
             n_iov = req_area->iov_count;
             iov_buf = req_area->iov_buf;
             if (last && n_iov > 0) {
-                iov = MPL_malloc(n_iov * sizeof(*iov));
+                iov = MPL_malloc(n_iov * sizeof(*iov), MPL_MEM_BUFFER);
                 MPIR_Assert(iov);
 
                 for (index = 0; index < n_iov; index++) {
@@ -460,7 +460,7 @@ static int _mxm_process_rdtype(MPIR_Request ** rreq_p, MPI_Datatype datatype,
     MPIR_Segment_count_contig_blocks(rreq->dev.segment_ptr, rreq->dev.segment_first, &last,
                                      (MPI_Aint *) & n_iov);
     MPIR_Assert(n_iov > 0);
-    iov = MPL_malloc(n_iov * sizeof(*iov));
+    iov = MPL_malloc(n_iov * sizeof(*iov), MPL_MEM_BUFFER);
     MPIR_Assert(iov);
 
     last = rreq->dev.segment_size;
@@ -478,7 +478,7 @@ static int _mxm_process_rdtype(MPIR_Request ** rreq_p, MPI_Datatype datatype,
 
     if (n_iov <= MXM_REQ_DATA_MAX_IOV) {
         if (n_iov > MXM_MPICH_MAX_IOV) {
-            *iov_buf = (mxm_req_buffer_t *) MPL_malloc(n_iov * sizeof(**iov_buf));
+            *iov_buf = (mxm_req_buffer_t *) MPL_malloc(n_iov * sizeof(**iov_buf), MPL_MEM_BUFFER);
             MPIR_Assert(*iov_buf);
         }
 
@@ -493,7 +493,7 @@ static int _mxm_process_rdtype(MPIR_Request ** rreq_p, MPI_Datatype datatype,
     else {
         MPI_Aint packsize = 0;
         MPIR_Pack_size_impl(rreq->dev.user_count, rreq->dev.datatype, &packsize);
-        rreq->dev.tmpbuf = MPL_malloc((size_t) packsize);
+        rreq->dev.tmpbuf = MPL_malloc((size_t) packsize, MPL_MEM_BUFFER);
         MPIR_Assert(rreq->dev.tmpbuf);
         rreq->dev.tmpbuf_sz = packsize;
         (*iov_buf)[0].ptr = rreq->dev.tmpbuf;

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_probe.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_probe.c
@@ -150,7 +150,7 @@ int MPID_nem_mxm_improbe(MPIDI_VC_t * vc, int source, int tag, MPIR_Comm * comm,
         req->status.MPI_SOURCE = mxm_req.completion.sender_imm;
         req->dev.recv_data_sz = mxm_req.completion.sender_len;
         MPIR_STATUS_SET_COUNT(req->status, req->dev.recv_data_sz);
-        req->dev.tmpbuf = MPL_malloc(req->dev.recv_data_sz);
+        req->dev.tmpbuf = MPL_malloc(req->dev.recv_data_sz, MPL_MEM_BUFFER);
         MPIR_Assert(req->dev.tmpbuf);
 
         mxm_req.base.completed_cb = NULL;

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_send.c
@@ -209,7 +209,7 @@ int MPID_nem_mxm_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr,
     MPIR_Assert(last > 0 && last - sreq->dev.segment_first > 0);
 
     if (last > 0) {
-        sreq->dev.tmpbuf = MPL_malloc((size_t) (sreq->dev.segment_size - sreq->dev.segment_first));
+        sreq->dev.tmpbuf = MPL_malloc((size_t) (sreq->dev.segment_size - sreq->dev.segment_first), MPL_MEM_BUFFER);
         MPIR_Assert(sreq->dev.tmpbuf);
         MPIR_Segment_pack(sreq->dev.segment_ptr, sreq->dev.segment_first, &last, sreq->dev.tmpbuf);
         MPIR_Assert(last == sreq->dev.segment_size);
@@ -306,7 +306,7 @@ int MPID_nem_mxm_send(MPIDI_VC_t * vc, const void *buf, MPI_Aint count, MPI_Data
 
             last = data_sz;
             if (packsize > 0) {
-                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize);
+                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize, MPL_MEM_BUFFER);
                 MPIR_Assert(sreq->dev.tmpbuf);
                 MPIR_Segment_init(buf, count, datatype, sreq->dev.segment_ptr, 0);
                 MPIR_Segment_pack(sreq->dev.segment_ptr, 0, &last, sreq->dev.tmpbuf);
@@ -409,7 +409,7 @@ int MPID_nem_mxm_ssend(MPIDI_VC_t * vc, const void *buf, MPI_Aint count, MPI_Dat
 
             last = data_sz;
             if (packsize > 0) {
-                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize);
+                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize, MPL_MEM_BUFFER);
                 MPIR_Assert(sreq->dev.tmpbuf);
                 MPIR_Segment_init(buf, count, datatype, sreq->dev.segment_ptr, 0);
                 MPIR_Segment_pack(sreq->dev.segment_ptr, 0, &last, sreq->dev.tmpbuf);
@@ -512,7 +512,7 @@ int MPID_nem_mxm_isend(MPIDI_VC_t * vc, const void *buf, MPI_Aint count, MPI_Dat
 
             last = data_sz;
             if (packsize > 0) {
-                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize);
+                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize, MPL_MEM_BUFFER);
                 MPIR_Assert(sreq->dev.tmpbuf);
                 MPIR_Segment_init(buf, count, datatype, sreq->dev.segment_ptr, 0);
                 MPIR_Segment_pack(sreq->dev.segment_ptr, 0, &last, sreq->dev.tmpbuf);
@@ -616,7 +616,7 @@ int MPID_nem_mxm_issend(MPIDI_VC_t * vc, const void *buf, MPI_Aint count, MPI_Da
 
             last = data_sz;
             if (packsize > 0) {
-                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize);
+                sreq->dev.tmpbuf = MPL_malloc((size_t) packsize, MPL_MEM_BUFFER);
                 MPIR_Assert(sreq->dev.tmpbuf);
                 MPIR_Segment_init(buf, count, datatype, sreq->dev.segment_ptr, 0);
                 MPIR_Segment_pack(sreq->dev.segment_ptr, 0, &last, sreq->dev.tmpbuf);

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -117,10 +117,10 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
                    GET_RCD_IGNORE_MASK(),
                    (void *) &(REQ_OFI(gl_data.conn_req)->ofi_context)), trecv);
 
-    addr = MPL_malloc(gl_data.bound_addrlen);
+    addr = MPL_malloc(gl_data.bound_addrlen, MPL_MEM_ADDRESS);
     MPIR_Assertp(addr);
 
-    vc = MPL_malloc(sizeof(MPIDI_VC_t));
+    vc = MPL_malloc(sizeof(MPIDI_VC_t), MPL_MEM_ADDRESS);
     MPIR_Assertp(vc);
 
     MPIDI_VC_Init(vc, NULL, 0);
@@ -216,7 +216,7 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
     VC_READY_CHECK(vc);
 
     pkt_len = REQ_OFI(rreq)->msg_bytes;
-    pack_buffer = (char *) MPL_malloc(pkt_len);
+    pack_buffer = (char *) MPL_malloc(pkt_len, MPL_MEM_BUFFER);
     /* If the pack buffer is NULL, let OFI handle the truncation
      * in the progress loop
      */
@@ -337,7 +337,7 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
     /* Post recv for connection requests */
     /* --------------------------------- */
     MPID_nem_ofi_create_req(&conn_req, 1);
-    conn_req->dev.user_buf = MPL_malloc(OFI_KVSAPPSTRLEN * sizeof(char));
+    conn_req->dev.user_buf = MPL_malloc(OFI_KVSAPPSTRLEN * sizeof(char), MPL_MEM_BUFFER);
     conn_req->dev.OnDataAvail = NULL;
     conn_req->dev.next = NULL;
     REQ_OFI(conn_req)->vc = NULL;       /* We don't know the source yet */
@@ -400,7 +400,7 @@ int MPID_nem_ofi_vc_connect(MPIDI_VC_t * vc)
     char bc[OFI_KVSAPPSTRLEN], *addr = NULL;
 
     BEGIN_FUNC(FCNAME);
-    addr = MPL_malloc(gl_data.bound_addrlen);
+    addr = MPL_malloc(gl_data.bound_addrlen, MPL_MEM_ADDRESS);
     MPIR_Assert(addr);
     MPIR_Assert(1 != VC_OFI(vc)->ready);
 
@@ -528,8 +528,8 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     uint64_t conn_req_send_bits;
 
     BEGIN_FUNC(FCNAME);
-    addr = MPL_malloc(gl_data.bound_addrlen);
-    bc = MPL_malloc(OFI_KVSAPPSTRLEN);
+    addr = MPL_malloc(gl_data.bound_addrlen, MPL_MEM_ADDRESS);
+    bc = MPL_malloc(OFI_KVSAPPSTRLEN, MPL_MEM_ADDRESS);
     MPIR_Assertp(addr);
     MPIR_Assertp(bc);
     my_bc = bc;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -250,7 +250,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* from KVS and store them in local  */
     /* table                             */
     /* --------------------------------- */
-    MPIR_CHKLMEM_MALLOC(addrs, char *, pg_p->size * gl_data.bound_addrlen, mpi_errno, "addrs");
+    MPIR_CHKLMEM_MALLOC(addrs, char *, pg_p->size * gl_data.bound_addrlen, mpi_errno, "addrs", MPL_MEM_ADDRESS);
 
     for (i = 0; i < pg_p->size; ++i) {
         MPL_snprintf(key, sizeof(key), "OFI-%d", i);
@@ -269,7 +269,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* The addressing mode is "map", so we must provide     */
     /* storage to store the per destination addresses       */
     /* ---------------------------------------------------- */
-    fi_addrs = MPL_malloc(pg_p->size * sizeof(fi_addr_t));
+    fi_addrs = MPL_malloc(pg_p->size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
     FI_RC(fi_av_insert(gl_data.av, addrs, pg_p->size, fi_addrs, 0ULL, NULL), avmap);
 
     /* --------------------------------- */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -228,7 +228,7 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
     MPID_nem_ofi_init_req(sreq);
     pkt_len = sizeof(MPIDI_CH3_Pkt_t) + sreq->dev.ext_hdr_sz + data_sz;
     if (sreq->dev.ext_hdr_sz > 0 && gl_data.iov_limit > 2) {
-      REQ_OFI(sreq)->real_hdr        = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t)+sreq->dev.ext_hdr_sz);
+      REQ_OFI(sreq)->real_hdr        = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t)+sreq->dev.ext_hdr_sz, MPL_MEM_BUFFER);
       MPIR_ERR_CHKANDJUMP1(REQ_OFI(sreq)->real_hdr == NULL, mpi_errno, MPI_ERR_OTHER,
                             "**nomem", "**nomem %s", "iSendContig extended header allocation");
       REQ_OFI(sreq)->iov[0].iov_base = REQ_OFI(sreq)->real_hdr;
@@ -243,7 +243,7 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
                   sreq->dev.ext_hdr_ptr, sreq->dev.ext_hdr_sz);
       }
     else if(sreq->dev.ext_hdr_sz == 0 && gl_data.iov_limit > 1) {
-        REQ_OFI(sreq)->real_hdr = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t));
+        REQ_OFI(sreq)->real_hdr = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP1(REQ_OFI(sreq)->real_hdr == NULL, mpi_errno, MPI_ERR_OTHER,
                              "**nomem", "**nomem %s", "iSendContig header allocation");
         MPIR_Memcpy(REQ_OFI(sreq)->real_hdr, hdr, hdr_sz);
@@ -254,7 +254,7 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
         REQ_OFI(sreq)->iov_count       = 2;
     }
     else {
-      pack_buffer = MPL_malloc(pkt_len);
+      pack_buffer = MPL_malloc(pkt_len, MPL_MEM_BUFFER);
       MPIR_ERR_CHKANDJUMP1(pack_buffer == NULL, mpi_errno, MPI_ERR_OTHER,
                            "**nomem", "**nomem %s", "iSendContig pack buffer allocation");
       MPIR_Memcpy(pack_buffer, hdr, hdr_sz);
@@ -290,7 +290,7 @@ int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc,
     last = sreq->dev.segment_size;
     data_sz = sreq->dev.segment_size - sreq->dev.segment_first;
     pkt_len = sizeof(MPIDI_CH3_Pkt_t) + sreq->dev.ext_hdr_sz + data_sz;
-    pack_buffer = MPL_malloc(pkt_len);
+    pack_buffer = MPL_malloc(pkt_len, MPL_MEM_BUFFER);
     MPIR_ERR_CHKANDJUMP1(pack_buffer == NULL, mpi_errno, MPI_ERR_OTHER,
                          "**nomem", "**nomem %s", "SendNonContig pack buffer allocation");
     MPIR_Memcpy(pack_buffer, hdr, hdr_sz);
@@ -327,7 +327,7 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
     sreq->dev.next = NULL;
     pkt_len = sizeof(MPIDI_CH3_Pkt_t) + data_sz;
     if(gl_data.iov_limit > 1) {
-      REQ_OFI(sreq)->real_hdr = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t));
+      REQ_OFI(sreq)->real_hdr = MPL_malloc(sizeof(MPIDI_CH3_Pkt_t), MPL_MEM_BUFFER);
       MPIR_Memcpy(REQ_OFI(sreq)->real_hdr, hdr, hdr_sz);
       REQ_OFI(sreq)->iov[0].iov_base = REQ_OFI(sreq)->real_hdr;
       REQ_OFI(sreq)->iov[0].iov_len  = sizeof(MPIDI_CH3_Pkt_t);
@@ -336,7 +336,7 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
       REQ_OFI(sreq)->iov_count       = 2;
     }
     else {
-      pack_buffer = MPL_malloc(pkt_len);
+      pack_buffer = MPL_malloc(pkt_len, MPL_MEM_BUFFER);
       MPIR_ERR_CHKANDJUMP1(pack_buffer == NULL, mpi_errno, MPI_ERR_OTHER,
                            "**nomem", "**nomem %s", "iStartContig pack buffer allocation");
       MPIR_Memcpy((void *) pack_buffer, hdr, hdr_sz);

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
@@ -142,7 +142,7 @@ static inline int ADD_SUFFIX(send_normal)(struct MPIDI_VC *vc,
     sreq->dev.match.parts.tag = match_bits;
     send_buffer = (char *) buf + dt_true_lb;
     if (!dt_contig) {
-        send_buffer = (char *) MPL_malloc(data_sz);
+        send_buffer = (char *) MPL_malloc(data_sz, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP1(send_buffer == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send buffer alloc");
         MPIDI_CH3U_Buffer_copy(buf, count, datatype, &err0,
@@ -415,7 +415,7 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_posted)(struct MPIDI_VC *vc, struct MPIR_Reques
         recv_buffer = (char *) rreq->dev.user_buf + dt_true_lb;
     }
     else {
-        recv_buffer = (char *) MPL_malloc(data_sz);
+        recv_buffer = (char *) MPL_malloc(data_sz, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP1(recv_buffer == NULL, mpi_errno, MPI_ERR_OTHER,
                              "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
         REQ_OFI(rreq)->pack_buffer = recv_buffer;

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_init.c
@@ -636,7 +636,7 @@ int MPID_nem_ptl_init_id(MPIDI_VC_t *vc)
 
     pmi_errno = PMI_KVS_Get_value_length_max(&val_max_sz);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
-    MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc");
+    MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc", MPL_MEM_ADDRESS);
 
     mpi_errno = vc->pg->getConnInfo(vc->pg_rank, bc, val_max_sz, vc->pg);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_nm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_nm.c
@@ -113,7 +113,7 @@ int MPID_nem_ptl_nm_init(void)
     overflow_me.min_free = PTL_MAX_EAGER;
 
     /* allocate all overflow space at once */
-    tmp_ptr = MPL_malloc(NUM_RECV_BUFS * BUFSIZE);
+    tmp_ptr = MPL_malloc(NUM_RECV_BUFS * BUFSIZE, MPL_MEM_BUFFER);
     expected_recv_ptr = tmp_ptr;
     expected_recv_idx = 0;
 
@@ -206,7 +206,7 @@ static inline int send_pkt(MPIDI_VC_t *vc, void *hdr_p, void *data_p, intptr_t d
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_SEND_PKT);
     
-    sendbuf = MPL_malloc(sendbuf_sz);
+    sendbuf = MPL_malloc(sendbuf_sz, MPL_MEM_BUFFER);
     MPIR_Assert(sendbuf != NULL);
     MPIR_Memcpy(sendbuf, hdr_p, sizeof(MPIDI_CH3_Pkt_t));
     sendbuf_ptr = sendbuf + sizeof(MPIDI_CH3_Pkt_t);
@@ -272,7 +272,7 @@ static int send_noncontig_pkt(MPIDI_VC_t *vc, MPIR_Request *sreq, void *hdr_p)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_SEND_NONCONTIG_PKT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_SEND_NONCONTIG_PKT);
 
-    sendbuf = MPL_malloc(sendbuf_sz);
+    sendbuf = MPL_malloc(sendbuf_sz, MPL_MEM_BUFFER);
     MPIR_Assert(sendbuf != NULL);
     MPIR_Memcpy(sendbuf, hdr_p, sizeof(MPIDI_CH3_Pkt_t));
     sendbuf_ptr = sendbuf + sizeof(MPIDI_CH3_Pkt_t);
@@ -295,7 +295,7 @@ static int send_noncontig_pkt(MPIDI_VC_t *vc, MPIR_Request *sreq, void *hdr_p)
 
         if (remaining) {  /* Post MEs for the remote gets */
             ptl_size_t *offset = (ptl_size_t *)sendbuf_ptr;
-            TMPBUF(sreq) = MPL_malloc(remaining);
+            TMPBUF(sreq) = MPL_malloc(remaining, MPL_MEM_BUFFER);
             *offset = (ptl_size_t)TMPBUF(sreq);
             first = last;
             last = sreq->dev.segment_size;
@@ -486,7 +486,7 @@ int MPID_nem_ptl_nm_ctl_event_handler(const ptl_event_t *e)
                 else {
                     MPIR_Request *req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
                     /* This request is actually complete; just needs to wait to enforce ordering */
-                    TMPBUF(req) = MPL_malloc(packet_sz);
+                    TMPBUF(req) = MPL_malloc(packet_sz, MPL_MEM_BUFFER);
                     MPIR_Assert(TMPBUF(req));
                     MPIR_Memcpy(TMPBUF(req), e->start, packet_sz);
                     REQ_PTL(req)->bytes_put = packet_sz;
@@ -506,7 +506,7 @@ int MPID_nem_ptl_nm_ctl_event_handler(const ptl_event_t *e)
                 MPIDI_CH3U_Request_decrement_cc(req, &incomplete);  /* We'll increment it below */
                 REQ_PTL(req)->event_handler = MPID_nem_ptl_nm_ctl_event_handler;
                 REQ_PTL(req)->bytes_put = packet_sz + remaining - sizeof(ptl_size_t);
-                TMPBUF(req) = MPL_malloc(REQ_PTL(req)->bytes_put);
+                TMPBUF(req) = MPL_malloc(REQ_PTL(req)->bytes_put, MPL_MEM_BUFFER);
                 MPIR_Assert(TMPBUF(req) != NULL);
                 MPIR_Memcpy(TMPBUF(req), e->start, packet_sz);
                 REQ_PTL(req)->recv_ptr = e->start;

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_poll.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_poll.c
@@ -30,7 +30,7 @@ int MPID_nem_ptl_poll_init(void)
 
     /* create overflow buffers */
     for (i = 0; i < NUM_OVERFLOW_ME; ++i) {
-        MPIR_CHKPMEM_MALLOC(overflow_buf[i], void *, OVERFLOW_LENGTH, mpi_errno, "overflow buffer");
+        MPIR_CHKPMEM_MALLOC(overflow_buf[i], void *, OVERFLOW_LENGTH, mpi_errno, "overflow buffer", MPL_MEM_BUFFER);
         mpi_errno = append_overflow(i);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_probe.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_probe.c
@@ -61,7 +61,7 @@ static int handle_mprobe(const ptl_event_t *e)
     MPIR_STATUS_SET_COUNT(req->status, NPTL_HEADER_GET_LENGTH(e->hdr_data));
     MPIDI_Request_set_sync_send_flag(req, e->hdr_data & NPTL_SSEND);
 
-    MPIR_CHKPMEM_MALLOC(req->dev.tmpbuf, void *, e->mlength, mpi_errno, "tmpbuf");
+    MPIR_CHKPMEM_MALLOC(req->dev.tmpbuf, void *, e->mlength, mpi_errno, "tmpbuf", MPL_MEM_BUFFER);
     MPIR_Memcpy((char *)req->dev.tmpbuf, e->start, e->mlength);
     req->dev.recv_data_sz = e->mlength;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_recv.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_recv.c
@@ -352,7 +352,7 @@ static int handler_recv_dequeue_large(const ptl_event_t *e)
     /* message won't fit in a single IOV, allocate buffer and unpack when received */
     /* FIXME: For now, allocate a single large buffer to hold entire message */
     MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, data_sz - PTL_LARGE_THRESHOLD,
-                        mpi_errno, "chunk_buffer");
+                        mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
     big_get(REQ_PTL(rreq)->chunk_buffer[0], data_sz - PTL_LARGE_THRESHOLD, vc, e->match_bits, rreq);
 
  fn_exit:
@@ -407,7 +407,7 @@ static int handler_recv_dequeue_unpack_large(const ptl_event_t *e)
     MPL_free(REQ_PTL(rreq)->chunk_buffer[0]);
 
     MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, rreq->dev.segment_size - rreq->dev.segment_first,
-                        mpi_errno, "chunk_buffer");
+                        mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
     big_get(REQ_PTL(rreq)->chunk_buffer[0], rreq->dev.segment_size - rreq->dev.segment_first, vc, e->match_bits, rreq);
 
  fn_exit:
@@ -509,7 +509,7 @@ int MPID_nem_ptl_recv_posted(MPIDI_VC_t *vc, MPIR_Request *rreq)
                 /* IOV is not long enough to describe entire message: recv into
                    buffer and unpack later */
                 MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "    IOV too long: using bounce buffer");
-                MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "chunk_buffer");
+                MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
                 me.start = REQ_PTL(rreq)->chunk_buffer[0];
                 me.length = data_sz;
                 REQ_PTL(rreq)->event_handler = handler_recv_dequeue_unpack_complete;
@@ -548,7 +548,7 @@ int MPID_nem_ptl_recv_posted(MPIDI_VC_t *vc, MPIR_Request *rreq)
                 /* IOV is not long enough to describe the first chunk: recv into
                    buffer and unpack later */
                 MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "    IOV too long: using bounce buffer for first chunk");
-                MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, PTL_LARGE_THRESHOLD, mpi_errno, "chunk_buffer");
+                MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, PTL_LARGE_THRESHOLD, mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
                 me.start = REQ_PTL(rreq)->chunk_buffer[0];
                 me.length = PTL_LARGE_THRESHOLD;
                 REQ_PTL(rreq)->event_handler = handler_recv_dequeue_unpack_large;
@@ -766,7 +766,7 @@ int MPID_nem_ptl_lmt_start_recv(MPIDI_VC_t *vc,  MPIR_Request *rreq, MPL_IOV s_c
             /* message won't fit in a single IOV, allocate buffer and unpack when received */
             /* FIXME: For now, allocate a single large buffer to hold entire message */
             MPIR_CHKPMEM_MALLOC(REQ_PTL(rreq)->chunk_buffer[0], void *, rreq->dev.segment_size - rreq->dev.segment_first,
-                                mpi_errno, "chunk_buffer");
+                                mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
             big_get(REQ_PTL(rreq)->chunk_buffer[0], rreq->dev.segment_size - rreq->dev.segment_first, vc, match_bits, rreq);
         }
     }

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_send.c
@@ -31,7 +31,7 @@ static void big_meappend(void *buf, ptl_size_t left_to_send, MPIDI_VC_t *vc, ptl
 
     /* allocate enough handles to cover all get operations */
     REQ_PTL(sreq)->get_me_p = MPL_malloc(sizeof(ptl_handle_me_t) *
-                                        ((left_to_send / MPIDI_nem_ptl_ni_limits.max_msg_size) + 1));
+                                        ((left_to_send / MPIDI_nem_ptl_ni_limits.max_msg_size) + 1), MPL_MEM_OTHER);
 
     /* queue up as many entries as necessary to describe the entire message */
     for (i = 0; left_to_send > 0; i++) {
@@ -193,7 +193,7 @@ static int send_msg(ptl_hdr_data_t ssend_flag, struct MPIDI_VC *vc, const void *
         
         /* IOV is not long enough to describe entire message */
         MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "    IOV too long: using bounce buffer");
-        MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "chunk_buffer");
+        MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "chunk_buffer", MPL_MEM_BUFFER);
         MPIR_Segment_init(buf, count, datatype, sreq->dev.segment_ptr, 0);
         sreq->dev.segment_first = 0;
         last = data_sz;
@@ -268,7 +268,7 @@ static int send_msg(ptl_hdr_data_t ssend_flag, struct MPIDI_VC *vc, const void *
                 me.ignore_bits = 0;
                 me.min_free = 0;
 
-                MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->get_me_p, ptl_handle_me_t *, sizeof(ptl_handle_me_t), mpi_errno, "get_me_p");
+                MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->get_me_p, ptl_handle_me_t *, sizeof(ptl_handle_me_t), mpi_errno, "get_me_p", MPL_MEM_BUFFER);
 
                 ret = PtlMEAppend(MPIDI_nem_ptl_ni, MPIDI_nem_ptl_get_pt, &me, PTL_PRIORITY_LIST, sreq,
                                   &REQ_PTL(sreq)->get_me_p[0]);
@@ -301,7 +301,7 @@ static int send_msg(ptl_hdr_data_t ssend_flag, struct MPIDI_VC *vc, const void *
     }
 
     /* allocate a temporary buffer and copy all the data to send */
-    MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "tmpbuf");
+    MPIR_CHKPMEM_MALLOC(REQ_PTL(sreq)->chunk_buffer[0], void *, data_sz, mpi_errno, "tmpbuf", MPL_MEM_BUFFER);
 
     last = data_sz;
     MPIR_Segment_pack(sreq->dev.segment_ptr, 0, &last, REQ_PTL(sreq)->chunk_buffer[0]);

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
@@ -87,7 +87,7 @@ static int find_target(ptl_process_t id, struct rptl_target **target)
 
     /* if the target does not already exist, create one */
     if (t == NULL) {
-        MPIR_CHKPMEM_MALLOC(t, struct rptl_target *, sizeof(struct rptl_target), mpi_errno, "rptl target");
+        MPIR_CHKPMEM_MALLOC(t, struct rptl_target *, sizeof(struct rptl_target), mpi_errno, "rptl target", MPL_MEM_ADDRESS);
         DL_APPEND(rptl_info.target_list, t);
 
         t->id = id;
@@ -608,12 +608,12 @@ static int stash_event(struct rptl_op *op, ptl_event_t event)
 
     if (event.type == PTL_EVENT_SEND) {
         MPIR_CHKPMEM_MALLOC(op->u.put.send, ptl_event_t *, sizeof(ptl_event_t), mpi_errno,
-                            "ptl event");
+                            "ptl event", MPL_MEM_OTHER);
         memcpy(op->u.put.send, &event, sizeof(ptl_event_t));
     }
     else {
         MPIR_CHKPMEM_MALLOC(op->u.put.ack, ptl_event_t *, sizeof(ptl_event_t), mpi_errno,
-                            "ptl event");
+                            "ptl event", MPL_MEM_OTHER);
         memcpy(op->u.put.ack, &event, sizeof(ptl_event_t));
     }
 

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_init.c
@@ -153,7 +153,7 @@ int MPID_nem_ptl_rptl_ptinit(ptl_handle_ni_t ni_handle, ptl_handle_eq_t eq_handl
 
     /* setup the parts of rptls that can be done before world size or
      * target information */
-    MPIR_CHKPMEM_MALLOC(rptl, struct rptl *, sizeof(struct rptl), mpi_errno, "rptl");
+    MPIR_CHKPMEM_MALLOC(rptl, struct rptl *, sizeof(struct rptl), mpi_errno, "rptl", MPL_MEM_ADDRESS);
     DL_APPEND(rptl_info.rptl_list, rptl);
 
     rptl->local_state = RPTL_LOCAL_STATE_ACTIVE;
@@ -180,7 +180,7 @@ int MPID_nem_ptl_rptl_ptinit(ptl_handle_ni_t ni_handle, ptl_handle_eq_t eq_handl
     if (rptl->control.pt != PTL_PT_ANY) {
         MPIR_CHKPMEM_MALLOC(rptl->control.me, ptl_handle_me_t *,
                             2 * rptl_info.world_size * sizeof(ptl_handle_me_t), mpi_errno,
-                            "rptl target info");
+                            "rptl target info", MPL_MEM_BUFFER);
         for (i = 0; i < 2 * rptl_info.world_size; i++) {
             ret = rptli_post_control_buffer(rptl->ni, rptl->control.pt, &rptl->control.me[i]);
             RPTLU_ERR_POP(ret, "Error in rptli_post_control_buffer\n");

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_op.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_op.c
@@ -26,7 +26,7 @@ int rptli_op_alloc(struct rptl_op **op, struct rptl_target *target)
 
     if (target->op_pool == NULL) {
         MPIR_CHKPMEM_MALLOC(op_segment, struct rptl_op_pool_segment *, sizeof(struct rptl_op_pool_segment),
-                            mpi_errno, "op pool segment");
+                            mpi_errno, "op pool segment", MPL_MEM_OTHER);
         DL_APPEND(target->op_segment_list, op_segment);
 
         for (i = 0; i < RPTL_OP_POOL_SEGMENT_COUNT; i++)

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -159,9 +159,9 @@ static int alloc_sc_plfd_tbls (void)
     MPIR_Assert(MPID_nem_tcp_plfd_tbl == NULL);
 
     MPIR_CHKPMEM_MALLOC (g_sc_tbl, sockconn_t *, g_tbl_capacity * sizeof(sockconn_t),
-                         mpi_errno, "connection table");
+                         mpi_errno, "connection table", MPL_MEM_ADDRESS);
     MPIR_CHKPMEM_MALLOC (MPID_nem_tcp_plfd_tbl, struct pollfd *, g_tbl_capacity * sizeof(struct pollfd),
-                         mpi_errno, "pollfd table");
+                         mpi_errno, "pollfd table", MPL_MEM_ADDRESS);
 #if defined(MPICH_DEBUG_MEMINIT)
     /* We initialize the arrays in order to eliminate spurious valgrind errors
        that occur when poll(2) returns 0.  See valgrind bugzilla#158425 and
@@ -228,9 +228,9 @@ static int expand_sc_plfd_tbls (void)
     MPL_DBG_MSG_FMT(MPIDI_NEM_TCP_DBG_DET, VERBOSE, (MPL_DBG_FDEST, "expand_sc_plfd_tbls Entry"));
     MPL_DBG_MSG_FMT(MPIDI_NEM_TCP_DBG_DET, VERBOSE, (MPL_DBG_FDEST, "expand_sc_plfd_tbls b4 g_sc_tbl[0].fd=%d", g_sc_tbl[0].fd));
     MPIR_CHKPMEM_MALLOC (new_sc_tbl, sockconn_t *, new_capacity * sizeof(sockconn_t),
-                         mpi_errno, "expanded connection table");
+                         mpi_errno, "expanded connection table", MPL_MEM_ADDRESS);
     MPIR_CHKPMEM_MALLOC (new_plfd_tbl, struct pollfd *, new_capacity * sizeof(struct pollfd),
-                         mpi_errno, "expanded pollfd table");
+                         mpi_errno, "expanded pollfd table", MPL_MEM_ADDRESS);
 
     MPIR_Memcpy (new_sc_tbl, g_sc_tbl, g_tbl_capacity * sizeof(sockconn_t));
     MPIR_Memcpy (new_plfd_tbl, MPID_nem_tcp_plfd_tbl, g_tbl_capacity * sizeof(struct pollfd));
@@ -605,7 +605,7 @@ static int recv_id_or_tmpvc_info(sockconn_t *const sc, int *got_sc_eof)
 	iov[0].iov_len = sizeof(sc->pg_rank);
 	pg_id_len = hdr.datalen - sizeof(MPIDI_nem_tcp_idinfo_t);
 	if (pg_id_len != 0) {
-	    MPIR_CHKLMEM_MALLOC (pg_id, char *, pg_id_len, mpi_errno, "sockconn pg_id");
+	    MPIR_CHKLMEM_MALLOC (pg_id, char *, pg_id_len, mpi_errno, "sockconn pg_id", MPL_MEM_OTHER);
 	    iov[1].iov_base = (void *)pg_id;
 	    iov[1].iov_len = pg_id_len;
 	    ++iov_cnt;
@@ -648,7 +648,7 @@ static int recv_id_or_tmpvc_info(sockconn_t *const sc, int *got_sc_eof)
 
         MPL_DBG_MSG_FMT(MPIDI_NEM_TCP_DBG_DET, VERBOSE, (MPL_DBG_FDEST, "PKT_TMPVC_INFO: sc->fd=%d", sc->fd));
         /* create a new VC */
-        MPIR_CHKPMEM_MALLOC (vc, MPIDI_VC_t *, sizeof(MPIDI_VC_t), mpi_errno, "real vc from tmp vc");
+        MPIR_CHKPMEM_MALLOC (vc, MPIDI_VC_t *, sizeof(MPIDI_VC_t), mpi_errno, "real vc from tmp vc", MPL_MEM_ADDRESS);
         /* --BEGIN ERROR HANDLING-- */
         if (vc == NULL) {
             mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL, FCNAME, __LINE__, MPI_ERR_OTHER, "**nomem", NULL);
@@ -845,7 +845,7 @@ int MPID_nem_tcp_connect(struct MPIDI_VC *const vc)
             pmi_errno = PMI_KVS_Get_value_length_max(&val_max_sz);
             MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
 #endif
-            MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc");
+            MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc", MPL_MEM_OTHER);
             
             sc->is_tmpvc = FALSE;
             
@@ -970,7 +970,7 @@ static int cleanup_and_free_sc_plfd(sockconn_t *const sc)
     INIT_SC_ENTRY(sc, idx);
     INIT_POLLFD_ENTRY(plfd);
 
-    MPIR_CHKPMEM_MALLOC(node, freenode_t *, sizeof(freenode_t), mpi_errno, "free node");
+    MPIR_CHKPMEM_MALLOC(node, freenode_t *, sizeof(freenode_t), mpi_errno, "free node", MPL_MEM_OTHER);
     node->index = idx;
     Q_ENQUEUE(&freeq, node);
 
@@ -1750,7 +1750,7 @@ int MPID_nem_tcp_sm_init(void)
     MPID_nem_tcp_plfd_tbl = NULL;
     alloc_sc_plfd_tbls();
     
-    MPIR_CHKPMEM_MALLOC(recv_buf, char*, MPID_NEM_TCP_RECV_MAX_PKT_LEN, mpi_errno, "TCP temporary buffer");
+    MPIR_CHKPMEM_MALLOC(recv_buf, char*, MPID_NEM_TCP_RECV_MAX_PKT_LEN, mpi_errno, "TCP temporary buffer", MPL_MEM_BUFFER);
     MPIR_CHKPMEM_COMMIT();
 
  fn_exit:

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_getip.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_getip.c
@@ -102,7 +102,7 @@ int MPIDI_GetIPInterface( MPIDI_CH3I_nem_tcp_ifaddr_t *ifaddr, int *found )
 	struct ifconf			ifconf;
 	int				rc;
 
-	buf_ptr = (char *) MPL_malloc(buf_len);
+	buf_ptr = (char *) MPL_malloc(buf_len, MPL_MEM_BUFFER);
 	if (buf_ptr == NULL) {
 	    MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d", buf_len);
 	}

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -24,7 +24,7 @@ static struct {MPID_nem_tcp_send_q_element_t *top;} free_buffers = {0};
         if (S_EMPTY (free_buffers))                                                                                                     \
         {                                                                                                                               \
             MPIR_CHKPMEM_MALLOC (*(e), MPID_nem_tcp_send_q_element_t *, sizeof(MPID_nem_tcp_send_q_element_t),      \
-                                 mpi_errno, "send queue element");                                                                      \
+                                 mpi_errno, "send queue element", MPL_MEM_BUFFER);                                                      \
         }                                                                                                                               \
         else                                                                                                                            \
         {                                                                                                                               \
@@ -52,7 +52,7 @@ int MPID_nem_tcp_send_init(void)
         MPID_nem_tcp_send_q_element_t *e;
         
         MPIR_CHKPMEM_MALLOC (e, MPID_nem_tcp_send_q_element_t *,
-                             sizeof(MPID_nem_tcp_send_q_element_t), mpi_errno, "send queue element");
+                             sizeof(MPID_nem_tcp_send_q_element_t), mpi_errno, "send queue element", MPL_MEM_BUFFER);
         S_PUSH (&free_buffers, e);
     }
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -251,7 +251,7 @@ int MPIDI_CH3_Connect_to_root (const char *port_name, MPIDI_VC_t **new_vc)
 
     *new_vc = NULL; /* so that the err handling knows to cleanup */
 
-    MPIR_CHKPMEM_MALLOC (vc, MPIDI_VC_t *, sizeof(MPIDI_VC_t), mpi_errno, "vc");
+    MPIR_CHKPMEM_MALLOC (vc, MPIDI_VC_t *, sizeof(MPIDI_VC_t), mpi_errno, "vc", MPL_MEM_ADDRESS);
     /* FIXME - where does this vc get freed?
        ANSWER (goodell@) - ch3u_port.c FreeNewVC
                            (but the VC_Destroy is in this file) */
@@ -340,7 +340,7 @@ int MPID_nem_register_initcomp_cb(int (* callback)(void))
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_REGISTER_INITCOMP_CB);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_REGISTER_INITCOMP_CB);
-    MPIR_CHKPMEM_MALLOC(ep, initcomp_cb_t *, sizeof(*ep), mpi_errno, "initcomp callback element");
+    MPIR_CHKPMEM_MALLOC(ep, initcomp_cb_t *, sizeof(*ep), mpi_errno, "initcomp callback element", MPL_MEM_OTHER);
 
     ep->callback = callback;
     INITCOMP_S_PUSH(ep);

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -1145,7 +1145,7 @@ int MPIDI_CH3_Connection_terminate(MPIDI_VC_t * vc)
                    have completed.  */
                 vc_term_element_t *ep;
                 MPL_DBG_MSG(MPIDI_CH3_DBG_DISCONNECT, TYPICAL, "Shm send queue not empty, waiting to terminate");
-                MPIR_CHKPMEM_MALLOC(ep, vc_term_element_t *, sizeof(vc_term_element_t), mpi_errno, "vc_term_element");
+                MPIR_CHKPMEM_MALLOC(ep, vc_term_element_t *, sizeof(vc_term_element_t), mpi_errno, "vc_term_element", MPL_MEM_ADDRESS);
                 ep->vc = vc;
                 ep->req = MPIDI_CH3I_shm_sendq.tail;
                 MPIR_Request_add_ref(ep->req); /* make sure this doesn't get released before we can check it */
@@ -1250,7 +1250,7 @@ int MPIDI_CH3I_Register_anysource_notification(void (*enqueue_fn)(MPIR_Request *
     qn_ent_t *ent;
     MPIR_CHKPMEM_DECL(1);
 
-    MPIR_CHKPMEM_MALLOC(ent, qn_ent_t *, sizeof(qn_ent_t), mpi_errno, "queue entry");
+    MPIR_CHKPMEM_MALLOC(ent, qn_ent_t *, sizeof(qn_ent_t), mpi_errno, "queue entry", MPL_MEM_BUFFER);
 
     ent->enqueue_fn = enqueue_fn;
     ent->dequeue_fn = dequeue_fn;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
@@ -174,9 +174,9 @@ static int MPIDI_CH3I_SHM_Wins_match(MPIR_Win ** win_ptr, MPIR_Win ** matched_wi
 
     comm_size = (*win_ptr)->comm_ptr->local_size;
 
-    MPIR_CHKLMEM_MALLOC(node_ranks, int *, node_size * sizeof(int), mpi_errno, "node_ranks");
+    MPIR_CHKLMEM_MALLOC(node_ranks, int *, node_size * sizeof(int), mpi_errno, "node_ranks", MPL_MEM_RMA);
     MPIR_CHKLMEM_MALLOC(node_ranks_in_shm_node, int *, node_size * sizeof(int),
-                        mpi_errno, "node_ranks_in_shm_comm");
+                        mpi_errno, "node_ranks_in_shm_comm", MPL_MEM_RMA);
 
     for (i = 0; i < node_size; i++) {
         node_ranks[i] = i;
@@ -305,7 +305,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
     node_size = (*win_ptr)->comm_ptr->node_comm->local_size;
 
     MPIR_CHKLMEM_MALLOC(base_shm_offs, MPI_Aint *, node_size * sizeof(MPI_Aint),
-                        mpi_errno, "base_shm_offs");
+                        mpi_errno, "base_shm_offs", MPL_MEM_RMA);
 
     /* Return the first matched shared window.
      * It is noted that the shared windows including all local processes are
@@ -319,7 +319,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
 
     (*win_ptr)->shm_allocated = TRUE;
     MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, void **,
-                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs");
+                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs", MPL_MEM_SHM);
 
     /* Compute the base address of shm buffer on each process.
      * shm_base_addrs[i] = my_shm_base_addr + off[i] */
@@ -448,7 +448,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
     (*win_ptr)->basic_info_table = (MPIDI_Win_basic_info_t *) ((*win_ptr)->info_shm_base_addr);
 
     MPIR_CHKLMEM_MALLOC(tmp_buf, MPI_Aint *, 4 * comm_size * sizeof(MPI_Aint),
-                        mpi_errno, "tmp_buf");
+                        mpi_errno, "tmp_buf", MPL_MEM_RMA);
 
     tmp_buf[4 * comm_rank] = MPIR_Ptr_to_aint(base);
     tmp_buf[4 * comm_rank + 1] = size;
@@ -530,12 +530,12 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     /* allocate memory for the base addresses, disp_units, and
      * completion counters of all processes */
     MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, void **,
-                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs");
+                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs", MPL_MEM_SHM);
 
     /* get the sizes of the windows and window objectsof
      * all processes.  allocate temp. buffer for communication */
     MPIR_CHKLMEM_MALLOC(node_sizes, MPI_Aint *, node_size * sizeof(MPI_Aint), mpi_errno,
-                        "node_sizes");
+                        "node_sizes", MPL_MEM_RMA);
 
     /* FIXME: This needs to be fixed for heterogeneous systems */
     node_sizes[node_rank] = (MPI_Aint) size;

--- a/src/mpid/ch3/channels/nemesis/src/ch3i_comm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3i_comm.c
@@ -60,12 +60,12 @@ int MPIDI_CH3I_comm_create(MPIR_Comm *comm, void *param)
         }
 
         /* allocate and init new coll_fns table */
-        MPIR_CHKPMEM_MALLOC(cf, MPIR_Collops *, sizeof(*cf), mpi_errno, "cf");
+        MPIR_CHKPMEM_MALLOC(cf, MPIR_Collops *, sizeof(*cf), mpi_errno, "cf", MPL_MEM_COMM);
         *cf = *comm->coll_fns;
         cf->ref_count = 1;
         cf->Barrier = barrier;
         cf->prev_coll_fns = comm->coll_fns;
-        utarray_push_back(coll_fns_array, &cf);
+        utarray_push_back(coll_fns_array, &cf, MPL_MEM_COMM);
         
         /* replace coll_fns table */
         comm->coll_fns = cf;
@@ -279,7 +279,7 @@ int MPID_nem_coll_init(void)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_COLL_INIT);
 
-    utarray_new(coll_fns_array, &ut_ptr_icd);
+    utarray_new(coll_fns_array, &ut_ptr_icd, MPL_MEM_COMM);
     MPIR_Add_finalize(nem_coll_finalize, NULL, MPIR_FINALIZE_CALLBACK_PRIO-1);
     
  fn_exit:

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
@@ -245,7 +245,7 @@ static int reinit_pmi(void)
     
     MPL_free(MPIDI_Process.my_pg->id);
    
-    MPIDI_Process.my_pg->id = MPL_malloc(pg_id_sz + 1);
+    MPIDI_Process.my_pg->id = MPL_malloc(pg_id_sz + 1, MPL_MEM_ADDRESS);
     CHECK_ERR(MPIDI_Process.my_pg->id == NULL, "malloc failed");
 
     ret = PMI_KVS_Get_my_name(MPIDI_Process.my_pg->id, pg_id_sz);
@@ -257,7 +257,7 @@ static int reinit_pmi(void)
     
     MPL_free(MPIDI_Process.my_pg->connData);
    
-    MPIDI_Process.my_pg->connData = MPL_malloc(kvs_name_sz + 1);
+    MPIDI_Process.my_pg->connData = MPL_malloc(kvs_name_sz + 1, MPL_MEM_ADDRESS);
     CHECK_ERR(MPIDI_Process.my_pg->connData == NULL, "malloc failed");
 
     ret = PMI_KVS_Get_my_name(MPIDI_Process.my_pg->connData, kvs_name_sz);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
@@ -222,7 +222,7 @@ static int pkt_RTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
     {
         /* set for the cookie to be received into the tmp_cookie in the request */
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"haven't received entire cookie");
-        MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf");
+        MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
         rreq->ch.lmt_tmp_cookie.MPL_IOV_LEN = rts_pkt->cookie_len;
 
         rreq->dev.iov[0] = rreq->ch.lmt_tmp_cookie;
@@ -258,7 +258,7 @@ static int pkt_RTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
         {
             /* receive cookie into tmp_cookie in the request */
             MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"received entire cookie");
-            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf");
+            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
             rreq->ch.lmt_tmp_cookie.MPL_IOV_LEN = rts_pkt->cookie_len;
         
             MPIR_Memcpy(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, data, rts_pkt->cookie_len);
@@ -357,7 +357,7 @@ static int pkt_CTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
             /* create a recv req and set up to receive the cookie into the sreq's tmp_cookie */
             MPIR_Request *rreq;
 
-            MPIR_CHKPMEM_MALLOC(sreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, cts_pkt->cookie_len, mpi_errno, "tmp cookie buf");
+            MPIR_CHKPMEM_MALLOC(sreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, cts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
             sreq->ch.lmt_tmp_cookie.MPL_IOV_LEN = cts_pkt->cookie_len;
 
             MPIDI_Request_create_rreq(rreq, mpi_errno, goto fn_fail);
@@ -489,7 +489,7 @@ static int pkt_COOKIE_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, 
             MPIR_Request *rreq;
 
             MPIDI_Request_create_rreq(rreq, mpi_errno, goto fn_fail);
-            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, cookie_pkt->cookie_len, mpi_errno, "tmp cookie buf");
+            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.MPL_IOV_BUF, char *, cookie_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
             /* FIXME:  where does this request get freed? */
             rreq->ch.lmt_tmp_cookie.MPL_IOV_LEN = cookie_pkt->cookie_len;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
@@ -97,7 +97,7 @@ static int open_knem_dev(void)
 
     knem_has_dma = (info.features & KNEM_FEATURE_DMA);
 
-    knem_status = mmap(NULL, KNEM_STATUS_NR, PROT_READ|PROT_WRITE, MAP_SHARED, knem_fd, KNEM_STATUS_ARRAY_FILE_OFFSET);
+    knem_status = MPL_mmap(NULL, KNEM_STATUS_NR, PROT_READ|PROT_WRITE, MAP_SHARED, knem_fd, KNEM_STATUS_ARRAY_FILE_OFFSET);
     MPIR_ERR_CHKANDJUMP1(knem_status == MAP_FAILED, mpi_errno, MPI_ERR_OTHER, "**mmap",
                          "**mmap %d", errno);
     for (i = 0; i < KNEM_STATUS_NR; ++i) {

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
@@ -97,7 +97,7 @@ static int open_knem_dev(void)
 
     knem_has_dma = (info.features & KNEM_FEATURE_DMA);
 
-    knem_status = MPL_mmap(NULL, KNEM_STATUS_NR, PROT_READ|PROT_WRITE, MAP_SHARED, knem_fd, KNEM_STATUS_ARRAY_FILE_OFFSET);
+    knem_status = MPL_mmap(NULL, KNEM_STATUS_NR, PROT_READ|PROT_WRITE, MAP_SHARED, knem_fd, KNEM_STATUS_ARRAY_FILE_OFFSET, MPL_MEM_SHM);
     MPIR_ERR_CHKANDJUMP1(knem_status == MAP_FAILED, mpi_errno, MPI_ERR_OTHER, "**mmap",
                          "**mmap %d", errno);
     for (i = 0; i < KNEM_STATUS_NR; ++i) {
@@ -329,7 +329,7 @@ int MPID_nem_lmt_dma_initiate_lmt(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, MPIR_Req
     
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_LMT_DMA_INITIATE_LMT);
 
-    MPIR_CHKPMEM_MALLOC(sreq->ch.s_cookie, knem_cookie_t *, sizeof(knem_cookie_t), mpi_errno, "s_cookie");
+    MPIR_CHKPMEM_MALLOC(sreq->ch.s_cookie, knem_cookie_t *, sizeof(knem_cookie_t), mpi_errno, "s_cookie", MPL_MEM_BUFFER);
 
     mpi_errno = send_sreq_data(vc, sreq, sreq->ch.s_cookie);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -443,7 +443,7 @@ int MPID_nem_lmt_dma_start_recv(MPIDI_VC_t *vc, MPIR_Request *rreq, MPL_IOV s_co
 
     /* XXX DJG FIXME this looks like it always pushes! */
     /* push request if not complete for progress checks later */
-    node = MPL_malloc(sizeof(struct lmt_dma_node));
+    node = MPL_malloc(sizeof(struct lmt_dma_node), MPL_MEM_OTHER);
     node->vc = vc;
     node->req = rreq;
     node->status_p = status;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
@@ -198,7 +198,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV s_coo
 
     queue_initially_empty = LMT_SHM_Q_EMPTY(vc_ch->lmt_queue) && vc_ch->lmt_active_lmt == NULL;
 
-    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element");
+    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element", MPL_MEM_BUFFER);
     e->progress = lmt_shm_recv_progress;
     e->req = req;
     LMT_SHM_Q_ENQUEUE(&vc_ch->lmt_queue, e); /* MT: not thread safe */
@@ -217,7 +217,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV s_coo
 
         MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "lmt recv not finished:  enqueue");
 
-        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element");
+        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element", MPL_MEM_BUFFER);
         pe->vc = vc;
         LMT_SHM_L_ADD(pe);
         MPID_nem_local_lmt_pending = TRUE;
@@ -290,7 +290,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
 
     queue_initially_empty = LMT_SHM_Q_EMPTY(vc_ch->lmt_queue) && vc_ch->lmt_active_lmt == NULL;
 
-    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element");
+    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element", MPL_MEM_BUFFER);
     e->progress = lmt_shm_send_progress;
     e->req = req;
     LMT_SHM_Q_ENQUEUE(&vc_ch->lmt_queue, e); /* MT: not thread safe */
@@ -307,7 +307,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
         /* lmt send didn't finish, enqueue it to be completed later */
         lmt_shm_prog_element_t *pe;
 
-        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element");
+        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element", MPL_MEM_BUFFER);
         pe->vc = vc;
         LMT_SHM_L_ADD(pe);
         MPID_nem_local_lmt_pending = TRUE;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_vmsplice.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_vmsplice.c
@@ -288,7 +288,7 @@ int MPID_nem_lmt_vmsplice_start_recv(MPIDI_VC_t *vc, MPIR_Request *rreq, MPL_IOV
 
     /* push request if not complete for progress checks later */
     if (!complete) {
-        node = MPL_malloc(sizeof(struct lmt_vmsplice_node));
+        node = MPL_malloc(sizeof(struct lmt_vmsplice_node), MPL_MEM_OTHER);
         node->pipe_fd = pipe_fd;
         node->req = rreq;
         node->next = outstanding_head;
@@ -408,7 +408,7 @@ int MPID_nem_lmt_vmsplice_start_send(MPIDI_VC_t *vc, MPIR_Request *sreq, MPL_IOV
 
     if (!complete) {
         /* push for later progress */
-        node = MPL_malloc(sizeof(struct lmt_vmsplice_node));
+        node = MPL_malloc(sizeof(struct lmt_vmsplice_node), MPL_MEM_OTHER);
         node->pipe_fd = pipe_fd;
         node->req = sreq;
         node->next = outstanding_head;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -39,7 +39,7 @@ MPID_nem_mpich_init(void)
 
     MPID_nem_prefetched_cell = NULL;
 
-    MPIR_CHKPMEM_MALLOC (MPID_nem_recv_seqno, unsigned short *, sizeof(*MPID_nem_recv_seqno) * MPID_nem_mem_region.num_procs, mpi_errno, "recv seqno");
+    MPIR_CHKPMEM_MALLOC (MPID_nem_recv_seqno, unsigned short *, sizeof(*MPID_nem_recv_seqno) * MPID_nem_mem_region.num_procs, mpi_errno, "recv seqno", MPL_MEM_SHM);
 
     for (i = 0; i < MPID_nem_mem_region.num_procs; ++i)
     {
@@ -47,7 +47,7 @@ MPID_nem_mpich_init(void)
     }
 
     /* set up fbox queue */
-    MPIR_CHKPMEM_MALLOC (MPID_nem_fboxq_elem_list, MPID_nem_fboxq_elem_t *, MPID_nem_mem_region.num_local * sizeof(MPID_nem_fboxq_elem_t), mpi_errno, "fastbox element list");
+    MPIR_CHKPMEM_MALLOC (MPID_nem_fboxq_elem_list, MPID_nem_fboxq_elem_t *, MPID_nem_mem_region.num_local * sizeof(MPID_nem_fboxq_elem_t), mpi_errno, "fastbox element list", MPL_MEM_SHM);
 
     for (i = 0; i < MPID_nem_mem_region.num_local; ++i)
     {

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich_rma.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich_rma.c
@@ -24,7 +24,7 @@ MPID_nem_mpich_alloc_win (void **buf, int len, MPID_nem_mpich_win_t **win)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_MPICH_ALLOC_WIN);
 
-    MPIR_CHKPMEM_MALLOC (*win, MPID_nem_mpich_win_t *, sizeof (MPID_nem_mpich_win_t), mpi_errno, "rma win object");
+    MPIR_CHKPMEM_MALLOC (*win, MPID_nem_mpich_win_t *, sizeof (MPID_nem_mpich_win_t), mpi_errno, "rma win object", MPL_MEM_RMA);
 
     mpi_errno = MPID_nem_allocate_shared_memory ((char **)buf, len, &(*win)->handle);
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);
@@ -390,12 +390,12 @@ MPID_nem_mpich_deserialize_win (void *buf, int buf_len, MPID_nem_mpich_win_t **w
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_MPICH_DESERIALIZE_WIN);
 
-    MPIR_CHKPMEM_MALLOC (*win, MPID_nem_mpich_win_t *, sizeof (MPID_nem_mpich_win_t), mpi_errno, "win object");
+    MPIR_CHKPMEM_MALLOC (*win, MPID_nem_mpich_win_t *, sizeof (MPID_nem_mpich_win_t), mpi_errno, "win object", MPL_MEM_RMA);
 
     str_errno = MPL_str_get_int_arg (b, WIN_HANLEN_KEY, &handle_len);
     MPIR_ERR_CHKANDJUMP (str_errno == MPL_STR_NOMEM, mpi_errno, MPI_ERR_OTHER, "**nomem");
     MPIR_ERR_CHKANDJUMP (str_errno == MPL_STR_FAIL, mpi_errno, MPI_ERR_OTHER, "**windeserialize");
-    MPIR_CHKPMEM_MALLOC ((*win)->handle, char *, handle_len, mpi_errno, "window handle");
+    MPIR_CHKPMEM_MALLOC ((*win)->handle, char *, handle_len, mpi_errno, "window handle", MPL_MEM_RMA);
 
     str_errno = MPL_str_get_string_arg(b, WIN_HANDLE_KEY, (*win)->handle, handle_len);
     MPIR_ERR_CHKANDJUMP (str_errno == MPL_STR_NOMEM, mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -782,7 +782,7 @@ static int MPIDI_CH3I_Socki_sock_alloc(struct MPIDI_CH3I_Sock_set * sock_set, st
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3I_SOCKI_SOCK_ALLOC);
 
     /* FIXME: Should this use the CHKPMEM macros (perm malloc)? */
-    sock = MPL_malloc(sizeof(struct MPIDI_CH3I_Sock));
+    sock = MPL_malloc(sizeof(struct MPIDI_CH3I_Sock), MPL_MEM_ADDRESS);
     /* --BEGIN ERROR HANDLING-- */
     if (sock == NULL)
     {
@@ -815,7 +815,7 @@ static int MPIDI_CH3I_Socki_sock_alloc(struct MPIDI_CH3I_Sock_set * sock_set, st
     {
 	int elem;
 
-	pollfds = MPL_malloc((sock_set->poll_array_sz + MPIDI_CH3I_SOCK_SET_DEFAULT_SIZE) * sizeof(struct pollfd));
+	pollfds = MPL_malloc((sock_set->poll_array_sz + MPIDI_CH3I_SOCK_SET_DEFAULT_SIZE) * sizeof(struct pollfd), MPL_MEM_ADDRESS);
 	/* --BEGIN ERROR HANDLING-- */
 	if (pollfds == NULL)
 	{
@@ -824,7 +824,7 @@ static int MPIDI_CH3I_Socki_sock_alloc(struct MPIDI_CH3I_Sock_set * sock_set, st
 	    goto fn_fail;
 	}
 	/* --END ERROR HANDLING-- */
-	pollinfos = MPL_malloc((sock_set->poll_array_sz + MPIDI_CH3I_SOCK_SET_DEFAULT_SIZE) * sizeof(struct pollinfo));
+	pollinfos = MPL_malloc((sock_set->poll_array_sz + MPIDI_CH3I_SOCK_SET_DEFAULT_SIZE) * sizeof(struct pollinfo), MPL_MEM_ADDRESS);
 	/* --BEGIN ERROR HANDLING-- */
 	if (pollinfos == NULL)
 	{
@@ -1058,7 +1058,7 @@ static int MPIDI_CH3I_Socki_event_enqueue(struct pollinfo * pollinfo, MPIDI_CH3I
 	int i;
 	struct MPIDI_CH3I_Socki_eventq_table *eventq_table;
 
-	eventq_table = MPL_malloc(sizeof(struct MPIDI_CH3I_Socki_eventq_table));
+	eventq_table = MPL_malloc(sizeof(struct MPIDI_CH3I_Socki_eventq_table), MPL_MEM_OTHER);
 	/* --BEGIN ERROR HANDLING-- */
 	if (eventq_table == NULL)
 	{
@@ -1343,7 +1343,7 @@ int MPIDI_CH3I_Sock_create_set(struct MPIDI_CH3I_Sock_set ** sock_setp)
     /*
      * Allocate and initialized a new sock set structure
      */
-    sock_set = MPL_malloc(sizeof(struct MPIDI_CH3I_Sock_set));
+    sock_set = MPL_malloc(sizeof(struct MPIDI_CH3I_Sock_set), MPL_MEM_ADDRESS);
     /* --BEGIN ERROR HANDLING-- */
     if (sock_set == NULL)
     {

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -123,7 +123,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t);
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -142,7 +142,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
 
         _total_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -160,7 +160,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t);
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -440,7 +440,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
             /* dataloop is behind of extended header on origin.
              * TODO: support extended header array */
             ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t) + target_dtp_ptr->dataloop_size;
-            ext_hdr_ptr = MPL_malloc(ext_hdr_sz);
+            ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_BUFFER);
             MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
             if (!ext_hdr_ptr) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -598,7 +598,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
                 if (stream_unit_count > 1) {
                     rma_op->multi_reqs =
-                        (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size);
+                        (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_BUFFER);
                     for (i = 0; i < rma_op->reqs_size; i++)
                         rma_op->multi_reqs[i] = NULL;
                 }
@@ -746,7 +746,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
     if (rma_op->reqs_size > 1) {
         rma_op->multi_reqs =
-            (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size);
+            (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_BUFFER);
         for (i = 0; i < rma_op->reqs_size; i++)
             rma_op->multi_reqs[i] = NULL;
     }
@@ -946,7 +946,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
          * dataloop is behind of extended header on origin.
          * TODO: support extended header array */
         ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t) + dtp->dataloop_size;
-        ext_hdr_ptr = MPL_malloc(ext_hdr_sz);
+        ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_BUFFER);
         MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
         if (!ext_hdr_ptr) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -374,7 +374,7 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
         first = stream_offset;
         last = stream_offset + stream_size;
 
-        packed_buf = MPL_malloc(stream_size);
+        packed_buf = MPL_malloc(stream_size, MPL_MEM_BUFFER);
 
         seg = MPIR_Segment_alloc();
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
@@ -386,7 +386,7 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
         MPIR_Datatype_is_contig(basic_type, &is_predef_contig);
 
         if (!is_predef_contig) {
-            void *tmpbuf = MPL_malloc(stream_count * predefined_dtp_extent);
+            void *tmpbuf = MPL_malloc(stream_count * predefined_dtp_extent, MPL_MEM_BUFFER);
             mpi_errno = MPIR_Localcopy(tmpbuf, stream_count, basic_type,
                                        packed_buf, stream_size, MPI_BYTE);
             if (mpi_errno != MPI_SUCCESS)
@@ -521,7 +521,7 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
         first = stream_offset;
         last = stream_offset + stream_size;
 
-        packed_buf = MPL_malloc(stream_size);
+        packed_buf = MPL_malloc(stream_size, MPL_MEM_BUFFER);
 
         seg = MPIR_Segment_alloc();
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
@@ -533,7 +533,7 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
         MPIR_Datatype_is_contig(basic_type, &is_predef_contig);
 
         if (!is_predef_contig) {
-            void *tmpbuf = MPL_malloc(stream_count * predefined_dtp_extent);
+            void *tmpbuf = MPL_malloc(stream_count * predefined_dtp_extent, MPL_MEM_BUFFER);
             mpi_errno = MPIR_Localcopy(tmpbuf, stream_count, basic_type,
                                        packed_buf, stream_size, MPI_BYTE);
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -820,7 +820,7 @@ extern MPIDI_CH3U_SRBuf_element_t * MPIDI_CH3U_SRBuf_pool;
         MPIDI_CH3U_SRBuf_element_t * tmp;                               \
         if (!MPIDI_CH3U_SRBuf_pool) {                                   \
              MPIDI_CH3U_SRBuf_pool =                                    \
-                MPL_malloc(sizeof(MPIDI_CH3U_SRBuf_element_t));        \
+                MPL_malloc(sizeof(MPIDI_CH3U_SRBuf_element_t), MPL_MEM_BUFFER); \
             MPIDI_CH3U_SRBuf_pool->next = NULL;                         \
         }                                                               \
         tmp = MPIDI_CH3U_SRBuf_pool;                                    \
@@ -1113,7 +1113,7 @@ int MPIDI_CH3U_Win_gather_info(void *, MPI_Aint, int, MPIR_Info *, MPIR_Comm *,
 void* MPIDI_CH3I_Alloc_mem(size_t size, MPIR_Info *info_ptr);
 /* fallback to MPL_malloc if channel does not have its own RMA memory allocator */
 #else
-#define MPIDI_CH3I_Alloc_mem(size, info_ptr)    MPL_malloc(size)
+#define MPIDI_CH3I_Alloc_mem(size, info_ptr, class)    MPL_malloc(size, class)
 #endif
 
 #ifdef MPIDI_CH3I_HAS_FREE_MEM

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -718,7 +718,7 @@ void MPID_Request_free_hook(MPIR_Request *);
 void MPID_Request_destroy_hook(MPIR_Request *);
 int MPID_Request_complete(MPIR_Request *);
 
-void *MPID_Alloc_mem( size_t size, MPIR_Info *info );
+void *MPID_Alloc_mem( size_t size, MPIR_Info *info, MPL_memory_class class );
 int MPID_Free_mem( void *ptr );
 
 /* Prototypes and definitions for the node ID code.  This is used to support

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -410,7 +410,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
         if (new_ptr != NULL) {
             if (win_ptr->current_target_lock_data_bytes + buf_size <
                 MPIR_CVAR_CH3_RMA_TARGET_LOCK_DATA_BYTES) {
-                new_ptr->data = MPL_malloc(buf_size);
+                new_ptr->data = MPL_malloc(buf_size, MPL_MEM_BUFFER);
             }
 
             if (new_ptr->data == NULL) {
@@ -965,7 +965,7 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
         vec_len = dtp->max_contig_blocks * target_count + 1;
         /* +1 needed because Rob says so */
         dloop_vec = (DLOOP_VECTOR *)
-            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR));
+            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR), MPL_MEM_DATATYPE);
         /* --BEGIN ERROR HANDLING-- */
         if (!dloop_vec) {
             mpi_errno =
@@ -1159,7 +1159,7 @@ static inline int fill_ranks_in_win_grp(MPIR_Win * win_ptr, MPIR_Group * group_p
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_FILL_RANKS_IN_WIN_GRP);
 
     MPIR_CHKLMEM_MALLOC(ranks_in_grp, int *, group_ptr->size * sizeof(int),
-                        mpi_errno, "ranks_in_grp");
+                        mpi_errno, "ranks_in_grp", MPL_MEM_RMA);
     for (i = 0; i < group_ptr->size; i++)
         ranks_in_grp[i] = i;
 

--- a/src/mpid/ch3/src/ch3u_buffer.c
+++ b/src/mpid/ch3/src/ch3u_buffer.c
@@ -129,7 +129,7 @@ void MPIDI_CH3U_Buffer_copy(
 	MPIR_Segment rseg;
 	intptr_t rfirst;
 
-	buf = MPL_malloc(MPIDI_COPY_BUFFER_SZ);
+	buf = MPL_malloc(MPIDI_COPY_BUFFER_SZ, MPL_MEM_BUFFER);
 	/* --BEGIN ERROR HANDLING-- */
 	if (buf == NULL)
 	{

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -89,7 +89,7 @@ int MPIDI_CH3I_Comm_init(void)
             char *envstr;
             int size = strlen("HCOLL_BCOL=") + strlen(MPID_CH3I_CH_HCOLL_BCOL) + 1;
 
-            MPIR_CHKLMEM_MALLOC(envstr, char *, size, mpi_errno, "**malloc");
+            MPIR_CHKLMEM_MALLOC(envstr, char *, size, mpi_errno, "**malloc", MPL_MEM_COMM);
             MPL_snprintf(envstr, size, "HCOLL_BCOL=%s", MPID_CH3I_CH_HCOLL_BCOL);
 
             r = MPL_putenv(envstr);
@@ -358,7 +358,7 @@ int MPIDI_CH3U_Comm_register_create_hook(int (*hook_fn)(struct MPIR_Comm *, void
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3U_COMM_REGISTER_CREATE_HOOK);
 
-    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt");
+    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt", MPL_MEM_OTHER);
 
     elt->hook_fn = hook_fn;
     elt->param = param;
@@ -387,7 +387,7 @@ int MPIDI_CH3U_Comm_register_destroy_hook(int (*hook_fn)(struct MPIR_Comm *, voi
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3U_COMM_REGISTER_DESTROY_HOOK);
 
-    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt");
+    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt", MPL_MEM_OTHER);
 
     elt->hook_fn = hook_fn;
     elt->param = param;

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -49,7 +49,7 @@ static int  mpi_to_pmi_keyvals( MPIR_Info *info_ptr, PMI_keyval_t **kv_ptr,
     if (nkeys == 0) {
 	goto fn_exit;
     }
-    kv = (PMI_keyval_t *)MPL_malloc( nkeys * sizeof(PMI_keyval_t) );
+    kv = (PMI_keyval_t *)MPL_malloc( nkeys * sizeof(PMI_keyval_t), MPL_MEM_DYNAMIC );
     if (!kv) { MPIR_ERR_POP(mpi_errno); }
 
     for (i=0; i<nkeys; i++) {
@@ -59,7 +59,7 @@ static int  mpi_to_pmi_keyvals( MPIR_Info *info_ptr, PMI_keyval_t **kv_ptr,
         MPIR_ERR_CHKANDJUMP1(!flag, mpi_errno, MPI_ERR_OTHER,"**infonokey", "**infonokey %s", key);
 
 	kv[i].key = MPL_strdup(key);
-	kv[i].val = MPL_malloc( vallen + 1 );
+	kv[i].val = MPL_malloc( vallen + 1, MPL_MEM_DYNAMIC );
 	if (!kv[i].key || !kv[i].val) { 
 	    MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem" );
 	}
@@ -124,7 +124,7 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 	for (i=0; i<count; i++) {
 	    total_num_processes += maxprocs[i];
 	}
-	pmi_errcodes = (int*)MPL_malloc(sizeof(int) * total_num_processes);
+	pmi_errcodes = (int*)MPL_malloc(sizeof(int) * total_num_processes, MPL_MEM_DYNAMIC);
 	if (pmi_errcodes == NULL) {
 	    MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem");
 	}
@@ -144,13 +144,13 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 #ifdef USE_PMI2_API
         MPIR_Assert(count > 0);
         {
-            int *argcs = MPL_malloc(count*sizeof(int));
+            int *argcs = MPL_malloc(count*sizeof(int), MPL_MEM_DYNAMIC);
             struct MPIR_Info preput;
             struct MPIR_Info *preput_p[1] = { &preput };
 
             MPIR_Assert(argcs);
             /*
-            info_keyval_sizes = MPL_malloc(count * sizeof(int));
+            info_keyval_sizes = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
             */
 
             /* FIXME cheating on constness */
@@ -199,9 +199,9 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
            the necessary arrays of key/value pairs */
 
         /* convert the infos into PMI keyvals */
-        info_keyval_sizes   = (int *) MPL_malloc(count * sizeof(int));
+        info_keyval_sizes   = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
         info_keyval_vectors = 
-            (PMI_keyval_t**) MPL_malloc(count * sizeof(PMI_keyval_t*));
+            (PMI_keyval_t**) MPL_malloc(count * sizeof(PMI_keyval_t*), MPL_MEM_DYNAMIC);
         if (!info_keyval_sizes || !info_keyval_vectors) { 
             MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem");
         }

--- a/src/mpid/ch3/src/ch3u_eager.c
+++ b/src/mpid/ch3/src/ch3u_eager.c
@@ -450,7 +450,7 @@ int MPIDI_CH3_PktHandler_EagerShortSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, v
 	    /* printf( "Allocating into tmp\n" ); fflush(stdout); */
 	    recv_data_sz = rreq->dev.recv_data_sz;
         MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_buffer_size, recv_data_sz);
-	    rreq->dev.tmpbuf = MPL_malloc(recv_data_sz);
+	    rreq->dev.tmpbuf = MPL_malloc(recv_data_sz, MPL_MEM_BUFFER);
 	    if (!rreq->dev.tmpbuf) {
 		MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem");
 	    }

--- a/src/mpid/ch3/src/ch3u_handle_connection.c
+++ b/src/mpid/ch3/src/ch3u_handle_connection.c
@@ -467,7 +467,7 @@ int MPIDI_CH3U_Get_failed_group(int last_rank, MPIR_Group **failed_group)
         goto fn_exit;
     }
 
-    utarray_new(failed_procs, &ut_int_icd);
+    utarray_new(failed_procs, &ut_int_icd, MPL_MEM_OTHER);
 
     /* parse list of failed processes.  This is a comma separated list
        of ranks or ranges of ranks (e.g., "1, 3-5, 11") */
@@ -477,7 +477,7 @@ int MPIDI_CH3U_Get_failed_group(int last_rank, MPIR_Group **failed_group)
         parse_rank(&rank);
         ++i;
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER, VERBOSE, "Found failed rank: %d", rank);
-        utarray_push_back(failed_procs, &rank);
+        utarray_push_back(failed_procs, &rank, MPL_MEM_OTHER);
         MPIDI_last_known_failed = rank;
         MPIR_ERR_CHKINTERNAL(*c != ',' && *c != '\0', mpi_errno, "error parsing failed process list");
         if (*c == '\0' || last_rank == rank)

--- a/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_pkt.c
@@ -248,7 +248,7 @@ int MPIDI_CH3U_Receive_data_unexpected(MPIR_Request * rreq, void *buf, intptr_t 
        with flow control */
     MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"unexpected request allocated");
     
-    rreq->dev.tmpbuf = MPL_malloc(rreq->dev.recv_data_sz);
+    rreq->dev.tmpbuf = MPL_malloc(rreq->dev.recv_data_sz, MPL_MEM_BUFFER);
     if (!rreq->dev.tmpbuf) {
 	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,"**nomem","**nomem %d",
 			     rreq->dev.recv_data_sz);
@@ -383,7 +383,7 @@ int MPIDI_CH3U_Post_data_receive_unexpected(MPIR_Request * rreq)
        with flow control */
     MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"unexpected request allocated");
     
-    rreq->dev.tmpbuf = MPL_malloc(rreq->dev.recv_data_sz);
+    rreq->dev.tmpbuf = MPL_malloc(rreq->dev.recv_data_sz, MPL_MEM_BUFFER);
     if (!rreq->dev.tmpbuf) {
 	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,"**nomem","**nomem %d",
 			     rreq->dev.recv_data_sz);

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -324,7 +324,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_GET_ACCUM_RESP);
 
     MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, void *, stream_data_len,
-                        mpi_errno, "GACC resp. buffer");
+                        mpi_errno, "GACC resp. buffer", MPL_MEM_BUFFER);
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
@@ -464,7 +464,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     resp_req->dev.target_win_handle = rreq->dev.target_win_handle;
     resp_req->dev.flags = rreq->dev.flags;
 
-    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, void *, type_size, mpi_errno, "FOP resp. buffer");
+    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, void *, type_size, mpi_errno, "FOP resp. buffer", MPL_MEM_BUFFER);
 
     /* here we increment the Active Target counter to guarantee the GET-like
      * operation are completed when counter reaches zero. */
@@ -1463,7 +1463,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     recv_count = MPL_MIN((total_len / type_size), (MPIDI_CH3U_SRBuf_size / type_extent));
     MPIR_Assert(recv_count > 0);
 
-    sreq->dev.user_buf = (void *) MPL_malloc(recv_count * type_size);
+    sreq->dev.user_buf = (void *) MPL_malloc(recv_count * type_size, MPL_MEM_BUFFER);
 
     MPIR_Datatype_is_contig(get_accum_pkt->datatype, &is_contig);
 
@@ -1600,7 +1600,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
         resp_req->dev.target_win_handle = win_ptr->handle;
         resp_req->dev.flags = fop_pkt->flags;
 
-        resp_req->dev.user_buf = (void *) MPL_malloc(type_size);
+        resp_req->dev.user_buf = (void *) MPL_malloc(type_size, MPL_MEM_BUFFER);
 
         /* here we increment the Active Target counter to guarantee the GET-like
          * operation are completed when counter reaches zero. */

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -655,7 +655,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 	   and rank */
 	MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
 			    local_comm_size*sizeof(pg_translation),
-			    mpi_errno,"local_translation");
+			    mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
 
 	/* Make a list of the local communicator's process groups and encode 
 	   them in strings to be sent to the other side.
@@ -702,10 +702,10 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 
     MPIR_CHKLMEM_MALLOC(remote_pg,MPIDI_PG_t**,
 			n_remote_pgs * sizeof(MPIDI_PG_t*),
-			mpi_errno,"remote_pg");
+			mpi_errno,"remote_pg", MPL_MEM_DYNAMIC);
     MPIR_CHKLMEM_MALLOC(remote_translation,pg_translation*,
 			remote_comm_size * sizeof(pg_translation),
-			mpi_errno,"remote_translation");
+			mpi_errno,"remote_translation", MPL_MEM_DYNAMIC);
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"allocated remote process groups");
 
     /* Exchange the process groups and their corresponding KVSes */
@@ -888,7 +888,7 @@ static int ExtractLocalPGInfo( MPIR_Comm *comm_p,
     
     cur_index = 0;
     MPIR_CHKPMEM_MALLOC(pg_list,pg_node*,sizeof(pg_node),mpi_errno,
-			"pg_list");
+			"pg_list", MPL_MEM_ADDRESS);
     
     pg_list->pg_id = MPL_strdup(comm_p->dev.vcrt->vcr_table[0]->pg->id);
     pg_list->index = cur_index++;
@@ -923,7 +923,7 @@ static int ExtractLocalPGInfo( MPIR_Comm *comm_p,
 	if (pg_iter == NULL) {
 	    /* We use MPL_malloc directly because we do not know in
 	       advance how many nodes we may allocate */
-	    pg_iter = (pg_node*)MPL_malloc(sizeof(pg_node));
+	    pg_iter = (pg_node*)MPL_malloc(sizeof(pg_node), MPL_MEM_DYNAMIC);
 	    if (!pg_iter) {
 		MPIR_ERR_POP(mpi_errno);
 	    }
@@ -994,7 +994,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	    if (mpi_errno != MPI_SUCCESS) {
 		MPIR_ERR_POP(mpi_errno);
 	    }
-	    pg_str = (char*)MPL_malloc(j);
+	    pg_str = (char*)MPL_malloc(j, MPL_MEM_DYNAMIC);
 	    if (pg_str == NULL) {
 		MPIR_ERR_POP(mpi_errno);
 	    }
@@ -1014,7 +1014,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 
 	if (rank != root) {
 	    /* The root has already allocated this string */
-	    pg_str = (char*)MPL_malloc(j);
+	    pg_str = (char*)MPL_malloc(j, MPL_MEM_DYNAMIC);
 	    if (pg_str == NULL) {
 		MPIR_ERR_POP(mpi_errno);
 	    }
@@ -1063,7 +1063,7 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
 
     MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
 			peer_comm_size*sizeof(pg_translation),
-			mpi_errno,"local_translation");
+			mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
     
     if (rank == root) {
 	/* Get the process groups known to the *peercomm* */
@@ -1097,7 +1097,7 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 	if (rank != root) {
-	    pg_str = (char *)MPL_malloc(len);
+	    pg_str = (char *)MPL_malloc(len, MPL_MEM_DYNAMIC);
             if (!pg_str) {
                 MPIR_CHKMEM_SETERR(mpi_errno, len, "pg_str");
                 goto fn_exit;
@@ -1262,7 +1262,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
 	   rank */
 	MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
 			    local_comm_size*sizeof(pg_translation),
-			    mpi_errno,"local_translation");
+			    mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
 
 	/* Make a list of the local communicator's process groups and encode 
 	   them in strings to be sent to the other side.
@@ -1300,10 +1300,10 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     context_id       = recv_ints[2];
     MPIR_CHKLMEM_MALLOC(remote_pg,MPIDI_PG_t**,
 			n_remote_pgs * sizeof(MPIDI_PG_t*),
-			mpi_errno,"remote_pg");
+			mpi_errno,"remote_pg", MPL_MEM_DYNAMIC);
     MPIR_CHKLMEM_MALLOC(remote_translation,pg_translation*,
 			remote_comm_size * sizeof(pg_translation),
-			mpi_errno, "remote_translation");
+			mpi_errno, "remote_translation", MPL_MEM_DYNAMIC);
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,TERSE,(MPL_DBG_FDEST,"[%d]accept:remote process groups: %d\nremote comm size: %d\n", rank, n_remote_pgs, remote_comm_size));
 
     /* Exchange the process groups and their corresponding KVSes */
@@ -1867,7 +1867,7 @@ static int MPIDI_CH3I_Port_connreq_create(MPIDI_VC_t * vc, MPIDI_CH3I_Port_connr
 
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKPMEM_MALLOC(connreq, MPIDI_CH3I_Port_connreq_t *, sizeof(MPIDI_CH3I_Port_connreq_t),
-                        mpi_errno, "comm_conn");
+                        mpi_errno, "comm_conn", MPL_MEM_DYNAMIC);
 
     connreq->vc = vc;
     MPIDI_CH3I_PORT_CONNREQ_SET_STAT(connreq, INITED);
@@ -1937,7 +1937,7 @@ int MPIDI_CH3I_Port_init(int port_name_tag)
 
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKPMEM_MALLOC(port, MPIDI_CH3I_Port_t *, sizeof(MPIDI_CH3I_Port_t),
-                        mpi_errno, "comm_port");
+                        mpi_errno, "comm_port", MPL_MEM_DYNAMIC);
 
     port->port_name_tag = port_name_tag;
     port->accept_connreq_q.head = port->accept_connreq_q.tail = 0;

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -193,7 +193,7 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
 
     if ((flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) && is_derived_dt) {
         (*ext_hdr_sz) = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t);
-        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t));
+        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t), MPL_MEM_BUFFER);
         if ((*ext_hdr_ptr) == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_derived_t");
@@ -201,7 +201,7 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
     }
     else if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
         (*ext_hdr_sz) = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
-        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t));
+        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t), MPL_MEM_BUFFER);
         if ((*ext_hdr_ptr) == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_t");
@@ -209,7 +209,7 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
     }
     else if (is_derived_dt) {
         (*ext_hdr_sz) = sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t);
-        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t));
+        (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t), MPL_MEM_BUFFER);
         if ((*ext_hdr_ptr) == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_derived_t");
@@ -361,7 +361,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
             /* allocate extended header in the request,
              * only including fixed-length variables defined in packet type. */
             req->dev.ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t);
-            req->dev.ext_hdr_ptr = MPL_malloc(req->dev.ext_hdr_sz);
+            req->dev.ext_hdr_ptr = MPL_malloc(req->dev.ext_hdr_sz, MPL_MEM_BUFFER);
             if (!req->dev.ext_hdr_ptr) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                                      "MPIDI_CH3_Ext_pkt_put_derived_t");
@@ -369,7 +369,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
             /* put dataloop in a separate buffer to be reused in datatype.
              * It will be freed when free datatype. */
-            req->dev.dataloop = MPL_malloc(put_pkt->info.dataloop_size);
+            req->dev.dataloop = MPL_malloc(put_pkt->info.dataloop_size, MPL_MEM_BUFFER);
             if (!req->dev.dataloop) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d",
                                      put_pkt->info.dataloop_size);
@@ -587,7 +587,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         /* allocate extended header in the request,
          * only including fixed-length variables defined in packet type. */
         req->dev.ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t);
-        req->dev.ext_hdr_ptr = MPL_malloc(req->dev.ext_hdr_sz);
+        req->dev.ext_hdr_ptr = MPL_malloc(req->dev.ext_hdr_sz, MPL_MEM_BUFFER);
         if (!req->dev.ext_hdr_ptr) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                                  "MPIDI_CH3_Ext_pkt_get_derived_t");
@@ -595,7 +595,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         /* put dataloop in a separate buffer to be reused in datatype.
          * It will be freed when free datatype. */
-        req->dev.dataloop = MPL_malloc(get_pkt->info.dataloop_size);
+        req->dev.dataloop = MPL_malloc(get_pkt->info.dataloop_size, MPL_MEM_BUFFER);
         if (!req->dev.dataloop) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d",
                                  get_pkt->info.dataloop_size);
@@ -798,7 +798,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
 
             /* Put dataloop in a separate buffer to be reused in datatype.
              * It will be freed when free datatype. */
-            req->dev.dataloop = MPL_malloc(accum_pkt->info.dataloop_size);
+            req->dev.dataloop = MPL_malloc(accum_pkt->info.dataloop_size, MPL_MEM_BUFFER);
             if (!req->dev.dataloop) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d",
                                      accum_pkt->info.dataloop_size);
@@ -1084,7 +1084,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
             /* Put dataloop in a separate buffer to be reused in datatype.
              * It will be freed when free datatype. */
-            req->dev.dataloop = MPL_malloc(get_accum_pkt->info.dataloop_size);
+            req->dev.dataloop = MPL_malloc(get_accum_pkt->info.dataloop_size, MPL_MEM_BUFFER);
             if (!req->dev.dataloop) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d",
                                      get_accum_pkt->info.dataloop_size);
@@ -1459,7 +1459,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
             MPIR_Datatype_get_extent_macro(fop_pkt->datatype, extent);
 
-            req->dev.user_buf = MPL_malloc(extent);
+            req->dev.user_buf = MPL_malloc(extent, MPL_MEM_BUFFER);
             if (!req->dev.user_buf) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d", extent);
             }

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -557,8 +557,8 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
 
     /* Perform basic algorithm by calling reduce-scatter */
     if (!scalable_fence_enabled) {
-        MPIR_CHKLMEM_MALLOC(rma_target_marks, int *, comm_size * sizeof(int),
-                            mpi_errno, "rma_target_marks");
+      MPIR_CHKLMEM_MALLOC(rma_target_marks, int *, comm_size * sizeof(int),
+                            mpi_errno, "rma_target_marks", MPL_MEM_RMA);
         for (i = 0; i < comm_size; i++)
             rma_target_marks[i] = 0;
 
@@ -746,15 +746,15 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
         rank = win_ptr->comm_ptr->rank;
 
         MPIR_CHKLMEM_MALLOC(post_ranks_in_win_grp, int *,
-                            post_grp_size * sizeof(int), mpi_errno, "post_ranks_in_win_grp");
+                            post_grp_size * sizeof(int), mpi_errno, "post_ranks_in_win_grp", MPL_MEM_RMA);
         mpi_errno = fill_ranks_in_win_grp(win_ptr, post_grp_ptr, post_ranks_in_win_grp);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
         MPIR_CHKLMEM_MALLOC(req, MPI_Request *, post_grp_size * sizeof(MPI_Request),
-                            mpi_errno, "req");
+                            mpi_errno, "req", MPL_MEM_RMA);
         MPIR_CHKLMEM_MALLOC(status, MPI_Status *, post_grp_size * sizeof(MPI_Status),
-                            mpi_errno, "status");
+                            mpi_errno, "status", MPL_MEM_RMA);
 
         /* Send a 0-byte message to the source processes */
         for (i = 0; i < post_grp_size; i++) {
@@ -859,7 +859,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 
     MPIR_CHKPMEM_MALLOC(win_ptr->start_ranks_in_win_grp, int *,
                         win_ptr->start_grp_size * sizeof(int),
-                        mpi_errno, "win_ptr->start_ranks_in_win_grp");
+                        mpi_errno, "win_ptr->start_ranks_in_win_grp",
+                        MPL_MEM_RMA);
 
     mpi_errno = fill_ranks_in_win_grp(win_ptr, group_ptr, win_ptr->start_ranks_in_win_grp);
     if (mpi_errno)
@@ -878,10 +879,10 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
         if (win_ptr->shm_allocated == TRUE) {
             int node_comm_size = comm_ptr->node_comm->local_size;
             MPIR_CHKLMEM_MALLOC(intra_start_req, MPI_Request *,
-                                node_comm_size * sizeof(MPI_Request), mpi_errno, "intra_start_req");
+                                node_comm_size * sizeof(MPI_Request), mpi_errno, "intra_start_req", MPL_MEM_RMA);
             MPIR_CHKLMEM_MALLOC(intra_start_status, MPI_Status *,
                                 node_comm_size * sizeof(MPI_Status),
-                                mpi_errno, "intra_start_status");
+                                mpi_errno, "intra_start_status", MPL_MEM_RMA);
         }
 
         intra_cnt = 0;

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -58,12 +58,13 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
      * completion counters of all processes */
     MPIR_CHKPMEM_MALLOC((*win_ptr)->basic_info_table, MPIDI_Win_basic_info_t *,
                         comm_size * sizeof(MPIDI_Win_basic_info_t),
-                        mpi_errno, "(*win_ptr)->basic_info_table");
+                        mpi_errno, "(*win_ptr)->basic_info_table",
+                        MPL_MEM_RMA);
 
     /* get the addresses of the windows, window objects, and completion
      * counters of all processes.  allocate temp. buffer for communication */
     MPIR_CHKLMEM_MALLOC(tmp_buf, MPI_Aint *, 4 * comm_size * sizeof(MPI_Aint),
-                        mpi_errno, "tmp_buf");
+                        mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
     /* FIXME: This needs to be fixed for heterogeneous systems */
     /* FIXME: If we wanted to validate the transfer as within range at the
@@ -255,7 +256,7 @@ int MPIDI_CH3U_Win_allocate_no_shm(MPI_Aint size, int disp_unit, MPIR_Info * inf
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_MPIDI_CH3U_WIN_ALLOCATE_NO_SHM);
 
     if (size > 0) {
-        MPIR_CHKPMEM_MALLOC(*base_pp, void *, size, mpi_errno, "(*win_ptr)->base");
+        MPIR_CHKPMEM_MALLOC(*base_pp, void *, size, mpi_errno, "(*win_ptr)->base", MPL_MEM_RMA);
         MPL_VG_MEM_INIT(*base_pp, size);
     }
     else if (size == 0) {

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -18,7 +18,7 @@ static void group_to_bitarray(MPIR_Group *group, MPIR_Comm *orig_comm, int **bit
 
     /* Calculate the bitarray size in ints and allocate space */
     *bitarray_size = (orig_comm->local_size / (8 * sizeof(int)) + (orig_comm->local_size % (8 * sizeof(int)) ? 1 : 0));
-    *bitarray = (int *) MPL_malloc(sizeof(int) * *bitarray_size);
+    *bitarray = (int *) MPL_malloc(sizeof(int) * *bitarray_size, MPL_MEM_OTHER);
 
     /* If the group is empty, return an empty bitarray. */
     if (group == MPIR_Group_empty) {
@@ -27,8 +27,8 @@ static void group_to_bitarray(MPIR_Group *group, MPIR_Comm *orig_comm, int **bit
     }
 
     /* Get the ranks of group in orig_comm */
-    group_ranks = (int *) MPL_malloc(sizeof(int) * group->size);
-    comm_ranks = (int *) MPL_malloc(sizeof(int) * group->size);
+    group_ranks = (int *) MPL_malloc(sizeof(int) * group->size, MPL_MEM_OTHER);
+    comm_ranks = (int *) MPL_malloc(sizeof(int) * group->size, MPL_MEM_OTHER);
 
     for (i = 0; i < group->size; i++) group_ranks[i] = i;
     for (i = 0; i < *bitarray_size; i++) (*bitarray)[i] = 0;
@@ -58,14 +58,14 @@ static MPIR_Group *bitarray_to_group(MPIR_Comm *comm_ptr, int *bitarray)
     int i, found = 0;
 
     /* Create a utarray to make storing the ranks easier */
-    utarray_new(ranks_array, &ut_int_icd);
+    utarray_new(ranks_array, &ut_int_icd, MPL_MEM_OTHER);
 
     MPIR_Comm_group_impl(comm_ptr, &comm_group);
 
     /* Converts the bitarray into a utarray */
     for (i = 0; i < comm_ptr->local_size; i++) {
         if (bitarray[i / (sizeof(int) * 8)] & (0x1 << (i % (sizeof(int) * 8)))) {
-            utarray_push_back(ranks_array, &i);
+            utarray_push_back(ranks_array, &i, MPL_MEM_OTHER);
             found++;
         }
     }
@@ -109,7 +109,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
 
     /* Generate a bitarray based on the list of failed procs */
     group_to_bitarray(local_fail, comm_ptr, &bitarray, &bitarray_size);
-    remote_bitarray = MPL_malloc(sizeof(int) * bitarray_size);
+    remote_bitarray = MPL_malloc(sizeof(int) * bitarray_size, MPL_MEM_OTHER);
     if (local_fail != MPIR_Group_empty)
         MPIR_Group_release(local_fail);
 

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -147,10 +147,10 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     /* Create the string that will cache the last group of failed processes
      * we received from PMI */
 #ifdef USE_PMI2_API
-    MPIDI_failed_procs_string = MPL_malloc(sizeof(char) * PMI2_MAX_VALLEN);
+    MPIDI_failed_procs_string = MPL_malloc(sizeof(char) * PMI2_MAX_VALLEN, MPL_MEM_STRINGS);
 #else
     PMI_KVS_Get_value_length_max(&val);
-    MPIDI_failed_procs_string = MPL_malloc(sizeof(char) * (val+1));
+    MPIDI_failed_procs_string = MPL_malloc(sizeof(char) * (val+1), MPL_MEM_STRINGS);
 #endif
 
     /*
@@ -463,7 +463,7 @@ static int init_pg( int *argc, char ***argv,
 #ifdef USE_PMI2_API
         
         /* This memory will be freed by the PG_Destroy if there is an error */
-	pg_id = MPL_malloc(MAX_JOBID_LEN);
+	pg_id = MPL_malloc(MAX_JOBID_LEN, MPL_MEM_STRINGS);
 	if (pg_id == NULL) {
 	    MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,"**nomem","**nomem %d",
 				 MAX_JOBID_LEN);
@@ -486,7 +486,7 @@ static int init_pg( int *argc, char ***argv,
 	}
 
 	/* This memory will be freed by the PG_Destroy if there is an error */
-	pg_id = MPL_malloc(pg_id_sz + 1);
+	pg_id = MPL_malloc(pg_id_sz + 1, MPL_MEM_OTHER);
 	if (pg_id == NULL) {
 	    MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,"**nomem","**nomem %d",
 				 pg_id_sz+1);
@@ -504,7 +504,7 @@ static int init_pg( int *argc, char ***argv,
     }
     else {
 	/* Create a default pg id */
-	pg_id = MPL_malloc(2);
+	pg_id = MPL_malloc(2, MPL_MEM_OTHER);
 	if (pg_id == NULL) {
 	    MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**nomem");
 	}
@@ -585,7 +585,7 @@ int MPIDI_CH3I_BCInit( char **bc_val_p, int *val_max_sz_p )
     }
 #endif
     /* This memroy is returned by this routine */
-    *bc_val_p = MPL_malloc(*val_max_sz_p);
+    *bc_val_p = MPL_malloc(*val_max_sz_p, MPL_MEM_ADDRESS);
     if (*bc_val_p == NULL) {
 	MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER, "**nomem","**nomem %d",
 			     *val_max_sz_p);

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -156,14 +156,14 @@ int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_Win ** 
 #define FUNCNAME MPID_Alloc_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
     void *ap = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ALLOC_MEM);
 
-    ap = MPIDI_CH3I_Alloc_mem(size, info_ptr);
+    ap = MPIDI_CH3I_Alloc_mem(size, info_ptr, class);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ALLOC_MEM);
     return ap;
@@ -329,7 +329,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
 
     MPIR_CHKPMEM_MALLOC((*win_ptr)->op_pool_start, MPIDI_RMA_Op_t *,
                         sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE, mpi_errno,
-                        "RMA op pool");
+                        "RMA op pool", MPL_MEM_RMA);
     (*win_ptr)->op_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE; i++) {
         (*win_ptr)->op_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
@@ -340,7 +340,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
         MPL_MIN(MPIR_CVAR_CH3_RMA_TARGET_WIN_POOL_SIZE, MPIR_Comm_size(win_comm_ptr));
     MPIR_CHKPMEM_MALLOC((*win_ptr)->target_pool_start, MPIDI_RMA_Target_t *,
                         sizeof(MPIDI_RMA_Target_t) * win_target_pool_size, mpi_errno,
-                        "RMA target pool");
+                        "RMA target pool", MPL_MEM_RMA);
     (*win_ptr)->target_pool_head = NULL;
     for (i = 0; i < win_target_pool_size; i++) {
         (*win_ptr)->target_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
@@ -349,7 +349,8 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
 
     (*win_ptr)->num_slots = MPL_MIN(MPIR_CVAR_CH3_RMA_SLOTS_SIZE, MPIR_Comm_size(win_comm_ptr));
     MPIR_CHKPMEM_MALLOC((*win_ptr)->slots, MPIDI_RMA_Slot_t *,
-                        sizeof(MPIDI_RMA_Slot_t) * (*win_ptr)->num_slots, mpi_errno, "RMA slots");
+                        sizeof(MPIDI_RMA_Slot_t) * (*win_ptr)->num_slots, mpi_errno, "RMA slots",
+                        MPL_MEM_RMA);
     for (i = 0; i < (*win_ptr)->num_slots; i++) {
         (*win_ptr)->slots[i].target_list_head = NULL;
     }
@@ -358,7 +359,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
                         MPIDI_RMA_Target_lock_entry_t *,
                         sizeof(MPIDI_RMA_Target_lock_entry_t) *
                         MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE, mpi_errno,
-                        "RMA lock entry pool");
+                        "RMA lock entry pool", MPL_MEM_RMA);
     (*win_ptr)->target_lock_entry_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE; i++) {
         DL_APPEND((*win_ptr)->target_lock_entry_pool_head,

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -74,7 +74,7 @@ int MPIDI_VCRT_Create(int size, struct MPIDI_VCRT **vcrt_ptr)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_VCRT_CREATE);
 
-    MPIR_CHKPMEM_MALLOC(vcrt, MPIDI_VCRT_t *, sizeof(MPIDI_VCRT_t) + (size - 1) * sizeof(MPIDI_VC_t *),	mpi_errno, "**nomem");
+    MPIR_CHKPMEM_MALLOC(vcrt, MPIDI_VCRT_t *, sizeof(MPIDI_VCRT_t) + (size - 1) * sizeof(MPIDI_VC_t *),	mpi_errno, "**nomem", MPL_MEM_ADDRESS);
     vcrt->handle = HANDLE_SET_KIND(0, HANDLE_KIND_INVALID);
     MPIR_Object_set_ref(vcrt, 1);
     vcrt->size = size;
@@ -469,7 +469,7 @@ static int check_disjoint_lpids(int lpids1[], int n1, int lpids2[], int n2)
 
     if (mask_size > N_STATIC_LPID32) {
         MPIR_CHKLMEM_MALLOC(lpidmask,uint32_t*,mask_size*sizeof(uint32_t),
-                            mpi_errno,"lpidmask");
+                            mpi_errno,"lpidmask", MPL_MEM_DYNAMIC);
     }
     else {
         lpidmask = lpidmaskPrealloc;
@@ -554,10 +554,10 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
                                        *remote_size ));
         /* With this information, we can now send and receive the
            global process ids from the peer. */
-        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids");
-        *remote_lpids = (int*) MPL_malloc((*remote_size)*sizeof(int));
-        MPIR_CHKLMEM_MALLOC(local_gpids,MPIDI_Gpid*,local_size*sizeof(MPIDI_Gpid), mpi_errno,"local_gpids");
-        MPIR_CHKLMEM_MALLOC(local_lpids,int*,local_size*sizeof(int), mpi_errno,"local_lpids");
+        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids", MPL_MEM_DYNAMIC);
+        *remote_lpids = (int*) MPL_malloc((*remote_size)*sizeof(int), MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(local_gpids,MPIDI_Gpid*,local_size*sizeof(MPIDI_Gpid), mpi_errno,"local_gpids", MPL_MEM_DYNAMIC);
+        MPIR_CHKLMEM_MALLOC(local_lpids,int*,local_size*sizeof(int), mpi_errno,"local_lpids", MPL_MEM_DYNAMIC);
 
         mpi_errno = MPIDI_GPID_GetAllInComm( local_comm_ptr, local_size, local_gpids, &singlePG );
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -627,8 +627,8 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         *remote_size = comm_info[0];
-        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids");
-        *remote_lpids = (int*) MPL_malloc((*remote_size)*sizeof(int));
+        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids", MPL_MEM_DYNAMIC);
+        *remote_lpids = (int*) MPL_malloc((*remote_size)*sizeof(int), MPL_MEM_ADDRESS);
         mpi_errno = MPID_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
                                      local_comm_ptr, &errflag );
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -913,7 +913,7 @@ int MPIDI_Populate_vc_node_ids(MPIDI_PG_t *pg, int our_pg_rank)
     int mpi_errno = MPI_SUCCESS;
     int i;
     int *out_nodemap;
-    out_nodemap = (int *) MPL_malloc(pg->size * sizeof(int));
+    out_nodemap = (int *) MPL_malloc(pg->size * sizeof(int), MPL_MEM_ADDRESS);
 
     mpi_errno = MPIR_NODEMAP_build_nodemap(pg->size, our_pg_rank, out_nodemap, &g_max_node_id);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -98,7 +98,7 @@ int MPIDI_RMA_init(void)
 
     MPIR_CHKPMEM_MALLOC(global_rma_op_pool_start, MPIDI_RMA_Op_t *,
                         sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_GLOBAL_POOL_SIZE,
-                        mpi_errno, "RMA op pool");
+                        mpi_errno, "RMA op pool", MPL_MEM_RMA);
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_GLOBAL_POOL_SIZE; i++) {
         global_rma_op_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
         DL_APPEND(global_rma_op_pool_head, &(global_rma_op_pool_start[i]));
@@ -106,7 +106,7 @@ int MPIDI_RMA_init(void)
 
     MPIR_CHKPMEM_MALLOC(global_rma_target_pool_start, MPIDI_RMA_Target_t *,
                         sizeof(MPIDI_RMA_Target_t) * MPIR_CVAR_CH3_RMA_TARGET_GLOBAL_POOL_SIZE,
-                        mpi_errno, "RMA target pool");
+                        mpi_errno, "RMA target pool", MPL_MEM_RMA);
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_GLOBAL_POOL_SIZE; i++) {
         global_rma_target_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
         DL_APPEND(global_rma_target_pool_head, &(global_rma_target_pool_start[i]));

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -171,7 +171,7 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CONNECTION_ALLOC);
 
     MPIR_CHKPMEM_MALLOC(conn,MPIDI_CH3I_Connection_t*,
-			sizeof(MPIDI_CH3I_Connection_t),mpi_errno,"conn");
+			sizeof(MPIDI_CH3I_Connection_t),mpi_errno,"conn", MPL_MEM_DYNAMIC);
 
     /* FIXME: This size is unchanging, so get it only once (at most); 
        we might prefer for connections to simply point at the single process
@@ -184,7 +184,7 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
 			     "**pmi_get_id_length_max",
 			     "**pmi_get_id_length_max %d", pmi_errno);
 #endif
-    MPIR_CHKPMEM_MALLOC(conn->pg_id,char*,id_sz + 1,mpi_errno,"conn->pg_id");
+    MPIR_CHKPMEM_MALLOC(conn->pg_id,char*,id_sz + 1,mpi_errno,"conn->pg_id", MPL_MEM_DYNAMIC);
     conn->pg_id[0] = 0;           /* Be careful about pg_id in case a later 
 				     error */
     *connp = conn;
@@ -223,7 +223,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
 
     /* First, create a new vc (we may use this to pass to a generic
        connection routine) */
-    MPIR_CHKPMEM_MALLOC(vc,MPIDI_VC_t *,sizeof(MPIDI_VC_t),mpi_errno,"vc");
+    MPIR_CHKPMEM_MALLOC(vc,MPIDI_VC_t *,sizeof(MPIDI_VC_t),mpi_errno,"vc", MPL_MEM_DYNAMIC);
     /* FIXME - where does this vc get freed? */
 
     *new_vc = vc;
@@ -757,7 +757,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
 	MPIDI_CH3I_Pkt_sc_open_resp_t *openresp = 
 	    (MPIDI_CH3I_Pkt_sc_open_resp_t *)&conn->pkt.type;
 
-	vc = (MPIDI_VC_t *) MPL_malloc(sizeof(MPIDI_VC_t));
+	vc = (MPIDI_VC_t *) MPL_malloc(sizeof(MPIDI_VC_t), MPL_MEM_ADDRESS);
 	/* --BEGIN ERROR HANDLING-- */
 	if (vc == NULL) {
 	    mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL, FCNAME, __LINE__, MPI_ERR_OTHER,

--- a/src/mpid/ch3/util/sock/ch3u_getinterfaces.c
+++ b/src/mpid/ch3/util/sock/ch3u_getinterfaces.c
@@ -227,7 +227,7 @@ static int MPIDI_CH3U_GetIPInterface( MPIDI_CH3I_Sock_ifaddr_t *ifaddr, int *fou
 	struct ifconf			ifconf;
 	int				rc;
 
-	buf_ptr = (char *) MPL_malloc(buf_len);
+	buf_ptr = (char *) MPL_malloc(buf_len, MPL_MEM_BUFFER);
 	if (buf_ptr == NULL) {
 	    fprintf( stderr, "Unable to allocate %d bytes\n", buf_len );
 	    return 1;

--- a/src/mpid/ch3/util/sock/findinterfaces.c
+++ b/src/mpid/ch3/util/sock/findinterfaces.c
@@ -117,7 +117,7 @@ static int GetLocalIPs(int32_t *pIP, int max)
 	struct ifconf			ifconf;
 	int				rc;
 
-	buf_ptr = (char *) MPL_malloc(buf_len);
+	buf_ptr = (char *) MPL_malloc(buf_len, MPL_MEM_BUFFER);
 	if (buf_ptr == NULL)
 	    return 0;
 	

--- a/src/mpid/ch3/util/unordered/unordered.c
+++ b/src/mpid/ch3/util/unordered/unordered.c
@@ -18,7 +18,7 @@ int MPIDI_CH3U_Handle_unordered_recv_pkt(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt)
 
 #if defined(MPIDI_CH3_MSGS_UNORDERED)
 
-#define MPIDI_CH3U_Pkt_send_container_alloc() (MPL_malloc(sizeof(MPIDI_CH3_Pkt_send_container_t)))
+#define MPIDI_CH3U_Pkt_send_container_alloc() (MPL_malloc(sizeof(MPIDI_CH3_Pkt_send_container_t), MPL_MEM_BUFFER))
 #define MPIDI_CH3U_Pkt_send_container_free(pc_) MPL_free(pc_)
 
 #undef FUNCNAME

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -45,7 +45,7 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vnis)
 
     MPIDI_CH4_Global.comm_req_lists = (MPIDI_CH4U_comm_req_list_t *)
         MPL_calloc(MPIR_MAX_CONTEXT_MASK * MPIR_CONTEXT_INT_BITS,
-                   sizeof(MPIDI_CH4U_comm_req_list_t));
+                   sizeof(MPIDI_CH4U_comm_req_list_t), MPL_MEM_OTHER);
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDI_CH4_Global.posted_list = NULL;
     MPIDI_CH4_Global.unexp_list = NULL;
@@ -228,7 +228,7 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vnis)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    MPIDI_CH4U_map_create((void**)&(MPIDI_CH4_Global.win_map));
+    MPIDI_CH4U_map_create((void**)&(MPIDI_CH4_Global.win_map), MPL_MEM_RMA);
 
     mpi_errno = MPIDI_CH4R_RMA_Init_sync_pvars();
     if (mpi_errno)

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -131,7 +131,7 @@ MPIDI_CH4I_API(int, Win_flush_all, MPIR_Win *);
 MPIDI_CH4I_API(int, Get_accumulate, const void *, int, MPI_Datatype, void *, int, MPI_Datatype, int,
                MPI_Aint, int, MPI_Datatype, MPI_Op, MPIR_Win *);
 MPIDI_CH4I_API(int, Win_lock_all, int, MPIR_Win *);
-MPIDI_CH4I_API(void *, Alloc_mem, size_t, MPIR_Info *);
+MPIDI_CH4I_API(void *, Alloc_mem, size_t, MPIR_Info *, MPL_memory_class class);
 MPIDI_CH4I_API(int, Free_mem, void *);
 MPIDI_CH4I_API(int, Get_node_id, MPIR_Comm *, int rank, int *);
 MPIDI_CH4I_API(int, Get_max_node_id, MPIR_Comm *, int *);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -94,7 +94,7 @@ typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, int count, MPI_Datatype datatype
 typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, int count, MPI_Datatype datatype,
                                       MPIR_Request * message, MPIR_Request ** rreqp);
 typedef int (*MPIDI_NM_mpi_cancel_recv_t) (MPIR_Request * rreq);
-typedef void *(*MPIDI_NM_mpi_alloc_mem_t) (size_t size, MPIR_Info * info_ptr);
+typedef void *(*MPIDI_NM_mpi_alloc_mem_t) (size_t size, MPIR_Info * info_ptr, MPL_memory_class class);
 typedef int (*MPIDI_NM_mpi_free_mem_t) (void *ptr);
 typedef int (*MPIDI_NM_mpi_improbe_t) (int source, int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                        int *flag, MPIR_Request ** message, MPI_Status * status);
@@ -610,9 +610,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, int count, MPI_Datat
                                                  MPIR_Request * message,
                                                  MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size,
-                                                      MPIR_Info *
-                                                      info_ptr) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr,
+                                                      MPL_memory_class class) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_free_mem(void *ptr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
                                                   int context_offset, MPIDI_av_entry_t *addr, int *flag,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -583,14 +583,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
     void *ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLOC_MEM);
 
-    ret = MPIDI_NM_native_func->mpi_alloc_mem(size, info_ptr);
+    ret = MPIDI_NM_native_func->mpi_alloc_mem(size, info_ptr, class);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLOC_MEM);
     return ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -79,7 +79,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
     }
 
     if (am_hdr_sz > MPIDI_OFI_BUF_POOL_SIZE) {
-        am_hdr_buf = (char *) MPL_malloc(am_hdr_sz);
+        am_hdr_buf = (char *) MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
         is_allocated = 1;
     }
     else {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -214,7 +214,7 @@ static inline int MPIDI_OFI_handle_long_am_hdr(MPIDI_OFI_am_header_t * msg_hdr)
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info) = *lmt_msg;
     MPIDI_OFI_AMREQUEST_HDR(rreq, msg_hdr) = *msg_hdr;
     MPIDI_OFI_AMREQUEST_HDR(rreq, rreq_ptr) = (void *) rreq;
-    MPIDI_OFI_AMREQUEST_HDR(rreq, am_hdr) = MPL_malloc(msg_hdr->am_hdr_sz);
+    MPIDI_OFI_AMREQUEST_HDR(rreq, am_hdr) = MPL_malloc(msg_hdr->am_hdr_sz, MPL_MEM_BUFFER);
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_cntr) =
         ((msg_hdr->am_hdr_sz - 1) / MPIDI_Global.max_send) + 1;
     MPIDI_OFI_do_rdma_read(MPIDI_OFI_AMREQUEST_HDR(rreq, am_hdr), lmt_msg->am_hdr_src,

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.h
@@ -24,10 +24,10 @@ static inline int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMM_CREATE_HOOK);
 
-    MPIDI_CH4U_map_create(&MPIDI_OFI_COMM(comm).huge_send_counters);
-    MPIDI_CH4U_map_create(&MPIDI_OFI_COMM(comm).huge_recv_counters);
-    MPIDI_OFI_index_allocator_create(&MPIDI_OFI_COMM(comm).win_id_allocator, 0);
-    MPIDI_OFI_index_allocator_create(&MPIDI_OFI_COMM(comm).rma_id_allocator, 1);
+    MPIDI_CH4U_map_create(&MPIDI_OFI_COMM(comm).huge_send_counters, MPL_MEM_COMM);
+    MPIDI_CH4U_map_create(&MPIDI_OFI_COMM(comm).huge_recv_counters, MPL_MEM_COMM);
+    MPIDI_OFI_index_allocator_create(&MPIDI_OFI_COMM(comm).win_id_allocator, 0, MPL_MEM_RMA);
+    MPIDI_OFI_index_allocator_create(&MPIDI_OFI_COMM(comm).rma_id_allocator, 1, MPL_MEM_RMA);
 
     mpi_errno = MPIDI_CH4U_init_comm(comm);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -209,7 +209,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
                 LL_DELETE(MPIDI_unexp_huge_recv_head, MPIDI_unexp_huge_recv_tail, list_ptr);
 
                 recv = list_ptr;
-                MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv);
+                MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv, MPL_MEM_COMM);
                 break;
             }
         }
@@ -220,11 +220,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
 
         MPL_DBG_MSG_FMT(MPIR_DBG_PT2PT,VERBOSE,(MPL_DBG_FDEST, "CREATING HUGE POSTED ENTRY: (%d, %d, %llu)", comm_ptr->context_id, MPIDI_OFI_cqe_get_source(wc), (MPIDI_OFI_TAG_MASK & wc->tag)));
 
-        recv = (MPIDI_OFI_huge_recv_t *) MPL_calloc(sizeof(*recv), 1);
+        recv = (MPIDI_OFI_huge_recv_t *) MPL_calloc(sizeof(*recv), 1, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(recv == NULL, mpi_errno, MPI_ERR_OTHER, "**outofmemory");
-        MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv);
+        MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv, MPL_MEM_BUFFER);
 
-        list_ptr = (MPIDI_OFI_huge_recv_list_t *) MPL_calloc(sizeof(*list_ptr), 1);
+        list_ptr = (MPIDI_OFI_huge_recv_list_t *) MPL_calloc(sizeof(*list_ptr), 1, MPL_MEM_BUFFER);
         if (!list_ptr) MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         list_ptr->comm_id = comm_ptr->context_id;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -270,8 +270,8 @@ int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(void);
-void MPIDI_OFI_index_allocator_create(void **_indexmap, int start);
-int MPIDI_OFI_index_allocator_alloc(void *_indexmap);
+void MPIDI_OFI_index_allocator_create(void **_indexmap, int start, MPL_memory_class class);
+int MPIDI_OFI_index_allocator_alloc(void *_indexmap, MPL_memory_class class);
 void MPIDI_OFI_index_allocator_free(void *_indexmap, int index);
 void MPIDI_OFI_index_allocator_destroy(void *_indexmap);
 
@@ -285,7 +285,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_an
     memset((char *) req + MPIDI_REQUEST_HDR_SIZE, 0,
            sizeof(MPIDI_OFI_win_request_t) - MPIDI_REQUEST_HDR_SIZE);
     req->noncontig =
-        (MPIDI_OFI_win_noncontig_t *) MPL_calloc(1, (extra) + sizeof(*(req->noncontig)));
+        (MPIDI_OFI_win_noncontig_t *) MPL_calloc(1, (extra) + sizeof(*(req->noncontig)), MPL_MEM_BUFFER);
     return req;
 }
 
@@ -461,7 +461,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_conn_manager_insert_conn(fi_addr_t conn,
         old_max = MPIDI_Global.conn_mgr.max_n_conn;
         new_max = old_max + 1;
         MPIDI_Global.conn_mgr.free_conn_id =
-            (int *) MPL_realloc(MPIDI_Global.conn_mgr.free_conn_id, new_max * sizeof(int));
+            (int *) MPL_realloc(MPIDI_Global.conn_mgr.free_conn_id, new_max * sizeof(int), MPL_MEM_ADDRESS);
         for (i = old_max; i < new_max - 1; ++i) {
             MPIDI_Global.conn_mgr.free_conn_id[i] = i + 1;
         }

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -277,8 +277,8 @@ static inline int MPIDI_OFI_conn_manager_init()
     MPIDI_Global.conn_mgr.n_conn = 0;
 
     MPIDI_Global.conn_mgr.conn_list =
-        (MPIDI_OFI_conn_t *) mmap(NULL, MPIDI_Global.conn_mgr.mmapped_size,
-                                  PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+        (MPIDI_OFI_conn_t *) MPL_mmap(NULL, MPIDI_Global.conn_mgr.mmapped_size,
+                                      PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     MPIR_ERR_CHKANDSTMT(MPIDI_Global.conn_mgr.conn_list == MAP_FAILED, mpi_errno,
                         MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
@@ -363,7 +363,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
         MPL_free(close_msg);
     }
 
-    munmap((void *) MPIDI_Global.conn_mgr.conn_list, MPIDI_Global.conn_mgr.mmapped_size);
+    MPL_munmap((void *) MPIDI_Global.conn_mgr.conn_list, MPIDI_Global.conn_mgr.mmapped_size);
     MPL_free(MPIDI_Global.conn_mgr.free_conn_id);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -97,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
             DLOOP_Offset last = dt_ptr->size * count;
 
             size = o_size*num_contig + sizeof(*(MPIDI_OFI_REQUEST(rreq, noncontig.nopack)));
-            MPIDI_OFI_REQUEST(rreq, noncontig.nopack) = (struct iovec *) MPL_malloc(size);
+            MPIDI_OFI_REQUEST(rreq, noncontig.nopack) = (struct iovec *) MPL_malloc(size, MPL_MEM_BUFFER);
             memset(MPIDI_OFI_REQUEST(rreq, noncontig.nopack), 0, size);
 
             MPIR_Segment_init(buf, count, datatype, &seg, 0);
@@ -131,7 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
             }
 
             if (countp_huge >= 1 && huge) {
-                originv_huge = (struct iovec *) MPL_malloc(sizeof(struct iovec) * countp_huge);
+                originv_huge = (struct iovec *) MPL_malloc(sizeof(struct iovec) * countp_huge, MPL_MEM_BUFFER);
 
                 for (j = 0; j < num_contig; j++) {
                     l = 0;
@@ -190,7 +190,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
   unpack:
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_PACK;
         MPIDI_OFI_REQUEST(rreq, noncontig.pack) =
-            (MPIDI_OFI_pack_t *) MPL_malloc(data_sz + sizeof(MPIR_Segment));
+            (MPIDI_OFI_pack_t *) MPL_malloc(data_sz + sizeof(MPIR_Segment), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(rreq, noncontig.pack->pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
         recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack->pack_buffer);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -23,7 +23,7 @@
         int tmp;                                                        \
         MPIDI_OFI_chunk_request *creq;                                  \
         MPIR_cc_incr((*sigreq)->cc_ptr, &tmp);                          \
-        creq=(MPIDI_OFI_chunk_request*)MPL_malloc(sizeof(*creq));       \
+        creq=(MPIDI_OFI_chunk_request*)MPL_malloc(sizeof(*creq), MPL_MEM_BUFFER);       \
         creq->event_id = MPIDI_OFI_EVENT_CHUNK_DONE;                    \
         creq->parent   = *sigreq;                                       \
         msg.context    = &creq->context;                                \
@@ -181,7 +181,7 @@ static inline void MPIDI_OFI_win_datatype_map(MPIDI_OFI_win_datatype_t * dt)
     else {
         unsigned map_size = dt->pointer->max_contig_blocks * dt->count + 1;
         dt->num_contig = map_size;
-        dt->map = (DLOOP_VECTOR *) MPL_malloc(map_size * sizeof(DLOOP_VECTOR));
+        dt->map = (DLOOP_VECTOR *) MPL_malloc(map_size * sizeof(DLOOP_VECTOR), MPL_MEM_RMA);
         MPIR_Assert(dt->map != NULL);
 
         MPIR_Segment seg;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -164,7 +164,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
             num_contig = map_size;  /* map_size is the maximum number of iovecs that can be generated */
 
             size = o_size*num_contig + sizeof(*(MPIDI_OFI_REQUEST(sreq, noncontig.nopack)));
-            MPIDI_OFI_REQUEST(sreq, noncontig.nopack) = (struct iovec *) MPL_malloc(size);
+            MPIDI_OFI_REQUEST(sreq, noncontig.nopack) = (struct iovec *) MPL_malloc(size, MPL_MEM_BUFFER);
             memset(MPIDI_OFI_REQUEST(sreq, noncontig.nopack), 0, size);
 
             MPIR_Segment_init(buf, count, datatype, &seg, 0);
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
             }
 
             if (countp_huge >= 1 && huge) {
-                originv_huge = (struct iovec *) MPL_malloc(sizeof(struct iovec) * countp_huge);
+                originv_huge = (struct iovec *) MPL_malloc(sizeof(struct iovec) * countp_huge, MPL_MEM_BUFFER);
 
                 for (j=0; j<num_contig; j++) {
                     l = 0;
@@ -252,7 +252,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
         MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_SEND_PACK;
 
         MPIDI_OFI_REQUEST(sreq, noncontig.pack) =
-            (MPIDI_OFI_pack_t *) MPL_malloc(data_sz + sizeof(MPIR_Segment));
+            (MPIDI_OFI_pack_t *) MPL_malloc(data_sz + sizeof(MPIR_Segment), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(sreq, noncontig.pack) == NULL, mpi_errno, MPI_ERR_OTHER,
                              "**nomem", "**nomem %s", "Send Pack buffer alloc");
         size_t segment_first;
@@ -301,7 +301,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
         MPID_THREAD_CS_ENTER(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
 
         /* Set up a memory region for the lmt data transfer */
-        ctrl.rma_key = MPIDI_OFI_index_allocator_alloc(MPIDI_OFI_COMM(comm).rma_id_allocator);
+        ctrl.rma_key = MPIDI_OFI_index_allocator_alloc(MPIDI_OFI_COMM(comm).rma_id_allocator, MPL_MEM_RMA);
         MPIR_Assert(ctrl.rma_key < MPIDI_Global.max_huge_rmas);
         if (MPIDI_OFI_ENABLE_MR_SCALABLE)
             rma_key = ctrl.rma_key << MPIDI_Global.huge_rma_shift;
@@ -316,7 +316,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
                                         NULL), mr_reg); /* In:  context             */
 
         /* Create map to the memory region */
-        MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm).huge_send_counters, sreq->handle, huge_send_mr);
+        MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm).huge_send_counters, sreq->handle, huge_send_mr, MPL_MEM_BUFFER);
 
         if (!MPIDI_OFI_ENABLE_MR_SCALABLE) {
             /* MR_BASIC */

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.h
@@ -391,9 +391,9 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         *remote_size = req[0].msglen / sizeof(size_t);
         *out_root = req[0].tag;
         MPIR_CHKPMEM_MALLOC((*remote_upid_size), size_t*,
-                            (*remote_size) * sizeof(size_t), mpi_errno, "remote_upid_size");
+                            (*remote_size) * sizeof(size_t), mpi_errno, "remote_upid_size", MPL_MEM_ADDRESS);
         MPIR_CHKPMEM_MALLOC((*remote_node_ids), int*,
-                            (*remote_size) * sizeof(int), mpi_errno, "remote_node_ids");
+                            (*remote_size) * sizeof(int), mpi_errno, "remote_node_ids", MPL_MEM_ADDRESS);
 
         req[0].done = 0;
         req[0].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
@@ -413,7 +413,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
 
         for (i = 0; i < (*remote_size); i++) remote_upid_recvsize += (*remote_upid_size)[i];
         MPIR_CHKPMEM_MALLOC((*remote_upids), char*, remote_upid_recvsize,
-                            mpi_errno, "remote_upids");
+                            mpi_errno, "remote_upids", MPL_MEM_ADDRESS);
 
         MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       *remote_upids,
@@ -451,7 +451,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         /* Step 1: get local upids (with size) and node ids for sending */
         MPIDI_NM_get_local_upids(comm_ptr, &local_upid_size, &local_upids);
         for (i = 0; i < local_size; i++) local_upid_sendsize += local_upid_size[i];
-        local_node_ids = (int*) MPL_malloc(local_size * sizeof(int));
+        local_node_ids = (int*) MPL_malloc(local_size * sizeof(int), MPL_MEM_ADDRESS);
         for (i = 0; i < comm_ptr->local_size; i++)
             MPIDI_CH4U_get_node_id(comm_ptr, i, &local_node_ids[i]);
 
@@ -591,7 +591,7 @@ static inline int MPIDI_NM_mpi_comm_connect(const char *port_name,
                                 &remote_size, &remote_upid_size, &remote_upids,
                                 &remote_node_ids));
         MPIR_CHKLMEM_MALLOC(remote_lupids, int*, remote_size * sizeof(int),
-                            mpi_errno, "remote_lupids");
+                            mpi_errno, "remote_lupids", MPL_MEM_ADDRESS);
 
         MPIDIU_upids_to_lupids(remote_size, remote_upid_size, remote_upids, &remote_lupids,
                                remote_node_ids);
@@ -780,7 +780,7 @@ static inline int MPIDI_NM_mpi_comm_accept(const char *port_name,
                                 &remote_node_ids));
         MPIDI_OFI_CALL(fi_av_remove(MPIDI_Global.av, &conn, 1, 0ULL), avmap);
         MPIR_CHKLMEM_MALLOC(remote_lupids, int*, remote_size * sizeof(int),
-                            mpi_errno, "remote_lupids");
+                            mpi_errno, "remote_lupids", MPL_MEM_ADDRESS);
         MPIDIU_upids_to_lupids(remote_size, remote_upid_size, remote_upids, &remote_lupids,
                                remote_node_ids);
         /* the parent comm group is alawys the low group */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -739,7 +739,7 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
             goto fn_fail;
 
         if (anyfail && map_ptr != NULL && map_ptr != MAP_FAILED)
-            munmap(map_ptr, mapsize);
+            MPL_munmap(map_ptr, mapsize);
     }
 
     if (anyfail) {      /* Still fails after retry, report error. */

--- a/src/mpid/ch4/netmod/portals4/ptl_am.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_am.h
@@ -41,7 +41,7 @@ static inline int MPIDI_NM_am_isend(int rank,
 
     /* fast path: there's no data to be sent */
     if (count == 0) {
-        send_buf = MPL_malloc(am_hdr_sz);
+        send_buf = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
         sreq->dev.ch4.am.netmod_am.portals4.pack_buffer = send_buf;
 
@@ -62,7 +62,7 @@ static inline int MPIDI_NM_am_isend(int rank,
         ptl_md_t md;
         ptl_iovec_t iovec[2];
 
-        send_buf = MPL_malloc(am_hdr_sz);
+        send_buf = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
         sreq->dev.ch4.am.netmod_am.portals4.pack_buffer = send_buf;
 
@@ -86,7 +86,7 @@ static inline int MPIDI_NM_am_isend(int rank,
         MPIR_Segment *segment;
         MPI_Aint last;
 
-        send_buf = MPL_malloc(am_hdr_sz + data_sz);
+        send_buf = MPL_malloc(am_hdr_sz + data_sz, MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
         segment = MPIR_Segment_alloc();
         MPIR_Segment_init(data, count, datatype, segment, 0);
@@ -158,7 +158,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
         ptl_md_t md;
         ptl_iovec_t iovec[2];
 
-        send_buf = MPL_malloc(am_hdr_sz);
+        send_buf = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
         sreq->dev.ch4.am.netmod_am.portals4.pack_buffer = send_buf;
 
@@ -182,7 +182,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
         MPIR_Segment *segment;
         MPI_Aint last;
 
-        send_buf = MPL_malloc(am_hdr_sz + data_sz);
+        send_buf = MPL_malloc(am_hdr_sz + data_sz, MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
         segment = MPIR_Segment_alloc();
         MPIR_Segment_init(data, count, datatype, segment, 0);
@@ -230,7 +230,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     /* create an internal request for the inject */
     inject_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIDI_NM_am_request_init(inject_req);
-    send_buf = MPL_malloc(am_hdr_sz);
+    send_buf = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
     MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
     inject_req->dev.ch4.am.netmod_am.portals4.pack_buffer = send_buf;
 
@@ -267,7 +267,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     /* create an internal request for the inject */
     inject_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     MPIDI_NM_am_request_init(inject_req);
-    send_buf = MPL_malloc(am_hdr_sz);
+    send_buf = MPL_malloc(am_hdr_sz, MPL_MEM_BUFFER);
     MPIR_Memcpy(send_buf, am_hdr, am_hdr_sz);
     inject_req->dev.ch4.am.netmod_am.portals4.pack_buffer = send_buf;
 

--- a/src/mpid/ch4/netmod/portals4/ptl_init.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_init.h
@@ -125,11 +125,11 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     ret = PMI_KVS_Get_key_length_max(&key_max_sz);
     ret = PMI_KVS_Get_value_length_max(&val_max_sz);
     ret = PMI_KVS_Get_name_length_max(&name_max_sz);
-    MPIDI_PTL_global.kvsname = MPL_malloc(name_max_sz);
+    MPIDI_PTL_global.kvsname = MPL_malloc(name_max_sz, MPL_MEM_ADDRESS);
     ret = PMI_KVS_Get_my_name(MPIDI_PTL_global.kvsname, name_max_sz);
 
-    keyS = MPL_malloc(key_max_sz);
-    valS = MPL_malloc(val_max_sz);
+    keyS = MPL_malloc(key_max_sz, MPL_MEM_ADDRESS);
+    valS = MPL_malloc(val_max_sz, MPL_MEM_ADDRES);
     buscard = valS;
     val_sz_left = val_max_sz;
 
@@ -151,7 +151,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     ret = PMI_Barrier();
 
     /* get and store business cards in address table */
-    MPIDI_PTL_global.addr_table = MPL_malloc(size * sizeof(MPIDI_PTL_addr_t));
+    MPIDI_PTL_global.addr_table = MPL_malloc(size * sizeof(MPIDI_PTL_addr_t), MPL_MEM_ADDRESS);
     for (i = 0; i < size; i++) {
         MPL_snprintf(keyS, key_max_sz*sizeof(char), "PTL-%d", i);
         ret = PMI_KVS_Get(MPIDI_PTL_global.kvsname, keyS, valS, val_max_sz);
@@ -168,11 +168,11 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* Setup CH4R Active Messages */
     MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
     for (i = 0; i < MPIDI_PTL_NUM_OVERFLOW_BUFFERS; i++) {
-        MPIDI_PTL_global.overflow_bufs[i] = MPL_malloc(MPIDI_PTL_OVERFLOW_BUFFER_SZ);
+        MPIDI_PTL_global.overflow_bufs[i] = MPL_malloc(MPIDI_PTL_OVERFLOW_BUFFER_SZ, MPL_MEM_BUFFER);
         MPIDI_PTL_append_overflow(i);
     }
 
-    MPIDI_PTL_global.node_map = MPL_malloc(size * sizeof(*MPIDI_PTL_global.node_map));
+    MPIDI_PTL_global.node_map = MPL_malloc(size * sizeof(*MPIDI_PTL_global.node_map), MPL_MEM_ADDRESS);
     mpi_errno =
         MPIDI_CH4U_build_nodemap(rank, comm_world, size, MPIDI_PTL_global.node_map,
                                  &MPIDI_PTL_global.max_node_id);
@@ -254,9 +254,9 @@ static inline int MPIDI_NM_mpi_free_mem(void *ptr)
     return MPIDI_CH4U_mpi_free_mem(ptr);
 }
 
-static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
-    return MPIDI_CH4U_mpi_alloc_mem(size, info_ptr);
+    return MPIDI_CH4U_mpi_alloc_mem(size, info_ptr, class);
 }
 
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -76,9 +76,9 @@ static inline int MPIDI_NM_mpi_free_mem(void *ptr)
     return MPIDI_CH4U_mpi_free_mem(ptr);
 }
 
-static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
-    return MPIDI_CH4U_mpi_alloc_mem(size, info_ptr);
+    return MPIDI_CH4U_mpi_alloc_mem(size, info_ptr, class);
 }
 
 

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -108,7 +108,7 @@ static inline int MPIDI_NM_am_isend(int rank,
 
     if (dt_contig) {
         /* just pack and send for now */
-        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr));
+        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
         MPIR_Memcpy(send_buf + am_hdr_sz + sizeof(ucx_hdr), (char *) data + dt_true_lb, data_sz);
@@ -122,7 +122,7 @@ static inline int MPIDI_NM_am_isend(int rank,
         MPIR_Segment_init(data, count, datatype, segment_ptr, 0);
         segment_first = 0;
         last = data_sz;
-        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr));
+        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
 
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
@@ -197,7 +197,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
     }
 
     /* copy headers to send buffer */
-    send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr));
+    send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
     ucx_hdr.handler_id = handler_id;
     ucx_hdr.data_sz = data_sz;
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
@@ -289,7 +289,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
     ucx_hdr.data_sz = data_sz;
 
     /* just pack and send for now */
-    send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr));
+    send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
     MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
     if (dt_contig) {
@@ -371,7 +371,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     ucx_hdr.data_sz = 0;
 
     /* just pack and send for now */
-    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr));
+    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
     MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
@@ -419,7 +419,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     ucx_hdr.handler_id = handler_id;
 
     /* just pack and send for now */
-    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr));
+    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
     MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
     MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
     ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -25,7 +25,7 @@ static inline void *MPIDI_UCX_Start_pack(void *context, const void *buffer, size
     struct MPIDI_UCX_pack_state *state;
     MPI_Aint packsize;
 
-    state = MPL_malloc(sizeof(struct MPIDI_UCX_pack_state));
+    state = MPL_malloc(sizeof(struct MPIDI_UCX_pack_state), MPL_MEM_DATATYPE);
     segment_ptr = MPIR_Segment_alloc();
     MPIR_Pack_size_impl(count, *datatype, &packsize);
     /* Todo: Add error handling */
@@ -43,7 +43,7 @@ static inline void *MPIDI_UCX_Start_unpack(void *context, void *buffer, size_t c
     struct MPIDI_UCX_pack_state *state;
     MPI_Aint packsize;
 
-    state = MPL_malloc(sizeof(struct MPIDI_UCX_pack_state));
+    state = MPL_malloc(sizeof(struct MPIDI_UCX_pack_state), MPL_MEM_DATATYPE);
     MPIR_Pack_size_impl(count, *datatype, &packsize);
     segment_ptr = MPIR_Segment_alloc();
     /* Todo: Add error handling */

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -114,7 +114,7 @@ static inline int MPIDI_NM_progress(int vni, int blocking)
     message_handle =
         ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
     while (message_handle) {
-        am_buf = MPL_malloc(info.length);
+        am_buf = MPL_malloc(info.length, MPL_MEM_BUFFER);
         ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
                                                                       am_buf,
                                                                       info.length,

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -85,7 +85,7 @@ static inline void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_t status,
             /* FIXME: we have no way of passing the tag bits back in this case */
             ucp_request->req = (void *)UCS_ERR_MESSAGE_TRUNCATED;
         } else {
-            ucp_request->req = MPL_malloc(sizeof(ucp_tag_recv_info_t));
+            ucp_request->req = MPL_malloc(sizeof(ucp_tag_recv_info_t), MPL_MEM_BUFFER);
             memcpy(ucp_request->req, info, sizeof(ucp_tag_recv_info_t));
         }
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -65,7 +65,7 @@ static inline int MPIDI_UCX_noncontig_put(const void *origin_addr,
     segment_first = 0;
     last = size;
 
-    buffer = MPL_malloc(size);
+    buffer = MPL_malloc(size, MPL_MEM_BUFFER);
     MPIR_Assert(buffer);
     MPIR_Segment_pack(segment_ptr, segment_first, &last, buffer);
     MPIR_Segment_free(segment_ptr);

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -34,7 +34,7 @@ static inline int MPIDI_UCX_Win_allgather(MPIR_Win * win, size_t length,
 
     ucp_context_h ucp_context = MPIDI_UCX_global.context;
 
-    MPIDI_UCX_WIN(win).info_table = MPL_malloc(sizeof(MPIDI_UCX_win_info_t) * comm_ptr->local_size);
+    MPIDI_UCX_WIN(win).info_table = MPL_malloc(sizeof(MPIDI_UCX_win_info_t) * comm_ptr->local_size, MPL_MEM_OTHER);
 
     /* Only non-zero region maps to device. */
     rkey_size = 0;
@@ -68,7 +68,7 @@ static inline int MPIDI_UCX_Win_allgather(MPIR_Win * win, size_t length,
         MPIDI_UCX_CHK_STATUS(status);
     }
 
-    rkey_sizes = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size);
+    rkey_sizes = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size, MPL_MEM_OTHER);
     rkey_sizes[comm_ptr->rank] = (int) rkey_size;
     mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, 1, MPI_INT,
                                     rkey_sizes, 1, MPI_INT, comm_ptr, &err);
@@ -76,7 +76,7 @@ static inline int MPIDI_UCX_Win_allgather(MPIR_Win * win, size_t length,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    recv_disps = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size);
+    recv_disps = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size, MPL_MEM_OTHER);
 
 
     for (i = 0; i < comm_ptr->local_size; i++) {
@@ -84,7 +84,7 @@ static inline int MPIDI_UCX_Win_allgather(MPIR_Win * win, size_t length,
         cntr += rkey_sizes[i];
     }
 
-    rkey_recv_buff = MPL_malloc(cntr);
+    rkey_recv_buff = MPL_malloc(cntr, MPL_MEM_OTHER);
 
     /* allgather */
     mpi_errno = MPIR_Allgatherv_impl(rkey_buffer, rkey_size, MPI_BYTE,
@@ -114,7 +114,7 @@ static inline int MPIDI_UCX_Win_allgather(MPIR_Win * win, size_t length,
         else
             MPIDI_UCX_CHK_STATUS(status);
     }
-    share_data = MPL_malloc(comm_ptr->local_size * sizeof(struct _UCX_share));
+    share_data = MPL_malloc(comm_ptr->local_size * sizeof(struct _UCX_share), MPL_MEM_OTHER);
 
     share_data[comm_ptr->rank].disp = disp_unit;
     share_data[comm_ptr->rank].addr = (MPI_Aint) * base_ptr;

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -47,11 +47,11 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     MPIDI_POSIX_mem_region.num_seg = 1;
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.seg, MPIDU_shm_seg_info_t *,
                         MPIDI_POSIX_mem_region.num_seg * sizeof(MPIDU_shm_seg_info_t), mpi_errno,
-                        "mem_region segments");
+                        "mem_region segments", MPL_MEM_SHM);
     MPIR_CHKPMEM_MALLOC(local_procs, int *, size * sizeof(int), mpi_errno,
-                        "local process index array");
+                        "local process index array", MPL_MEM_SHM);
     MPIR_CHKPMEM_MALLOC(local_ranks, int *, size * sizeof(int), mpi_errno,
-                        "mem_region local ranks");
+                        "mem_region local ranks", MPL_MEM_SHM);
 
     for (i = 0; i < size; i++) {
         av = MPIDIU_comm_rank_to_av(MPIR_Process.comm_world, i);
@@ -78,7 +78,7 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     mpi_errno =
         MPIDU_shm_seg_alloc(MAX
                             ((num_local * ((num_local - 1) * sizeof(MPIDI_POSIX_fastbox_t))),
-                             MPIDI_POSIX_ASYMM_NULL_VAL), (void **) &fastboxes_p);
+                             MPIDI_POSIX_ASYMM_NULL_VAL), (void **) &fastboxes_p, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -86,21 +86,21 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     /* Request data cells region */
     mpi_errno =
         MPIDU_shm_seg_alloc(num_local * MPIDI_POSIX_NUM_CELLS * sizeof(MPIDI_POSIX_cell_t),
-                            (void **) &cells_p);
+                            (void **) &cells_p, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     /* Request free q region */
     mpi_errno =
-        MPIDU_shm_seg_alloc(num_local * sizeof(MPIDI_POSIX_queue_t), (void **) &free_queues_p);
+        MPIDU_shm_seg_alloc(num_local * sizeof(MPIDI_POSIX_queue_t), (void **) &free_queues_p, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     /* Request recv q region */
     mpi_errno =
-        MPIDU_shm_seg_alloc(num_local * sizeof(MPIDI_POSIX_queue_t), (void **) &recv_queues_p);
+        MPIDU_shm_seg_alloc(num_local * sizeof(MPIDI_POSIX_queue_t), (void **) &recv_queues_p, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -108,7 +108,7 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     /* Request shared collectives barrier vars region */
     mpi_errno =
         MPIDU_shm_seg_alloc(MPIDI_POSIX_NUM_BARRIER_VARS * sizeof(MPIDI_POSIX_barrier_vars_t),
-                            (void **) &MPIDI_POSIX_mem_region.barrier_vars);
+                            (void **) &MPIDI_POSIX_mem_region.barrier_vars, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -117,7 +117,7 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     mpi_errno =
         MPIDU_shm_seg_commit(&MPIDI_POSIX_mem_region.memory, &MPIDI_POSIX_mem_region.barrier,
                              num_local, local_rank, MPIDI_POSIX_mem_region.local_procs[0],
-                             MPIDI_POSIX_mem_region.rank);
+                             MPIDI_POSIX_mem_region.rank, MPL_MEM_SHM);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -150,9 +150,9 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
 
     /* Tables of pointers to shared memory Qs */
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.FreeQ, MPIDI_POSIX_queue_ptr_t *,
-                        size * sizeof(MPIDI_POSIX_queue_ptr_t), mpi_errno, "FreeQ");
+                        size * sizeof(MPIDI_POSIX_queue_ptr_t), mpi_errno, "FreeQ", MPL_MEM_SHM);
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.RecvQ, MPIDI_POSIX_queue_ptr_t *,
-                        size * sizeof(MPIDI_POSIX_queue_ptr_t), mpi_errno, "RecvQ");
+                        size * sizeof(MPIDI_POSIX_queue_ptr_t), mpi_errno, "RecvQ", MPL_MEM_SHM);
 
     /* Init table entry for our Qs */
     MPIDI_POSIX_mem_region.FreeQ[rank] = &free_queues_p[local_rank];
@@ -193,9 +193,9 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
 
     /* Allocate table of pointers to fastboxes */
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.mailboxes.in, MPIDI_POSIX_fastbox_t **,
-                        num_local * sizeof(MPIDI_POSIX_fastbox_t *), mpi_errno, "fastboxes");
+                        num_local * sizeof(MPIDI_POSIX_fastbox_t *), mpi_errno, "fastboxes", MPL_MEM_SHM);
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_mem_region.mailboxes.out, MPIDI_POSIX_fastbox_t **,
-                        num_local * sizeof(MPIDI_POSIX_fastbox_t *), mpi_errno, "fastboxes");
+                        num_local * sizeof(MPIDI_POSIX_fastbox_t *), mpi_errno, "fastboxes", MPL_MEM_SHM);
 
     MPIR_Assert(num_local > 0);
 

--- a/src/mpid/ch4/shm/posix/posix_progress.h
+++ b/src/mpid/ch4/shm/posix/posix_progress.h
@@ -202,7 +202,7 @@ static inline int MPIDI_POSIX_progress_recv(int blocking, int *completion_count)
             MPIDI_POSIX_REQUEST(rreq)->type = cell->pkt.mpich.type;
 
             if (data_sz > 0) {
-                MPIDI_POSIX_REQUEST(rreq)->user_buf = (char *) MPL_malloc(data_sz);
+                MPIDI_POSIX_REQUEST(rreq)->user_buf = (char *) MPL_malloc(data_sz, MPL_MEM_SHM);
                 MPIR_Memcpy(MPIDI_POSIX_REQUEST(rreq)->user_buf, (void *) cell->pkt.mpich.p.payload,
                             data_sz);
             }

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -431,7 +431,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_alpha(const void *sendbuf,
         MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
-                            mpi_errno, "temporary buffer");
+                            mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *)((char*)tmp_buf - true_lb);
     }

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -157,7 +157,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
             break;
         case MPIDI_RANK_MAP_MLUT:
             max_n_avts = MPIDIU_get_max_n_avts();
-            uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int));
+            uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int), MPL_MEM_ADDRESS);
             memset(uniq_avtids, 0, max_n_avts * sizeof(int));
             for (i = 0; i < MPIDI_COMM(comm, map).size; i++) {
                 if (uniq_avtids[MPIDI_COMM(comm, map).irreg.mlut.gpid[i].avtid] == 0) {
@@ -176,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
             break;
         case MPIDI_RANK_MAP_MLUT:
             max_n_avts = MPIDIU_get_max_n_avts();
-            uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int));
+            uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int), MPL_MEM_ADDRESS);
             memset(uniq_avtids, 0, max_n_avts * sizeof(int));
             for (i = 0; i < MPIDI_COMM(comm, local_map).size; i++) {
                 if (uniq_avtids[MPIDI_COMM(comm, local_map).irreg.mlut.gpid[i].avtid] == 0) {
@@ -226,7 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_free_hook(MPIR_Comm * comm)
         break;
     case MPIDI_RANK_MAP_MLUT:
         max_n_avts = MPIDIU_get_max_n_avts();
-        uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int));
+        uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int), MPL_MEM_ADDRESS);
         memset(uniq_avtids, 0, max_n_avts * sizeof(int));
         for (i = 0; i < MPIDI_COMM(comm, map).size; i++) {
             if (uniq_avtids[MPIDI_COMM(comm, map).irreg.mlut.gpid[i].avtid] == 0) {
@@ -245,7 +245,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_free_hook(MPIR_Comm * comm)
         break;
     case MPIDI_RANK_MAP_MLUT:
         max_n_avts = MPIDIU_get_max_n_avts();
-        uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int));
+        uniq_avtids = (int *) MPL_malloc(max_n_avts * sizeof(int), MPL_MEM_ADDRESS);
         memset(uniq_avtids, 0, max_n_avts * sizeof(int));
         for (i = 0; i < MPIDI_COMM(comm, local_map).size; i++) {
             if (uniq_avtids[MPIDI_COMM(comm, local_map).irreg.mlut.gpid[i].avtid] == 0) {
@@ -366,9 +366,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
                          local_size, *remote_size, pure_intracomm));
 
         MPIR_CHKPMEM_MALLOC((*remote_lupids), int *, (*remote_size) * sizeof(int),
-                            mpi_errno, "remote_lupids");
+                            mpi_errno, "remote_lupids", MPL_MEM_ADDRESS);
         MPIR_CHKLMEM_MALLOC(local_lupids, int *, local_size * sizeof(int),
-                            mpi_errno, "local_lupids");
+                            mpi_errno, "local_lupids", MPL_MEM_ADDRESS);
         for (i = 0; i < local_size; i++) {
             MPIDIU_comm_rank_to_pid(local_comm, i, &lpid, &avtid);
             local_lupids[i] = MPIDIU_LUPID_CREATE(avtid, lpid);
@@ -379,7 +379,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
         if (!pure_intracomm) {
             /* Stage 1.1 UPID exchange between leaders */
             MPIR_CHKLMEM_MALLOC(remote_upid_size, size_t *, (*remote_size) * sizeof(size_t),
-                                mpi_errno, "remote_upid_size");
+                                mpi_errno, "remote_upid_size", MPL_MEM_ADDRESS);
 
             mpi_errno = MPIDI_NM_get_local_upids(local_comm, &local_upid_size, &local_upids);
             if (mpi_errno)
@@ -398,7 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
             for (i = 0; i < *remote_size; i++)
                 upid_recv_size += remote_upid_size[i];
             MPIR_CHKLMEM_MALLOC(remote_upids, char *, upid_recv_size * sizeof(char),
-                                mpi_errno, "remote_upids");
+                                mpi_errno, "remote_upids", MPL_MEM_ADDRESS);
             mpi_errno = MPIC_Sendrecv(local_upids, upid_send_size, MPI_BYTE,
                                       remote_leader, cts_tag,
                                       remote_upids, upid_recv_size, MPI_BYTE,
@@ -408,10 +408,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
                 MPIR_ERR_POP(mpi_errno);
 
             MPIR_CHKLMEM_MALLOC(local_node_ids, int *,
-                                local_size * sizeof(int), mpi_errno, "local_node_ids");
+                                local_size * sizeof(int), mpi_errno, "local_node_ids", MPL_MEM_ADDRESS);
             MPIR_CHKLMEM_MALLOC(remote_node_ids, int *,
                                 (*remote_size) * sizeof(int),
-                                mpi_errno, "remote_node_ids");
+                                mpi_errno, "remote_node_ids", MPL_MEM_ADDRESS);
             for (i = 0; i < local_size; i++) {
                 MPIDI_CH4U_get_node_id(local_comm, i, &local_node_ids[i]);
             }

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -169,7 +169,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_ADD);
 
     MPIDI_CH4U_win_target_t *target_ptr = NULL;
-    target_ptr = (MPIDI_CH4U_win_target_t *) MPL_malloc(sizeof(MPIDI_CH4U_win_target_t));
+    target_ptr = (MPIDI_CH4U_win_target_t *) MPL_malloc(sizeof(MPIDI_CH4U_win_target_t), MPL_MEM_RMA);
     target_ptr->rank = rank;
     MPIR_cc_set(&target_ptr->local_cmpl_cnts, 0);
     MPIR_cc_set(&target_ptr->remote_cmpl_cnts, 0);
@@ -177,7 +177,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR
     target_ptr->sync.access_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     target_ptr->sync.assert_mode = 0;
 
-    HASH_ADD(hash_handle, MPIDI_CH4U_WIN(win, targets), rank, sizeof(int), target_ptr);
+    HASH_ADD(hash_handle, MPIDI_CH4U_WIN(win, targets), rank, sizeof(int), target_ptr, MPL_MEM_RMA);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_WIN_TARGET_ADD);
     return target_ptr;
@@ -843,10 +843,10 @@ static inline void MPIDI_win_check_group_local_completed(MPIR_Win * win,
 #define FUNCNAME MPIDI_CH4U_map_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_create(void **out_map)
+MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_create(void **out_map, MPL_memory_class class)
 {
     MPIDI_CH4U_map_t *map;
-    map = MPL_malloc(sizeof(MPIDI_CH4U_map_t));
+    map = MPL_malloc(sizeof(MPIDI_CH4U_map_t), class);
     MPIR_Assert(map != NULL);
     map->head = NULL;
     *out_map = map;
@@ -869,17 +869,17 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_destroy(void *in_map)
 #define FUNCNAME MPIDI_CH4U_map_set
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void *val)
+MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void *val, MPL_memory_class class)
 {
     MPIDI_CH4U_map_t *map;
     MPIDI_CH4U_map_entry_t *map_entry;
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
     map = (MPIDI_CH4U_map_t *) in_map;
-    map_entry = MPL_malloc(sizeof(MPIDI_CH4U_map_entry_t));
+    map_entry = MPL_malloc(sizeof(MPIDI_CH4U_map_entry_t), class);
     MPIR_Assert(map_entry != NULL);
     map_entry->key = id;
     map_entry->value = val;
-    HASH_ADD(hh, map->head, key, sizeof(uint64_t), map_entry);
+    HASH_ADD(hh, map->head, key, sizeof(uint64_t), map_entry, class);
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
 }
 

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
         MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmi_init", "**pmi_init %d", pmi_errno);
     }
 
-    MPIDI_CH4_Global.jobid = (char *) MPL_malloc(MPIDI_MAX_JOBID_LEN);
+    MPIDI_CH4_Global.jobid = (char *) MPL_malloc(MPIDI_MAX_JOBID_LEN, MPL_MEM_OTHER);
     pmi_errno = PMI2_Job_GetId(MPIDI_CH4_Global.jobid, MPIDI_MAX_JOBID_LEN);
     if (pmi_errno != PMI_SUCCESS) {
         MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmi_job_getid",
@@ -180,7 +180,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
                              "**pmi_kvs_get_name_length_max %d", pmi_errno);
     }
 
-    MPIDI_CH4_Global.jobid = (char *) MPL_malloc(max_pmi_name_length);
+    MPIDI_CH4_Global.jobid = (char *) MPL_malloc(max_pmi_name_length, MPL_MEM_OTHER);
     pmi_errno = PMI_KVS_Get_my_name(MPIDI_CH4_Global.jobid, max_pmi_name_length);
     if (pmi_errno != PMI_SUCCESS) {
         MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmi_kvs_get_my_name",
@@ -212,7 +212,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 
     MPIDI_av_table[0] = (MPIDI_av_table_t *)
         MPL_malloc(size * sizeof(MPIDI_av_entry_t)
-                   + sizeof(MPIDI_av_table_t));
+                   + sizeof(MPIDI_av_table_t), MPL_MEM_ADDRESS);
 
     MPIDI_av_table[0]->size = size;
     MPIR_Object_set_ref(MPIDI_av_table[0], 1);
@@ -467,13 +467,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_processor_name(char *name, int namelen, in
 #define FUNCNAME MPID_Alloc_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+MPL_STATIC_INLINE_PREFIX void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
     void *p;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ALLOC_MEM);
 
-    p = MPIDI_NM_mpi_alloc_mem(size, info_ptr);
+    p = MPIDI_NM_mpi_alloc_mem(size, info_ptr, class);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ALLOC_MEM);
     return p;

--- a/src/mpid/ch4/src/ch4_spawn.h
+++ b/src/mpid/ch4/src/ch4_spawn.h
@@ -51,7 +51,7 @@ static inline int MPIDI_mpi_to_pmi_keyvals(MPIR_Info * info_ptr,
     if (nkeys == 0)
         goto fn_exit;
 
-    kv = (PMI_keyval_t *) MPL_malloc(nkeys * sizeof(PMI_keyval_t));
+    kv = (PMI_keyval_t *) MPL_malloc(nkeys * sizeof(PMI_keyval_t), MPL_MEM_BUFFER);
 
     for (i = 0; i < nkeys; i++) {
         mpi_errno = MPIR_Info_get_nthkey_impl(info_ptr, i, key);
@@ -59,7 +59,7 @@ static inline int MPIDI_mpi_to_pmi_keyvals(MPIR_Info * info_ptr,
             MPIR_ERR_POP(mpi_errno);
         MPIR_Info_get_valuelen_impl(info_ptr, key, &vallen, &flag);
         kv[i].key = (const char *) MPL_strdup(key);
-        kv[i].val = (char *) MPL_malloc(vallen + 1);
+        kv[i].val = (char *) MPL_malloc(vallen + 1, MPL_MEM_BUFFER);
         MPIR_Info_get_impl(info_ptr, key, vallen + 1, kv[i].val, &flag);
     }
 
@@ -126,7 +126,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_spawn_multiple(int count,
         for (i = 0; i < count; i++)
             total_num_processes += maxprocs[i];
 
-        pmi_errcodes = (int *) MPL_malloc(sizeof(int) * total_num_processes);
+        pmi_errcodes = (int *) MPL_malloc(sizeof(int) * total_num_processes, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!pmi_errcodes, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         for (i = 0; i < total_num_processes; i++)
@@ -136,9 +136,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_spawn_multiple(int count,
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        info_keyval_sizes = (int *) MPL_malloc(count * sizeof(int));
+        info_keyval_sizes = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!info_keyval_sizes, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        info_keyval_vectors = (PMI_keyval_t **) MPL_malloc(count * sizeof(PMI_keyval_t *));
+        info_keyval_vectors = (PMI_keyval_t **) MPL_malloc(count * sizeof(PMI_keyval_t *), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!info_keyval_vectors, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         if (!info_ptrs)

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -1107,7 +1107,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_check_disjoint_lupids(int lupids1[], int n1,
 
     if (mask_size > 128) {
         MPIR_CHKLMEM_MALLOC(lupidmask, uint32_t *, mask_size * sizeof(uint32_t),
-                            mpi_errno, "lupidmask");
+                            mpi_errno, "lupidmask", MPL_MEM_COMM);
     }
     else {
         lupidmask = lupidmaskPrealloc;

--- a/src/mpid/ch4/src/ch4r_buf.h
+++ b/src/mpid/ch4/src/ch4r_buf.h
@@ -34,14 +34,14 @@ static inline MPIU_buf_pool_t *MPIDI_create_buf_pool(int num, int size,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CREATE_BUF_POOL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CREATE_BUF_POOL);
 
-    buf_pool = (MPIU_buf_pool_t *) MPL_malloc(sizeof(*buf_pool));
+    buf_pool = (MPIU_buf_pool_t *) MPL_malloc(sizeof(*buf_pool), MPL_MEM_BUFFER);
     MPIR_Assert(buf_pool);
     MPID_Thread_mutex_create(&buf_pool->lock, &ret);
 
     buf_pool->size = size;
     buf_pool->num = num;
     buf_pool->next = NULL;
-    buf_pool->memory_region = MPL_malloc(num * (sizeof(MPIU_buf_t) + size));
+    buf_pool->memory_region = MPL_malloc(num * (sizeof(MPIU_buf_t) + size), MPL_MEM_BUFFER);
     MPIR_Assert(buf_pool->memory_region);
 
     curr = (MPIU_buf_t *) buf_pool->memory_region;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -247,7 +247,7 @@ static inline int MPIDI_do_send_target(void **data,
         n_iov = (int) num_iov;
         MPIR_Assert(n_iov > 0);
         MPIDI_CH4U_REQUEST(rreq, req->iov) =
-            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_BUFFER);
         MPIR_Assert(MPIDI_CH4U_REQUEST(rreq, req->iov));
 
         last = *p_data_sz;
@@ -396,7 +396,7 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
         rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RECV, 2);
         MPIDI_CH4U_REQUEST(rreq, datatype) = MPI_BYTE;
         if (p_data_sz) {
-            MPIDI_CH4U_REQUEST(rreq, buffer) = (char *) MPL_malloc(*p_data_sz);
+            MPIDI_CH4U_REQUEST(rreq, buffer) = (char *) MPL_malloc(*p_data_sz, MPL_MEM_BUFFER);
             MPIDI_CH4U_REQUEST(rreq, count) = *p_data_sz;
         }
         else {

--- a/src/mpid/ch4/src/ch4r_comm.h
+++ b/src/mpid/ch4/src/ch4r_comm.h
@@ -141,23 +141,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm *local_c
         pure_intracomm = map_info[3];
 
         MPIR_CHKPMEM_MALLOC((*remote_lupids), int*, (*remote_size) * sizeof(int),
-                            mpi_errno, "remote_lupids");
+                            mpi_errno, "remote_lupids", MPL_MEM_COMM);
         if (!pure_intracomm) {
             MPIR_CHKLMEM_MALLOC(_remote_upid_size, size_t*, (*remote_size) * sizeof(size_t),
-                                mpi_errno, "_remote_upid_size");
+                                mpi_errno, "_remote_upid_size", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_intra(_remote_upid_size, *remote_size, MPI_UNSIGNED_LONG,
                                          local_leader, local_comm, &errflag);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_CHKLMEM_MALLOC(_remote_upids, char*, upid_recv_size * sizeof(char),
-                                mpi_errno, "_remote_upids");
+                                mpi_errno, "_remote_upids", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_intra(_remote_upids, upid_recv_size, MPI_BYTE,
                                          local_leader, local_comm, &errflag);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_CHKLMEM_MALLOC(_remote_node_ids, int*,
                                 (*remote_size) * sizeof(int),
-                                mpi_errno, "_remote_node_ids");
+                                mpi_errno, "_remote_node_ids", MPL_MEM_COMM);
             mpi_errno =
                 MPIR_Bcast_intra(_remote_node_ids, (*remote_size) * sizeof(int), MPI_BYTE,
                                  local_leader, local_comm, &errflag);
@@ -196,7 +196,7 @@ static inline int MPIDIU_alloc_lut(MPIDI_rank_map_lut_t ** lut, int size)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ALLOC_LUT);
 
     new_lut = (MPIDI_rank_map_lut_t *) MPL_malloc(sizeof(MPIDI_rank_map_lut_t)
-                                                  + size * sizeof(MPIDI_lpid_t));
+                                                  + size * sizeof(MPIDI_lpid_t), MPL_MEM_ADDRESS);
     if (new_lut == NULL) {
         *lut = NULL;
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
@@ -250,7 +250,7 @@ static inline int MPIDIU_alloc_mlut(MPIDI_rank_map_mlut_t ** mlut, int size)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_ALLOC_MLUT);
 
     new_mlut = (MPIDI_rank_map_mlut_t *) MPL_malloc(sizeof(MPIDI_rank_map_mlut_t)
-                                                    + size * sizeof(MPIDI_gpid_t));
+                                                    + size * sizeof(MPIDI_gpid_t), MPL_MEM_ADDRESS);
     if (new_mlut == NULL) {
         *mlut = NULL;
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -110,12 +110,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_destroy_comm(MPIR_Comm * comm)
 #define FUNCNAME MPIDI_CH4U_mpi_alloc_mem
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr, MPL_memory_class class)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_ALLOC_MEM);
     void *p;
-    p = MPL_malloc(size);
+    p = MPL_malloc(size, class);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_MPI_ALLOC_MEM);
     return p;
 }

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -524,13 +524,13 @@ static inline int MPIDIU_avt_init()
     MPIDI_CH4_Global.avt_mgr.n_avts = 0;
 
     MPIDI_av_table = (MPIDI_av_table_t **)
-                      mmap(NULL, MPIDI_CH4_Global.avt_mgr.mmapped_size,
-                           PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
+                      MPL_mmap(NULL, MPIDI_CH4_Global.avt_mgr.mmapped_size,
+                               PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     MPIR_ERR_CHKANDSTMT(MPIDI_av_table == MAP_FAILED, mpi_errno, MPI_ERR_NO_MEM,
                         goto fn_fail, "**nomem");
 
     MPIDI_CH4_Global.node_map = (int **)
-                                mmap(NULL, MPIDI_CH4_Global.avt_mgr.mmapped_size,
+                                MPL_mmap(NULL, MPIDI_CH4_Global.avt_mgr.mmapped_size,
                                      PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0);
     MPIR_ERR_CHKANDSTMT(MPIDI_CH4_Global.node_map == MAP_FAILED, mpi_errno,
                         MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
@@ -557,8 +557,8 @@ static inline int MPIDIU_avt_destroy()
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_AVT_DESTROY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_AVT_DESTROY);
 
-    munmap((void *)MPIDI_CH4_Global.node_map, MPIDI_CH4_Global.avt_mgr.mmapped_size);
-    munmap((void *)MPIDI_av_table, MPIDI_CH4_Global.avt_mgr.mmapped_size);
+    MPL_munmap((void *)MPIDI_CH4_Global.node_map, MPIDI_CH4_Global.avt_mgr.mmapped_size);
+    MPL_munmap((void *)MPIDI_av_table, MPIDI_CH4_Global.avt_mgr.mmapped_size);
     MPL_free(MPIDI_CH4_Global.avt_mgr.free_avtid);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_AVT_DESTROY);

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -107,7 +107,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
     n_iov = (int) num_iov;
     MPIR_Assert(n_iov > 0);
     am_hdr.n_iov = n_iov;
-    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_BUFFER);
     MPIR_Assert(dt_iov);
 
     last = data_sz;
@@ -248,7 +248,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     n_iov = (int) num_iov;
     MPIR_Assert(n_iov > 0);
     am_hdr.n_iov = n_iov;
-    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_BUFFER);
     MPIR_Assert(dt_iov);
 
     last = data_sz;
@@ -379,7 +379,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     n_iov = (int) num_iov;
     MPIR_Assert(n_iov > 0);
     am_hdr.n_iov = n_iov;
-    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_BUFFER);
     MPIR_Assert(dt_iov);
 
     last = data_sz;
@@ -542,7 +542,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     n_iov = (int) num_iov;
     MPIR_Assert(n_iov > 0);
     am_hdr.n_iov = n_iov;
-    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+    dt_iov = (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_BUFFER);
     MPIR_Assert(dt_iov);
 
     last = data_sz;
@@ -931,7 +931,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     if (data_sz == 0)
         goto fn_exit;
 
-    p_data = MPL_malloc(data_sz * 2);
+    p_data = MPL_malloc(data_sz * 2, MPL_MEM_BUFFER);
     MPIR_Assert(p_data);
     MPIR_Memcpy(p_data, (char *) origin_addr, data_sz);
     MPIR_Memcpy((char *) p_data + data_sz, (char *) compare_addr, data_sz);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -417,7 +417,7 @@ static inline void MPIDI_win_lock_req_proc(int handler_id,
 
     MPIR_T_PVAR_TIMER_START(RMA, rma_winlock_getlocallock);
     struct MPIDI_CH4U_win_lock *lock = (struct MPIDI_CH4U_win_lock *)
-        MPL_calloc(1, sizeof(struct MPIDI_CH4U_win_lock));
+        MPL_calloc(1, sizeof(struct MPIDI_CH4U_win_lock), MPL_MEM_RMA);
 
     lock->mtype = handler_id;
     lock->rank = info->origin_rank;
@@ -641,7 +641,7 @@ static inline int MPIDI_do_accumulate_op(void *source_buf, int source_count,
         vec_len = dtp->max_contig_blocks * target_count + 1;
         /* +1 needed because Rob says so */
         dloop_vec = (DLOOP_VECTOR *)
-            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR));
+            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR), MPL_MEM_RMA);
         /* --BEGIN ERROR HANDLING-- */
         if (!dloop_vec) {
             mpi_errno =
@@ -796,7 +796,7 @@ static inline int MPIDI_handle_get_acc_cmpl(MPIR_Request * rreq)
 
     /* MPIDI_CS_ENTER(); */
 
-    original = (char *) MPL_malloc(data_sz);
+    original = (char *) MPL_malloc(data_sz, MPL_MEM_RMA);
     MPIR_Assert(original);
 
     if (MPIDI_CH4U_REQUEST(rreq, req->areq.op) == MPI_NO_OP) {
@@ -880,7 +880,7 @@ static inline void MPIDI_handle_acc_data(void **data, size_t * p_data_sz, int *i
     MPIDI_Datatype_check_size(MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
                               MPIDI_CH4U_REQUEST(rreq, req->areq.origin_count), data_sz);
     if (data_sz) {
-        p_data = MPL_malloc(data_sz);
+        p_data = MPL_malloc(data_sz, MPL_MEM_RMA);
         MPIR_Assert(p_data);
     }
 
@@ -946,7 +946,7 @@ static inline int MPIDI_get_target_cmpl_cb(MPIR_Request * req)
         data_sz += iov[i].iov_len;
     }
 
-    p_data = (char *) MPL_malloc(data_sz);
+    p_data = (char *) MPL_malloc(data_sz, MPL_MEM_RMA);
     MPIR_Assert(p_data);
 
     offset = 0;
@@ -1419,7 +1419,7 @@ static inline int MPIDI_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
         n_iov = (int) num_iov;
         MPIR_Assert(n_iov > 0);
         MPIDI_CH4U_REQUEST(areq, req->iov) =
-            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_RMA);
         MPIR_Assert(MPIDI_CH4U_REQUEST(areq, req->iov));
 
         last = data_sz;
@@ -1591,7 +1591,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
     offset = win->disp_unit * msg_hdr->target_disp;
     if (msg_hdr->n_iov) {
         int i;
-        dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov);
+        dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
         MPIR_Assert(dt_iov);
 
         iov = (struct iovec *) ((char *) am_hdr + sizeof(*msg_hdr));
@@ -1626,7 +1626,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
         n_iov = (int) num_iov;
         MPIR_Assert(n_iov > 0);
         MPIDI_CH4U_REQUEST(rreq, req->iov) =
-            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_RMA);
         MPIR_Assert(MPIDI_CH4U_REQUEST(rreq, req->iov));
 
         last = data_sz;
@@ -1684,7 +1684,7 @@ static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
     /* Base adjustment for iov will be done after we get the entire iovs,
      * at MPIDI_CH4U_put_data_target_msg_cb */
     MPIR_Assert(msg_hdr->n_iov);
-    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov);
+    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
     MPIR_Assert(dt_iov);
 
     MPIDI_CH4U_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
@@ -2000,7 +2000,7 @@ static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_REQUEST(*req, rank) = msg_hdr->src_rank;
 
     MPIR_Assert(dt_contig == 1);
-    p_data = MPL_malloc(data_sz * 2);
+    p_data = MPL_malloc(data_sz * 2, MPL_MEM_RMA);
     MPIR_Assert(p_data);
 
     *p_data_sz = data_sz * 2;
@@ -2044,7 +2044,7 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIDI_Datatype_check_size(msg_hdr->origin_datatype, msg_hdr->origin_count, data_sz);
     if (data_sz) {
-        p_data = MPL_malloc(data_sz);
+        p_data = MPL_malloc(data_sz, MPL_MEM_RMA);
         MPIR_Assert(p_data);
     }
 
@@ -2081,7 +2081,7 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
         goto fn_exit;
     }
 
-    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov);
+    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
     MPIR_Assert(dt_iov);
 
     iov = (struct iovec *) ((char *) msg_hdr + sizeof(*msg_hdr));
@@ -2172,7 +2172,7 @@ static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_REQUEST(*req, req->areq.data_sz) = msg_hdr->result_data_sz;
     MPIDI_CH4U_REQUEST(*req, rank) = msg_hdr->src_rank;
 
-    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov);
+    dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
     MPIDI_CH4U_REQUEST(rreq, req->areq.dt_iov) = dt_iov;
     MPIR_Assert(dt_iov);
 
@@ -2264,7 +2264,7 @@ static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_REQUEST(rreq, rank) = msg_hdr->src_rank;
 
     if (msg_hdr->n_iov) {
-        iov = (struct iovec *) MPL_malloc(msg_hdr->n_iov * sizeof(*iov));
+        iov = (struct iovec *) MPL_malloc(msg_hdr->n_iov * sizeof(*iov), MPL_MEM_RMA);
         MPIR_Assert(iov);
 
         *data = (void *) iov;
@@ -2340,7 +2340,7 @@ static inline int MPIDI_get_ack_target_msg_cb(int handler_id, void *am_hdr,
         n_iov = (int) num_iov;
         MPIR_Assert(n_iov > 0);
         MPIDI_CH4U_REQUEST(rreq, req->iov) =
-            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec));
+            (struct iovec *) MPL_malloc(n_iov * sizeof(struct iovec), MPL_MEM_RMA);
         MPIR_Assert(MPIDI_CH4U_REQUEST(rreq, req->iov));
 
         last = data_sz;

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -243,9 +243,8 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
 
             if (comm->rank == maxloc_result.loc) {
                 map_pointer = (uintptr_t) MPIDI_CH4R_generate_random_addr(mapsize);
-                baseP = mmap((void *) map_pointer,
-                             mapsize,
-                             PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+                baseP = MPL_mmap((void *) map_pointer, mapsize,
+                                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
             }
 
             mpi_errno = MPIR_Bcast_impl(&map_pointer,
@@ -258,9 +257,8 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
                 int rc = MPIDI_CH4R_check_maprange_ok((void *) map_pointer, mapsize);
 
                 if (rc) {
-                    baseP = mmap((void *) map_pointer,
-                                 mapsize,
-                                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+                    baseP = MPL_mmap((void *) map_pointer, mapsize,
+                                     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
                 }
                 else
                     baseP = (void *) -1ULL;
@@ -277,7 +275,7 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
                 goto fn_fail;
 
             if (result == 0 && baseP != (void *) -1ULL)
-                munmap(baseP, mapsize);
+                MPL_munmap(baseP, mapsize);
         }
     }
     else

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -244,7 +244,7 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
             if (comm->rank == maxloc_result.loc) {
                 map_pointer = (uintptr_t) MPIDI_CH4R_generate_random_addr(mapsize);
                 baseP = MPL_mmap((void *) map_pointer, mapsize,
-                                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+                                 PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0, MPL_MEM_RMA);
             }
 
             mpi_errno = MPIR_Bcast_impl(&map_pointer,
@@ -258,7 +258,7 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
 
                 if (rc) {
                     baseP = MPL_mmap((void *) map_pointer, mapsize,
-                                     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+                                     PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0, MPL_MEM_RMA);
                 }
                 else
                     baseP = (void *) -1ULL;
@@ -275,7 +275,7 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
                 goto fn_fail;
 
             if (result == 0 && baseP != (void *) -1ULL)
-                MPL_munmap(baseP, mapsize);
+                MPL_munmap(baseP, mapsize, MPL_MEM_RMA);
         }
     }
     else
@@ -285,7 +285,7 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
     if (iter == 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     "WARNING: Win_allocate:  Unable to allocate symmetric heap\n");
-        baseP = MPL_malloc(size);
+        baseP = MPL_malloc(size, MPL_MEM_RMA);
         MPIR_ERR_CHKANDJUMP((baseP == NULL), mpi_errno, MPI_ERR_BUFFER, "**bufnull");
         MPIDI_CH4U_WIN(win, mmap_sz) = -1ULL;
         MPIDI_CH4U_WIN(win, mmap_addr) = NULL;

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -723,14 +723,14 @@ static inline int MPIDI_CH4R_win_finalize(MPIR_Win ** win_ptr)
 
     if (win->create_flavor == MPI_WIN_FLAVOR_ALLOCATE && win->base) {
         if (MPIDI_CH4U_WIN(win, mmap_sz) > 0)
-            munmap(MPIDI_CH4U_WIN(win, mmap_addr), MPIDI_CH4U_WIN(win, mmap_sz));
+            MPL_munmap(MPIDI_CH4U_WIN(win, mmap_addr), MPIDI_CH4U_WIN(win, mmap_sz));
         else if (MPIDI_CH4U_WIN(win, mmap_sz) == -1)
             MPL_free(win->base);
     }
 
     if (win->create_flavor == MPI_WIN_FLAVOR_SHARED) {
         if (MPIDI_CH4U_WIN(win, mmap_addr))
-            munmap(MPIDI_CH4U_WIN(win, mmap_addr), MPIDI_CH4U_WIN(win, mmap_sz));
+            MPL_munmap(MPIDI_CH4U_WIN(win, mmap_addr), MPIDI_CH4U_WIN(win, mmap_sz));
         MPL_free(MPIDI_CH4U_WIN(win, sizes));
     }
 
@@ -1031,7 +1031,7 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
             goto fn_fail;
 
         if (anyfail && map_ptr != NULL && map_ptr != MAP_FAILED)
-            munmap(map_ptr, mapsize);
+            MPL_munmap(map_ptr, mapsize);
     }
 
     if (anyfail) {      /* Still fails after retry, report error. */

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -203,7 +203,7 @@ int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
         MPIR_ERR_POP(mpi_errno);
     }
     comm_ptr->hcoll_priv.hcoll_origin_coll_fns = comm_ptr->coll_fns;
-    comm_ptr->coll_fns = (MPIR_Collops *) MPL_malloc(sizeof(MPIR_Collops));
+    comm_ptr->coll_fns = (MPIR_Collops *) MPL_malloc(sizeof(MPIR_Collops), MPL_MEM_COMM);
     memset(comm_ptr->coll_fns, 0, sizeof(MPIR_Collops));
     if (comm_ptr->hcoll_priv.hcoll_origin_coll_fns != 0) {
         memcpy(comm_ptr->coll_fns, comm_ptr->hcoll_priv.hcoll_origin_coll_fns,

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -401,7 +401,7 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
 
     /* this mem will be freed by the progress engine when the request is completed */
     MPIR_CHKPMEM_MALLOC(s, struct MPIDU_Sched *, sizeof(struct MPIDU_Sched), mpi_errno,
-                        "schedule object");
+                        "schedule object", MPL_MEM_COMM);
 
     s->size = MPIDU_SCHED_INITIAL_ENTRIES;
     s->idx = 0;
@@ -415,7 +415,7 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
     /* this mem will be freed by the progress engine when the request is completed */
     MPIR_CHKPMEM_MALLOC(s->entries, struct MPIDU_Sched_entry *,
                         MPIDU_SCHED_INITIAL_ENTRIES * sizeof(struct MPIDU_Sched_entry), mpi_errno,
-                        "schedule entries vector");
+                        "schedule entries vector", MPL_MEM_COMM);
 
     /* TODO in a debug build, defensively mark all entries as status=INVALID */
 
@@ -533,7 +533,7 @@ static int MPIDU_Sched_add_entry(struct MPIDU_Sched *s, int *idx, struct MPIDU_S
 
     if (s->num_entries == s->size) {
         /* need to grow the entries array */
-        s->entries = MPL_realloc(s->entries, 2 * s->size * sizeof(struct MPIDU_Sched_entry));
+        s->entries = MPL_realloc(s->entries, 2 * s->size * sizeof(struct MPIDU_Sched_entry), MPL_MEM_COMM);
         if (s->entries == NULL)
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         s->size *= 2;

--- a/src/mpid/common/shm/mpidu_shm.h
+++ b/src/mpid/common/shm/mpidu_shm.h
@@ -36,9 +36,9 @@ typedef struct MPIDU_shm_seg_info
     char *addr;
 } MPIDU_shm_seg_info_t;
 
-int MPIDU_shm_seg_alloc(size_t len, void **ptr_p);
+int MPIDU_shm_seg_alloc(size_t len, void **ptr_p, MPL_memory_class class);
 int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
-                     int num_local, int local_rank, int local_procs_0, int rank);
+                     int num_local, int local_rank, int local_procs_0, int rank, MPL_memory_class class);
 int MPIDU_shm_seg_destroy(MPIDU_shm_seg_t *memory, int num_local);
 
 int MPIDU_shm_barrier_init(MPIDU_shm_barrier_t *barrier_region,

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -76,7 +76,7 @@ static asym_check_region* asym_check_region_p = NULL;
 #define FUNCNAME MPIDU_shm_seg_alloc
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_shm_seg_alloc(size_t len, void **ptr_p)
+int MPIDU_shm_seg_alloc(size_t len, void **ptr_p, MPL_memory_class class)
 {
     int mpi_errno = MPI_SUCCESS;
     alloc_elem_t *ep;
@@ -92,7 +92,7 @@ int MPIDU_shm_seg_alloc(size_t len, void **ptr_p)
     MPIR_Assert(len);
     MPIR_Assert(ptr_p);
 
-    MPIR_CHKPMEM_MALLOC(ep, alloc_elem_t *, sizeof(alloc_elem_t), mpi_errno, "el");
+    MPIR_CHKPMEM_MALLOC(ep, alloc_elem_t *, sizeof(alloc_elem_t), mpi_errno, "el", class);
     
     ep->ptr_p = ptr_p;
     ep->len = len;
@@ -130,7 +130,7 @@ int MPIDU_shm_seg_alloc(size_t len, void **ptr_p)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
-                     int num_local, int local_rank, int local_procs_0, int rank)
+                     int num_local, int local_rank, int local_procs_0, int rank, MPL_memory_class class)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -159,7 +159,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
     MPIR_Assert(segment_len > 0);
 
     /* allocate an area to check if the segment was allocated symmetrically */
-    mpi_errno = MPIDU_shm_seg_alloc(sizeof(asym_check_region), (void **) &asym_check_region_p);
+    mpi_errno = MPIDU_shm_seg_alloc(sizeof(asym_check_region), (void **) &asym_check_region_p, class);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     mpi_errno = MPL_shm_hnd_init(&(memory->hnd));
@@ -220,7 +220,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
     else {
-        MPIR_CHKLMEM_MALLOC(key, char *, PMI2_MAX_KEYLEN, mpi_errno, "key");
+        MPIR_CHKLMEM_MALLOC(key, char *, PMI2_MAX_KEYLEN, mpi_errno, "key", MPL_MEM_SHM);
         MPL_snprintf(key, PMI2_MAX_KEYLEN, "sharedFilename-%d", num_segments);
 
         if (local_rank == 0) {
@@ -254,7 +254,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
             int found = FALSE;
 
             /* Allocate space for pmi key and val */
-            MPIR_CHKLMEM_MALLOC(val, char *, PMI2_MAX_VALLEN, mpi_errno, "val");
+            MPIR_CHKLMEM_MALLOC(val, char *, PMI2_MAX_VALLEN, mpi_errno, "val", MPL_MEM_SHM);
 
             /* get name of shared file */
             mpi_errno = PMI2_Info_GetNodeAttr(key, val, PMI2_MAX_VALLEN, &found, TRUE);
@@ -301,7 +301,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
     {
         char *addr;
 
-        MPIR_CHKPMEM_MALLOC(addr, char *, segment_len + MPIDU_SHM_CACHE_LINE_LEN, mpi_errno, "segment");
+        MPIR_CHKPMEM_MALLOC(addr, char *, segment_len + MPIDU_SHM_CACHE_LINE_LEN, mpi_errno, "segment", class);
 
         memory->base_addr = addr;
         current_addr =
@@ -326,11 +326,11 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t *memory, MPIDU_shm_barrier_t **barrier,
         /* Allocate space for pmi key and val */
         pmi_errno = PMI_KVS_Get_key_length_max(&key_max_sz);
         MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
-        MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key");
+        MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key", class);
 
         pmi_errno = PMI_KVS_Get_value_length_max(&val_max_sz);
         MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
-        MPIR_CHKLMEM_MALLOC(val, char *, val_max_sz, mpi_errno, "val");
+        MPIR_CHKLMEM_MALLOC(val, char *, val_max_sz, mpi_errno, "val", class);
 
         mpi_errno = PMI_KVS_Get_my_name(kvs_name, 256);
         if (mpi_errno) MPIR_ERR_POP (mpi_errno);

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -606,7 +606,7 @@ do {                                                                    \
 #define MPIDU_THREADPRIV_KEY_CREATE                                     \
     do {                                                                \
         int err_ = 0;                                                   \
-        MPL_THREADPRIV_KEY_CREATE(MPIR_Per_thread_key, MPIR_Per_thread, &err_); \
+        MPL_THREADPRIV_KEY_CREATE(MPIR_Per_thread_key, MPIR_Per_thread, &err_, MPL_MEM_THREAD); \
         MPIR_Assert(err_ == 0);                                         \
     } while (0)
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -125,7 +125,7 @@ if test "$pac_cv_have___typeof" = "yes" ; then
 fi
 
 dnl Check if the necessary headers are available
-AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h unistd.h errno.h windows.h)
+AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h unistd.h errno.h windows.h sys/mman.h)
 
 # A C99 compliant compiler should have inttypes.h for fixed-size int types
 AC_CHECK_HEADERS(inttypes.h stdint.h)

--- a/src/mpl/include/mpl_shm.h
+++ b/src/mpl/include/mpl_shm.h
@@ -58,7 +58,7 @@
 /* Returns 0 on success, -1 on error */
 #define MPL_shm_hnd_ref_alloc(hnd)(                               \
     ((hnd)->ghnd = (MPLI_shm_ghnd_t)                               \
-                    MPL_malloc(MPLI_SHM_GHND_SZ)) ? 0 : -1        \
+                    MPL_malloc(MPLI_SHM_GHND_SZ, MPL_MEM_SHM)) ? 0 : -1 \
 )
 
 
@@ -91,10 +91,10 @@
 /* Allocate mem for global handle.
  * Returns 0 on success, -1 on failure 
  */
-static inline int MPLI_shm_ghnd_alloc(MPL_shm_hnd_t hnd)
+static inline int MPLI_shm_ghnd_alloc(MPL_shm_hnd_t hnd, MPL_memory_class class)
 {
     if(!(hnd->ghnd)){
-        hnd->ghnd = (MPLI_shm_ghnd_t)MPL_malloc(MPLI_SHM_GHND_SZ);
+        hnd->ghnd = (MPLI_shm_ghnd_t)MPL_malloc(MPLI_SHM_GHND_SZ, class);
         if(!(hnd->ghnd)){ return -1; }
     }
     /* Global handle is no longer static */
@@ -105,9 +105,9 @@ static inline int MPLI_shm_ghnd_alloc(MPL_shm_hnd_t hnd)
 
 /* Allocate mem for handle. Lazy allocation for global handle */
 /* Returns 0 on success, -1 on error */
-static inline int MPLI_shm_hnd_alloc(MPL_shm_hnd_t *hnd_ptr)
+static inline int MPLI_shm_hnd_alloc(MPL_shm_hnd_t *hnd_ptr, MPL_memory_class class)
 {
-    *hnd_ptr = (MPL_shm_hnd_t) MPL_malloc(MPL_SHM_HND_SZ);
+    *hnd_ptr = (MPL_shm_hnd_t) MPL_malloc(MPL_SHM_HND_SZ, class);
     if(*hnd_ptr){
         (*hnd_ptr)->flag = MPLI_SHM_FLAG_GHND_STATIC;
     }

--- a/src/mpl/include/mpl_thread_priv.h
+++ b/src/mpl/include/mpl_thread_priv.h
@@ -24,14 +24,14 @@ void MPLI_cleanup_tls(void *a);
    whether MPL is initialized with thread safety, one or the other is used.
  */
 
-#define MPL_THREADPRIV_KEY_CREATE(key, var, err_ptr_)                   \
+#define MPL_THREADPRIV_KEY_CREATE(key, var, err_ptr_, class_)           \
     do {                                                                \
         void *thread_ptr;                                               \
                                                                         \
         MPL_thread_tls_create(MPLI_cleanup_tls, &(key) , err_ptr_);     \
         if (unlikely(*((int *) err_ptr_)))                              \
             break;                                                      \
-        thread_ptr = MPL_calloc(1, sizeof(var));                        \
+        thread_ptr = MPL_calloc(1, sizeof(var), class_);                \
         if (unlikely(!thread_ptr)) {                                    \
             *((int *) err_ptr_) = MPL_THREAD_ERROR;                     \
             break;                                                      \
@@ -47,7 +47,7 @@ void MPLI_cleanup_tls(void *a);
             if (unlikely(*((int *) err_ptr_)))                          \
                 break;                                                  \
             if (!thread_ptr) {                                          \
-                thread_ptr = MPL_calloc(1, sizeof(var));                \
+                thread_ptr = MPL_calloc(1, sizeof(var), MPL_MEM_OTHER); \
                 if (unlikely(!thread_ptr)) {                            \
                     *((int *) err_ptr_) = MPL_THREAD_ERROR;             \
                     break;                                              \

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -103,12 +103,78 @@ char *MPL_strdup(const char *str);
 
 #define MPL_realloc(a,b)    MPL_trrealloc((a),(b),__LINE__,__FILE__)
 
+/*M
+  MPL_mmap - Map memory
+
+  Synopsis:
+.vb
+  void *MPL_mmap( void *addr, size_t length, int prot, int flags, int fd, off_t offset )
+.ve
+
+  Input Parameters:
+. addr - Starting address for the new mapping
+. length - Length of the mapping
+. prot - Desired memory protection of the mapping
+. flags - Determines whether updates to the mapping are visible to other
+  processes mapping the same region, and whether updates are carried
+  through to the underlying file.
+. fd - The file backing the memory region
+. offset - Offset into the file
+
+  Notes:
+  This routine will often be implemented as the simple macro
+.vb
+  #define MPL_mmap(a,b,c,d,e,f) mmap(a,b,c,d,e,f)
+.ve
+  However, it can also be defined as
+.vb
+  #define MPL_mmap(a,b,c,d,e,f) MPL_trmmap(a,b,c,d,e,f,__LINE__,__FILE__)
+.ve
+  where 'MPL_trmmap' is a tracing version of 'mmap' that is included with
+  MPICH.
+
+  Module:
+  Utility
+  M*/
+#define MPL_mmap(a,b,c,d,e,f) MPL_trmmap((a),(b),(c),(d),(e),(f),__LINE__,__FILE__)
+
+/*M
+  MPL_munmap - Unmapmemory
+
+  Synopsis:
+.vb
+  void *MPL_munmap( void *addr, size_t length )
+.ve
+
+  Input Parameters:
+. addr - Starting address for the new mapping
+. length - Length of the mapping
+
+  Notes:
+  This routine will often be implemented as the simple macro
+.vb
+  #define MPL_munmap(a,b) munmap(a,b)
+.ve
+  However, it can also be defined as
+.vb
+  #define MPL_munmap(a,b) MPL_trmunmap(a,b,__LINE__,__FILE__)
+.ve
+  where 'MPL_trmunmap' is a tracing version of 'munmap' that is included with
+  MPICH.
+
+  Module:
+  Utility
+  M*/
+#define MPL_munmap(a,b) MPL_trmunmap((a),(b),__LINE__,__FILE__)
+
 #else /* MPL_USE_MEMORY_TRACING */
 /* No memory tracing; just use native functions */
 #define MPL_malloc(a)    malloc((size_t)(a))
 #define MPL_calloc(a,b)  calloc((size_t)(a),(size_t)(b))
 #define MPL_free(a)      free((void *)(a))
 #define MPL_realloc(a,b)  realloc((void *)(a),(size_t)(b))
+#define MPL_mmap(a,b,c,d,e,f) mmap((void *)(a),(size_t)(b),(int)(c),(int)(d),(int)(e),(off_t)(f))
+#define MPL_munmap(a,b)  munmap((void *)(a),(size_t)(b))
 
 #endif /* MPL_USE_MEMORY_TRACING */
 
@@ -190,6 +256,9 @@ void MPL_trfree(void *, int, const char[]);
 int MPL_trvalid(const char[]);
 int MPL_trvalid2(const char[],int,const char[]);
 void *MPL_trcalloc(size_t, size_t, int, const char[]);
+#include <sys/types.h>
+void *MPL_trmmap(void *, size_t, int, int, int, off_t, int, const char[]);
+void MPL_trmunmap(void *, size_t, int, const char[]);
 void *MPL_trrealloc(void *, size_t, int, const char[]);
 void *MPL_trstrdup(const char *, int, const char[]);
 

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -183,7 +183,8 @@ typedef union {
    gcc - this lets gcc-style compilers know that the returned pointer
    does not alias any pointer prior to the call.
  */
-void MPL_trinit(int, int);
+void MPL_trinit(void);
+void MPL_trconfig(int, int);
 void *MPL_trmalloc(size_t, int, const char[]);
 void MPL_trfree(void *, int, const char[]);
 int MPL_trvalid(const char[]);

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -86,6 +86,8 @@ static volatile size_t TRMaxMemAllow = 0;
 
 static int TR_is_threaded = 0;
 
+static int is_configured = 0;
+
 #if MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE
 
 static MPL_thread_mutex_t memalloc_mutex;
@@ -161,11 +163,9 @@ static void addrToHex(void *addr, char string[MAX_ADDRESS_CHARS])
    MPL_trinit - Setup the space package.  Only needed for
    error messages and flags.
 +*/
-void MPL_trinit(int rank, int need_thread_safety)
+void MPL_trinit()
 {
     char *s;
-
-    world_rank = rank;
 
     /* FIXME: We should use generalized parameter handling here
      * to allow use of the command line as well as environment
@@ -193,6 +193,14 @@ void MPL_trinit(int rank, int need_thread_safety)
         long l = atol(s);
         TRMaxOverhead = (size_t)l;
     }
+}
+
+void MPL_trconfig(int rank, int need_thread_safety)
+{
+    world_rank = rank;
+
+    if (is_configured)
+        return;
 
     /* If the upper layer asked for thread safety and there's no
      * threading package available, we need to return an error. */
@@ -213,6 +221,8 @@ void MPL_trinit(int rank, int need_thread_safety)
         TR_is_threaded = 1;
     }
 #endif
+
+    is_configured = 1;
 }
 
 /*+C

--- a/src/mpl/src/shm/mpl_shm.c
+++ b/src/mpl/src/shm/mpl_shm.c
@@ -35,7 +35,7 @@ int MPL_shm_hnd_deserialize(MPL_shm_hnd_t hnd, const char *str_hnd, size_t str_h
 {
     int rc = -1;
     MPLI_shm_hnd_reset_val(hnd);
-    rc = MPLI_shm_ghnd_alloc(hnd);
+    rc = MPLI_shm_ghnd_alloc(hnd, MPL_MEM_SHM);
     rc = MPLI_shm_ghnd_set_by_val(hnd, "%s", str_hnd);
     rc = MPL_shm_seg_open(hnd, 0);
     return rc;
@@ -86,7 +86,7 @@ int MPL_shm_hnd_deserialize_by_ref(MPL_shm_hnd_t hnd, char **ser_hnd_ptr)
 int MPL_shm_hnd_init(MPL_shm_hnd_t *hnd_ptr)
 {
     int rc = -1;
-    rc = MPLI_shm_hnd_alloc(hnd_ptr);
+    rc = MPLI_shm_hnd_alloc(hnd_ptr, MPL_MEM_SHM);
     MPLI_shm_hnd_reset_val(*hnd_ptr);
     return rc;
 }

--- a/src/mpl/src/shm/mpl_shm_mmap.c
+++ b/src/mpl/src/shm/mpl_shm_mmap.c
@@ -82,8 +82,8 @@ static inline int MPL_shm_seg_create_attach_templ(
 
     if(flag & MPLI_SHM_FLAG_SHM_ATTACH){
         void *buf_ptr = NULL;
-        buf_ptr = mmap(NULL, seg_sz, PROT_READ | PROT_WRITE,
-                        MAP_SHARED, MPLI_shm_lhnd_get(hnd), 0);
+        buf_ptr = MPL_mmap(NULL, seg_sz, PROT_READ | PROT_WRITE,
+                           MAP_SHARED, MPLI_shm_lhnd_get(hnd), 0);
         *shm_addr_ptr = (char*)buf_ptr;
     }
 

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -47,7 +47,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     int err = MPL_THREAD_SUCCESS;
 
     /* FIXME: faster allocation, or avoid it all together? */
-    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info));
+    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info), MPL_MEM_THREAD);
     if (thread_info != NULL) {
         pthread_attr_t attr;
 

--- a/src/mpl/src/thread/mpl_thread_solaris.c
+++ b/src/mpl/src/thread/mpl_thread_solaris.c
@@ -43,7 +43,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     int err = MPL_THREAD_SUCCESS;
 
     /* FIXME: faster allocation, or avoid it all together? */
-    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info));
+    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info), MPL_MEM_THREAD);
     if (thread_info != NULL) {
         thread_info->func = func;
         thread_info->data = data;

--- a/src/mpl/src/thread/mpl_thread_win.c
+++ b/src/mpl/src/thread/mpl_thread_win.c
@@ -41,7 +41,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     struct MPLI_thread_info *thread_info;
     int err = MPL_THREAD_SUCCESS;
 
-    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info));
+    thread_info = (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info), MPL_MEM_THREAD);
     if (thread_info != NULL) {
         thread_info->func = func;
         thread_info->data = data;
@@ -239,12 +239,12 @@ void MPL_thread_cond_wait(MPL_thread_cond_t * cond, MPL_thread_mutex_t * mutex, 
         return;
     }
     if (cond->fifo_tail == NULL) {
-        cond->fifo_tail = (MPLI_win_thread_cond_fifo_t *) MPL_malloc(sizeof(MPLI_win_thread_cond_fifo_t));
+        cond->fifo_tail = (MPLI_win_thread_cond_fifo_t *) MPL_malloc(sizeof(MPLI_win_thread_cond_fifo_t), MPL_MEM_THREAD);
         cond->fifo_head = cond->fifo_tail;
     }
     else {
         cond->fifo_tail->next =
-            (MPLI_win_thread_cond_fifo_t *) MPL_malloc(sizeof(MPLI_win_thread_cond_fifo_t));
+            (MPLI_win_thread_cond_fifo_t *) MPL_malloc(sizeof(MPLI_win_thread_cond_fifo_t), MPL_MEM_THREAD);
         cond->fifo_tail = cond->fifo_tail->next;
     }
     if (cond->fifo_tail == NULL) {

--- a/src/nameserv/file/file_nameserv.c
+++ b/src/nameserv/file/file_nameserv.c
@@ -71,7 +71,7 @@ int MPID_NS_Create( const MPIR_Info *info_ptr, MPID_NS_Handle *handle_ptr )
     struct stat st;
     int        err, ret;
 
-    *handle_ptr = (MPID_NS_Handle)MPL_malloc( sizeof(struct MPID_NS_Handle) );
+    *handle_ptr = (MPID_NS_Handle)MPL_malloc( sizeof(struct MPID_NS_Handle), MPL_MEM_PM );
     /* --BEGIN ERROR HANDLING-- */
     if (!*handle_ptr) {
 	err = MPIR_Err_create_code( MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**nomem", 0 );

--- a/src/pm/gforker/mpiexec.c
+++ b/src/pm/gforker/mpiexec.c
@@ -161,7 +161,7 @@ int main( int argc, char *argv[], char *envp[] )
        init, allowing an MPI process to contact a waiting mpiexec that 
        would serve as a process manager.  This option is not implemented */
     if (getenv("MPIEXEC_USE_PORT")) {
-	s.pmiinfo.portName = (char *)MPL_malloc( 1024 );
+	s.pmiinfo.portName = (char *)MPL_malloc( 1024, MPL_MEM_PM );
 	if (!s.pmiinfo.portName) {
 	    MPL_error_printf( "Failed to allocate storage for portName" );
 	}

--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -621,7 +621,7 @@ HYD_status HYDU_sock_cloexec(int fd);
     {                                                                   \
         (p) = NULL; /* initialize p in case assert fails */             \
         HYDU_ASSERT(size, status);                                      \
-        (p) = (type) MPL_malloc((size));                                \
+        (p) = (type) MPL_malloc((size), MPL_MEM_PM);                 \
         if ((p) == NULL)                                                \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
@@ -631,7 +631,7 @@ HYD_status HYDU_sock_cloexec(int fd);
 #define HYDU_REALLOC_OR_JUMP(p, type, size, status)                     \
     {                                                                   \
         HYDU_ASSERT(size, status);                                      \
-        (p) = (type) MPL_realloc((p),(size));                           \
+        (p) = (type) MPL_realloc((p),(size), MPL_MEM_PM);            \
         if ((p) == NULL)                                                \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -505,13 +505,13 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
                          (sizeof(struct cache_elem) * (num_elems + token_count)), status);
     for (i = 0; i < num_elems; i++) {
         struct cache_elem *elem = cache_get + i;
-        HASH_ADD_STR(hash_get, key, elem);
+        HASH_ADD_STR(hash_get, key, elem, MPL_MEM_PM);
     }
     for (; i < num_elems + token_count; i++) {
         struct cache_elem *elem = cache_get + i;
         elem->key = MPL_strdup(tokens[i - num_elems].key);
         elem->val = MPL_strdup(tokens[i - num_elems].val);
-        HASH_ADD_STR(hash_get, key, elem);
+        HASH_ADD_STR(hash_get, key, elem, MPL_MEM_PM);
     }
     num_elems += token_count;
 

--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -471,7 +471,7 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 
     /* This will be the control socket for this proxy */
     proxy->control_fd = fd;
-    HASH_ADD_INT(HYD_server_info.proxy_hash, control_fd, proxy);
+    HASH_ADD_INT(HYD_server_info.proxy_hash, control_fd, proxy, MPL_MEM_PM);
 
     /* Send out the executable information */
     status = send_exec_info(proxy);

--- a/src/pm/hydra/utils/dbg/dbg.c
+++ b/src/pm/hydra/utils/dbg/dbg.c
@@ -14,7 +14,8 @@ HYD_status HYDU_dbg_init(const char *str)
     HYD_status status = HYD_SUCCESS;
 
 #ifdef USE_MEMORY_TRACING
-    MPL_trinit(0, 0);
+    MPL_trinit();
+    MPL_trconfig(0, 0);
 #endif
 
     if (gethostname(hostname, MAX_HOSTNAME_LEN) < 0)

--- a/src/pm/remshell/mpiexec.c
+++ b/src/pm/remshell/mpiexec.c
@@ -266,7 +266,7 @@ int mypostfork( void *predata, void *data, ProcessState *pState )
 	char rankStr[12];
 
 	/* Insert into app->args */
-        newargs = (const char **) MPL_malloc( (app->nArgs + 14 + 1) *
+        newargs = (const char **) MPL_malloc( (app->nArgs + 14 + 1, MPL_MEM_PM) *
 					  sizeof(char *) );
 	if (!pState->hostname) {
 	    MPL_error_printf( "No hostname avaliable for %s\n", app->exename );

--- a/src/pm/util/cmnargs.c
+++ b/src/pm/util/cmnargs.c
@@ -123,7 +123,7 @@ int MPIE_Args( int argc, char *argv[], ProcessUniverse *mypUniv,
        override the environment */
 
     /* Allocate the members of the ProcessUniverse structure */
-    mypUniv->worlds = (ProcessWorld*) MPL_malloc( sizeof(ProcessWorld) );
+    mypUniv->worlds = (ProcessWorld*) MPL_malloc( sizeof(ProcessWorld), MPL_MEM_PM );
     mypUniv->worlds->nApps     = 0;
     mypUniv->worlds->nProcess  = 0;
     mypUniv->worlds->nextWorld = 0;
@@ -273,7 +273,7 @@ int MPIE_Args( int argc, char *argv[], ProcessUniverse *mypUniv,
 	    }
 	    
 	    /* Create a new app and add to the app list*/
-	    pApp = (ProcessApp*) MPL_malloc( sizeof(ProcessApp) );
+	    pApp = (ProcessApp*) MPL_malloc( sizeof(ProcessApp), MPL_MEM_PM );
 	    *nextAppPtr = pApp;
 	    nextAppPtr = &(pApp->nextApp);
 	    pApp->nextApp = 0;
@@ -584,7 +584,7 @@ int MPIE_ParseSoftspec( const char *str, ProcessSoftSpec *sspec )
 	p1++;
     }
     sspec->nelm   = nelm;
-    sspec->tuples = (int (*)[3]) MPL_malloc( nelm * sizeof(int [3]));
+    sspec->tuples = (int (*)[3]) MPL_malloc( nelm * sizeof(int [3]), MPL_MEM_PM);
 
     nelm = 0;
     while ( *p ) {

--- a/src/pm/util/dbgiface.c
+++ b/src/pm/util/dbgiface.c
@@ -80,7 +80,7 @@ int MPIE_InitForDebugger( ProcessWorld *pWorld )
     static char myhostname[MAX_HOST_NAME+1];
 
     MPIR_proctable = (struct MPIR_PROCDESC *)
-	MPL_malloc( np * sizeof(struct MPIR_PROCDESC) );
+	MPL_malloc( np * sizeof(struct MPIR_PROCDESC), MPL_MEM_PM );
 
     i = 0;
     while (apps && i < np) {

--- a/src/pm/util/env.c
+++ b/src/pm/util/env.c
@@ -44,7 +44,7 @@ int MPIE_ArgsCheckForEnv( int argc, char *argv[], ProcessWorld *pWorld,
 
     if ( strncmp( argv[0], "-env",  4) == 0) {
 	if (!*appEnv) {
-	    env = (EnvInfo *)MPL_malloc( sizeof(EnvInfo) );
+	    env = (EnvInfo *)MPL_malloc( sizeof(EnvInfo), MPL_MEM_PM );
 	    env->includeAll = 1;
 	    env->envPairs   = 0;
 	    env->envNames   = 0;
@@ -56,7 +56,7 @@ int MPIE_ArgsCheckForEnv( int argc, char *argv[], ProcessWorld *pWorld,
     }
     else if (strncmp( argv[0], "-genv", 5 ) == 0) {
 	if (!pWorld->genv) {
-	    env = (EnvInfo *)MPL_malloc( sizeof(EnvInfo) );
+	    env = (EnvInfo *)MPL_malloc( sizeof(EnvInfo), MPL_MEM_PM );
 	    env->includeAll = 1;
 	    env->envPairs   = 0;
 	    env->envNames   = 0;
@@ -77,7 +77,7 @@ int MPIE_ArgsCheckForEnv( int argc, char *argv[], ProcessWorld *pWorld,
 	if (!argv[1] || !argv[2]) {
 	    mpiexec_usage( "Missing arguments to -env or -genv" );
 	}
-	p             = (EnvData *)MPL_malloc( sizeof(EnvData) );
+	p             = (EnvData *)MPL_malloc( sizeof(EnvData), MPL_MEM_PM );
 	p->name       = (const char *)MPL_strdup( argv[1] );
 	p->value      = (const char *)MPL_strdup( argv[2] );
 	p->envvalue   = 0;
@@ -104,9 +104,9 @@ int MPIE_ArgsCheckForEnv( int argc, char *argv[], ProcessWorld *pWorld,
 	    while (*lPtr && *lPtr != ',') lPtr++;
             /* The length of any environment string will fit in an int */
 	    namelen       = (int)(lPtr - name);
-	    p             = (EnvData *)MPL_malloc( sizeof(EnvData) );
+	    p             = (EnvData *)MPL_malloc( sizeof(EnvData), MPL_MEM_PM );
 	    p->value      = 0;
-	    p->name       = (const char *)MPL_malloc( namelen + 1 );
+	    p->name       = (const char *)MPL_malloc( namelen + 1, MPL_MEM_PM );
 	    p->envvalue   = 0;
 	    for (i=0; i<namelen; i++) ((char *)p->name)[i] = name[i];
 	    ((char *)p->name)[namelen] = 0;
@@ -261,7 +261,7 @@ int MPIE_EnvInitData( EnvData *elist, int getValue )
 		value = "";
 	    }
 	    slen = strlen( elist->name ) + strlen(value) + 2;
-	    str  = (char *)MPL_malloc( slen );
+	    str  = (char *)MPL_malloc( slen, MPL_MEM_PM );
 	    if (!str) {
 		return 1;
 	    }
@@ -290,7 +290,7 @@ int MPIE_Putenv( ProcessWorld *pWorld, const char *env_string )
 
     /* FIXME: This should be getGenv (so allocation/init in one place) */
     if (!pWorld->genv) {
-	genv = (EnvInfo *)MPL_malloc( sizeof(EnvInfo) );
+	genv = (EnvInfo *)MPL_malloc( sizeof(EnvInfo), MPL_MEM_PM );
 	genv->includeAll = 1;
 	genv->envPairs   = 0;
 	genv->envNames   = 0;
@@ -298,7 +298,7 @@ int MPIE_Putenv( ProcessWorld *pWorld, const char *env_string )
     }
     genv           = pWorld->genv;
 
-    p              = (EnvData *)MPL_malloc( sizeof(EnvData) );
+    p              = (EnvData *)MPL_malloc( sizeof(EnvData), MPL_MEM_PM );
     if (!p) return 1;
     p->name        = 0;
     p->value       = 0;

--- a/src/pm/util/labelout.c
+++ b/src/pm/util/labelout.c
@@ -90,7 +90,7 @@ int IOLabelSetupFinishInServer( IOLabelSetup *iofds, ProcessState *pState )
     close( iofds->readErr[1] );
 
     /* We need dedicated storage for the private data */
-    leader = (IOLabel *)MPL_malloc( sizeof(IOLabel) );
+    leader = (IOLabel *)MPL_malloc( sizeof(IOLabel), MPL_MEM_PM );
     if (useLabels) {
 	IOLabelSetLabelText( outLabelPattern, 
 			     leader->label, sizeof(leader->label),
@@ -101,7 +101,7 @@ int IOLabelSetupFinishInServer( IOLabelSetup *iofds, ProcessState *pState )
     }
     leader->lastNL = 1;
     leader->dest   = stdout;
-    leadererr = (IOLabel *)MPL_malloc( sizeof(IOLabel) );
+    leadererr = (IOLabel *)MPL_malloc( sizeof(IOLabel), MPL_MEM_PM );
     if (useLabels) {
 	IOLabelSetLabelText( errLabelPattern, 
 			     leadererr->label, sizeof(leadererr->label),

--- a/src/pm/util/pmiserv.c
+++ b/src/pm/util/pmiserv.c
@@ -237,7 +237,7 @@ PMIProcess *PMISetupNewProcess( int fd, ProcessState *pState )
 {
     PMIProcess *pmiprocess;
 
-    pmiprocess = (PMIProcess *)MPL_malloc( sizeof(PMIProcess) );
+    pmiprocess = (PMIProcess *)MPL_malloc( sizeof(PMIProcess), MPL_MEM_PM );
     if (!pmiprocess) return 0;
     pmiprocess->fd           = fd;
     pmiprocess->nextChar     = pmiprocess->readBuf;
@@ -265,14 +265,13 @@ PMIProcess *PMISetupNewProcess( int fd, ProcessState *pState )
 int PMISetupNewGroup( int nProcess, PMIKVSpace *kvs )
 {
     PMIGroup *g;
-    curPMIGroup = (PMIGroup *)MPL_malloc( sizeof(PMIGroup) );
+    curPMIGroup = (PMIGroup *)MPL_malloc( sizeof(PMIGroup), MPL_MEM_PM );
     if (!curPMIGroup) return 1;
 
     curPMIGroup->nProcess   = nProcess;
     curPMIGroup->groupID    = pmimaster.nGroups++;
     curPMIGroup->nInBarrier = 0;
-    curPMIGroup->pmiProcess = (PMIProcess **)MPL_malloc(
-					 sizeof(PMIProcess*) * nProcess );
+    curPMIGroup->pmiProcess = (PMIProcess **)MPL_malloc( sizeof(PMIProcess*) * nProcess, MPL_MEM_PM );
     if (!curPMIGroup->pmiProcess) return 1;
     curPMIGroup->nextGroup  = 0;
     curNprocess             = 0;
@@ -456,7 +455,7 @@ static PMIKVSpace *fPMIKVSAllocate( void )
     static int kvsnum = 0;    /* Used to generate names */
 
     /* Create the space */
-    kvs = (PMIKVSpace *)MPL_malloc( sizeof(PMIKVSpace) );
+    kvs = (PMIKVSpace *)MPL_malloc( sizeof(PMIKVSpace), MPL_MEM_PM );
     if (!kvs) {
 	MPL_internal_error_printf( "too many kvs's\n" );
 	return 0;
@@ -544,7 +543,7 @@ static int fPMIKVSAddPair( PMIKVSpace *kvs,
 	pprev = &(p->nextPair);
 	p = p->nextPair;
     }
-    pair = (PMIKVPair *)MPL_malloc( sizeof(PMIKVPair) );
+    pair = (PMIKVPair *)MPL_malloc( sizeof(PMIKVPair), MPL_MEM_PM );
     if (!pair) {
 	return -1;
     }
@@ -1011,7 +1010,7 @@ static int fPMI_Handle_spawn( PMIProcess *pentry )
     DBG_PRINTFCOND(pmidebug,( "Entering fPMI_Handle_spawn\n" ));
 
     if (!pentry->spawnWorld) {
-	pWorld = (ProcessWorld *)MPL_malloc( sizeof(ProcessWorld) );
+	pWorld = (ProcessWorld *)MPL_malloc( sizeof(ProcessWorld), MPL_MEM_PM );
 	if (!pWorld) return 1;
 	
 	pentry->spawnWorld = pWorld;
@@ -1036,7 +1035,7 @@ static int fPMI_Handle_spawn( PMIProcess *pentry )
        commands */ 
 
     /* Create a new app */
-    app = (ProcessApp *)MPL_malloc( sizeof(ProcessApp) );
+    app = (ProcessApp *)MPL_malloc( sizeof(ProcessApp), MPL_MEM_PM );
     if (!app) return 1;
     app->myAppNum  = 0;
     app->exename   = 0;
@@ -1191,7 +1190,7 @@ static int fPMI_Handle_spawn( PMIProcess *pentry )
     }	
 
     if (app->nArgs > 0) {
-	app->args  = (const char **)MPL_malloc( app->nArgs * sizeof(char *) );
+	app->args  = (const char **)MPL_malloc( app->nArgs * sizeof(char *), MPL_MEM_PM );
 	for (i=0; i<app->nArgs; i++) {
 	    app->args[i] = args[i];
 	    args[i]      = 0;

--- a/src/pm/util/process.c
+++ b/src/pm/util/process.c
@@ -114,8 +114,7 @@ int MPIE_ForkProcesses( ProcessWorld *pWorld, char *envp[],
     while (app) {
 	/* Allocate process state if necessary */
 	if (!app->pState) {
-            pState = (ProcessState *)MPL_malloc(
-		app->nProcess * sizeof(ProcessState) );
+            pState = (ProcessState *)MPL_malloc( app->nProcess * sizeof(ProcessState), MPL_MEM_PM );
 	    if (!pState) {
 		return -1;
 	    }
@@ -255,8 +254,8 @@ int MPIE_ExecProgram( ProcessState *pState, char *envp[] )
     char pathstring[MAXPATHLEN+10];
     /* We allocate these on the heap to help catch array overrun errors
        such as those in ticket #719.  */
-    char **client_env = MPL_malloc(MAX_CLIENT_ENV * sizeof(char *));
-    char **client_arg = MPL_malloc(MAX_CLIENT_ARG * sizeof(char *));
+    char **client_env = MPL_malloc(MAX_CLIENT_ENV * sizeof(char *), MPL_MEM_PM);
+    char **client_arg = MPL_malloc(MAX_CLIENT_ARG * sizeof(char *), MPL_MEM_PM);
 
     app = pState->app;
 
@@ -992,7 +991,7 @@ int MPIE_SetupSingleton( ProcessUniverse *mypUniv )
 
     pWorld		  = &mypUniv->worlds[0];
     pWorld->nProcess      = 1;
-    pApp		  = (ProcessApp *) MPL_malloc( sizeof(ProcessApp) );
+    pApp		  = (ProcessApp *) MPL_malloc( sizeof(ProcessApp), MPL_MEM_PM );
     pApp->nextApp	  = 0;
     pWorld->nApps	  = 1;
     pWorld->apps          = pApp;
@@ -1006,7 +1005,7 @@ int MPIE_SetupSingleton( ProcessUniverse *mypUniv )
     pApp->args		  = 0;
     pApp->nArgs		  = 0;
     pApp->myAppNum	  = 0;
-    pState		  = (ProcessState *) MPL_malloc( sizeof(ProcessState) );
+    pState		  = (ProcessState *) MPL_malloc( sizeof(ProcessState), MPL_MEM_PM );
     pApp->pState	  = pState;
 
     pState[0].app	  = pApp;

--- a/src/pm/util/rm.c
+++ b/src/pm/util/rm.c
@@ -75,8 +75,7 @@ int MPIE_ChooseHosts( ProcessWorld *pWorld,
     app = pWorld->apps;
     while (app) {
 	if (!app->pState) {
-            pState = (ProcessState *)MPL_malloc(
-		app->nProcess * sizeof(ProcessState) );
+            pState = (ProcessState *)MPL_malloc( app->nProcess * sizeof(ProcessState), MPL_MEM_PM );
 	    if (!pState) {
 		return -1;
 	    }
@@ -256,7 +255,7 @@ MachineTable *MPIE_ReadMachines( const char *arch, int nNeeded,
 	MPL_error_printf( "Could not open machines file %s\n", machinesfile );
 	return 0;
     }
-    mt = (MachineTable *)MPL_malloc( sizeof(MachineTable) );
+    mt = (MachineTable *)MPL_malloc( sizeof(MachineTable), MPL_MEM_PM );
     if (!mt) {
 	MPL_internal_error_printf( "Could not allocate machine table\n" );
 	return 0;
@@ -264,7 +263,7 @@ MachineTable *MPIE_ReadMachines( const char *arch, int nNeeded,
     
     /* This may be larger than needed if the machines file has
        fewer entries than nNeeded */
-    mt->desc = (MachineDesc *)MPL_malloc( nNeeded * sizeof(MachineDesc) );
+    mt->desc = (MachineDesc *)MPL_malloc( nNeeded * sizeof(MachineDesc), MPL_MEM_PM );
     if (!mt->desc) {
 	return 0;
     }

--- a/src/pmi/pmi2/simple/pmi2compat.h
+++ b/src/pmi/pmi2/simple/pmi2compat.h
@@ -6,7 +6,7 @@
 
 #include "mpiimpl.h"
 
-#define PMI2U_Malloc MPL_malloc
+#define PMI2U_Malloc(size_) MPL_malloc(size_, MPL_MEM_PM)
 #define PMI2U_Free MPL_free
 #define PMI2U_Strdup MPL_strdup
 #define PMI2U_Strnapp MPL_strnapp

--- a/src/util/logging/rlog/TraceInput/logformat_trace_InputLog.c
+++ b/src/util/logging/rlog/TraceInput/logformat_trace_InputLog.c
@@ -222,7 +222,7 @@ Java_logformat_trace_InputLog_getNextCategory( JNIEnv *env, jobject this )
     if ( legend_sz ) {
         legend_max  = legend_sz+1;
 	if (legend_max > ACHAR_LENGTH)
-	    legend_base = (char *) MPL_malloc( legend_max * sizeof( char ) );
+	    legend_base = (char *) MPL_malloc( legend_max * sizeof( char ), MPL_MEM_DEBUG );
 	else
 	    legend_base = slegend_base;
     }
@@ -233,7 +233,7 @@ Java_logformat_trace_InputLog_getNextCategory( JNIEnv *env, jobject this )
     if ( label_sz > 0 ) {
         label_max   = label_sz+1;
 	if (label_max > ACHAR_LENGTH)
-	    label_base  = (char *) MPL_malloc( label_max * sizeof( char ) );
+	    label_base  = (char *) MPL_malloc( label_max * sizeof( char ), MPL_MEM_DEBUG );
 	else
 	    label_base = slabel_base;
     }
@@ -244,7 +244,7 @@ Java_logformat_trace_InputLog_getNextCategory( JNIEnv *env, jobject this )
     if ( methods_sz > 0 ) {
         methods_max  = methods_sz;
 	if (methods_max > AINT_LENGTH)
-	    methods_base = (int *)  MPL_malloc( methods_max * sizeof( int ) );
+	    methods_base = (int *)  MPL_malloc( methods_max * sizeof( int ), MPL_MEM_DEBUG );
 	else
 	    methods_base = smethods_base;
     }
@@ -378,20 +378,20 @@ Java_logformat_trace_InputLog_getNextYCoordMap( JNIEnv *env, jobject this )
     }
 
     /* Prepare various arrays for C data */
-    title_name    = (char *) MPL_malloc( max_title_name * sizeof(char) );
-    column_names  = (char **) MPL_malloc( (ncolumns-1) * sizeof(char *) );
+    title_name    = (char *) MPL_malloc( max_title_name * sizeof(char), MPL_MEM_DEBUG );
+    column_names  = (char **) MPL_malloc( (ncolumns-1) * sizeof(char *), MPL_MEM_DEBUG );
     for ( icol = 0; icol < ncolumns-1; icol++ )
         column_names[ icol ] = (char *) MPL_malloc( max_column_name
                                               * sizeof(char) );
     coordmap_max  = nrows * ncolumns;
-    coordmap_base = (int *) MPL_malloc( coordmap_max * sizeof( int ) );
+    coordmap_base = (int *) MPL_malloc( coordmap_max * sizeof( int ), MPL_MEM_DEBUG );
     coordmap_sz   = 0;
     coordmap_pos  = 0;
 
    	methods_pos  = 0;
     if ( methods_sz > 0 ) {
         methods_max  = methods_sz;
-        methods_base = (int *) MPL_malloc( methods_max * sizeof( int ) );
+        methods_base = (int *) MPL_malloc( methods_max * sizeof( int ), MPL_MEM_DEBUG );
     }
     else
         methods_base = NULL;
@@ -539,19 +539,19 @@ Java_logformat_trace_InputLog_getNextPrimitive( JNIEnv *env, jobject this )
     tcoord_pos  = 0;
     tcoord_max  = tcoord_sz;
     if (tcoord_max > ADOUBLE_LENGTH)
-	tcoord_base = (double *) MPL_malloc( tcoord_max * sizeof( double ) );
+	tcoord_base = (double *) MPL_malloc( tcoord_max * sizeof( double ), MPL_MEM_DEBUG );
     else
 	tcoord_base = stcoord_base;
     ycoord_pos  = 0;
     ycoord_max  = ycoord_sz;
     if (ycoord_max > AINT_LENGTH)
-	ycoord_base = (int *)    MPL_malloc( ycoord_max * sizeof( int ) );
+	ycoord_base = (int *)    MPL_malloc( ycoord_max * sizeof( int ), MPL_MEM_DEBUG );
     else
 	ycoord_base = sycoord_base;
     info_pos    = 0;
     info_max    = info_sz;
     if (info_max > AINT_LENGTH)
-	info_base   = (char *)   MPL_malloc( info_max * sizeof( char ) );
+	info_base   = (char *)   MPL_malloc( info_max * sizeof( char ), MPL_MEM_DEBUG );
     else
 	info_base = sinfo_base;
     ierr = TRACE_Get_next_primitive( tracefile, &type_idx,
@@ -676,7 +676,7 @@ Java_logformat_trace_InputLog_getNextComposite( JNIEnv *env, jobject this )
     if ( cm_info_sz > 0 ) {
         cm_info_pos    = 0;
         cm_info_max    = cm_info_sz;
-        cm_info_base   = (char *)   MPL_malloc( cm_info_max * sizeof( char ) );
+        cm_info_base   = (char *)   MPL_malloc( cm_info_max * sizeof( char ), MPL_MEM_DEBUG );
         ierr = TRACE_Get_next_composite( tracefile, &cmplx_type_idx,
                                          &cm_info_sz, cm_info_base,
                                          &cm_info_pos, cm_info_max );

--- a/src/util/logging/rlog/TraceInput/trace_input.c
+++ b/src/util/logging/rlog/TraceInput/trace_input.c
@@ -81,7 +81,7 @@ TRACE_EXPORT int TRACE_Open( const char filespec[], TRACE_file *fp )
 	return TRACEINPUT_SUCCESS;
     }
 
-    *fp = (_trace_file*)MPL_malloc(sizeof(_trace_file));
+    *fp = (_trace_file*)MPL_malloc(sizeof(_trace_file), MPL_MEM_DEBUG);
     if (*fp == NULL)
 	return TRACEINPUT_FAIL;
 
@@ -96,15 +96,15 @@ TRACE_EXPORT int TRACE_Open( const char filespec[], TRACE_file *fp )
     (*fp)->bArrowAvail = (RLOG_GetNextArrow(pInput, &(*fp)->arrow) == 0);
     if (pInput->nNumRanks > 0)
     {
-	(*fp)->ppEvent = (RLOG_EVENT**)MPL_malloc(sizeof(RLOG_EVENT*) * pInput->nNumRanks);
-	(*fp)->ppEventAvail = (int**)MPL_malloc(sizeof(int*) * pInput->nNumRanks);
+	(*fp)->ppEvent = (RLOG_EVENT**)MPL_malloc(sizeof(RLOG_EVENT*) * pInput->nNumRanks, MPL_MEM_DEBUG);
+	(*fp)->ppEventAvail = (int**)MPL_malloc(sizeof(int*) * pInput->nNumRanks, MPL_MEM_DEBUG);
 
 	for (i=0; i<pInput->nNumRanks; i++)
 	{
 	    if (pInput->pNumEventRecursions[i] > 0)
 	    {
-		(*fp)->ppEvent[i] = (RLOG_EVENT*)MPL_malloc(sizeof(RLOG_EVENT) * pInput->pNumEventRecursions[i]);
-		(*fp)->ppEventAvail[i] = (int*)MPL_malloc(sizeof(int) * pInput->pNumEventRecursions[i]);
+		(*fp)->ppEvent[i] = (RLOG_EVENT*)MPL_malloc(sizeof(RLOG_EVENT) * pInput->pNumEventRecursions[i], MPL_MEM_DEBUG);
+		(*fp)->ppEventAvail[i] = (int*)MPL_malloc(sizeof(int) * pInput->pNumEventRecursions[i], MPL_MEM_DEBUG);
 	    }
 	    else
 	    {

--- a/src/util/logging/rlog/irlog2rlog.c
+++ b/src/util/logging/rlog/irlog2rlog.c
@@ -144,7 +144,7 @@ ArrowNode *GetArrowNode(int rank)
 	pNode = pNode->pNext;
     }
 
-    pNode = (ArrowNode *)MPL_malloc(sizeof(ArrowNode));
+    pNode = (ArrowNode *)MPL_malloc(sizeof(ArrowNode), MPL_MEM_DEBUG);
     pNode->pEndList = NULL;
     pNode->pStartList = NULL;
     pNode->rank = rank;
@@ -228,7 +228,7 @@ void SaveArrow(RLOG_IARROW *pArrow)
 	pEnd = ExtractEndNode(pNode, pArrow->rank, pArrow->tag);
 	if (pEnd == NULL)
 	{
-	    pStart = (StartArrowStruct *)MPL_malloc(sizeof(StartArrowStruct));
+	    pStart = (StartArrowStruct *)MPL_malloc(sizeof(StartArrowStruct), MPL_MEM_DEBUG);
 	    pStart->src = pArrow->rank;
 	    pStart->tag = pArrow->tag;
 	    pStart->length = pArrow->length;
@@ -279,7 +279,7 @@ void SaveArrow(RLOG_IARROW *pArrow)
 	}
 	else
 	{
-	    pEnd = (EndArrowStruct *)MPL_malloc(sizeof(EndArrowStruct));
+	    pEnd = (EndArrowStruct *)MPL_malloc(sizeof(EndArrowStruct), MPL_MEM_DEBUG);
 	    pEnd->src = pArrow->remote;
 	    pEnd->tag = pArrow->tag;
 	    pEnd->timestamp = pArrow->timestamp;
@@ -314,7 +314,7 @@ RecursionStruct *GetLevel(int rank, int recursion)
 	pLevel = pLevel->next;
     }
 
-    pLevel = (RecursionStruct*)MPL_malloc(sizeof(RecursionStruct));
+    pLevel = (RecursionStruct*)MPL_malloc(sizeof(RecursionStruct), MPL_MEM_DEBUG);
     MPL_snprintf(pLevel->filename, 1024*sizeof(char), "irlog.%d.%d.tmp", rank, recursion);
     pLevel->fout = fopen(pLevel->filename, "w+b");
     pLevel->rank = rank;
@@ -352,7 +352,7 @@ void SaveState(RLOG_STATE *pState)
 	pIter = pIter->next;
     }
 
-    pIter = (RLOG_State_list*)MPL_malloc(sizeof(RLOG_State_list));
+    pIter = (RLOG_State_list*)MPL_malloc(sizeof(RLOG_State_list), MPL_MEM_DEBUG);
     memcpy(&pIter->state, pState, sizeof(RLOG_STATE));
     pIter->next = g_pList;
     g_pList = pIter;
@@ -388,7 +388,7 @@ void AppendFile(FILE *fout, FILE *fin)
     int num_read, num_written;
     char *buffer, *buf;
 
-    buffer = (char*)MPL_malloc(sizeof(char) * BUFFER_SIZE);
+    buffer = (char*)MPL_malloc(sizeof(char) * BUFFER_SIZE, MPL_MEM_DEBUG);
 
     total = ftell(fin);
     fseek(fin, 0L, SEEK_SET);
@@ -601,7 +601,7 @@ void GenerateNewArgv(int *pargc, char ***pargv, int n)
     size_t str_sz;
 
     length = (sizeof(char*) * (n+3)) +strlen((*pargv)[0]) + 1 + strlen((*pargv)[1]) + 1 + (15 * n);
-    buffer = (char*)MPL_malloc(length);
+    buffer = (char*)MPL_malloc(length, MPL_MEM_DEBUG);
 
     argc = n+2;
     argv = (char**)buffer;
@@ -670,7 +670,7 @@ int main(int argc, char *argv[])
     }
 
     /* read the arrows from all the files in order */
-    ppInput = (IRLOG_IOStruct**)MPL_malloc(nNumInputs * sizeof(IRLOG_IOStruct*));
+    ppInput = (IRLOG_IOStruct**)MPL_malloc(nNumInputs * sizeof(IRLOG_IOStruct*), MPL_MEM_DEBUG);
     for (i=0; i<nNumInputs; i++)
     {
 	ppInput[i] = IRLOG_CreateInputStruct(argv[i+2]);

--- a/src/util/logging/rlog/irlogutil.c
+++ b/src/util/logging/rlog/irlogutil.c
@@ -58,7 +58,7 @@ IRLOG_IOStruct *IRLOG_CreateInputStruct(const char *filename)
     IRLOG_IOStruct *pInput;
 
     /* allocate an input structure */
-    pInput = (IRLOG_IOStruct*)MPL_malloc(sizeof(IRLOG_IOStruct));
+    pInput = (IRLOG_IOStruct*)MPL_malloc(sizeof(IRLOG_IOStruct), MPL_MEM_DEBUG);
     if (pInput == NULL)
     {
 	MPL_error_printf("malloc failed - %s\n", strerror(errno));
@@ -100,7 +100,7 @@ IRLOG_IOStruct *IRLOG_CreateOutputStruct(const char *filename)
     IRLOG_IOStruct *pOutput = NULL;
 
     /* allocate a data structure */
-    pOutput = (IRLOG_IOStruct*)MPL_malloc(sizeof(IRLOG_IOStruct));
+    pOutput = (IRLOG_IOStruct*)MPL_malloc(sizeof(IRLOG_IOStruct), MPL_MEM_DEBUG);
     if (pOutput == NULL)
     {
 	MPL_error_printf("malloc failed - %s\n", strerror(errno));

--- a/src/util/logging/rlog/minalignrlog.c
+++ b/src/util/logging/rlog/minalignrlog.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 	}
     }
 
-    pOffset = (double*)MPL_malloc(range * sizeof(double));
+    pOffset = (double*)lPL_malloc(range * sizeof(double), MPL_MEM_DEBUG);
     if (pOffset == NULL)
     {
 	printf("malloc failed\n");

--- a/src/util/logging/rlog/rlog.c
+++ b/src/util/logging/rlog/rlog.c
@@ -65,7 +65,7 @@ RLOG_Struct* RLOG_InitLog(int rank, int size)
 {
     RLOG_Struct* pRLOG;
 
-    pRLOG = (RLOG_Struct*)MPL_malloc(sizeof(RLOG_Struct));
+    pRLOG = (RLOG_Struct*)MPL_malloc(sizeof(RLOG_Struct), MPL_MEM_DEBUG);
     if (pRLOG == NULL)
 	return NULL;
 

--- a/src/util/logging/rlog/rlogutil.c
+++ b/src/util/logging/rlog/rlogutil.c
@@ -81,7 +81,7 @@ RLOG_IOStruct *RLOG_CreateInputStruct(const char *filename)
     int type, length;
 
     /* allocate an input structure */
-    pInput = (RLOG_IOStruct*)MPL_malloc(sizeof(RLOG_IOStruct));
+    pInput = (RLOG_IOStruct*)MPL_malloc(sizeof(RLOG_IOStruct), MPL_MEM_DEBUG);
     if (pInput == NULL)
     {
 	MPL_error_printf("malloc failed - %s\n", strerror(errno));
@@ -125,14 +125,14 @@ RLOG_IOStruct *RLOG_CreateInputStruct(const char *filename)
 	    pInput->nNumRanks = pInput->header.nMaxRank + 1 - pInput->header.nMinRank;
 	    min_rank = pInput->header.nMinRank;
 	    
-	    pInput->pRank = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int));
-	    pInput->pNumEventRecursions = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int));
-	    pInput->ppNumEvents = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->ppCurEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->ppCurGlobalEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->gppCurEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*));
-	    pInput->gppPrevEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*));
-	    pInput->ppEventOffset = (long**)MPL_malloc(pInput->nNumRanks * sizeof(long*));
+	    pInput->pRank = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int), MPL_MEM_DEBUG);
+	    pInput->pNumEventRecursions = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int), MPL_MEM_DEBUG);
+	    pInput->ppNumEvents = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->ppCurEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->ppCurGlobalEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->gppCurEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*), MPL_MEM_DEBUG);
+	    pInput->gppPrevEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*), MPL_MEM_DEBUG);
+	    pInput->ppEventOffset = (long**)MPL_malloc(pInput->nNumRanks * sizeof(long*), MPL_MEM_DEBUG);
 	    for (i=0; i<pInput->nNumRanks; i++)
 	    {
 		pInput->pRank[i] = -1;
@@ -171,12 +171,12 @@ RLOG_IOStruct *RLOG_CreateInputStruct(const char *filename)
 	    /*printf("levels: %d\n", pInput->nNumEventRecursions);*/
 	    if (pInput->pNumEventRecursions[rank_index])
 	    {
-		pInput->ppCurEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->ppCurGlobalEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->gppCurEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT));
-		pInput->gppPrevEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT));
-		pInput->ppNumEvents[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->ppEventOffset[rank_index] = (long*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(long));
+		pInput->ppCurEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->ppCurGlobalEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->gppCurEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT), MPL_MEM_DEBUG);
+		pInput->gppPrevEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT), MPL_MEM_DEBUG);
+		pInput->ppNumEvents[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->ppEventOffset[rank_index] = (long*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(long), MPL_MEM_DEBUG);
 	    }
 	    for (i=0; i<pInput->pNumEventRecursions[rank_index]; i++)
 	    {
@@ -234,7 +234,7 @@ static int ModifyArrows(FILE *f, int nNumArrows, int nMin, double *pOffsets, int
     arrow_pos = ftell(f);
     if (arrow_pos == -1)
 	return errno;
-    pArray = (RLOG_ARROW*)MPL_malloc(nNumArrows * sizeof(RLOG_ARROW));
+    pArray = (RLOG_ARROW*)MPL_malloc(nNumArrows * sizeof(RLOG_ARROW), MPL_MEM_DEBUG);
     if (pArray)
     {
 	MPL_msg_printf("Modifying %d arrows\n", nNumArrows);
@@ -344,7 +344,7 @@ int RLOG_ModifyEvents(const char *filename, double *pOffsets, int n)
     int error;
 
     /* allocate an input structure */
-    pInput = (RLOG_IOStruct*)MPL_malloc(sizeof(RLOG_IOStruct));
+    pInput = (RLOG_IOStruct*)MPL_malloc(sizeof(RLOG_IOStruct), MPL_MEM_DEBUG);
     if (pInput == NULL)
     {
 	MPL_error_printf("malloc failed - %s\n", strerror(errno));
@@ -388,14 +388,14 @@ int RLOG_ModifyEvents(const char *filename, double *pOffsets, int n)
 	    pInput->nNumRanks = pInput->header.nMaxRank + 1 - pInput->header.nMinRank;
 	    min_rank = pInput->header.nMinRank;
 	    
-	    pInput->pRank = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int));
-	    pInput->pNumEventRecursions = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int));
-	    pInput->ppNumEvents = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->ppCurEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->ppCurGlobalEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*));
-	    pInput->gppCurEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*));
-	    pInput->gppPrevEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*));
-	    pInput->ppEventOffset = (long**)MPL_malloc(pInput->nNumRanks * sizeof(long*));
+	    pInput->pRank = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int), MPL_MEM_DEBUG);
+	    pInput->pNumEventRecursions = (int*)MPL_malloc(pInput->nNumRanks * sizeof(int), MPL_MEM_DEBUG);
+	    pInput->ppNumEvents = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->ppCurEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->ppCurGlobalEvent = (int**)MPL_malloc(pInput->nNumRanks * sizeof(int*), MPL_MEM_DEBUG);
+	    pInput->gppCurEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*), MPL_MEM_DEBUG);
+	    pInput->gppPrevEvent = (RLOG_EVENT**)MPL_malloc(pInput->nNumRanks * sizeof(RLOG_EVENT*), MPL_MEM_DEBUG);
+	    pInput->ppEventOffset = (long**)MPL_malloc(pInput->nNumRanks * sizeof(long*), MPL_MEM_DEBUG);
 	    for (i=0; i<pInput->nNumRanks; i++)
 	    {
 		pInput->pRank[i] = -1;
@@ -441,12 +441,12 @@ int RLOG_ModifyEvents(const char *filename, double *pOffsets, int n)
 	    /*printf("levels: %d\n", pInput->nNumEventRecursions);*/
 	    if (pInput->pNumEventRecursions[rank_index])
 	    {
-		pInput->ppCurEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->ppCurGlobalEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->gppCurEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT));
-		pInput->gppPrevEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT));
-		pInput->ppNumEvents[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int));
-		pInput->ppEventOffset[rank_index] = (long*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(long));
+		pInput->ppCurEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->ppCurGlobalEvent[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->gppCurEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT), MPL_MEM_DEBUG);
+		pInput->gppPrevEvent[rank_index] = (RLOG_EVENT*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(RLOG_EVENT), MPL_MEM_DEBUG);
+		pInput->ppNumEvents[rank_index] = (int*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(int), MPL_MEM_DEBUG);
+		pInput->ppEventOffset[rank_index] = (long*)MPL_malloc(pInput->pNumEventRecursions[rank_index] * sizeof(long), MPL_MEM_DEBUG);
 	    }
 	    for (i=0; i<pInput->pNumEventRecursions[rank_index]; i++)
 	    {

--- a/src/util/mem/handlemem.c
+++ b/src/util/mem/handlemem.c
@@ -78,7 +78,7 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr)
     }
 
     if (objmem->indirect_size > 0) {
-        nIndirect = (int *) MPL_calloc(objmem->indirect_size, sizeof(int));
+        nIndirect = (int *) MPL_calloc(objmem->indirect_size, sizeof(int), MPL_MEM_OBJECT);
     }
     /* Count the number of items in the avail list.  These include
      * all objects, whether direct or indirect allocation */

--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -86,9 +86,9 @@ static inline int MPIR_NODEMAP_publish_node_id(int sz, int myrank)
     pmi_errno = PMI_KVS_Get_key_length_max(&key_max_sz);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
 
-    MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key");
+    MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key", MPL_MEM_ADDRESS);
 
-    MPIR_CHKLMEM_MALLOC(kvs_name, char *, 256, mpi_errno, "kvs_name");
+    MPIR_CHKLMEM_MALLOC(kvs_name, char *, 256, mpi_errno, "kvs_name", MPL_MEM_ADDRESS);
     pmi_errno = PMI_KVS_Get_my_name(kvs_name, 256);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
     /* Put my hostname id */
@@ -197,7 +197,7 @@ static inline int MPIR_NODEMAP_parse_mapping(char *map_str,
         ++d;
     }
 
-    MPIR_CHKPMEM_MALLOC(*map, MPIR_NODEMAP_map_block_t *, sizeof(MPIR_NODEMAP_map_block_t) * num_blocks, mpi_errno, "map");
+    MPIR_CHKPMEM_MALLOC(*map, MPIR_NODEMAP_map_block_t *, sizeof(MPIR_NODEMAP_map_block_t) * num_blocks, mpi_errno, "map", MPL_MEM_ADDRESS);
 
     /* parse block descriptors */
     for (i = 0; i < num_blocks; ++i) {
@@ -429,13 +429,13 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
     /* Allocate space for pmi key and value */
     pmi_errno = PMI_KVS_Get_key_length_max(&key_max_sz);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
-    MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key");
+    MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key", MPL_MEM_ADDRESS);
 
     pmi_errno = PMI_KVS_Get_value_length_max(&val_max_sz);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
-    MPIR_CHKLMEM_MALLOC(value, char *, val_max_sz, mpi_errno, "value");
+    MPIR_CHKLMEM_MALLOC(value, char *, val_max_sz, mpi_errno, "value", MPL_MEM_ADDRESS);
 
-    MPIR_CHKLMEM_MALLOC(kvs_name, char *, 256, mpi_errno, "kvs_name");
+    MPIR_CHKLMEM_MALLOC(kvs_name, char *, 256, mpi_errno, "kvs_name", MPL_MEM_ADDRESS);
     pmi_errno = PMI_KVS_Get_my_name(kvs_name, 256);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d", pmi_errno);
     /* See if process manager supports PMI_process_mapping keyval */
@@ -461,8 +461,8 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
 
     /* Allocate temporary structures.  These would need to be persistent if
        we somehow were able to support dynamic processes via this method. */
-    MPIR_CHKLMEM_MALLOC(node_names, char **, sz * sizeof(char*), mpi_errno, "node_names");
-    MPIR_CHKLMEM_MALLOC(node_name_buf, char *, sz * key_max_sz * sizeof(char), mpi_errno, "node_name_buf");
+    MPIR_CHKLMEM_MALLOC(node_names, char **, sz * sizeof(char*), mpi_errno, "node_names", MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(node_name_buf, char *, sz * key_max_sz * sizeof(char), mpi_errno, "node_name_buf", MPL_MEM_ADDRESS);
 
     /* Gather hostnames */
     for (i = 0; i < sz; ++i)
@@ -480,7 +480,7 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
         {
             /* This is us, no need to perform a get */
             int ret;
-            char *hostname = (char*) MPL_malloc(sizeof(char) * MAX_HOSTNAME_LEN);
+            char *hostname = (char*) MPL_malloc(sizeof(char) * MAX_HOSTNAME_LEN, MPL_MEM_ADDRESS);
             ret = gethostname(hostname, MAX_HOSTNAME_LEN);
             MPIR_ERR_CHKANDJUMP2(ret == -1, mpi_errno, MPI_ERR_OTHER, "**sock_gethost", "**sock_gethost %s %d", MPIR_Strerror(errno), errno);
             hostname[MAX_HOSTNAME_LEN-1] = '\0';

--- a/src/util/procmap/local_proc.c
+++ b/src/util/procmap/local_proc.c
@@ -85,16 +85,16 @@ int MPIR_Find_local_and_external(MPIR_Comm *comm, int *local_size_p, int *local_
     /* these two will be realloc'ed later to the appropriate size (currently unknown) */
     /* FIXME: realloc doesn't guarantee that the allocated area will be 
        shrunk - so using realloc is not an appropriate strategy. */
-    MPIR_CHKPMEM_MALLOC (external_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno, "external_ranks");
-    MPIR_CHKPMEM_MALLOC (local_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno, "local_ranks");
+    MPIR_CHKPMEM_MALLOC (external_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno, "external_ranks", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC (local_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno, "local_ranks", MPL_MEM_COMM);
 
-    MPIR_CHKPMEM_MALLOC (internode_table, int *, sizeof(int) * comm->remote_size, mpi_errno, "internode_table");
-    MPIR_CHKPMEM_MALLOC (intranode_table, int *, sizeof(int) * comm->remote_size, mpi_errno, "intranode_table");
+    MPIR_CHKPMEM_MALLOC (internode_table, int *, sizeof(int) * comm->remote_size, mpi_errno, "internode_table", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC (intranode_table, int *, sizeof(int) * comm->remote_size, mpi_errno, "intranode_table", MPL_MEM_COMM);
 
     mpi_errno = MPID_Get_max_node_id(comm, &max_node_id);
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);
     MPIR_Assert(max_node_id >= 0);
-    MPIR_CHKLMEM_MALLOC (nodes, int *, sizeof(int) * (max_node_id + 1), mpi_errno, "nodes");
+    MPIR_CHKLMEM_MALLOC (nodes, int *, sizeof(int) * (max_node_id + 1), mpi_errno, "nodes", MPL_MEM_COMM);
 
     /* nodes maps node_id to rank in external_ranks of leader for that node */
     for (i = 0; i < (max_node_id + 1); ++i)
@@ -178,12 +178,12 @@ int MPIR_Find_local_and_external(MPIR_Comm *comm, int *local_size_p, int *local_
 
     *local_size_p = local_size;
     *local_rank_p = local_rank;
-    *local_ranks_p =  MPL_realloc (local_ranks, sizeof(int) * local_size);
+    *local_ranks_p =  MPL_realloc (local_ranks, sizeof(int) * local_size, MPL_MEM_COMM);
     MPIR_ERR_CHKANDJUMP (*local_ranks_p == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem2");
 
     *external_size_p = external_size;
     *external_rank_p = external_rank;
-    *external_ranks_p = MPL_realloc (external_ranks, sizeof(int) * external_size);
+    *external_ranks_p = MPL_realloc (external_ranks, sizeof(int) * external_size, MPL_MEM_COMM);
     MPIR_ERR_CHKANDJUMP (*external_ranks_p == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem2");
 
     /* no need to realloc */

--- a/src/util/wrappers/mpiu_sock_wrappers.h
+++ b/src/util/wrappers/mpiu_sock_wrappers.h
@@ -487,7 +487,7 @@ static inline int MPIU_SOCKW_Timeval_hnd_init(
     MPIR_Assert(hnd_ptr);
 
     *hnd_ptr = (MPIU_SOCKW_Timeval_hnd_t)
-                MPL_malloc(sizeof(MPIU_SOCKW_Timeval_t_));
+                MPL_malloc(sizeof(MPIU_SOCKW_Timeval_t_), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP1( !(*hnd_ptr), mpi_errno, MPI_ERR_OTHER,
         "**nomem", "**nomem %s", "handle to timeval");
 
@@ -568,7 +568,7 @@ static inline int MPIU_SOCKW_Waitset_hnd_init(
     }
 
     *hnd_ptr = (MPIU_SOCKW_Waitset_hnd_t) MPL_malloc(
-            sizeof(MPIU_SOCKW_Waitset_));
+            sizeof(MPIU_SOCKW_Waitset_), MPL_MEM_OTHER);
 
     MPIR_ERR_CHKANDJUMP1(!(*hnd_ptr), mpi_errno, MPI_ERR_OTHER,
         "**nomem", "**nomem %s", "handle to waitset");
@@ -586,7 +586,7 @@ static inline int MPIU_SOCKW_Waitset_hnd_init(
 
     /* FIXME: Cheating - Expand dynamically */
     (*hnd_ptr)->fdset = (MPIU_SOCKW_Waitset_sock_hnd_ *)
-        MPL_malloc(FD_SETSIZE * sizeof(MPIU_SOCKW_Waitset_sock_hnd_));
+        MPL_malloc(FD_SETSIZE * sizeof(MPIU_SOCKW_Waitset_sock_hnd_), MPL_MEM_OTHER);
 
     MPIR_ERR_CHKANDJUMP1(!((*hnd_ptr)->fdset), mpi_errno, MPI_ERR_OTHER,
         "**nomem", "**nomem %s", "fdset array in waitSet");

--- a/test/mpi/datatype/segtest.c
+++ b/test/mpi/datatype/segtest.c
@@ -42,7 +42,7 @@ MPIR_Dataloop *MPIR_Dataloop_init_contig(int count)
 {
     MPIR_Dataloop *ct;
 
-    ct = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop));
+    ct = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop), MPL_MEM_OTHER);
     ct->kind = MPID_DTYPE_CONTIG | DATALOOP_FINAL_MASK;
     ct->loop_params.c_t.count = count;
     ct->loop_params.c_t.dataloop = 0;
@@ -59,7 +59,7 @@ MPIR_Dataloop *MPIR_Dataloop_init_vector(int count, int blocksize, int stride)
 {
     MPIR_Dataloop *v;
 
-    v = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop));
+    v = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop), MPL_MEM_OTHER);
     v->kind = MPID_DTYPE_VECTOR | DATALOOP_FINAL_MASK;
     v->loop_params.v_t.count = count;
     v->loop_params.v_t.blocksize = blocksize;
@@ -80,11 +80,11 @@ MPIR_Dataloop *MPIR_Dataloop_init_blockindexed(int count, int blocksize, MPI_Ain
     MPI_Aint extent;
     int i;
 
-    bi = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop));
+    bi = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop), MPL_MEM_OTHER);
     bi->kind = MPID_DTYPE_BLOCKINDEXED | DATALOOP_FINAL_MASK;
     bi->loop_params.bi_t.count = count;
     bi->loop_params.bi_t.blocksize = blocksize;
-    bi->loop_params.bi_t.offset = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * count);
+    bi->loop_params.bi_t.offset = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * count, MPL_MEM_OTHER);
     for (i = 0; i < count; i++) {
         bi->loop_params.bi_t.offset[i] = offset[i];
         if (offset[i] + blocksize > extent)
@@ -106,11 +106,11 @@ MPIR_Dataloop *MPIR_Dataloop_init_indexed(int count, int *blocksize, MPI_Aint * 
     MPI_Aint extent = 0;
     int i;
 
-    it = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop));
+    it = (MPIR_Dataloop *) MPL_malloc(sizeof(MPIR_Dataloop), MPL_MEM_OTHER);
     it->kind = MPID_DTYPE_INDEXED | DATALOOP_FINAL_MASK;
     it->loop_params.i_t.count = count;
-    it->loop_params.i_t.blocksize = (int *) MPL_malloc(sizeof(int) * count);
-    it->loop_params.i_t.offset = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * count);
+    it->loop_params.i_t.blocksize = (int *) MPL_malloc(sizeof(int) * count, MPL_MEM_OTHER);
+    it->loop_params.i_t.offset = (MPI_Aint *) MPL_malloc(sizeof(MPI_Aint) * count, MPL_MEM_OTHER);
     for (i = 0; i < count; i++) {
         it->loop_params.i_t.offset[i] = offset[i];
         it->loop_params.i_t.blocksize[i] = blocksize[i];
@@ -140,14 +140,14 @@ int main(int argc, char **argv)
     MPI_Type_vector(count, 1, 7, MPI_INT, &vectype);
 
     /* Initialize the data */
-    src_buf = (char *) MPL_malloc((count - 1) * stride + blocksize);
+    src_buf = (char *) MPL_malloc((count - 1) * stride + blocksize, MPL_MEM_OTHER);
     for (i = 0; i < (count - 1) * stride + blocksize; i++)
         src_buf[i] = -i;
     for (i = 0; i < count; i++) {
         for (j = 0; j < blocksize; j++)
             src_buf[i * stride + j] = i * blocksize + j;
     }
-    dest_buf = (char *) MPL_malloc(count * blocksize);
+    dest_buf = (char *) MPL_malloc(count * blocksize, MPL_MEM_OTHER);
     for (i = 0; i < count * blocksize; i++) {
         dest_buf[i] = -i;
     }

--- a/test/mpi/group/glpid.c
+++ b/test/mpi/group/glpid.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     group.rank = 0;
     group.idx_of_first_lpid = -1;
     group.lrank_to_lpid = (MPII_Group_pmap_t *)
-        MPL_malloc(group.size * sizeof(MPII_Group_pmap_t));
+        MPL_malloc(group.size * sizeof(MPII_Group_pmap_t), MPL_MEM_OTHER);
     for (i = 0; i < group.size; i++) {
         group.lrank_to_lpid[i].lrank = i;
         group.lrank_to_lpid[i].lpid = group.size - i - 1;


### PR DESCRIPTION
We've been trying to improve the way we do memory tracing so we can better understand where memory is going, especially as things scale. To make that easier, I added a bunch of "classes" of memory that get applied to each memory allocation. This means that I needed to change the API for `MPI_malloc` to be able to pass in this new class.

This also meant that some "upstream" functions also had to take in the new class. An example is the set of utarray functions since they allocate memory on MPICH's behalf.

This PR does not include changes for CH3, which obviously need to be included in order for this to get merged, but I wanted to go ahead and discuss it before doing that work.