### PR TITLE
NULL argument checks

### DIFF
--- a/src/mpi/comm/comm_create.c
+++ b/src/mpi/comm/comm_create.c
@@ -520,6 +520,7 @@ int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm)
             /* Check the group ptr */
             MPIR_Group_valid_ptr( group_ptr, mpi_errno );
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newcomm, "newcomm", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_create_group.c
+++ b/src/mpi/comm/comm_create_group.c
@@ -194,6 +194,7 @@ int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm * ne
             /* Check the group ptr */
             MPIR_Group_valid_ptr( group_ptr, mpi_errno );
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newcomm, "newcomm", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_dup.c
+++ b/src/mpi/comm/comm_dup.c
@@ -178,7 +178,8 @@ int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm)
 	    "**mpi_comm_dup %C %p", comm, newcomm);
     }
 #   endif
-    *newcomm = MPI_COMM_NULL;
+    if (newcomm)
+        *newcomm = MPI_COMM_NULL;
     mpi_errno = MPIR_Err_return_comm( comm_ptr, FCNAME, mpi_errno );
     goto fn_exit;
     /* --END ERROR HANDLING-- */

--- a/src/mpi/comm/comm_get_info.c
+++ b/src/mpi/comm/comm_get_info.c
@@ -109,6 +109,7 @@ int MPI_Comm_get_info(MPI_Comm comm, MPI_Info * info_used)
             /* Validate pointers */
             MPIR_Comm_valid_ptr( comm_ptr, mpi_errno, TRUE );
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(info_used, "info_used", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_group.c
+++ b/src/mpi/comm/comm_group.c
@@ -142,6 +142,7 @@ int MPI_Comm_group(MPI_Comm comm, MPI_Group *group)
             MPIR_Comm_valid_ptr( comm_ptr, mpi_errno, TRUE );
             /* If comm_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(group, "group", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_remote_size.c
+++ b/src/mpi/comm/comm_remote_size.c
@@ -90,6 +90,7 @@ int MPI_Comm_remote_size(MPI_Comm comm, int *size)
 						  "**commnotinter", 0 );
 	    }
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_size.c
+++ b/src/mpi/comm/comm_size.c
@@ -87,6 +87,7 @@ int MPI_Comm_size( MPI_Comm comm, int *size )
             MPIR_Comm_valid_ptr( comm_ptr, mpi_errno, TRUE );
 	    /* If comm_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -170,6 +170,7 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info,
             /* If comm_ptr is not valid, it will be reset to null */
             if (mpi_errno)
                 goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newcomm, "newcomm", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -261,6 +261,7 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
 		    MPIR_ERRTEST_COMM(peer_comm, mpi_errno);
 		}
 	    }
+           MPIR_ERRTEST_ARGNULL(newintercomm, "newintercomm", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -303,6 +304,7 @@ int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
 		    MPIR_ERR_SET(mpi_errno,MPI_ERR_RANK,"**ranksdistinct");
 		}
 		if (mpi_errno) goto fn_fail;
+               MPIR_ERRTEST_ARGNULL(newintercomm, "newintercomm", mpi_errno);
 	    }
 	    MPID_END_ERROR_CHECKS;
 	}

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -163,6 +163,7 @@ int MPI_Type_contiguous(int count,
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 	    }
+	    MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -82,6 +82,7 @@ int MPI_Type_create_resized(MPI_Datatype oldtype,
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
 	    /* If datatype_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_extent.c
+++ b/src/mpi/datatype/type_extent.c
@@ -84,6 +84,7 @@ int MPI_Type_extent(MPI_Datatype datatype, MPI_Aint *extent)
             /* Validate datatype_ptr */
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_extent.c
+++ b/src/mpi/datatype/type_get_extent.c
@@ -96,6 +96,8 @@ int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
             /* Validate datatype_ptr */
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(lb, "lb", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_extent_x.c
+++ b/src/mpi/datatype/type_get_extent_x.c
@@ -106,6 +106,8 @@ int MPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *exten
 
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(lb, "lb", mpi_errno);
         }
         MPID_END_ERROR_CHECKS
     }

--- a/src/mpi/datatype/type_get_true_extent.c
+++ b/src/mpi/datatype/type_get_true_extent.c
@@ -98,6 +98,8 @@ int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb,
             /* Validate datatype_ptr */
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(true_lb, "true_lb", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(true_extent, "true_extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_true_extent_x.c
+++ b/src/mpi/datatype/type_get_true_extent_x.c
@@ -106,6 +106,8 @@ int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Co
 
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(true_lb, "true_lb", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(true_extent, "true_extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS
     }

--- a/src/mpi/datatype/type_lb.c
+++ b/src/mpi/datatype/type_lb.c
@@ -101,6 +101,7 @@ int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint *displacement)
             /* Validate datatype_ptr */
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(displacement, "displacement", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_size_x.c
+++ b/src/mpi/datatype/type_size_x.c
@@ -98,6 +98,7 @@ int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size)
 
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS
     }

--- a/src/mpi/datatype/type_ub.c
+++ b/src/mpi/datatype/type_ub.c
@@ -86,6 +86,7 @@ int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint *displacement)
             /* Validate datatype_ptr */
             MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(displacement, "displacement", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -126,6 +126,7 @@ int MPI_Type_vector(int count,
 		MPIR_Datatype_valid_ptr(old_ptr, mpi_errno);
                 if (mpi_errno) goto fn_fail;
 	    }
+           MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_difference.c
+++ b/src/mpi/group/group_difference.c
@@ -175,6 +175,7 @@ int MPI_Group_difference(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup
             MPIR_Group_valid_ptr( group_ptr2, mpi_errno );
 	    /* If either group_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newgroup, "newgroup", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_intersection.c
+++ b/src/mpi/group/group_intersection.c
@@ -175,6 +175,7 @@ int MPI_Group_intersection(MPI_Group group1, MPI_Group group2, MPI_Group *newgro
             MPIR_Group_valid_ptr( group_ptr2, mpi_errno );
 	    /* If either group_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newgroup, "newgroup", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_range_excl.c
+++ b/src/mpi/group/group_range_excl.c
@@ -192,6 +192,7 @@ int MPI_Group_range_excl(MPI_Group group, int n, int ranges[][3],
 							   ranges, n );
 	    }
             if (mpi_errno) goto fn_fail;
+	     MPIR_ERRTEST_ARGNULL(newgroup, "newgroup", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_range_incl.c
+++ b/src/mpi/group/group_range_incl.c
@@ -168,6 +168,7 @@ int MPI_Group_range_incl(MPI_Group group, int n, int ranges[][3],
 							   ranges, n );
 	    }
             if (mpi_errno) goto fn_fail;
+	     MPIR_ERRTEST_ARGNULL(newgroup, "newgroup", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_rank.c
+++ b/src/mpi/group/group_rank.c
@@ -85,6 +85,7 @@ int MPI_Group_rank(MPI_Group group, int *rank)
             MPIR_Group_valid_ptr( group_ptr, mpi_errno );
 	    /* If group_ptr is not value, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+	     MPIR_ERRTEST_ARGNULL(rank, "rank", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_size.c
+++ b/src/mpi/group/group_size.c
@@ -84,6 +84,7 @@ int MPI_Group_size(MPI_Group group, int *size)
             MPIR_Group_valid_ptr( group_ptr, mpi_errno );
 	    /* If group_ptr is not value, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_translate_ranks.c
+++ b/src/mpi/group/group_translate_ranks.c
@@ -193,6 +193,7 @@ int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
 		    }
 		}
 	    }
+	    MPIR_ERRTEST_ARGNULL(ranks2, "ranks2", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/group/group_union.c
+++ b/src/mpi/group/group_union.c
@@ -208,6 +208,7 @@ int MPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup)
 	    MPIR_Group_valid_ptr( group_ptr2, mpi_errno );
 	    /* If group_ptr is not valid, it will be reset to null */
             if (mpi_errno) goto fn_fail;
+            MPIR_ERRTEST_ARGNULL(newgroup, "newgroup", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/test/mpi/errors/comm/Makefile.am
+++ b/test/mpi/errors/comm/Makefile.am
@@ -12,5 +12,6 @@ EXTRA_DIST = testlist
 ## for all programs that are just built from the single corresponding source
 ## file, we don't need per-target _SOURCES rules, automake will infer them
 ## correctly
-noinst_PROGRAMS = cfree ccreate1 manysplit userdup too_many_comms too_many_comms2 too_many_comms3 too_many_icomms too_many_icomms2
-
+noinst_PROGRAMS = cfree ccreate1 manysplit userdup too_many_comms too_many_comms2 too_many_comms3 too_many_icomms too_many_icomms2 \
+comm_create_test comm_create_group_test comm_dup_test comm_get_info_test comm_group_test comm_remote_size_test comm_size_test comm_split_test \
+comm_split_type_test intercomm_create_test

--- a/test/mpi/errors/comm/comm_create_group_test.c
+++ b/test/mpi/errors/comm/comm_create_group_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int errs = 0, mpi_errno, errclass, rank, size;
+    MPI_Comm dup_comm;
+    MPI_Group group;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm);
+    MPI_Comm_group(dup_comm, &group);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_create_group for NULL variable */
+    mpi_errno = MPI_Comm_create_group(dup_comm, group, 10, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&dup_comm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+  }

--- a/test/mpi/errors/comm/comm_create_test.c
+++ b/test/mpi/errors/comm/comm_create_test.c
@@ -1,0 +1,34 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int errs = 0, errclass, mpi_errno;
+    int rank, size;
+    MPI_Comm comm;
+    MPI_Group group, group1;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_group(comm, &group);
+    MPI_Comm_group(group, &group1);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_create for NULL variable */
+    mpi_errno = MPI_Comm_create(group, group1, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Group_free(&group);
+    MPI_Group_free(&group1);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/comm/comm_dup_test.c
+++ b/test/mpi/errors/comm/comm_dup_test.c
@@ -1,0 +1,25 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int err = 0, errclass, mpi_errno;
+    int rank, size;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_dup for NULL variable */
+    mpi_errno = MPI_Comm_dup(comm, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+ }

--- a/test/mpi/errors/comm/comm_get_info_test.c
+++ b/test/mpi/errors/comm/comm_get_info_test.c
@@ -1,0 +1,29 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int errs = 0, errclass, mpi_errno;
+    int rank, size;
+    MPI_Comm dup_comm;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm);
+
+    /*test comm_get_info for NULL variable */
+    mpi_errno = MPI_Comm_get_info(dup_comm, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&dup_comm);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+ }

--- a/test/mpi/errors/comm/comm_group_test.c
+++ b/test/mpi/errors/comm/comm_group_test.c
@@ -1,0 +1,33 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int errs = 0, errclass, mpi_errno;
+    int rank, size;
+    MPI_Comm dup_comm;
+    MPI_Group group;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+    MPI_Comm_dup(MPI_COMM_WORLD, &dup_comm);
+    MPI_Comm_group(dup_comm, &group);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_group for NULL variable */
+    mpi_errno = MPI_Comm_group(dup_comm, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&dup_comm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+  }

--- a/test/mpi/errors/comm/comm_remote_size_test.c
+++ b/test/mpi/errors/comm/comm_remote_size_test.c
@@ -1,0 +1,41 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    MPI_Comm comm, newcomm, scomm, intercomm;
+    MPI_Group group;
+    int rank, size, color, newrank;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_group(comm, &group);
+
+    MPI_Comm_create(comm, group, &newcomm);
+    color = rank % 2;
+    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &scomm);
+    MPI_Intercomm_create(scomm, 0, MPI_COMM_WORLD, 1-color, 52, &intercomm);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_rank(intercomm, &newrank);
+    /*test comm_remote_size for NULL variable */
+    mpi_errno = MPI_Comm_remote_size(intercomm, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Comm_free(&scomm);
+    MPI_Comm_free(&intercomm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/comm/comm_size_test.c
+++ b/test/mpi/errors/comm/comm_size_test.c
@@ -1,0 +1,24 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    int rank, size;
+    int errclass, errs = 0, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_size for NULL variable */
+    mpi_errno = MPI_Comm_size(MPI_COMM_WORLD, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+   }

--- a/test/mpi/errors/comm/comm_split_test.c
+++ b/test/mpi/errors/comm/comm_split_test.c
@@ -1,0 +1,37 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    MPI_Comm comm, newcomm;
+    MPI_Group group;
+    int rank, size, color;
+    int errs = 0, mpi_errno, errclass;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_group(comm, &group);
+
+    MPI_Comm_create(comm, group, &newcomm);
+    color = rank % 2;
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+    MPI_Error_class(mpi_errno, &errclass);
+
+    /*test comm_split for NULL variable */
+    mpi_errno = MPI_Comm_split(MPI_COMM_WORLD, color, rank, NULL);
+
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/comm/comm_split_type_test.c
+++ b/test/mpi/errors/comm/comm_split_type_test.c
@@ -1,0 +1,39 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    MPI_Comm comm, newcomm, scomm;
+    MPI_Group group;
+    MPI_Info newinfo;
+    int rank, size, color;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_group(comm, &group);
+
+    MPI_Comm_create(comm, group, &newcomm);
+    color = rank % 2;
+    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &scomm);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /*test comm_split_type for NULL variable */
+    mpi_errno = MPI_Comm_split_type(scomm, 2, 4, newinfo, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Comm_free(&scomm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/comm/intercomm_create_test.c
+++ b/test/mpi/errors/comm/intercomm_create_test.c
@@ -1,0 +1,38 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char* argv[])
+{
+    MPI_Comm comm, newcomm, scomm;
+    MPI_Group group;
+    int rank, size, color;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+    MPI_Comm_group(comm, &group);
+
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_create(comm, group, &newcomm);
+    color = rank % 2;
+    MPI_Comm_split(MPI_COMM_WORLD, color, rank, &scomm);
+    /*test inercomm_create for NULL variable */
+    mpi_errno = MPI_Intercomm_create(scomm, 0, MPI_COMM_WORLD, 1-color, 52, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&scomm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&group);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/Makefile.am
+++ b/test/mpi/errors/datatype/Makefile.am
@@ -12,5 +12,6 @@ EXTRA_DIST = testlist
 ## for all programs that are just built from the single corresponding source
 ## file, we don't need per-target _SOURCES rules, automake will infer them
 ## correctly
-noinst_PROGRAMS = getcnterr
+noinst_PROGRAMS = getcnterr type_contiguous_test type_create_resized_test type_extent_test type_get_extent_test type_get_true_extent_test /
+type_get_true_extent_x_test type_lb_test type_ub_test type_size_x_test type_vector_test
 

--- a/test/mpi/errors/datatype/type_contiguous_test.c
+++ b/test/mpi/errors/datatype/type_contiguous_test.c
@@ -1,0 +1,26 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    int errs = 0, mpi_errno, errclass;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking type_contiguous for NULL variable */
+    mpi_errno = MPI_Type_contiguous(3, MPI_INT, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_create_resized_test.c
+++ b/test/mpi/errors/datatype/type_create_resized_test.c
@@ -1,0 +1,26 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking type_create_resized for NULL variable */
+    mpi_errno = MPI_Type_create_resized( MPI_INT, 0, 3 * sizeof(int), NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_extent_test.c
+++ b/test/mpi/errors/datatype/type_extent_test.c
@@ -1,0 +1,28 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    int errclass, errs = 0, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking type_extent for NULL variable */
+    type = MPI_INT;
+    mpi_errno = MPI_Type_extent(type, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_get_extent_test.c
+++ b/test/mpi/errors/datatype/type_get_extent_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    MPI_Aint lb;
+    int errs =0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    type = MPI_INT;
+    MPI_Type_size(type, &size);
+    /* Checking type_get_extent for NULL variable */
+    mpi_errno = MPI_Type_get_extent(type, &lb, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_get_true_extent_test.c
+++ b/test/mpi/errors/datatype/type_get_true_extent_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    MPI_Aint lb;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    type = MPI_INT;
+    MPI_Type_size(type, &size);
+    /* Checking type_get_true_extent for NULL variable */
+    mpi_errno = MPI_Type_get_true_extent(type, &lb, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_get_true_extent_x_test.c
+++ b/test/mpi/errors/datatype/type_get_true_extent_x_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    MPI_Count lb;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    type = MPI_INT;
+    MPI_Type_size(type, &size);
+    /* Checking type_get_true_extent_x for NULL variable */
+    mpi_errno = MPI_Type_get_extent_x(type, &lb, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_lb_test.c
+++ b/test/mpi/errors/datatype/type_lb_test.c
@@ -1,0 +1,30 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    type = MPI_INT;
+    MPI_Type_size(type, &size);
+    /* Checking type_lb for NULL variable */
+    mpi_errno = MPI_Type_lb(type, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_size_x_test.c
+++ b/test/mpi/errors/datatype/type_size_x_test.c
@@ -1,0 +1,29 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    int errs = 0, mpi_errno, errclass;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking type_size_x for NULL variable */
+    type = MPI_INT;
+    mpi_errno = MPI_Type_size_x(type, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_ub_test.c
+++ b/test/mpi/errors/datatype/type_ub_test.c
@@ -1,0 +1,30 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type;
+    int errs = 0, mpi_errno, errclass;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    type = MPI_INT;
+    MPI_Type_size(type, &size);
+    /* Checking type_ub for NULL variable */
+    mpi_errno = MPI_Type_ub(type, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/datatype/type_vector_test.c
+++ b/test/mpi/errors/datatype/type_vector_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Datatype type2, type;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Type_contiguous(3, MPI_INT, &type2);
+    MPI_Type_commit(&type2);
+    /* Checking type_vector for NULL variable */
+    mpi_errno = MPI_Type_vector(3, 2, 3, type2, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Type_free(&type);
+    MPI_Type_free(&type2);
+    MTest_Finlaize();
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/Makefile.am
+++ b/test/mpi/errors/group/Makefile.am
@@ -12,5 +12,6 @@ EXTRA_DIST = testlist
 ## for all programs that are just built from the single corresponding source
 ## file, we don't need per-target _SOURCES rules, automake will infer them
 ## correctly
-noinst_PROGRAMS = gerr
+noinst_PROGRAMS = gerr group_difference_test group_intersection_test group_range_excl_test group_range_incl_test group_rank_test group_size_test \
+group_translate_ranks_test group_union_test
 

--- a/test/mpi/errors/group/group_difference_test.c
+++ b/test/mpi/errors/group/group_difference_test.c
@@ -1,0 +1,43 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1, g2;
+    MPI_Comm comm, newcomm, dupcomm;
+    int rank, size;
+    int worldrank;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init( &argc, &argv );
+    MPI_Comm_rank( MPI_COMM_WORLD, &worldrank );
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group( comm, &basegroup );
+    MPI_Comm_rank( comm, &rank );
+    MPI_Comm_size( comm, &size );
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split( comm, 0, size - rank, &newcomm );
+    MPI_Comm_group( newcomm, &g1);
+    MPI_Comm_dup( comm, &dupcomm );
+    MPI_Comm_group( dupcomm, &g2 );
+
+    /* checking group_difference for NULL variable */
+    mpi_errno = MPI_Group_difference( g1, g2, NULL );
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Group_free(&basegroup);
+    MPI_Group_free(&g1);
+    MPI_Group_free(&g2);
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Comm_free(&dupcomm);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_intersection_test.c
+++ b/test/mpi/errors/group/group_intersection_test.c
@@ -1,0 +1,39 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1;
+    MPI_Comm comm, newcomm;
+    int rank, size;
+    int worldrank;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split(comm, 0, size - rank, &newcomm);
+    MPI_Comm_group(newcomm, &g1);
+
+    /* Checking group_intersection for NULL variable */
+    mpi_errno = MPI_Group_intersection(basegroup, g1, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&basegroup);
+    MPI_Group_free(&g1);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_range_excl_test.c
+++ b/test/mpi/errors/group/group_range_excl_test.c
@@ -1,0 +1,42 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1;
+    MPI_Comm comm, newcomm;
+    int errs=0, mpi_errno, errclass, rank, size;
+    int range[1][3];
+    int worldrank;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split(comm, 0, size - rank, &newcomm);
+    MPI_Comm_group(newcomm, &g1);
+
+    /* Checking group_range_excl for NULL variable */
+    range[0][0] = 1;
+    range[0][1] = size-1;
+    range[0][2] = 1;
+    mpi_errno = MPI_Group_range_excl(basegroup, 1, range, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&basegroup);
+    MPI_Group_free(&g1);
+    MTest_Finalize();
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_range_incl_test.c
+++ b/test/mpi/errors/group/group_range_incl_test.c
@@ -1,0 +1,42 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1;
+    MPI_Comm comm, newcomm;
+    int errs = 0, mpi_errno, errclass, rank, size;
+    int range[1][3];
+    int worldrank;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split(comm, 0, size - rank, &newcomm);
+    MPI_Comm_group(newcomm, &g1);
+
+    /* Checking group_range_excl for NULL variable */
+    range[0][0] = 1;
+    range[0][1] = size-1;
+    range[0][2] = 1;
+    mpi_errno = MPI_Group_range_incl(basegroup, 1, range, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&basegroup);
+    MPI_Group_free(&g1);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_rank_test.c
+++ b/test/mpi/errors/group/group_rank_test.c
@@ -1,0 +1,31 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Comm comm;
+    int worldrank, rank;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking group_rank for NULL variable */
+    mpi_errno = MPI_Group_rank(basegroup, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Group_free(&basegroup);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_size_test.c
+++ b/test/mpi/errors/group/group_size_test.c
@@ -1,0 +1,33 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Comm comm;
+    int rank, size;
+    int worldrank;
+    int errs = 0, errclass, mpi_errno;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    /* Checking group_size for NULL variable */
+    mpi_errno = MPI_Group_size(basegroup, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Group_free(&basegroup);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_translate_ranks_test.c
+++ b/test/mpi/errors/group/group_translate_ranks_test.c
@@ -1,0 +1,43 @@
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1;
+    MPI_Comm comm, newcomm;
+    int errs = 0, mpi_errno, rank, size;
+    int i, errclass, nranks, *ranks;
+    int worldrank;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &worldrank);
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group(comm, &basegroup);
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split( comm, 0, size - rank, &newcomm );
+    MPI_Comm_group( newcomm, &g1);
+    ranks = (int *)malloc( size * sizeof(int) );
+    for (i=0; i<size; i++) ranks[i] = i;
+    nranks = size;
+
+    /*Checking group_ranslate_ranks for NULL variable */
+    mpi_errno = MPI_Group_translate_ranks(g1, nranks, ranks, basegroup, NULL);
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Group_free(&basegroup);
+    MPI_GRoup_free(&g1);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+

--- a/test/mpi/errors/group/group_union_test.c
+++ b/test/mpi/errors/group/group_union_test.c
@@ -1,0 +1,42 @@
+#include <mpi.h>
+#include <stdio.h>
+#include "mpitest.h"
+
+int main(int argc, char **argv)
+{
+    MPI_Group basegroup;
+    MPI_Group g1, g2;
+    MPI_Comm comm, newcomm, dupcomm;
+    int errs = 0, mpi_errno, rank, size;
+    int errclass, worldrank;
+
+    MTest_Init( &argc, &argv );
+    MPI_Comm_rank( MPI_COMM_WORLD, &worldrank );
+    comm = MPI_COMM_WORLD;
+    MPI_Comm_group( comm, &basegroup );
+    MPI_Comm_rank( comm, &rank );
+    MPI_Comm_size( comm, &size );
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    MPI_Comm_split( comm, 0, size - rank, &newcomm );
+    MPI_Comm_group( newcomm, &g1);
+    MPI_Comm_dup( comm, &dupcomm );
+    MPI_Comm_group( dupcomm, &g2 );
+
+    /* checking group_union for NULL variable */
+    mpi_errno = MPI_Group_union( g1, g2, NULL );
+    MPI_Error_class(mpi_errno, &errclass);
+    if (errclass != MPI_ERR_ARG)
+        ++errs;
+
+    MPI_Comm_free(&comm);
+    MPI_Comm_free(&newcomm);
+    MPI_Comm_free(&dupcomm);
+    MPI_Group_free(&basegroup);
+    MPI_Group_free(&g1);
+    MPI_Group_free(&g2);
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    return 0;
+}
+


### PR DESCRIPTION
When the User makes a call to MPI_Comm_dup(MPI_COMM_WORLD, NULL) the program gives Segmentation error. To avoid this and capture the error, the newcomm argument is checked for NULL in comm_dup.c.  
This PR is to fix #1673 