### PR TITLE
CH4/OFI: Set tag_ub after choosing capability set

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -386,8 +386,6 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     CH4_COMPILE_TIME_ASSERT(sizeof(MPIR_Request) >= sizeof(MPIDI_OFI_win_request_t));
     CH4_COMPILE_TIME_ASSERT(sizeof(MPIR_Context_id_t) * 8 >= MPIDI_OFI_AM_CONTEXT_ID_BITS);
 
-    *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
-
     MPID_Thread_mutex_create(&MPIDI_OFI_THREAD_UTIL_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDI_OFI_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDI_OFI_THREAD_FI_MUTEX, &thr_err);
@@ -522,6 +520,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIDI_OFI_CALL(fi_getinfo(fi_version, NULL, NULL, 0ULL, hints, &prov), addrinfo);
     MPIDI_OFI_CHOOSE_PROVIDER(prov, &prov_use, "No suitable provider provider found");
 
+    *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
 
     if (MPIDI_OFI_ENABLE_RUNTIME_CHECKS) {
         /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
If the capability set is chosen dynamically, setting the tag_ub value
too early will leave it as a really low default. Moving this to after
the selection of the proper capability set makes the value more
reasonable.

This is a patch for #2614 