### PR TITLE
CH4/OFI: All types of `FI_MULTI_RECV` completion entries are not handled correctly

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -681,7 +681,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_ent
         goto fn_exit;
     }
     else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_RECV)) {
-        mpi_errno = MPIDI_OFI_am_recv_event(wc, req);
+        if (wc->flags & FI_RECV)
+            mpi_errno = MPIDI_OFI_am_recv_event(wc, req);
 
         if (unlikely((wc->flags & FI_MULTI_RECV) && !buffered))
             MPIDI_OFI_am_repost_event(wc, req);


### PR DESCRIPTION
Testing active message with bgq provider and found this problem
when the multi_recv buffer is completely consumed and must be
returned to the user.

There are two ways a provider may signal that the original receive
buffer posted with the FI_MULTI_RECV flag has been consumed. From
the fi_cq man page (https://ofiwg.github.io/libfabric/master/man/fi_cq.3.html):

> FI_MULTI_RECV
> This flag applies to receive buffers that were posted with the
> FI_MULTI_RECV flag set. This completion flag indicates that the
> original receive buffer referenced by the completion has been
> consumed and was released by the provider. Providers may set this
> flag on the last message that is received into the multi-recv
> buffer, **or may generate a separate completion that indicates
> that the buffer has been released.**
>
> Applications can distinguish between these two cases by examining
> the completion entry flags field. If additional flags, such as
> FI_RECV, are set, the completion is associated with a received
> message. In this case, the buf field will reference the location
> where the received message was placed into the multi-recv buffer.
> Other fields in the completion entry will be determined based on
> the received message. **If other flag bits are zero, the provider
> is reporting that the multi-recv buffer has been released, and
> the completion entry is not associated with a received message.**

fixes csr/mpich-ofi#223