### PR TITLE
CH4/OFI: Move OFI version into capability sets

### DIFF
--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -40,7 +40,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_MINIMAL,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_MINIMAL,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_MINIMAL,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_MINIMAL
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_MINIMAL,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* psm */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_PSM,
@@ -59,7 +61,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_PSM,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_PSM,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_PSM,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_PSM,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_PSM
     },
     { /* psm2 */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_PSM2,
@@ -78,7 +82,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_PSM2,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_PSM2,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_PSM2,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM2
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM2,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_PSM2,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_PSM2
     },
     { /* gni */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_GNI,
@@ -97,7 +103,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_GNI,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_GNI,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_GNI,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_GNI
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_GNI,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_GNI,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_GNI
     },
     { /* sockets */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_SOCKETS,
@@ -116,7 +124,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_SOCKETS,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_SOCKETS,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_SOCKETS,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_SOCKETS
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_SOCKETS,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_SOCKETS,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_SOCKETS
     },
     { /* bgq */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_BGQ,
@@ -135,7 +145,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_BGQ,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_BGQ,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_BGQ,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_BGQ
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_BGQ,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_BGQ,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_BGQ
     },
     { /* verbs */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_VERBS,
@@ -154,6 +166,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_VERBS,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_VERBS,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_VERBS,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_VERBS
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_VERBS,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_VERBS,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_VERBS
     }
 };

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -77,6 +77,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
  * MPIDI_OFI_CONTEXT_BITS              The number of bits used for the context ID in an OFI message
  * MPIDI_OFI_SOURCE_BITS               The number of bits used for the source rank in an OFI message
  * MPIDI_OFI_TAG_BITS                  The number of bits used for the tag in an OFI message
+ * MPIDI_OFI_MAJOR_VERSION             The major API version of libfabric required
+ * MPIDI_OFI_MINOR_VERSION             The minor API version of libfabric required
  */
 
 #define MPIDI_OFI_ENABLE_DATA_PSM               MPIDI_OFI_OFF
@@ -100,6 +102,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_PSM              (16)
 #define MPIDI_OFI_SOURCE_BITS_PSM               (24)
 #define MPIDI_OFI_TAG_BITS_PSM                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_PSM             1
+#define MPIDI_OFI_MINOR_VERSION_PSM             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_PSM
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -123,6 +127,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_PSM
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_PSM
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_PSM2               MPIDI_OFI_OFF
@@ -146,6 +152,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_PSM2              (16)
 #define MPIDI_OFI_SOURCE_BITS_PSM2               (24)
 #define MPIDI_OFI_TAG_BITS_PSM2                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_PSM2            1
+#define MPIDI_OFI_MINOR_VERSION_PSM2            5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_PSM2
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -169,6 +177,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM2
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM2
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM2
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_PSM2
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_PSM2
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_GNI               MPIDI_OFI_OFF
@@ -192,6 +202,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_GNI              (16)
 #define MPIDI_OFI_SOURCE_BITS_GNI               (24)
 #define MPIDI_OFI_TAG_BITS_GNI                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_GNI             1
+#define MPIDI_OFI_MINOR_VERSION_GNI             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_GNI
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -215,6 +227,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_GNI
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_GNI
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_GNI
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_GNI
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_GNI
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_SOCKETS               MPIDI_OFI_ON
@@ -238,6 +252,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_SOCKETS              (16)
 #define MPIDI_OFI_SOURCE_BITS_SOCKETS               (0)
 #define MPIDI_OFI_TAG_BITS_SOCKETS                  (31)
+#define MPIDI_OFI_MAJOR_VERSION_SOCKETS         1
+#define MPIDI_OFI_MINOR_VERSION_SOCKETS         5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_SOCKETS
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -261,6 +277,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_SOCKETS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_SOCKETS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_SOCKETS
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_SOCKETS
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_SOCKETS
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_BGQ               MPIDI_OFI_ON
@@ -284,6 +302,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_BGQ              (16)
 #define MPIDI_OFI_SOURCE_BITS_BGQ               (0)
 #define MPIDI_OFI_TAG_BITS_BGQ                  (31)
+#define MPIDI_OFI_MAJOR_VERSION_BGQ             1
+#define MPIDI_OFI_MINOR_VERSION_BGQ             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_BGQ
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -307,6 +327,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_BGQ
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_BGQ
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_BGQ
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_BGQ
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_BGQ
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_VERBS               MPIDI_OFI_OFF
@@ -330,6 +352,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_VERBS              (16)
 #define MPIDI_OFI_SOURCE_BITS_VERBS               (24)
 #define MPIDI_OFI_TAG_BITS_VERBS                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_VERBS             1
+#define MPIDI_OFI_MINOR_VERSION_VERBS             4
 
 #ifdef MPIDI_CH4_OFI_USE_SET_VERBS
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -353,6 +377,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_VERBS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_VERBS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_VERBS
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_VERBS
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_VERBS
 #endif
 
 /* capability set for default provider (to request the minimal supported capability) */
@@ -377,6 +403,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_MINIMAL              (16)
 #define MPIDI_OFI_SOURCE_BITS_MINIMAL               (24)
 #define MPIDI_OFI_TAG_BITS_MINIMAL                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_MINIMAL             1
+#define MPIDI_OFI_MINOR_VERSION_MINIMAL             0
 
 #ifdef MPIDI_CH4_OFI_USE_SET_RUNTIME
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     1
@@ -397,6 +425,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_Global.settings.context_bits
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_Global.settings.source_bits
 #define MPIDI_OFI_TAG_BITS                  MPIDI_Global.settings.tag_bits
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_Global.settings.major_version
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_Global.settings.minor_version
 #endif
 
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -196,6 +196,26 @@ cvars:
         tag. The default value is -1, indicating that no value is set and that
         the default will be defined in the ofi_types.h file.
 
+    - name        : MPIR_CVAR_CH4_OFI_MAJOR_VERSION
+      category    : CH4_OFI
+      type        : int
+      default     : 1
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Specifies the major version of the OFI library. The default is 1.
+
+    - name        : MPIR_CVAR_CH4_OFI_MINOR_VERSION
+      category    : CH4_OFI
+      type        : int
+      default     : 0
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Specifies the major version of the OFI library. The default is 0.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -494,6 +514,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
             /* could not find suitable provider. ok, let's try fallback mode */
             MPIDI_OFI_init_global_settings(prov_first->fabric_attr->prov_name);
             MPIDI_OFI_init_hints(hints);
+            fi_version = FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
             MPIDI_OFI_CALL(fi_getinfo(fi_version, NULL, NULL, 0ULL, hints, &prov), addrinfo);
             MPIDI_OFI_CHOOSE_PROVIDER(prov, &prov_use, "No suitable provider provider found");
 
@@ -517,6 +538,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         fi_freeinfo(prov_first);
     }
 
+    fi_version = FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
     MPIDI_OFI_CALL(fi_getinfo(fi_version, NULL, NULL, 0ULL, hints, &prov), addrinfo);
     MPIDI_OFI_CHOOSE_PROVIDER(prov, &prov_use, "No suitable provider provider found");
 
@@ -1488,6 +1510,10 @@ static inline int MPIDI_OFI_init_global_settings(char *prov_name)
                                                         prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].source_bits : MPIR_CVAR_CH4_OFI_RANK_BITS;
     MPIDI_Global.settings.tag_bits                  = MPIR_CVAR_CH4_OFI_TAG_BITS != 20 ? MPIR_CVAR_CH4_OFI_TAG_BITS :
                                                         prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].tag_bits : MPIR_CVAR_CH4_OFI_TAG_BITS;
+    MPIDI_Global.settings.major_version             = MPIR_CVAR_CH4_OFI_MAJOR_VERSION != 1 ? MPIR_CVAR_CH4_OFI_MAJOR_VERSION :
+                                                        prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].major_version : MPIR_CVAR_CH4_OFI_MAJOR_VERSION;
+    MPIDI_Global.settings.minor_version             = MPIR_CVAR_CH4_OFI_MINOR_VERSION != 0 ? MPIR_CVAR_CH4_OFI_MINOR_VERSION :
+                                                        prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].minor_version : MPIR_CVAR_CH4_OFI_MINOR_VERSION;
     return MPI_SUCCESS;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -28,8 +28,6 @@
      : __FILE__                                 \
 )
 #define MPIDI_OFI_MAP_NOT_FOUND            ((void*)(-1UL))
-#define MPIDI_OFI_MAJOR_VERSION            1
-#define MPIDI_OFI_MINOR_VERSION            0
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
 #define MPIDI_OFI_NUM_AM_BUFFERS           (8)
 #define MPIDI_OFI_AM_BUFF_SZ               (1 * 1024 * 1024)
@@ -329,6 +327,8 @@ typedef struct {
     int context_bits;
     int source_bits;
     int tag_bits;
+    int major_version;
+    int minor_version;
 } MPIDI_OFI_capabilities_t;
 
 typedef struct {


### PR DESCRIPTION
In general, when optimizing, we want to use the latest and greatest
version of the libfabric library because we need things like
FI_CONTEXT2 or FI_RESTRICTED_COMP. On the other hand, when using runtime
capabilities, we'd like to maintain as much backward compatibility as
possible.

To do this, the compile time capability sets will specifiy a specific
libfabric version and the runtime capability set will specify libfabric
1.0 for now. This can be upgraded later as we drop support for older
versions of libfabric.