### PR TITLE
CH4/OFI: Clean up MPIDI_OFI_huge_counter_t

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -557,12 +557,6 @@ typedef struct MPIDI_OFI_huge_recv {
                                          * (when in the unexpected list) */
 } MPIDI_OFI_huge_recv_t;
 
-typedef struct MPIDI_OFI_huge_counter_t {
-    uint16_t counter;
-    uint16_t outstanding;
-    struct fid_mr *mr;
-} MPIDI_OFI_huge_counter_t;
-
 /* The list of posted huge receives that haven't been matched yet. These need
  * to get matched up when handling the control message that starts transfering
  * data from the remote memory region and we need a way of matching up the


### PR DESCRIPTION
* struct MPIDI_OFI_huge_counter_t had two unused members, namely
  "counter" and "outstanding".
* This struct is used to send large requests that meet criteria
  data_sz > both: MPIDI_Global.max_buffered_send and
  MPIDI_Global.max_send (ofi_send.h).
* Getting rid of the member "counter"
 * "counter" is used in an assignment operation (ofi_send.h):
     ctrl.seqno = cntr->counter - 1;
 * Before this statement, "counter" is always assigned values 0
   followed by 1.
 * Therefore the above statement is always equivalent to:
     ctrl.seqno = 0;
 * So, we can directly assign value 0 in the above statement. "counter"
   is not used anywhere else. This means that we can get rid of it.
* Getting rid of the member "outstanding"
 * "outstanding" is used in the following conditional statement
   (ofi_events.h)":
     if (cntr->outstanding == 0)
 * The above statement is always true because "outstanding" is always
    assigned value 0 followed by 1. Then it is decremented back to 0
    (ofi_events.h). Therefore this if statement is not necessary and,
    we can get rid of the member "outstanding".
* Getting rid of MPIDI_OFI_huge_counter_t and replacing it with fid_mr
  * After removing the two unused members, MPIDI_OFI_huge_counter_t
  has a single member, which is of type fid_mr. So, we can now directly
  use fid_mr instead of MPIDI_OFI_huge_counter_t.

Therefore, we remove the struct MPIDI_OFI_huge_counter_t and use fid_mr
instead. As a result, we also remove the unused members "counter" and
"outstanding" of MPIDI_OFI_huge_counter_t and also remove them from
statements where there they are referenced.

fixes csr/mpich-ofi#534