### PR TITLE
Specify Perl paths relative to current directory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -712,7 +712,7 @@ if [ $do_bindings = "yes" ] ; then
 	# Double precision vs. Real*8 option
 	rm -f src/binding/fortran/use_mpi/mpi_base.f90.orig
 	( cd src/binding/fortran/use_mpi && chmod a+x ./buildiface && ./buildiface )
-	( cd src/binding/fortran/use_mpi && ../mpif_h/buildiface -infile=cf90t.h -deffile=cf90tdefs)
+	( cd src/binding/fortran/use_mpi && ../mpif_h/buildiface -infile=cf90t.h -deffile=./cf90tdefs)
 	echo "done"
     fi
     if [ $build_f08 = "yes" ] ; then

--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -2,7 +2,7 @@
 # (Tested with -w; 10/5/04)
 # 
 # Find the parse.sub routine.
-my $maintdir = "maint";
+my $maintdir = "./maint";
 my $rootdir  = ".";
 if ( ! -s "maint/parse.sub" ) {
     my $program = $0;

--- a/maint/extractfixme.in
+++ b/maint/extractfixme.in
@@ -3,7 +3,7 @@
 # Tested with -w 10/28/05
 # 
 # Find the parse.sub routine.
-my $maintdir = "maint";
+my $maintdir = "./maint";
 my $rootdir  = ".";
 if ( ! -s "maint/parse.sub" ) {
     my $program = $0;

--- a/maint/extractstates.in
+++ b/maint/extractstates.in
@@ -46,7 +46,7 @@ $pattern = '\.[chi](pp){0,1}$';
 $exceptionsFile = "estates.txt";
 
 # Load in the routines to extract strings from files
-$maintdir = "maint";
+$maintdir = "./maint";
 require "$maintdir/extractstrings";
 
 # These are "states" that are internal to a function, but still 

--- a/maint/parsetest
+++ b/maint/parsetest
@@ -1,6 +1,6 @@
 #! /usr/bin/env perl
 #
-require "maint/parse.sub";
+require "./maint/parse.sub";
 
 $debug = 1;
 while (<>) {


### PR DESCRIPTION
Perl removed "." from the set of default search paths in @INC. Make sure
we specify "./<foo>" for any files included or used from within the
MPICH repo. Fixes #2643