### PR TITLE
Add support for libfabric 1.5 features

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -24,7 +24,11 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        If non-null, choose an OFI provider by name
+        If non-null, choose an OFI provider by name. If using with the CH4
+        device and using a provider that supports an older version of the
+        libfabric API then the default version of the installed library,
+        specifying the OFI version via the appropriate CVARs is also
+        recommended.
 
     - name        : MPIR_CVAR_OFI_DUMP_PROVIDERS
       category    : DEVELOPER

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -40,7 +40,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_MINIMAL,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_MINIMAL,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_MINIMAL,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_MINIMAL
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_MINIMAL,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* psm */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_PSM,
@@ -59,7 +61,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_PSM,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_PSM,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_PSM,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* psm2 */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_PSM2,
@@ -78,7 +82,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_PSM2,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_PSM2,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_PSM2,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM2
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_PSM2,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* gni */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_GNI,
@@ -97,7 +103,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_GNI,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_GNI,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_GNI,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_GNI
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_GNI,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* sockets */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_SOCKETS,
@@ -116,7 +124,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_SOCKETS,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_SOCKETS,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_SOCKETS,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_SOCKETS
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_SOCKETS,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* bgq */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_BGQ,
@@ -135,7 +145,9 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_BGQ,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_BGQ,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_BGQ,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_BGQ
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_BGQ,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     },
     { /* verbs */
         .enable_data               = MPIDI_OFI_ENABLE_DATA_VERBS,
@@ -154,6 +166,8 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
         .fetch_atomic_iovecs       = MPIDI_OFI_FETCH_ATOMIC_IOVECS_VERBS,
         .context_bits              = MPIDI_OFI_CONTEXT_BITS_VERBS,
         .source_bits               = MPIDI_OFI_SOURCE_BITS_VERBS,
-        .tag_bits                  = MPIDI_OFI_TAG_BITS_VERBS
+        .tag_bits                  = MPIDI_OFI_TAG_BITS_VERBS,
+        .major_version             = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
+        .minor_version             = MPIDI_OFI_MINOR_VERSION_MINIMAL
     }
 };

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -81,6 +81,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
  * === Compile time only ===
  * MPIDI_OFI_MAJOR_VERSION             The major API version of libfabric required
  * MPIDI_OFI_MINOR_VERSION             The minor API version of libfabric required
+ * MPIDI_OFI_CONTEXT_STRUCTS           The number of fi_context structs needed for the provider
  */
 
 #define MPIDI_OFI_ENABLE_DATA_PSM               MPIDI_OFI_OFF
@@ -129,9 +130,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_PSM
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_PSM
+#define MPIDI_OFI_CONTEXT_STRUCTS           1
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_PSM2               MPIDI_OFI_OFF
@@ -180,9 +181,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM2
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM2
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM2
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_PSM2
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_PSM2
+#define MPIDI_OFI_CONTEXT_STRUCTS           1
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_GNI               MPIDI_OFI_OFF
@@ -231,9 +232,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_GNI
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_GNI
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_GNI
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_GNI
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_GNI
+#define MPIDI_OFI_CONTEXT_STRUCTS           1
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_SOCKETS               MPIDI_OFI_ON
@@ -282,9 +283,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_SOCKETS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_SOCKETS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_SOCKETS
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_SOCKETS
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_SOCKETS
+#define MPIDI_OFI_CONTEXT_STRUCTS           1
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_BGQ               MPIDI_OFI_ON
@@ -333,9 +334,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_BGQ
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_BGQ
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_BGQ
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_BGQ
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_BGQ
+#define MPIDI_OFI_CONTEXT_STRUCTS           2
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_VERBS               MPIDI_OFI_OFF
@@ -384,9 +385,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_VERBS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_VERBS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_VERBS
-/* === Compile time only === */
-#define MPIDI_OFI_MAJOR_VERSION             1
-#define MPIDI_OFI_MINOR_VERSION             5
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_VERBS
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_VERBS
+#define MPIDI_OFI_CONTEXT_STRUCTS           1
 #endif
 
 /* capability set for default provider (to request the minimal supported capability) */
@@ -435,6 +436,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_TAG_BITS                  MPIDI_Global.settings.tag_bits
 #define MPIDI_OFI_MAJOR_VERSION             MPIDI_Global.settings.major_version
 #define MPIDI_OFI_MINOR_VERSION             MPIDI_Global.settings.minor_version
+#define MPIDI_OFI_CONTEXT_STRUCTS           2 /* Compile time configurable only */
 #endif
 
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -77,6 +77,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
  * MPIDI_OFI_CONTEXT_BITS              The number of bits used for the context ID in an OFI message
  * MPIDI_OFI_SOURCE_BITS               The number of bits used for the source rank in an OFI message
  * MPIDI_OFI_TAG_BITS                  The number of bits used for the tag in an OFI message
+ *
+ * === Compile time only ===
+ * MPIDI_OFI_MAJOR_VERSION             The major API version of libfabric required
+ * MPIDI_OFI_MINOR_VERSION             The minor API version of libfabric required
  */
 
 #define MPIDI_OFI_ENABLE_DATA_PSM               MPIDI_OFI_OFF
@@ -100,6 +104,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_PSM              (16)
 #define MPIDI_OFI_SOURCE_BITS_PSM               (24)
 #define MPIDI_OFI_TAG_BITS_PSM                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_PSM             1
+#define MPIDI_OFI_MINOR_VERSION_PSM             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_PSM
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -123,6 +129,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_PSM2               MPIDI_OFI_OFF
@@ -146,6 +155,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_PSM2              (16)
 #define MPIDI_OFI_SOURCE_BITS_PSM2               (24)
 #define MPIDI_OFI_TAG_BITS_PSM2                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_PSM2             1
+#define MPIDI_OFI_MINOR_VERSION_PSM2             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_PSM2
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -169,6 +180,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_PSM2
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_PSM2
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_PSM2
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_GNI               MPIDI_OFI_OFF
@@ -192,6 +206,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_GNI              (16)
 #define MPIDI_OFI_SOURCE_BITS_GNI               (24)
 #define MPIDI_OFI_TAG_BITS_GNI                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_GNI             1
+#define MPIDI_OFI_MINOR_VERSION_GNI             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_GNI
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -215,6 +231,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_GNI
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_GNI
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_GNI
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_SOCKETS               MPIDI_OFI_ON
@@ -238,6 +257,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_SOCKETS              (16)
 #define MPIDI_OFI_SOURCE_BITS_SOCKETS               (0)
 #define MPIDI_OFI_TAG_BITS_SOCKETS                  (31)
+#define MPIDI_OFI_MAJOR_VERSION_SOCKETS             1
+#define MPIDI_OFI_MINOR_VERSION_SOCKETS             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_SOCKETS
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -261,6 +282,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_SOCKETS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_SOCKETS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_SOCKETS
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_BGQ               MPIDI_OFI_ON
@@ -284,6 +308,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_BGQ              (16)
 #define MPIDI_OFI_SOURCE_BITS_BGQ               (0)
 #define MPIDI_OFI_TAG_BITS_BGQ                  (31)
+#define MPIDI_OFI_MAJOR_VERSION_BGQ             1
+#define MPIDI_OFI_MINOR_VERSION_BGQ             5
 
 #ifdef MPIDI_CH4_OFI_USE_SET_BGQ
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -307,6 +333,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_BGQ
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_BGQ
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_BGQ
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 #define MPIDI_OFI_ENABLE_DATA_VERBS               MPIDI_OFI_OFF
@@ -330,6 +359,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_VERBS              (16)
 #define MPIDI_OFI_SOURCE_BITS_VERBS               (24)
 #define MPIDI_OFI_TAG_BITS_VERBS                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_VERBS             1
+#define MPIDI_OFI_MINOR_VERSION_VERBS             4
 
 #ifdef MPIDI_CH4_OFI_USE_SET_VERBS
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     MPIDI_OFI_OFF
@@ -353,6 +384,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_OFI_CONTEXT_BITS_VERBS
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_OFI_SOURCE_BITS_VERBS
 #define MPIDI_OFI_TAG_BITS                  MPIDI_OFI_TAG_BITS_VERBS
+/* === Compile time only === */
+#define MPIDI_OFI_MAJOR_VERSION             1
+#define MPIDI_OFI_MINOR_VERSION             5
 #endif
 
 /* capability set for default provider (to request the minimal supported capability) */
@@ -377,6 +411,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS_MINIMAL              (16)
 #define MPIDI_OFI_SOURCE_BITS_MINIMAL               (24)
 #define MPIDI_OFI_TAG_BITS_MINIMAL                  (20)
+#define MPIDI_OFI_MAJOR_VERSION_MINIMAL             FI_MAJOR_VERSION
+#define MPIDI_OFI_MINOR_VERSION_MINIMAL             FI_MINOR_VERSION
 
 #ifdef MPIDI_CH4_OFI_USE_SET_RUNTIME
 #define MPIDI_OFI_ENABLE_RUNTIME_CHECKS     1
@@ -397,6 +433,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
 #define MPIDI_OFI_CONTEXT_BITS              MPIDI_Global.settings.context_bits
 #define MPIDI_OFI_SOURCE_BITS               MPIDI_Global.settings.source_bits
 #define MPIDI_OFI_TAG_BITS                  MPIDI_Global.settings.tag_bits
+#define MPIDI_OFI_MAJOR_VERSION             MPIDI_Global.settings.major_version
+#define MPIDI_OFI_MINOR_VERSION             MPIDI_Global.settings.minor_version
 #endif
 
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1622,6 +1622,11 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
         hints->domain_attr->mr_mode = FI_MR_SCALABLE;
     else
         hints->domain_attr->mr_mode = FI_MR_BASIC;
+    if (FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION) >= FI_VERSION(1,5)) {
+#ifdef FI_RESTRICTED_COMP
+        hints->domain_attr->mode = FI_RESTRICTED_COMP;
+#endif
+    }
     hints->tx_attr->op_flags = FI_COMPLETION;
     /* direct RMA operations supported only with delivery complete mode,
      * else (AM mode) delivery complete is not required */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1528,7 +1528,7 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
     /* See man fi_getinfo for a list                                            */
     /* of all filters                                                           */
     /* mode:  Select capabilities that this netmod will support                 */
-    /*        FI_CONTEXT:  This netmod will pass in context into communication  */
+    /*        FI_CONTEXT(2):  This netmod will pass in context into communication */
     /*        to optimize storage locality between MPI requests and OFI opaque  */
     /*        data structures.                                                  */
     /*        FI_ASYNC_IOV:  MPICH will provide storage for iovecs on           */
@@ -1549,6 +1549,11 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
     /*           endpoint, so the netmod requires dynamic memory regions        */
     /* ------------------------------------------------------------------------ */
     hints->mode = FI_CONTEXT | FI_ASYNC_IOV;    /* We can handle contexts  */
+    if (FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION) >= FI_VERSION(1,5)) {
+#ifdef FI_CONTEXT2
+        hints->mode |= FI_CONTEXT2;
+#endif
+    }
     hints->caps = 0ULL;
 
     /* RMA interface is used in AM and in native modes,

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -196,6 +196,30 @@ cvars:
         tag. The default value is -1, indicating that no value is set and that
         the default will be defined in the ofi_types.h file.
 
+    - name        : MPIR_CVAR_CH4_OFI_MAJOR_VERSION
+      category    : CH4_OFI
+      type        : int
+      default     : FI_MAJOR_VERSION
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Specifies the major version of the OFI library. The default is the
+        major version of the OFI library used with MPICH. If using this CVAR,
+        it is recommeded that the user also specifies a specific OFI provider.
+
+    - name        : MPIR_CVAR_CH4_OFI_MINOR_VERSION
+      category    : CH4_OFI
+      type        : int
+      default     : FI_MINOR_VERSION
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Specifies the major version of the OFI library. The default is the
+        minor version of the OFI library used with MPICH. If using this CVAR,
+        it is recommeded that the user also specifies a specific OFI provider.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -1488,6 +1512,10 @@ static inline int MPIDI_OFI_init_global_settings(char *prov_name)
                                                         prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].source_bits : MPIR_CVAR_CH4_OFI_RANK_BITS;
     MPIDI_Global.settings.tag_bits                  = MPIR_CVAR_CH4_OFI_TAG_BITS != 20 ? MPIR_CVAR_CH4_OFI_TAG_BITS :
                                                         prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].tag_bits : MPIR_CVAR_CH4_OFI_TAG_BITS;
+    MPIDI_Global.settings.major_version             = MPIR_CVAR_CH4_OFI_MAJOR_VERSION != FI_MAJOR_VERSION ? MPIR_CVAR_CH4_OFI_MAJOR_VERSION :
+                                                        prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].major_version : MPIR_CVAR_CH4_OFI_MAJOR_VERSION;
+    MPIDI_Global.settings.minor_version             = MPIR_CVAR_CH4_OFI_MINOR_VERSION != FI_MINOR_VERSION ? MPIR_CVAR_CH4_OFI_MINOR_VERSION :
+                                                        prov_name ? MPIDI_OFI_caps_list[MPIDI_OFI_get_set_number(prov_name)].minor_version : MPIR_CVAR_CH4_OFI_MINOR_VERSION;
     return MPI_SUCCESS;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -105,7 +105,7 @@ typedef struct {
 } MPIDI_OFI_am_request_header_t;
 
 typedef struct {
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     MPIDI_OFI_am_request_header_t *req_hdr;
 } MPIDI_OFI_am_request_t;
@@ -117,7 +117,7 @@ typedef struct MPIDI_OFI_noncontig_t {
 } MPIDI_OFI_noncontig_t;
 
 typedef struct {
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     int util_id;
     struct MPIR_Comm *util_comm;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -241,21 +241,21 @@ enum {
 
 typedef struct {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     int index;
 } MPIDI_OFI_am_repost_request_t;
 
 typedef struct {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     MPIR_Request *signal_req;
 } MPIDI_OFI_ssendack_request_t;
 
 typedef struct {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     int done;
     uint32_t tag;
@@ -491,7 +491,7 @@ typedef struct {
 
 typedef struct {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     struct MPIDI_Iovec_array *next;
     union {
@@ -529,7 +529,7 @@ typedef struct {
 typedef struct MPIDI_OFI_win_request {
     MPIR_OBJECT_HEADER;
     char pad[MPIDI_REQUEST_HDR_SIZE - MPIDI_OFI_OBJECT_HEADER_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     struct MPIDI_OFI_win_request *next;
     int target_rank;
@@ -538,14 +538,14 @@ typedef struct MPIDI_OFI_win_request {
 
 typedef struct {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     MPIR_Request *parent;       /* Parent request           */
 } MPIDI_OFI_chunk_request;
 
 typedef struct MPIDI_OFI_huge_recv {
     char pad[MPIDI_REQUEST_HDR_SIZE];
-    struct fi_context context;  /* fixed field, do not move */
+    struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];  /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     int (*done_fn) (struct fi_cq_tagged_entry * wc, MPIR_Request * req);
     MPIDI_OFI_send_control_t remote_info;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -28,8 +28,6 @@
      : __FILE__                                 \
 )
 #define MPIDI_OFI_MAP_NOT_FOUND            ((void*)(-1UL))
-#define MPIDI_OFI_MAJOR_VERSION            1
-#define MPIDI_OFI_MINOR_VERSION            0
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
 #define MPIDI_OFI_NUM_AM_BUFFERS           (8)
 #define MPIDI_OFI_AM_BUFF_SZ               (1 * 1024 * 1024)
@@ -329,6 +327,8 @@ typedef struct {
     int context_bits;
     int source_bits;
     int tag_bits;
+    int major_version;
+    int minor_version;
 } MPIDI_OFI_capabilities_t;
 
 typedef struct {


### PR DESCRIPTION
If the libfabric library that's being used to compile and/or run is 1.5 or greater, enable some features to take advantage (`FI_CONTEXT2` and `FI_RESTRICTED_COMP`).

Note that this won't do well if the OFI library has providers that use different API versions and we want the lesser of the two versions. The assumption is that the sockets provider will always track the most current API version while another provider might lag behind. Even though the other provider could have better performance, this code would pick sockets because it has a higher API version and enables more features.

There is work going on to potentially fix this in the future on https://github.com/ofiwg/libfabric/issues/3073. Sean Hefty tells us that it's not very likely that this scenario will come up, but not impossible. For now, we'll kick the can down the road to a time where that comes up.

Replaces https://github.com/pmodels/mpich/pull/2652, https://github.com/pmodels/mpich/pull/2642, and https://github.com/pmodels/mpich/pull/2641.