### PR TITLE
MPL: Fix debug class detection logic

### DIFF
--- a/src/mpl/src/dbg/mpl_dbg.c
+++ b/src/mpl/src/dbg/mpl_dbg.c
@@ -268,8 +268,8 @@ void MPL_dbg_class_register(MPL_dbg_class class, const char *ucname, const char 
 
         for (i = 0; i < num_unregistered_classes; i++) {
             size_t slen = strlen(unregistered_classes[i]);
-            if (len == slen && (strncmp(unregistered_classes[i], lcname, len) ||
-                                strncmp(unregistered_classes[i], ucname, len))) {
+            if (len == slen && (!strncmp(unregistered_classes[i], lcname, len) ||
+                                !strncmp(unregistered_classes[i], ucname, len))) {
                 /* got a match */
                 MPL_dbg_active_classes |= class;
                 for (j = i; j < num_unregistered_classes - 1; j++)
@@ -924,8 +924,8 @@ static int dbg_set_class(const char *s)
         for (i = 0; i < num_classnames; i++) {
             size_t len = strlen(classnames[i].lcname);
 
-            if (slen == len && (strncmp(str, classnames[i].lcname, len) ||
-                                strncmp(str, classnames[i].ucname, len))) {
+            if (slen == len && (!strncmp(str, classnames[i].lcname, len) ||
+                                !strncmp(str, classnames[i].ucname, len))) {
                 /* we have a match */
                 MPL_dbg_active_classes |= classnames[i].classbits;
                 found_match = 1;


### PR DESCRIPTION
strncmp was used to compare debug class name but negation was
missing, thus resuting in an unexpected behavior.

For example, without this fix, setting MPICH_DBG_CLASS=CH4 would
give you ALL debug messages including things like function enter/exit,
which shouldn't appear.
With this fix, it correctly prints MPIDI_CH4_DBG_GENERAL class
messages only.