### PR TITLE
Fix load imbalance in implementation of Rabenseifner’s algorithm

### DIFF
--- a/src/mpi/coll/allreduce.c
+++ b/src/mpi/coll/allreduce.c
@@ -194,7 +194,7 @@ int MPIR_Allreduce_intra (
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int nbytes = 0;
-    int mask, dst, is_commutative, pof2, newrank, rem, newdst, i;
+    int mask, dst, is_commutative, pof2, newrank, rem, newdst;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
     int count_lhalf, count_rhalf, step, nsteps, wsize;
@@ -643,10 +643,12 @@ int MPIR_Allreduce_intra (
                                                        rcount[step], datatype, op);
 
                     /* Move the current window to the received message */
-                    rindex[step + 1] = rindex[step];
-                    sindex[step + 1] = rindex[step];
-                    wsize = rcount[step];
-                    step++;
+                    if (step + 1 < nsteps) {
+                        rindex[step + 1] = rindex[step];
+                        sindex[step + 1] = rindex[step];
+                        wsize = rcount[step];
+                        step++;
+                    }
                 }
             }
 
@@ -661,8 +663,8 @@ int MPIR_Allreduce_intra (
             if (newrank != -1) {
                 step = nsteps - 1; /* step = ilog2(p') - 1 */
 
-                for (int mask = pof2 >> 1; mask > 0; mask >>= 1) {
-                    int newdst = newrank ^ mask;
+                for (mask = pof2 >> 1; mask > 0; mask >>= 1) {
+                    newdst = newrank ^ mask;
                     /* find real rank of dest */
                     dst = (newdst < rem) ? newdst * 2 : newdst + rem;
 

--- a/src/mpi/coll/allreduce.c
+++ b/src/mpi/coll/allreduce.c
@@ -194,12 +194,14 @@ int MPIR_Allreduce_intra (
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int nbytes = 0;
-    int mask, dst, is_commutative, pof2, newrank, rem, newdst, i,
-        send_idx, recv_idx, last_idx, send_cnt, recv_cnt, *cnts, *disps; 
+    int mask, dst, is_commutative, pof2, newrank, rem, newdst, i;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
-    MPIR_CHKLMEM_DECL(3);
-    
+    int count_lhalf, count_rhalf, step, nsteps, wsize;
+    int *rindex, *rcount, *sindex, *scount;
+
+    MPIR_CHKLMEM_DECL(5);
+
     if (count == 0) goto fn_exit;
 
     is_commutative = MPIR_Op_is_commutative(op);
@@ -219,7 +221,7 @@ int MPIR_Allreduce_intra (
             if ((sendbuf == MPI_IN_PLACE) && (comm_ptr->node_comm->rank != 0)) {
                 /* IN_PLACE and not root of reduce. Data supplied to this
                    allreduce is in recvbuf. Pass that as the sendbuf to reduce. */
-			
+
                 mpi_errno = MPID_Reduce(recvbuf, NULL, count, datatype, op, 0, comm_ptr->node_comm, errflag);
                 if (mpi_errno) {
                     /* for communication errors, just record the error but continue */
@@ -327,97 +329,96 @@ int MPIR_Allreduce_intra (
 
         MPID_Datatype_get_size_macro(datatype, type_size);
 
-        /* find nearest power-of-two less than or equal to comm_size */
+        /* Find nearest power-of-two less than or equal to comm_size */
         pof2 = 1;
-        while (pof2 <= comm_size) pof2 <<= 1;
-        pof2 >>=1;
+        nsteps = -1;
+        while (pof2 <= comm_size) {
+            pof2 <<= 1;
+            nsteps++;
+        }
+        pof2 >>= 1;
 
         rem = comm_size - pof2;
 
-        /* In the non-power-of-two case, all even-numbered
-           processes of rank < 2*rem send their data to
-           (rank+1). These even-numbered processes no longer
-           participate in the algorithm until the very end. The
-           remaining processes form a nice power-of-two. */
-        
-        if (rank < 2*rem) {
-            if (rank % 2 == 0) { /* even */
-                mpi_errno = MPIC_Send(recvbuf, count,
-                                         datatype, rank+1,
-                                         MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
-                
-                /* temporarily set the rank to -1 so that this
-                   process does not pariticipate in recursive
-                   doubling */
-                newrank = -1; 
-            }
-            else { /* odd */
-                mpi_errno = MPIC_Recv(tmp_buf, count,
-                                         datatype, rank-1,
-                                         MPIR_ALLREDUCE_TAG, comm_ptr,
-                                         MPI_STATUS_IGNORE, errflag);
-                if (mpi_errno) {
-                    /* for communication errors, just record the error but continue */
-                    *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
-                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                }
-
-                /* do the reduction on received data. since the
-                   ordering is right, it doesn't matter whether
-                   the operation is commutative or not. */
-                mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, count, datatype, op);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-
-                /* change the rank */
-                newrank = rank / 2;
-            }
-        }
-        else  /* rank >= 2*rem */
-            newrank = rank - rem;
-        
         /* If op is user-defined or count is less than pof2, use
-           recursive doubling algorithm. Otherwise do a reduce-scatter
-           followed by allgather. (If op is user-defined,
-           derived datatypes are allowed and the user could pass basic
-           datatypes on one process and derived on another as long as
-           the type maps are the same. Breaking up derived
-           datatypes to do the reduce-scatter is tricky, therefore
-           using recursive doubling in that case.) */
+        recursive doubling algorithm. Otherwise do a reduce-scatter
+        followed by allgather. (If op is user-defined,
+        derived datatypes are allowed and the user could pass basic
+        datatypes on one process and derived on another as long as
+        the type maps are the same. Breaking up derived
+        datatypes to do the reduce-scatter is tricky, therefore
+        using recursive doubling in that case.) */
 
-        if (newrank != -1) {
-            if ((count*type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-                (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) ||  
-                (count < pof2)) { /* use recursive doubling */
-                mask = 0x1;
-                while (mask < pof2) {
-                    newdst = newrank ^ mask;
-                    /* find real rank of dest */
-                    dst = (newdst < rem) ? newdst*2 + 1 : newdst + rem;
-
-                    /* Send the most current data, which is in recvbuf. Recv
-                       into tmp_buf */ 
-                    mpi_errno = MPIC_Sendrecv(recvbuf, count, datatype,
-                                                 dst, MPIR_ALLREDUCE_TAG, tmp_buf,
-                                                 count, datatype, dst,
-                                                 MPIR_ALLREDUCE_TAG, comm_ptr,
-                                                 MPI_STATUS_IGNORE, errflag);
+        if ((count * type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
+            (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+            /*
+             * Use recursive doubling
+             */
+            if (rank < 2 * rem) {
+                if (rank % 2 == 0) { /* even */
+                    mpi_errno = MPIC_Send(recvbuf, count,
+                                          datatype, rank + 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
                     if (mpi_errno) {
                         /* for communication errors, just record the error but continue */
                         *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
                         MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
                         MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                     }
-                    
+
+                    /* temporarily set the rank to -1 so that this
+                       process does not pariticipate in recursive doubling */
+                    newrank = -1;
+                }
+                else { /* odd */
+                    mpi_errno = MPIC_Recv(tmp_buf, count,
+                                          datatype, rank - 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr,
+                                          MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+
+                    /* do the reduction on received data. since the
+                       ordering is right, it doesn't matter whether
+                       the operation is commutative or not. */
+                    mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, count, datatype, op);
+                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+
+                    /* change the rank */
+                    newrank = rank / 2;
+                }
+            }
+            else  /* rank >= 2 * rem */
+                newrank = rank - rem;
+
+            if (newrank != -1) {
+                mask = 0x1;
+                while (mask < pof2) {
+                    newdst = newrank ^ mask;
+                    /* find real rank of dest */
+                    dst = (newdst < rem) ? newdst * 2 + 1 : newdst + rem;
+
+                    /* Send the most current data, which is in recvbuf.
+                       Recv into tmp_buf */
+                    mpi_errno = MPIC_Sendrecv(recvbuf, count, datatype,
+                                              dst, MPIR_ALLREDUCE_TAG, tmp_buf,
+                                              count, datatype, dst,
+                                              MPIR_ALLREDUCE_TAG, comm_ptr,
+                                              MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+
                     /* tmp_buf contains data received in this step.
                        recvbuf contains data accumulated so far */
-                    
+
                     if (is_commutative  || (dst < rank)) {
                         /* op is commutative OR the order is already right */
                         mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, count, datatype, op);
@@ -437,127 +438,64 @@ int MPIR_Allreduce_intra (
                 }
             }
 
-            else {
-
-                /* do a reduce-scatter followed by allgather */
-
-                /* for the reduce-scatter, calculate the count that
-                   each process receives and the displacement within
-                   the buffer */
-
-		MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-		MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
-
-                for (i=0; i<(pof2-1); i++) 
-                    cnts[i] = count/pof2;
-                cnts[pof2-1] = count - (count/pof2)*(pof2-1);
-
-                disps[0] = 0;
-                for (i=1; i<pof2; i++)
-                    disps[i] = disps[i-1] + cnts[i-1];
-
-                mask = 0x1;
-                send_idx = recv_idx = 0;
-                last_idx = pof2;
-                while (mask < pof2) {
-                    newdst = newrank ^ mask;
-                    /* find real rank of dest */
-                    dst = (newdst < rem) ? newdst*2 + 1 : newdst + rem;
-
-                    send_cnt = recv_cnt = 0;
-                    if (newrank < newdst) {
-                        send_idx = recv_idx + pof2/(mask*2);
-                        for (i=send_idx; i<last_idx; i++)
-                            send_cnt += cnts[i];
-                        for (i=recv_idx; i<send_idx; i++)
-                            recv_cnt += cnts[i];
-                    }
-                    else {
-                        recv_idx = send_idx + pof2/(mask*2);
-                        for (i=send_idx; i<recv_idx; i++)
-                            send_cnt += cnts[i];
-                        for (i=recv_idx; i<last_idx; i++)
-                            recv_cnt += cnts[i];
-                    }
-
-/*                    printf("Rank %d, send_idx %d, recv_idx %d, send_cnt %d, recv_cnt %d, last_idx %d\n", newrank, send_idx, recv_idx,
-                           send_cnt, recv_cnt, last_idx);
-                           */
-                    /* Send data from recvbuf. Recv into tmp_buf */ 
-                    mpi_errno = MPIC_Sendrecv((char *) recvbuf +
-                                                 disps[send_idx]*extent,
-                                                 send_cnt, datatype,  
-                                                 dst, MPIR_ALLREDUCE_TAG, 
-                                                 (char *) tmp_buf +
-                                                 disps[recv_idx]*extent,
-                                                 recv_cnt, datatype, dst,
-                                                 MPIR_ALLREDUCE_TAG, comm_ptr,
-                                                 MPI_STATUS_IGNORE, errflag);
-                    if (mpi_errno) {
-                        /* for communication errors, just record the error but continue */
-                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
-                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
-                    }
-                    
-                    /* tmp_buf contains data received in this step.
-                       recvbuf contains data accumulated so far */
-                    
-                    /* This algorithm is used only for predefined ops
-                       and predefined ops are always commutative. */
-                    mpi_errno = MPIR_Reduce_local_impl(((char *) tmp_buf + disps[recv_idx]*extent),
-                                                       ((char *) recvbuf + disps[recv_idx]*extent),
-                                                       recv_cnt, datatype, op);
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-
-                    /* update send_idx for next iteration */
-                    send_idx = recv_idx;
-                    mask <<= 1;
-
-                    /* update last_idx, but not in last iteration
-                       because the value is needed in the allgather
-                       step below. */
-                    if (mask < pof2)
-                        last_idx = recv_idx + pof2/mask;
+            /* In the non-power-of-two case, all odd-numbered
+            processes of rank < 2 * rem send the result to
+            (rank - 1), the ranks who didn't participate above. */
+            if (rank < 2 * rem) {
+                if (rank % 2)  /* odd */
+                    mpi_errno = MPIC_Send(recvbuf, count,
+                                          datatype, rank - 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                else  /* even */
+                    mpi_errno = MPIC_Recv(recvbuf, count,
+                                          datatype, rank + 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr,
+                                          MPI_STATUS_IGNORE, errflag);
+                if (mpi_errno) {
+                    /* for communication errors, just record the error but continue */
+                    *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                    MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                    MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
+            }
+        }
+        else {
+            /*
+             * Use reduce-scatter followed by allgather
+             */
+            
+            /* Step 1. Reduce the number of processes to the nearest lower power of two
+             * (p' = 2^{\lfloor\log_2 p\rfloor}) by removing r = p - p' processes.
+             * 1. In the first 2r processes (ranks 0 to 2r - 1), all the even ranks send
+             *    the second half of the input vector to their right neighbor (rank + 1)
+             *    and all the odd ranks send the first half of the input vector to their
+             *    left neighbor (rank - 1).
+             * 2. All 2r processes compute the reduction on their half.
+             * 3. The odd ranks then send the result to their left neighbors
+             *    (the even ranks).
+             *
+             * The even ranks (0 to 2r - 1) now contain the reduction with the input
+             * vector on their right neighbors (the odd ranks). The first r even
+             * processes and the p - 2r last processes are renumbered from
+             * 0 to 2^{\floor(\log_2 p)} - 1. These odd ranks do not participate in the
+             * rest of the algorithm.
+             */
+            if (rank < 2 * rem) {
+                count_lhalf = count / 2;
+                count_rhalf = count - count_lhalf;
 
-                /* now do the allgather */
-
-                mask >>= 1;
-                while (mask > 0) {
-                    newdst = newrank ^ mask;
-                    /* find real rank of dest */
-                    dst = (newdst < rem) ? newdst*2 + 1 : newdst + rem;
-
-                    send_cnt = recv_cnt = 0;
-                    if (newrank < newdst) {
-                        /* update last_idx except on first iteration */
-                        if (mask != pof2/2)
-                            last_idx = last_idx + pof2/(mask*2);
-
-                        recv_idx = send_idx + pof2/(mask*2);
-                        for (i=send_idx; i<recv_idx; i++)
-                            send_cnt += cnts[i];
-                        for (i=recv_idx; i<last_idx; i++)
-                            recv_cnt += cnts[i];
-                    }
-                    else {
-                        recv_idx = send_idx - pof2/(mask*2);
-                        for (i=send_idx; i<last_idx; i++)
-                            send_cnt += cnts[i];
-                        for (i=recv_idx; i<send_idx; i++)
-                            recv_cnt += cnts[i];
-                    }
-
-                    mpi_errno = MPIC_Sendrecv((char *) recvbuf +
-                                                 disps[send_idx]*extent,
-                                                 send_cnt, datatype,  
-                                                 dst, MPIR_ALLREDUCE_TAG, 
-                                                 (char *) recvbuf +
-                                                 disps[recv_idx]*extent,
-                                                 recv_cnt, datatype, dst,
-                                                 MPIR_ALLREDUCE_TAG, comm_ptr,
-                                                 MPI_STATUS_IGNORE, errflag);
+                if (rank % 2 != 0) {
+                    /*
+                     * Odd process -- exchange with rank - 1
+                     * Send the left half of the input vector to the left neighbor,
+                     * Recv the right half of the input vector from the left neighbor
+                     */
+                    mpi_errno = MPIC_Sendrecv(recvbuf, count_lhalf, datatype,
+                                              rank - 1, MPIR_REDUCE_TAG,
+                                              (char *)tmp_buf + count_lhalf * extent,
+                                              count_rhalf, datatype, rank - 1,
+                                              MPIR_REDUCE_TAG, comm_ptr,
+                                              MPI_STATUS_IGNORE, errflag);
                     if (mpi_errno) {
                         /* for communication errors, just record the error but continue */
                         *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
@@ -565,33 +503,218 @@ int MPIR_Allreduce_intra (
                         MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                     }
 
-                    if (newrank > newdst) send_idx = recv_idx;
+                    /* Reduce on the right half of the buffers (result in recvbuf) */
+                    mpi_errno = MPIR_Reduce_local_impl((char *)tmp_buf +
+                                                       count_lhalf * extent,
+                                                       (char *)recvbuf +
+                                                       count_lhalf * extent,
+                                                       count_rhalf, datatype, op);
 
-                    mask >>= 1;
+                    /* Send the right half to the left neighbor */
+                    mpi_errno = MPIC_Send((char *)recvbuf + count_lhalf * extent,
+                                          count_rhalf, datatype, rank - 1,
+                                          MPIR_REDUCE_TAG, comm_ptr, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+                    /* Temporarily set the rank to -1 so that this process does not
+                    pariticipate in recursive doubling */
+                    newrank = -1;
+
+                } else {
+                    /*
+                     * Even process -- exchange with rank + 1
+                     * Send the right half of the input vector to the right neighbor,
+                     * Recv the left half of the input vector from the right neighbor
+                     */
+                    mpi_errno = MPIC_Sendrecv((char *)recvbuf + count_lhalf * extent,
+                                              count_rhalf, datatype, rank + 1,
+                                              MPIR_REDUCE_TAG, tmp_buf, count_lhalf,
+                                              datatype, rank + 1, MPIR_REDUCE_TAG,
+                                              comm_ptr, MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+
+                    /* Reduce on the left half of the buffers (result in recvbuf) */
+                    mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, count_lhalf,
+                                                       datatype, op);
+
+                    /* Recv the right half from the right neighbor */
+                    mpi_errno = MPIC_Recv((char *)recvbuf + count_lhalf * extent,
+                                          count_rhalf, datatype, rank + 1,
+                                          MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                          errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+                    newrank = rank / 2;
+                }
+            } else { /* rank >= 2 * rem */
+                newrank = rank - rem;
+            }
+
+            /*
+             * Step 2. Reduce-scatter implemented with recursive vector halving and
+             * recursive distance doubling. We have p' = 2^{\lfloor\log_2 p\rfloor}
+             * power-of-two number of processes with new ranks and result in recvbuf.
+             *
+             * The even-ranked processes send the right half of their buffer to rank + 1
+             * and the odd-ranked processes send the left half of their buffer to
+             * rank - 1. All processes then compute the reduction between the local
+             * buffer and the received buffer. In the next \log_2(p') - 1 steps, the
+             * buffers are recursively halved, and the distance is doubled. At the end,
+             * each of the p' processes has 1 / p' of the total reduction result.
+             */
+
+            /* We allocate these arrays on all processes, even if newrank = -1,
+            because if root is one of the excluded processes, we will
+            need them on the root later on below. */
+            MPIR_CHKLMEM_MALLOC(rindex, int *, nsteps * sizeof(*rindex), mpi_errno,
+                                "rindex buffer");
+            MPIR_CHKLMEM_MALLOC(rcount, int *, nsteps * sizeof(*rcount), mpi_errno,
+                                "rcount buffer");
+            MPIR_CHKLMEM_MALLOC(sindex, int *, nsteps * sizeof(*sindex), mpi_errno,
+                                "sindex buffer");
+            MPIR_CHKLMEM_MALLOC(scount, int *, nsteps * sizeof(*scount), mpi_errno,
+                                "scount buffer");
+
+            if (newrank != -1) {
+                step = 0;
+                wsize = count;
+                sindex[0] = rindex[0] = 0;
+
+                for (mask = 1; mask < pof2; mask <<= 1) {
+                    /*
+                     * On each iteration: rindex[step] = sindex[step] -- begining of the
+                     * current window. Length of the current window is storded in wsize.
+                     */
+                    newdst = newrank ^ mask;
+                    /* Find real rank of the dest */
+                    dst = (newdst < rem) ? newdst * 2 : newdst + rem;
+
+                    if (rank < dst) {
+                        /* Recv into the left half of the current window, send the right
+                         * half of the window to the peer (perform reduce on the left
+                         * half of the current window)
+                         */
+                        rcount[step] = wsize / 2;
+                        scount[step] = wsize - rcount[step];
+                        sindex[step] = rindex[step] + rcount[step];
+                    } else {
+                        /* Recv into the right half of the current window, send the left
+                         * half of the window to the peer (perform reduce on the right
+                         * half of the current window)
+                         */
+                        scount[step] = wsize / 2;
+                        rcount[step] = wsize - scount[step];
+                        rindex[step] = sindex[step] + scount[step];
+                    }
+
+                    /* Send part of data from the recvbuf, recv into the tmp_buf */
+                    mpi_errno = MPIC_Sendrecv((char *)recvbuf + sindex[step] * extent,
+                                              scount[step], datatype, dst,
+                                              MPIR_REDUCE_TAG,
+                                              (char *)tmp_buf + rindex[step] * extent,
+                                              rcount[step], datatype, dst,
+                                              MPIR_REDUCE_TAG, comm_ptr,
+                                              MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+
+                    /* Local reduce: recvbuf[] = tmp_buf[] <op> recvbuf[] */
+                    mpi_errno = MPIR_Reduce_local_impl((char *)tmp_buf +
+                                                       rindex[step] * extent,
+                                                       (char *)recvbuf +
+                                                       rindex[step] * extent,
+                                                       rcount[step], datatype, op);
+
+                    /* Move the current window to the received message */
+                    rindex[step + 1] = rindex[step];
+                    sindex[step + 1] = rindex[step];
+                    wsize = rcount[step];
+                    step++;
                 }
             }
-        }
 
-        /* In the non-power-of-two case, all odd-numbered
-           processes of rank < 2*rem send the result to
-           (rank-1), the ranks who didn't participate above. */
-        if (rank < 2*rem) {
-            if (rank % 2)  /* odd */
-                mpi_errno = MPIC_Send(recvbuf, count,
-                                         datatype, rank-1,
-                                         MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            else  /* even */
-                mpi_errno = MPIC_Recv(recvbuf, count,
-                                         datatype, rank+1,
-                                         MPIR_ALLREDUCE_TAG, comm_ptr,
-                                         MPI_STATUS_IGNORE, errflag);
-            if (mpi_errno) {
-                /* for communication errors, just record the error but continue */
-                *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
-                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
-                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+            /*
+             * Step 3. Allgather by the recursive doubling algorithm.
+             * Each process has 1 / p' of the total reduction result:
+             * rcount[nsteps - 1] elements in the rbuf[rindex[nsteps - 1], ...].
+             * All exchanges are executed in reverse order relative
+             * to recursive doubling (previous step).
+             */
+
+            if (newrank != -1) {
+                step = nsteps - 1; /* step = ilog2(p') - 1 */
+
+                for (int mask = pof2 >> 1; mask > 0; mask >>= 1) {
+                    int newdst = newrank ^ mask;
+                    /* find real rank of dest */
+                    dst = (newdst < rem) ? newdst * 2 : newdst + rem;
+
+                    /*
+                     * Send rcount[step] elements from rbuf[rindex[step]...]
+                     * Recv scount[step] elements to rbuf[sindex[step]...]
+                     */
+                    mpi_errno = MPIC_Sendrecv((char *)recvbuf + rindex[step] * extent,
+                                              rcount[step], datatype, dst,
+                                              MPIR_ALLREDUCE_TAG,
+                                              (char *)recvbuf + sindex[step] * extent,
+                                              scount[step], datatype, dst,
+                                              MPIR_ALLREDUCE_TAG, comm_ptr,
+                                              MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+                    step--;
+                }
             }
-        }
+            /*
+             * Step 4. Send total result to excluded odd ranks.
+             */
+            if (rank < 2 * rem) {
+                if (rank % 2 != 0) {
+                    /* Odd process -- recv result from rank - 1 */
+
+                    mpi_errno = MPIC_Recv(recvbuf, count, datatype, rank - 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr,
+                                          MPI_STATUS_IGNORE, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+                } else {
+                    /* Even process -- send result to rank + 1 */
+                    mpi_errno = MPIC_Send(recvbuf, count, datatype, rank + 1,
+                                          MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                    if (mpi_errno) {
+                        /* for communication errors, just record the error but continue */
+                        *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+                    }
+                }
+            }
+        } /* reduce-scatter followed by allgather */
     }
 
   fn_exit:

--- a/src/mpi/coll/allreduce.c
+++ b/src/mpi/coll/allreduce.c
@@ -327,6 +327,9 @@ int MPIR_Allreduce_intra (
             if (mpi_errno) MPIR_ERR_POP(mpi_errno);
         }
 
+        if (comm_size == 1)
+            goto fn_exit;
+
         MPID_Datatype_get_size_macro(datatype, type_size);
 
         /* Find nearest power-of-two less than or equal to comm_size */

--- a/src/mpi/coll/reduce.c
+++ b/src/mpi/coll/reduce.c
@@ -361,6 +361,14 @@ static int MPIR_Reduce_redscat_gather (
     /* should be buf+{this}? */
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
+    if (comm_size == 1) {
+        if (sendbuf != MPI_IN_PLACE) {
+            mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf,
+                                       count, datatype);
+        }
+        goto fn_exit;
+    }
+
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count*(MPL_MAX(extent,true_extent)),
                         mpi_errno, "temporary buffer");
     /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/reduce.c
+++ b/src/mpi/coll/reduce.c
@@ -329,7 +329,7 @@ static int MPIR_Reduce_redscat_gather (
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int comm_size, rank, type_size ATTRIBUTE((unused)), pof2, rem, newrank;
-    int mask, i, j, dst, newdst, nsteps, step, wsize;
+    int mask, dst, newdst, nsteps, step, wsize;
     int newroot, newdst_tree_root, newroot_tree_root;
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf;
@@ -575,10 +575,12 @@ static int MPIR_Reduce_redscat_gather (
                                                rcount[step], datatype, op);
 
             /* Move the current window to the received message */
-            rindex[step + 1] = rindex[step];
-            sindex[step + 1] = rindex[step];
-            wsize = rcount[step];
-            step++;
+            if (step + 1 < nsteps) {
+                rindex[step + 1] = rindex[step];
+                sindex[step + 1] = rindex[step];
+                wsize = rcount[step];
+                step++;
+            }
         }
     }
     /*

--- a/src/mpi/coll/reduce.c
+++ b/src/mpi/coll/reduce.c
@@ -251,38 +251,72 @@ fn_fail:
     goto fn_exit;
 }
 
-/* An implementation of Rabenseifner's reduce algorithm (see
-   http://www.hlrs.de/mpi/myreduce.html).
+/* An implementation of Rabenseifner's reduce algorithm [1, 2].
 
-   This algorithm implements the reduce in two steps: first a
-   reduce-scatter, followed by a gather to the root. A
-   recursive-halving algorithm (beginning with processes that are
-   distance 1 apart) is used for the reduce-scatter, and a binomial tree
-   algorithm is used for the gather. The non-power-of-two case is
-   handled by dropping to the nearest lower power-of-two: the first
-   few odd-numbered processes send their data to their left neighbors
-   (rank-1), and the reduce-scatter happens among the remaining
-   power-of-two processes. If the root is one of the excluded
-   processes, then after the reduce-scatter, rank 0 sends its result to
-   the root and exits; the root now acts as rank 0 in the binomial tree
-   algorithm for gather.
+   [1] Rajeev Thakur, Rolf Rabenseifner and William Gropp.
+       Optimization of Collective Communication Operations in MPICH //
+       The Int. Journal of High Performance Computing Applications. Vol 19,
+       Issue 1, pp. 49--66.
+   [2] http://www.hlrs.de/mpi/myreduce.html
 
-   For the power-of-two case, the cost for the reduce-scatter is 
-   lgp.alpha + n.((p-1)/p).beta + n.((p-1)/p).gamma. The cost for the
-   gather to root is lgp.alpha + n.((p-1)/p).beta. Therefore, the
-   total cost is:
-   Cost = 2.lgp.alpha + 2.n.((p-1)/p).beta + n.((p-1)/p).gamma
+  This algorithm is a combination of a reduce-scatter implemented with
+  recursive vector halving and recursive distance doubling, followed either
+  by a binomial tree gather.
 
-   For the non-power-of-two case, assuming the root is not one of the
-   odd-numbered processes that get excluded in the reduce-scatter,
-   Cost = (2.floor(lgp)+1).alpha + (2.((p-1)/p) + 1).n.beta + 
-           n.(1+(p-1)/p).gamma
-*/
+  Step 1. If the number of processes is not a power of two, reduce it to
+  the nearest lower power of two (p' = 2^{\lfloor\log_2 p\rfloor})
+  by removing r = p - p' extra processes as follows. In the first 2r processes
+  (ranks 0 to 2r - 1), all the even ranks send the second half of the input
+  vector to their right neighbor (rank + 1), and all the odd ranks send
+  the first half of the input vector to their left neighbor (rank - 1).
+  The even ranks compute the reduction on the first half of the vector and
+  the odd ranks compute the reduction on the second half. The odd ranks then
+  send the result to their left neighbors (the even ranks). As a result,
+  the even ranks among the first 2r processes now contain the reduction with
+  the input vector on their right neighbors (the odd ranks). These odd ranks
+  do not participate in the rest of the algorithm, which leaves behind
+  a power-of-two number of processes. The first r even-ranked processes and
+  the last p - 2r processes are now renumbered from 0 to p' - 1.
+
+  Step 2. The remaining processes now perform a reduce-scatter by using
+  recursive vector halving and recursive distance doubling. The even-ranked
+  processes send the second half of their buffer to rank + 1 and the odd-ranked
+  processes send the first half of their buffer to rank - 1. All processes
+  then compute the reduction between the local buffer and the received buffer.
+  In the next \log_2(p') - 1 steps, the buffers are recursively halved, and the
+  distance is doubled. At the end, each of the p' processes has 1 / p' of the
+  total reduction result.
+
+  Step 3. A binomial tree gather is performed by using recursive vector
+  doubling and distance halving. In the non-power-of-two case, if the root
+  happens to be one of those odd-ranked processes that would normally
+  be removed in the first step, then the role of this process and process 0
+  are interchanged.
+
+  Limitations: commutative operations only, count >= 2^{\lfloor\log_2 p\rfloor}
+  Recommendations: root = 0, otherwise it is required additional steps
+                   in the root process.
+
+  Memory consumption (per process):
+  1) rank != root: 2 * count * dtypesize + 4 * \log_2(p) * sizeof(int)
+  2) rank == root: count * dtypesize + 4 * \log_2(p) * sizeof(int)
+
+  For the power-of-two case, the cost for the reduce-scatter is
+  lgp.alpha + n.((p-1)/p).beta + n.((p-1)/p).gamma. The cost for the
+  gather to root is lgp.alpha + n.((p-1)/p).beta. Therefore, the
+  total cost is:
+  Cost = 2.lgp.alpha + 2.n.((p-1)/p).beta + n.((p-1)/p).gamma
+
+  For the non-power-of-two case, assuming the root is not one of the
+  odd-numbered processes that get excluded in the reduce-scatter,
+  Cost = (2.floor(lgp)+1).alpha + (2.((p-1)/p) + 1).n.beta +
+          n.(1+(p-1)/p).gamma
+ */
 #undef FUNCNAME
 #define FUNCNAME MPIR_Reduce_redscat_gather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIR_Reduce_redscat_gather ( 
+static int MPIR_Reduce_redscat_gather (
     const void *sendbuf,
     void *recvbuf,
     int count,
@@ -295,13 +329,13 @@ static int MPIR_Reduce_redscat_gather (
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int comm_size, rank, type_size ATTRIBUTE((unused)), pof2, rem, newrank;
-    int mask, *cnts, *disps, i, j, send_idx=0;
-    int recv_idx, last_idx=0, newdst;
-    int dst, send_cnt, recv_cnt, newroot, newdst_tree_root, newroot_tree_root; 
-    MPI_Aint true_lb, true_extent, extent; 
+    int mask, i, j, dst, newdst, nsteps, step, wsize;
+    int newroot, newdst_tree_root, newroot_tree_root;
+    MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf;
+    int *rindex, *rcount, *sindex, *scount, count_lhalf, count_rhalf;
 
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL(6);
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -322,7 +356,7 @@ static int MPIR_Reduce_redscat_gather (
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPID_Datatype_get_extent_macro(datatype, extent);
 
-    /* I think this is the worse case, so we can avoid an assert() 
+    /* I think this is the worse case, so we can avoid an assert()
      * inside the for loop */
     /* should be buf+{this}? */
     MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
@@ -331,12 +365,12 @@ static int MPIR_Reduce_redscat_gather (
                         mpi_errno, "temporary buffer");
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *)((char*)tmp_buf - true_lb);
-    
+
     /* If I'm not the root, then my recvbuf may not be valid, therefore
        I have to allocate a temporary one */
     if (rank != root) {
         MPIR_CHKLMEM_MALLOC(recvbuf, void *,
-                            count*(MPL_MAX(extent,true_extent)), 
+                            count*(MPL_MAX(extent,true_extent)),
                             mpi_errno, "receive buffer");
         recvbuf = (void *)((char*)recvbuf - true_lb);
     }
@@ -349,175 +383,240 @@ static int MPIR_Reduce_redscat_gather (
 
     MPID_Datatype_get_size_macro(datatype, type_size);
 
-    /* find nearest power-of-two less than or equal to comm_size */
+    /* Step 1. Reduce the number of processes to the nearest lower power of two
+     * (p' = 2^{\lfloor\log_2 p\rfloor}) by removing r = p - p' processes.
+     * 1. In the first 2r processes (ranks 0 to 2r - 1), all the even ranks send
+     *    the second half of the input vector to their right neighbor (rank + 1)
+     *    and all the odd ranks send the first half of the input vector to their
+     *    left neighbor (rank - 1).
+     * 2. All 2r processes compute the reduction on their half.
+     * 3. The odd ranks then send the result to their left neighbors
+     *    (the even ranks).
+     *
+     * The even ranks (0 to 2r - 1) now contain the reduction with the input
+     * vector on their right neighbors (the odd ranks). The first r even
+     * processes and the p - 2r last processes are renumbered from
+     * 0 to 2^{\floor(log_2 p)} - 1. These odd ranks do not participate in the
+     * rest of the algorithm.
+     */
+
+    /* Find nearest power-of-two less than or equal to comm_size */
     pof2 = 1;
-    while (pof2 <= comm_size) pof2 <<= 1;
-    pof2 >>=1;
+    nsteps = -1;
+    while (pof2 <= comm_size) {  /* O(\log_2(p)), TODO: use flp2 and ilog2 */
+        pof2 <<= 1;
+        nsteps++;
+    }
+    pof2 >>= 1;
 
     rem = comm_size - pof2;
+    if (rank < 2 * rem) {
+        count_lhalf = count / 2;
+        count_rhalf = count - count_lhalf;
 
-    /* In the non-power-of-two case, all odd-numbered
-       processes of rank < 2*rem send their data to
-       (rank-1). These odd-numbered processes no longer
-       participate in the algorithm until the very end. The
-       remaining processes form a nice power-of-two. 
-
-       Note that in MPI_Allreduce we have the even-numbered processes
-       send data to odd-numbered processes. That is better for
-       non-commutative operations because it doesn't require a
-       buffer copy. However, for MPI_Reduce, the most common case
-       is commutative operations with root=0. Therefore we want
-       even-numbered processes to participate the computation for
-       the root=0 case, in order to avoid an extra send-to-root
-       communication after the reduce-scatter. In MPI_Allreduce it
-       doesn't matter because all processes must get the result. */
-    
-    if (rank < 2*rem) {
-        if (rank % 2 != 0) { /* odd */
-            mpi_errno = MPIC_Send(recvbuf, count,
-                                     datatype, rank-1,
-                                     MPIR_REDUCE_TAG, comm_ptr, errflag);
+        if (rank % 2 != 0) {
+            /*
+             * Odd process -- exchange with rank - 1
+             * Send the left half of the input vector to the left neighbor,
+             * Recv the right half of the input vector from the left neighbor
+             */
+            mpi_errno = MPIC_Sendrecv(recvbuf, count_lhalf, datatype,
+                                      rank - 1, MPIR_REDUCE_TAG,
+                                      (char *)tmp_buf + count_lhalf * extent,
+                                      count_rhalf, datatype, rank - 1,
+                                      MPIR_REDUCE_TAG, comm_ptr,
+                                      MPI_STATUS_IGNORE, errflag);
             if (mpi_errno) {
                 /* for communication errors, just record the error but continue */
                 *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
                 MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
                 MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
             }
-            
-            /* temporarily set the rank to -1 so that this
-               process does not pariticipate in recursive
-               doubling */
-            newrank = -1; 
-        }
-        else { /* even */
-            mpi_errno = MPIC_Recv(tmp_buf, count,
-                                     datatype, rank+1,
-                                     MPIR_REDUCE_TAG, comm_ptr,
-                                     MPI_STATUS_IGNORE, errflag);
+
+            /* Reduce on the right half of the buffers (result in recvbuf) */
+            mpi_errno = MPIR_Reduce_local_impl((char *)tmp_buf +
+                                               count_lhalf * extent,
+                                               (char *)recvbuf +
+                                               count_lhalf * extent,
+                                               count_rhalf, datatype, op);
+
+            /* Send the right half to the left neighbor */
+            mpi_errno = MPIC_Send((char *)recvbuf + count_lhalf * extent,
+                                  count_rhalf, datatype, rank - 1,
+                                  MPIR_REDUCE_TAG, comm_ptr, errflag);
             if (mpi_errno) {
                 /* for communication errors, just record the error but continue */
                 *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
                 MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
                 MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
             }
-            
-            /* do the reduction on received data. */
-            /* This algorithm is used only for predefined ops
-               and predefined ops are always commutative. */
-	    mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, 
-					       count, datatype, op);
-            /* change the rank */
+            /* Temporarily set the rank to -1 so that this process does not
+               pariticipate in recursive doubling */
+            newrank = -1;
+
+        } else {
+            /*
+             * Even process -- exchange with rank + 1
+             * Send the right half of the input vector to the right neighbor,
+             * Recv the left half of the input vector from the right neighbor
+             */
+            mpi_errno = MPIC_Sendrecv((char *)recvbuf + count_lhalf * extent,
+                                      count_rhalf, datatype, rank + 1,
+                                      MPIR_REDUCE_TAG, tmp_buf, count_lhalf,
+                                      datatype, rank + 1, MPIR_REDUCE_TAG,
+                                      comm_ptr, MPI_STATUS_IGNORE, errflag);
+            if (mpi_errno) {
+                /* for communication errors, just record the error but continue */
+                *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+            }
+
+            /* Reduce on the left half of the buffers (result in recvbuf) */
+            mpi_errno = MPIR_Reduce_local_impl(tmp_buf, recvbuf, count_lhalf,
+                                               datatype, op);
+
+            /* Recv the right half from the right neighbor */
+            mpi_errno = MPIC_Recv((char *)recvbuf + count_lhalf * extent,
+                                  count_rhalf, datatype, rank + 1,
+                                  MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  errflag);
+            if (mpi_errno) {
+                /* for communication errors, just record the error but continue */
+                *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
+                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+            }
             newrank = rank / 2;
         }
-    }
-    else  /* rank >= 2*rem */
+    } else { /* rank >= 2 * rem */
         newrank = rank - rem;
-    
-    /* for the reduce-scatter, calculate the count that
-       each process receives and the displacement within
-       the buffer */
+    }
 
-    /* We allocate these arrays on all processes, even if newrank=-1,
+    /*
+     * Step 2. Reduce-scatter implemented with recursive vector halving and
+     * recursive distance doubling. We have p' = 2^{\lfloor\log_2 p\rfloor}
+     * power-of-two number of processes with new ranks and result in recvbuf.
+     *
+     * The even-ranked processes send the right half of their buffer to rank + 1
+     * and the odd-ranked processes send the left half of their buffer to
+     * rank - 1. All processes then compute the reduction between the local
+     * buffer and the received buffer. In the next \log_2(p') - 1 steps, the
+     * buffers are recursively halved, and the distance is doubled. At the end,
+     * each of the p' processes has 1 / p' of the total reduction result.
+     */
+
+    /* We allocate these arrays on all processes, even if newrank = -1,
        because if root is one of the excluded processes, we will
        need them on the root later on below. */
-    MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
-    MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
-    
+    MPIR_CHKLMEM_MALLOC(rindex, int *, nsteps * sizeof(*rindex), mpi_errno,
+                        "rindex buffer");
+    MPIR_CHKLMEM_MALLOC(rcount, int *, nsteps * sizeof(*rcount), mpi_errno,
+                        "rcount buffer");
+    MPIR_CHKLMEM_MALLOC(sindex, int *, nsteps * sizeof(*sindex), mpi_errno,
+                        "sindex buffer");
+    MPIR_CHKLMEM_MALLOC(scount, int *, nsteps * sizeof(*scount), mpi_errno,
+                        "scount buffer");
+
     if (newrank != -1) {
-        for (i=0; i<(pof2-1); i++) 
-            cnts[i] = count/pof2;
-        cnts[pof2-1] = count - (count/pof2)*(pof2-1);
-        
-        disps[0] = 0;
-        for (i=1; i<pof2; i++)
-            disps[i] = disps[i-1] + cnts[i-1];
-        
-        mask = 0x1;
-        send_idx = recv_idx = 0;
-        last_idx = pof2;
-        while (mask < pof2) {
+        step = 0;
+        wsize = count;
+        sindex[0] = rindex[0] = 0;
+
+        for (mask = 1; mask < pof2; mask <<= 1) {
+            /*
+             * On each iteration: rindex[step] = sindex[step] -- begining of the
+             * current window. Length of the current window is storded in wsize.
+             */
             newdst = newrank ^ mask;
-            /* find real rank of dest */
-            dst = (newdst < rem) ? newdst*2 : newdst + rem;
-            
-            send_cnt = recv_cnt = 0;
-            if (newrank < newdst) {
-                send_idx = recv_idx + pof2/(mask*2);
-                for (i=send_idx; i<last_idx; i++)
-                    send_cnt += cnts[i];
-                for (i=recv_idx; i<send_idx; i++)
-                    recv_cnt += cnts[i];
+            /* Find real rank of the dest */
+            dst = (newdst < rem) ? newdst * 2 : newdst + rem;
+
+            if (rank < dst) {
+                /*
+                 * Recv into the left half of the current window, send the right
+                 * half of the window to the peer (perform reduce on the left
+                 * half of the current window)
+                 */
+                rcount[step] = wsize / 2;
+                scount[step] = wsize - rcount[step];
+                sindex[step] = rindex[step] + rcount[step];
+            } else {
+                /*
+                 * Recv into the right half of the current window, send the left
+                 * half of the window to the peer (perform reduce on the right
+                 * half of the current window)
+                 */
+                scount[step] = wsize / 2;
+                rcount[step] = wsize - scount[step];
+                rindex[step] = sindex[step] + scount[step];
             }
-            else {
-                recv_idx = send_idx + pof2/(mask*2);
-                for (i=send_idx; i<recv_idx; i++)
-                    send_cnt += cnts[i];
-                for (i=recv_idx; i<last_idx; i++)
-                    recv_cnt += cnts[i];
-            }
-            
-/*                    printf("Rank %d, send_idx %d, recv_idx %d, send_cnt %d, recv_cnt %d, last_idx %d\n", newrank, send_idx, recv_idx,
-                  send_cnt, recv_cnt, last_idx);
-*/
-            /* Send data from recvbuf. Recv into tmp_buf */ 
-            mpi_errno = MPIC_Sendrecv((char *) recvbuf +
-                                         disps[send_idx]*extent,
-                                         send_cnt, datatype,
-                                         dst, MPIR_REDUCE_TAG,
-                                         (char *) tmp_buf +
-                                         disps[recv_idx]*extent,
-                                         recv_cnt, datatype, dst,
-                                         MPIR_REDUCE_TAG, comm_ptr,
-                                         MPI_STATUS_IGNORE, errflag);
+
+            /* Send part of data from the recvbuf, recv into the tmp_buf */
+            mpi_errno = MPIC_Sendrecv((char *)recvbuf + sindex[step] * extent,
+                                      scount[step], datatype, dst,
+                                      MPIR_REDUCE_TAG,
+                                      (char *)tmp_buf + rindex[step] * extent,
+                                      rcount[step], datatype, dst,
+                                      MPIR_REDUCE_TAG, comm_ptr,
+                                      MPI_STATUS_IGNORE, errflag);
             if (mpi_errno) {
                 /* for communication errors, just record the error but continue */
                 *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
                 MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
                 MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
             }
-            
-            /* tmp_buf contains data received in this step.
-               recvbuf contains data accumulated so far */
-            
-            /* This algorithm is used only for predefined ops
-               and predefined ops are always commutative. */
-	    mpi_errno = MPIR_Reduce_local_impl( 
-		       (char *) tmp_buf + disps[recv_idx]*extent,
-                       (char *) recvbuf + disps[recv_idx]*extent, 
-                       recv_cnt, datatype, op );
-            /* update send_idx for next iteration */
-            send_idx = recv_idx;
-            mask <<= 1;
 
-            /* update last_idx, but not in last iteration
-               because the value is needed in the gather
-               step below. */
-            if (mask < pof2)
-                last_idx = recv_idx + pof2/mask;
+            /* Local reduce: recvbuf[] = tmp_buf[] <op> recvbuf[] */
+            mpi_errno = MPIR_Reduce_local_impl((char *)tmp_buf +
+                                               rindex[step] * extent,
+                                               (char *)recvbuf +
+                                               rindex[step] * extent,
+                                               rcount[step], datatype, op);
+
+            /* Move the current window to the received message */
+            rindex[step + 1] = rindex[step];
+            sindex[step + 1] = rindex[step];
+            wsize = rcount[step];
+            step++;
         }
     }
+    /*
+     * Assertion: each process has 1 / p' of the total reduction result:
+     * rcount[nsteps - 1] elements in the recvbuf[rindex[nsteps - 1]...].
+     */
 
-    /* now do the gather to root */
-    
-    /* Is root one of the processes that was excluded from the
-       computation above? If so, send data from newrank=0 to
-       the root and have root take on the role of newrank = 0 */ 
-
-    if (root < 2*rem) {
+    /*
+     * Now do the gather to root.
+     * Setup the root process for gather operation.
+     * Case 1: root < 2r and root is odd -- root process was excluded on step 1
+     *         Recv data from process 0, newroot = 0, newrank = 0
+     * Case 2: root < 2r and root is even: newroot = root / 2
+     * Case 3: root >= 2r: newroot = root - r
+     */
+    newroot = 0;
+    if (root < 2 * rem) {
         if (root % 2 != 0) {
-            if (rank == root) {    /* recv */
-                /* initialize the arrays that weren't initialized */
-                for (i=0; i<(pof2-1); i++) 
-                    cnts[i] = count/pof2;
-                cnts[pof2-1] = count - (count/pof2)*(pof2-1);
-                
-                disps[0] = 0;
-                for (i=1; i<pof2; i++)
-                    disps[i] = disps[i-1] + cnts[i-1];
-                
-                mpi_errno = MPIC_Recv(recvbuf, cnts[0], datatype,
-                                         0, MPIR_REDUCE_TAG, comm_ptr,
-                                         MPI_STATUS_IGNORE, errflag);
+            newroot = 0;
+            if (rank == root) {
+                /*
+                 * Case 1: root < 2r and root is odd -- root process was
+                 * excluded on step 1 (newrank == -1).
+                 * Recv a data from the process 0.
+                 */
+                rindex[0] = 0;
+                step = 0, wsize = count;
+                for (mask = 1; mask < pof2; mask *= 2) {
+                    rcount[step] = wsize / 2;
+                    scount[step] = wsize - rcount[step];
+                    rindex[step] = 0;
+                    sindex[step] = rcount[step];
+                    step++;
+                    wsize /= 2;
+                }
+                mpi_errno = MPIC_Recv(recvbuf, rcount[nsteps - 1], datatype, 0,
+                                      MPIR_REDUCE_TAG, comm_ptr,
+                                      MPI_STATUS_IGNORE, errflag);
                 if (mpi_errno) {
                     /* for communication errors, just record the error but continue */
                     *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
@@ -525,12 +624,10 @@ static int MPIR_Reduce_redscat_gather (
                     MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
                 newrank = 0;
-                send_idx = 0;
-                last_idx = 2;
-            }
-            else if (newrank == 0) {  /* send */
-                mpi_errno = MPIC_Send(recvbuf, cnts[0], datatype,
-                                         root, MPIR_REDUCE_TAG, comm_ptr, errflag);
+            } else if (newrank == 0) {
+                /* Send a data to the root */
+                mpi_errno = MPIC_Send(recvbuf, rcount[nsteps - 1], datatype,
+                                      root, MPIR_REDUCE_TAG, comm_ptr, errflag);
                 if (mpi_errno) {
                     /* for communication errors, just record the error but continue */
                     *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
@@ -539,72 +636,47 @@ static int MPIR_Reduce_redscat_gather (
                 }
                 newrank = -1;
             }
-            newroot = 0;
+        } else {
+            /* Case 2: root < 2r and a root is even: newroot = root / 2 */
+            newroot = root / 2;
         }
-        else newroot = root / 2;
-    }
-    else
+    } else {
+        /* Case 3: root >= 2r: newroot = root - r */
         newroot = root - rem;
+    }
 
+    /*
+     * Step 3. Gather result at the newroot by the binomial tree algorithm.
+     * Each process has 1 / p' of the total reduction result:
+     * rcount[nsteps - 1] elements in the recvbuf[rindex[nsteps - 1]...].
+     * All exchanges are executed in reverse order relative
+     * to recursive doubling (previous step).
+     */
     if (newrank != -1) {
-        j = 0;
-        mask = 0x1;
-        while (mask < pof2) {
-            mask <<= 1;
-            j++;
-        }
-        mask >>= 1;
-        j--;
+        mask = pof2 >> 1;
+        step = nsteps - 1; /* step = \ilog_2(p') - 1 */
+
         while (mask > 0) {
             newdst = newrank ^ mask;
-
-            /* find real rank of dest */
-            dst = (newdst < rem) ? newdst*2 : newdst + rem;
-            /* if root is playing the role of newdst=0, adjust for
-               it */
-            if ((newdst == 0) && (root < 2*rem) && (root % 2 != 0))
+            /* Find real rank of the dest */
+            dst = (newdst < rem) ? newdst * 2 : newdst + rem;
+            /* If root is playing the role of newdst = 0, adjust for it */
+            if ((newdst == 0) && (root < 2 * rem) && (root % 2 != 0))
                 dst = root;
-            
-            /* if the root of newdst's half of the tree is the
-               same as the root of newroot's half of the tree, send to
-               newdst and exit, else receive from newdst. */
 
-            newdst_tree_root = newdst >> j;
-            newdst_tree_root <<= j;
-            
-            newroot_tree_root = newroot >> j;
-            newroot_tree_root <<= j;
+            /* If the root of newdst's half of the tree is the
+               same as the root of newroot's half of the tree,
+               send to newdst and exit, else receive from newdst. */
+            newdst_tree_root = newdst >> step;
+            newdst_tree_root <<= step;
+            newroot_tree_root = newroot >> step;
+            newroot_tree_root <<= step;
 
-            send_cnt = recv_cnt = 0;
-            if (newrank < newdst) {
-                /* update last_idx except on first iteration */
-                if (mask != pof2/2)
-                    last_idx = last_idx + pof2/(mask*2);
-                
-                recv_idx = send_idx + pof2/(mask*2);
-                for (i=send_idx; i<recv_idx; i++)
-                    send_cnt += cnts[i];
-                for (i=recv_idx; i<last_idx; i++)
-                    recv_cnt += cnts[i];
-            }
-            else {
-                recv_idx = send_idx - pof2/(mask*2);
-                for (i=send_idx; i<last_idx; i++)
-                    send_cnt += cnts[i];
-                for (i=recv_idx; i<send_idx; i++)
-                    recv_cnt += cnts[i];
-            }
-            
             if (newdst_tree_root == newroot_tree_root) {
-                /* send and exit */
-                /* printf("Rank %d, send_idx %d, send_cnt %d, last_idx %d\n", newrank, send_idx, send_cnt, last_idx);
-                   fflush(stdout); */
-                /* Send data from recvbuf. Recv into tmp_buf */ 
-                mpi_errno = MPIC_Send((char *) recvbuf +
-                                         disps[send_idx]*extent,
-                                         send_cnt, datatype,
-                                         dst, MPIR_REDUCE_TAG,
-                                         comm_ptr, errflag);
+                /* Send data from recvbuf and exit */
+                mpi_errno = MPIC_Send((char *)recvbuf + rindex[step] * extent,
+                                      rcount[step], datatype, dst,
+                                      MPIR_REDUCE_TAG, comm_ptr, errflag);
                 if (mpi_errno) {
                     /* for communication errors, just record the error but continue */
                     *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
@@ -612,16 +684,12 @@ static int MPIR_Reduce_redscat_gather (
                     MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
                 break;
-            }
-            else {
-                /* recv and continue */
-                /* printf("Rank %d, recv_idx %d, recv_cnt %d, last_idx %d\n", newrank, recv_idx, recv_cnt, last_idx);
-                   fflush(stdout); */
-                mpi_errno = MPIC_Recv((char *) recvbuf +
-                                         disps[recv_idx]*extent,
-                                         recv_cnt, datatype, dst,
-                                         MPIR_REDUCE_TAG, comm_ptr,
-                                         MPI_STATUS_IGNORE, errflag);
+            } else {
+                /* Recv and continue */
+                mpi_errno = MPIC_Recv((char *)recvbuf + sindex[step] * extent,
+                                      scount[step], datatype, dst,
+                                      MPIR_REDUCE_TAG, comm_ptr,
+                                      MPI_STATUS_IGNORE, errflag);
                 if (mpi_errno) {
                     /* for communication errors, just record the error but continue */
                     *errflag = MPIR_ERR_GET_CLASS(mpi_errno);
@@ -629,11 +697,8 @@ static int MPIR_Reduce_redscat_gather (
                     MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
             }
-            
-            if (newrank > newdst) send_idx = recv_idx;
-            
+            step--;
             mask >>= 1;
-            j--;
         }
     }
 


### PR DESCRIPTION
In the current implementation of Rabenseifner’s algorithm for Reduce and Allreduce
there is a load imbalance across the processes. The reason is non uniform  distribution
of count elements across pof2 processes on the reduce-scatter and {all}gather steps.
The last process pof2-1 is loaded more than others:

For example,
    commsize=13, count=13; pof2=8, cnts[0..6]=1, cnts[7]=6.
    commsize=1600, count=100000; pof2=1024, cnts[0..1022]=97, cnts[1023]=769.

This implementation does not use cnts[i] and disps[i] arrays, so memory consumption per process
is reduced from O(2^\floor{\log(p)}) to O(\log(p)). In addition, the need to calculate cnts[i]
on each step of the reduce-scatter is eliminated.

Signed-off-by: Mikhail Kurnosov <mkurnosov@gmail.com>