### PR TITLE
dt: Remove PREPEND_PREFIX from dataloop code

### DIFF
--- a/src/mpid/common/datatype/dataloop/darray_support.c
+++ b/src/mpid/common/datatype/dataloop/darray_support.c
@@ -20,10 +20,10 @@ static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nproc
 
 
 #undef FUNCNAME
-#define FUNCNAME PREPEND_PREFIX(Type_convert_darray)
+#define FUNCNAME MPIDU_Type_convert_darray
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int PREPEND_PREFIX(Type_convert_darray)(int size,
+int MPIDU_Type_convert_darray(int size,
 					int rank,
 					int ndims,
 					int *array_of_gsizes,

--- a/src/mpid/common/datatype/dataloop/dataloop.c
+++ b/src/mpid/common/datatype/dataloop/dataloop.c
@@ -57,7 +57,7 @@
 Input/output Parameters:
 . dataloop - pointer to dataloop structure
 @*/
-void PREPEND_PREFIX(Dataloop_free)(DLOOP_Dataloop **dataloop)
+void MPIDU_Dataloop_free(DLOOP_Dataloop **dataloop)
 {
 
     if (*dataloop == NULL) return;
@@ -95,7 +95,7 @@ Input Parameters:
 - all pointers in the region are relative to the start of the data region
   the first dataloop in the array is the root of the tree
 @*/
-void PREPEND_PREFIX(Dataloop_copy)(void *dest,
+void MPIDU_Dataloop_copy(void *dest,
 				   void *src,
 				   DLOOP_Size size)
 {
@@ -117,7 +117,7 @@ void PREPEND_PREFIX(Dataloop_copy)(void *dest,
     ptrdiff = (DLOOP_Offset) ((char *) dest - (char *) src);
 
     /* traverse structure updating pointers */
-    PREPEND_PREFIX(Dataloop_update)(dest, ptrdiff);
+    MPIDU_Dataloop_update(dest, ptrdiff);
 
     return;
 }
@@ -133,7 +133,7 @@ Input Parameters:
   This function is used to recursively update all the pointers in a
   dataloop tree.
 @*/
-void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
+void MPIDU_Dataloop_update(DLOOP_Dataloop *dataloop,
 				     DLOOP_Offset ptrdiff)
 {
     /* OPT: only declare these variables down in the Struct case */
@@ -162,7 +162,7 @@ void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
 		    (DLOOP_Dataloop *) DLOOP_OFFSET_CAST_TO_VOID_PTR
 		    (DLOOP_VOID_PTR_CAST_TO_OFFSET (char *) dataloop->loop_params.cm_t.dataloop + ptrdiff);
 
-		PREPEND_PREFIX(Dataloop_update)(dataloop->loop_params.cm_t.dataloop, ptrdiff);
+		MPIDU_Dataloop_update(dataloop->loop_params.cm_t.dataloop, ptrdiff);
 	    }
 	    break;
 
@@ -184,7 +184,7 @@ void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
 		    (DLOOP_Dataloop *) DLOOP_OFFSET_CAST_TO_VOID_PTR
 		    (DLOOP_VOID_PTR_CAST_TO_OFFSET (char *) dataloop->loop_params.bi_t.dataloop + ptrdiff);
 
-		PREPEND_PREFIX(Dataloop_update)(dataloop->loop_params.bi_t.dataloop, ptrdiff);
+		MPIDU_Dataloop_update(dataloop->loop_params.bi_t.dataloop, ptrdiff);
 	    }
 	    break;
 
@@ -214,7 +214,7 @@ void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
 		    (DLOOP_Dataloop *) DLOOP_OFFSET_CAST_TO_VOID_PTR
 		    (DLOOP_VOID_PTR_CAST_TO_OFFSET (char *) dataloop->loop_params.i_t.dataloop + ptrdiff);
 
-		PREPEND_PREFIX(Dataloop_update)(dataloop->loop_params.i_t.dataloop, ptrdiff);
+		MPIDU_Dataloop_update(dataloop->loop_params.i_t.dataloop, ptrdiff);
 	    }
 	    break;
 
@@ -257,7 +257,7 @@ void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
 	    }
 
 	    for (i=0; i < dataloop->loop_params.s_t.count; i++) {
-		PREPEND_PREFIX(Dataloop_update)(looparray[i], ptrdiff);
+		MPIDU_Dataloop_update(looparray[i], ptrdiff);
 	    }
 	    break;
 	default:
@@ -283,12 +283,12 @@ Input Parameters:
   The count parameter passed into this function will often be different
   from the count passed in at the MPI layer due to optimizations.
 @*/
-void PREPEND_PREFIX(Dataloop_alloc)(int kind,
+void MPIDU_Dataloop_alloc(int kind,
 				    DLOOP_Count count,
 				    DLOOP_Dataloop **new_loop_p,
 				    MPI_Aint *new_loop_sz_p)
 {
-    PREPEND_PREFIX(Dataloop_alloc_and_copy)(kind,
+    MPIDU_Dataloop_alloc_and_copy(kind,
 					    count,
 					    NULL,
 					    0,
@@ -314,7 +314,7 @@ Input Parameters:
   The count parameter passed into this function will often be different
   from the count passed in at the MPI layer.
 @*/
-void PREPEND_PREFIX(Dataloop_alloc_and_copy)(int kind,
+void MPIDU_Dataloop_alloc_and_copy(int kind,
 					     DLOOP_Count count,
 					     DLOOP_Dataloop *old_loop,
 					     DLOOP_Size old_loop_sz,
@@ -473,7 +473,7 @@ void PREPEND_PREFIX(Dataloop_alloc_and_copy)(int kind,
 
     pos = ((char *) new_loop) + (new_loop_sz - old_loop_sz);
     if (old_loop != NULL) {
-	PREPEND_PREFIX(Dataloop_copy)(pos, old_loop, old_loop_sz);
+	MPIDU_Dataloop_copy(pos, old_loop, old_loop_sz);
     }
 
     *new_loop_p    = new_loop;
@@ -504,7 +504,7 @@ Input Parameters:
   The caller is responsible for filling in the region pointed to by
   old_loop_p (count elements).
 @*/
-void PREPEND_PREFIX(Dataloop_struct_alloc)(DLOOP_Count count,
+void MPIDU_Dataloop_struct_alloc(DLOOP_Count count,
 					   DLOOP_Size old_loop_sz,
 					   int basic_ct,
 					   DLOOP_Dataloop **old_loop_p,
@@ -602,7 +602,7 @@ void PREPEND_PREFIX(Dataloop_struct_alloc)(DLOOP_Count count,
 
   Returns 0 on success, -1 on failure.
 @*/
-void PREPEND_PREFIX(Dataloop_dup)(DLOOP_Dataloop *old_loop,
+void MPIDU_Dataloop_dup(DLOOP_Dataloop *old_loop,
 				  DLOOP_Count old_loop_sz,
 				  DLOOP_Dataloop **new_loop_p)
 {
@@ -617,7 +617,7 @@ void PREPEND_PREFIX(Dataloop_dup)(DLOOP_Dataloop *old_loop,
 	return;
     }
 
-    PREPEND_PREFIX(Dataloop_copy)(new_loop, old_loop, old_loop_sz);
+    MPIDU_Dataloop_copy(new_loop, old_loop, old_loop_sz);
     *new_loop_p = new_loop;
     return;
 }
@@ -632,7 +632,7 @@ Input Parameters:
 
 @*/
 DLOOP_Offset
-PREPEND_PREFIX(Dataloop_stream_size)(struct DLOOP_Dataloop *dl_p,
+MPIDU_Dataloop_stream_size(struct DLOOP_Dataloop *dl_p,
 				     DLOOP_Offset (*sizefn)(DLOOP_Type el_type))
 {
     DLOOP_Offset tmp_sz, tmp_ct = 1;
@@ -647,7 +647,7 @@ PREPEND_PREFIX(Dataloop_stream_size)(struct DLOOP_Dataloop *dl_p,
             for (i = 0; i < dl_p->loop_params.s_t.count; i++)
             {
                 tmp_sz += (DLOOP_Offset)(dl_p->loop_params.s_t.blocksize_array[i]) *
-                    PREPEND_PREFIX(Dataloop_stream_size)(dl_p->loop_params.s_t.dataloop_array[i], sizefn);
+                    MPIDU_Dataloop_stream_size(dl_p->loop_params.s_t.dataloop_array[i], sizefn);
             }
             return tmp_sz * tmp_ct;
         }
@@ -717,7 +717,7 @@ Input Parameters:
 + dataloop - root of tree to dump
 - depth - starting depth; used to help keep up with where we are in the tree
 @*/
-void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
+void MPIDU_Dataloop_print(struct DLOOP_Dataloop *dataloop,
 				    int depth)
 {
     int i;
@@ -736,7 +736,7 @@ void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
 			     (int) dataloop->loop_params.c_t.count,
                              dataloop->loop_params.c_t.dataloop));
 	    if (!(dataloop->kind & DLOOP_FINAL_MASK))
-		PREPEND_PREFIX(Dataloop_print)(dataloop->loop_params.c_t.dataloop, depth+1);
+		MPIDU_Dataloop_print(dataloop->loop_params.c_t.dataloop, depth+1);
 	    break;
 	case DLOOP_KIND_VECTOR:
 	    MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE,VERBOSE,(MPL_DBG_FDEST,"\tVECTOR: count=%d, blksz=%d, stride=" DLOOP_OFFSET_FMT_DEC_SPEC ", datatype=%p\n",
@@ -745,7 +745,7 @@ void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
 			     (DLOOP_Offset) dataloop->loop_params.v_t.stride,
                              dataloop->loop_params.v_t.dataloop));
 	    if (!(dataloop->kind & DLOOP_FINAL_MASK))
-		PREPEND_PREFIX(Dataloop_print)(dataloop->loop_params.v_t.dataloop, depth+1);
+		MPIDU_Dataloop_print(dataloop->loop_params.v_t.dataloop, depth+1);
 	    break;
 	case DLOOP_KIND_BLOCKINDEXED:
 	    MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE,VERBOSE,(MPL_DBG_FDEST,"\tBLOCKINDEXED: count=%d, blksz=%d, datatype=%p\n",
@@ -754,7 +754,7 @@ void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
                              dataloop->loop_params.bi_t.dataloop));
 	    /* print out offsets later */
 	    if (!(dataloop->kind & DLOOP_FINAL_MASK))
-		PREPEND_PREFIX(Dataloop_print)(dataloop->loop_params.bi_t.dataloop, depth+1);
+		MPIDU_Dataloop_print(dataloop->loop_params.bi_t.dataloop, depth+1);
 	    break;
 	case DLOOP_KIND_INDEXED:
 	    MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE,VERBOSE,(MPL_DBG_FDEST,"\tINDEXED: count=%d, datatype=%p\n",
@@ -762,7 +762,7 @@ void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
                              dataloop->loop_params.i_t.dataloop));
 	    /* print out blocksizes and offsets later */
 	    if (!(dataloop->kind & DLOOP_FINAL_MASK))
-		PREPEND_PREFIX(Dataloop_print)(dataloop->loop_params.i_t.dataloop, depth+1);
+		MPIDU_Dataloop_print(dataloop->loop_params.i_t.dataloop, depth+1);
 	    break;
 	case DLOOP_KIND_STRUCT:
 	    MPL_DBG_MSG_D(MPIR_DBG_DATATYPE,VERBOSE,"\tSTRUCT: count=%d\n", (int) dataloop->loop_params.s_t.count);
@@ -778,7 +778,7 @@ void PREPEND_PREFIX(Dataloop_print)(struct DLOOP_Dataloop *dataloop,
 	    if (dataloop->kind & DLOOP_FINAL_MASK) break;
 
 	    for (i=0; i < dataloop->loop_params.s_t.count; i++) {
-		PREPEND_PREFIX(Dataloop_print)(dataloop->loop_params.s_t.dataloop_array[i],depth+1);
+		MPIDU_Dataloop_print(dataloop->loop_params.s_t.dataloop_array[i],depth+1);
 	    }
 	    break;
 	default:

--- a/src/mpid/common/datatype/dataloop/dataloop_create.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create.c
@@ -16,7 +16,7 @@ static void DLOOP_Dataloop_create_named(MPI_Datatype type,
 					int *dldepth_p,
 					int flag);
 
-void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
+void MPIDU_Dataloop_create(MPI_Datatype type,
 				     DLOOP_Dataloop **dlp_p,
 				     MPI_Aint *dlsz_p,
 				     int *dldepth_p,
@@ -54,7 +54,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
     {
         MPI_Datatype f90basetype;
         DLOOP_Handle_get_basic_type_macro(type, f90basetype);
-        PREPEND_PREFIX(Dataloop_create_contiguous)(1 /* count */,
+        MPIDU_Dataloop_create_contiguous(1 /* count */,
                                                    f90basetype,
                                                    dlp_p, dlsz_p,
                                                    dldepth_p,
@@ -75,7 +75,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	return;
     }
 
-    PREPEND_PREFIX(Type_access_contents)(type, &ints, &aints, &types);
+    MPIDU_Type_access_contents(type, &ints, &aints, &types);
 
     /* first check for zero count on types where that makes sense */
     switch(combiner) {
@@ -91,7 +91,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	case MPI_COMBINER_STRUCT_INTEGER:
 	case MPI_COMBINER_STRUCT:
 	    if (ints[0] == 0) {
-		PREPEND_PREFIX(Dataloop_create_contiguous)(0,
+		MPIDU_Dataloop_create_contiguous(0,
 							   MPI_INT,
 							   dlp_p,
 							   dlsz_p,
@@ -117,7 +117,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	if (old_dlp == NULL)
 	{
 	    /* no dataloop already present; create and store one */
-	    PREPEND_PREFIX(Dataloop_create)(types[0],
+	    MPIDU_Dataloop_create(types[0],
 					    &old_dlp,
 					    &old_dlsz,
 					    &old_dldepth,
@@ -137,12 +137,12 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
     {
 	case MPI_COMBINER_DUP:
 	    if (type0_combiner != MPI_COMBINER_NAMED) {
-		PREPEND_PREFIX(Dataloop_dup)(old_dlp, old_dlsz, dlp_p);
+		MPIDU_Dataloop_dup(old_dlp, old_dlsz, dlp_p);
 		*dlsz_p    = old_dlsz;
 		*dldepth_p = old_dldepth;
 	    }
 	    else {
-		PREPEND_PREFIX(Dataloop_create_contiguous)(1,
+		MPIDU_Dataloop_create_contiguous(1,
 							   types[0], 
 							   dlp_p, dlsz_p,
 							   dldepth_p,
@@ -151,12 +151,12 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	    break;
 	case MPI_COMBINER_RESIZED:
 	    if (type0_combiner != MPI_COMBINER_NAMED) {
-		PREPEND_PREFIX(Dataloop_dup)(old_dlp, old_dlsz, dlp_p);
+		MPIDU_Dataloop_dup(old_dlp, old_dlsz, dlp_p);
 		*dlsz_p    = old_dlsz;
 		*dldepth_p = old_dldepth;
 	    }
 	    else {
-		PREPEND_PREFIX(Dataloop_create_contiguous)(1,
+		MPIDU_Dataloop_create_contiguous(1,
 							   types[0], 
 							   dlp_p, dlsz_p,
 							   dldepth_p,
@@ -166,14 +166,14 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	    }
 	    break;
 	case MPI_COMBINER_CONTIGUOUS:
-	    PREPEND_PREFIX(Dataloop_create_contiguous)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_contiguous(ints[0] /* count */,
 						       types[0] /* oldtype */,
 						       dlp_p, dlsz_p,
 						       dldepth_p,
 						       flag);
 	    break;
 	case MPI_COMBINER_VECTOR:
-	    PREPEND_PREFIX(Dataloop_create_vector)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_vector(ints[0] /* count */,
 						   ints[1] /* blklen */,
 						   ints[2] /* stride */,
 						   0 /* stride not bytes */,
@@ -191,7 +191,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 		stride = aints[0];
 	    }
 
-	    PREPEND_PREFIX(Dataloop_create_vector)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_vector(ints[0] /* count */,
 						   ints[1] /* blklen */,
 						   stride,
 						   1 /* stride in bytes */,
@@ -200,7 +200,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 						   flag);
 	    break;
 	case MPI_COMBINER_INDEXED_BLOCK:
-	    PREPEND_PREFIX(Dataloop_create_blockindexed)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_blockindexed(ints[0] /* count */,
 							 ints[1] /* blklen */,
 							 &ints[2] /* disps */,
 							 0 /* disp not bytes */,
@@ -213,7 +213,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
             disps = (MPI_Aint *) DLOOP_Malloc(ints[0] * sizeof(MPI_Aint));
             for (i = 0; i < ints[0]; i++)
                 disps[i] = aints[i];
-	    PREPEND_PREFIX(Dataloop_create_blockindexed)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_blockindexed(ints[0] /* count */,
 							 ints[1] /* blklen */,
 							 disps /* disps */,
 							 1 /* disp is bytes */,
@@ -227,7 +227,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
             blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size));
             for (i = 0; i < ints[0]; i++)
                 blklen[i] = ints[1+i];
-	    PREPEND_PREFIX(Dataloop_create_indexed)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_indexed(ints[0] /* count */,
 						    blklen /* blklens */,
 						    &ints[ints[0]+1] /* disp */,
 						    0 /* disp not in bytes */,
@@ -252,7 +252,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	    blklen = (DLOOP_Size *) DLOOP_Malloc(ints[0] * sizeof(DLOOP_Size));
 	    for (i=0; i< ints[0]; i++)
 		blklen[i] = (DLOOP_Size) ints[1+i];
-	    PREPEND_PREFIX(Dataloop_create_indexed)(ints[0] /* count */,
+	    MPIDU_Dataloop_create_indexed(ints[0] /* count */,
 						    blklen /* blklens */,
 						    disps,
 						    1 /* disp in bytes */,
@@ -276,7 +276,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 		    DLOOP_Handle_get_loopptr_macro(types[i], old_dlp, flag);
 		    if (old_dlp == NULL)
 		    {
-			PREPEND_PREFIX(Dataloop_create)(types[i],
+			MPIDU_Dataloop_create(types[i],
 							&old_dlp,
 							&old_dlsz,
 							&old_dldepth,
@@ -302,7 +302,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 		disps = aints;
 	    }
 
-            err = PREPEND_PREFIX(Dataloop_create_struct)(ints[0] /* count */,
+            err = MPIDU_Dataloop_create_struct(ints[0] /* count */,
                                                          &ints[1] /* blklens */,
                                                          disps,
                                                          types /* oldtype array */,
@@ -318,7 +318,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	    break;
 	case MPI_COMBINER_SUBARRAY:
 	    ndims = ints[0];
-	    PREPEND_PREFIX(Type_convert_subarray)(ndims,
+	    MPIDU_Type_convert_subarray(ndims,
 						  &ints[1] /* sizes */,
 						  &ints[1+ndims] /* subsizes */,
 						  &ints[1+2*ndims] /* starts */,
@@ -326,7 +326,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 						  types[0],
 						  &tmptype);
 
-	    PREPEND_PREFIX(Dataloop_create)(tmptype,
+	    MPIDU_Dataloop_create(tmptype,
 					    dlp_p,
 					    dlsz_p,
 					    dldepth_p,
@@ -336,7 +336,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 	    break;
 	case MPI_COMBINER_DARRAY:
 	    ndims = ints[2];
-	    PREPEND_PREFIX(Type_convert_darray)(ints[0] /* size */,
+	    MPIDU_Type_convert_darray(ints[0] /* size */,
 						ints[1] /* rank */,
 						ndims,
 						&ints[3] /* gsizes */,
@@ -347,7 +347,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 						types[0],
 						&tmptype);
 
-	    PREPEND_PREFIX(Dataloop_create)(tmptype,
+	    MPIDU_Dataloop_create(tmptype,
 					    dlp_p,
 					    dlsz_p,
 					    dldepth_p,
@@ -362,7 +362,7 @@ void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
 
  clean_exit:
 
-    PREPEND_PREFIX(Type_release_contents)(type, &ints, &aints, &types);
+    MPIDU_Type_release_contents(type, &ints, &aints, &types);
 
     /* for now we just leave the intermediate dataloops in place.
      * could remove them to save space if we wanted.
@@ -409,7 +409,7 @@ static void DLOOP_Dataloop_create_named(MPI_Datatype type,
 	    DLOOP_Handle_get_loopdepth_macro(type, *dldepth_p, flag);
 	}
 	else {
-	    PREPEND_PREFIX(Dataloop_create_pairtype)(type,
+	    MPIDU_Dataloop_create_pairtype(type,
 						     dlp_p,
 						     dlsz_p,
 						     dldepth_p,

--- a/src/mpid/common/datatype/dataloop/dataloop_create.h
+++ b/src/mpid/common/datatype/dataloop/dataloop_create.h
@@ -9,18 +9,18 @@
 #define DATALOOP_CREATE_H
 
 /* Dataloop construction functions */
-void PREPEND_PREFIX(Dataloop_create)(MPI_Datatype type,
+void MPIDU_Dataloop_create(MPI_Datatype type,
 				     DLOOP_Dataloop **dlp_p,
 				     DLOOP_Size *dlsz_p,
 				     int *dldepth_p,
 				     int flag);
-int PREPEND_PREFIX(Dataloop_create_contiguous)(DLOOP_Count count,
+int MPIDU_Dataloop_create_contiguous(DLOOP_Count count,
 					       MPI_Datatype oldtype,
 					       DLOOP_Dataloop **dlp_p,
 					       DLOOP_Size *dlsz_p,
 					       int *dldepth_p,
 					       int flag);
-int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count count,
+int MPIDU_Dataloop_create_vector(DLOOP_Count count,
 					   DLOOP_Size blocklength,
 					   MPI_Aint stride,
 					   int strideinbytes,
@@ -29,7 +29,7 @@ int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count count,
 					   DLOOP_Size *dlsz_p,
 					   int *dldepth_p,
 					   int flag);
-int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count count,
+int MPIDU_Dataloop_create_blockindexed(DLOOP_Count count,
 						 DLOOP_Size blklen,
 						 const void *disp_array,
 						 int dispinbytes,
@@ -41,7 +41,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count count,
 /* we bump up the size of the blocklength array because create_struct might use
  * create_indexed in an optimization, and in course of doing so, generate a
  * request of a large blocklength. */
-int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count count,
+int MPIDU_Dataloop_create_indexed(DLOOP_Count count,
 					    const DLOOP_Size *blocklength_array,
 					    const void *displacement_array,
 					    int dispinbytes,
@@ -50,7 +50,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count count,
 					    DLOOP_Size *dlsz_p,
 					    int *dldepth_p,
 					    int flag);
-int PREPEND_PREFIX(Dataloop_create_struct)(DLOOP_Count count,
+int MPIDU_Dataloop_create_struct(DLOOP_Count count,
 					   const int *blklen_array,
 					   const MPI_Aint *disp_array,
 					   const MPI_Datatype *oldtype_array,
@@ -58,21 +58,21 @@ int PREPEND_PREFIX(Dataloop_create_struct)(DLOOP_Count count,
 					   DLOOP_Size *dlsz_p,
 					   int *dldepth_p,
 					   int flag);
-int PREPEND_PREFIX(Dataloop_create_pairtype)(MPI_Datatype type,
+int MPIDU_Dataloop_create_pairtype(MPI_Datatype type,
 					     DLOOP_Dataloop **dlp_p,
 					     DLOOP_Size *dlsz_p,
 					     int *dldepth_p,
 					     int flag);
 
 /* Helper functions for dataloop construction */
-int PREPEND_PREFIX(Type_convert_subarray)(int ndims,
+int MPIDU_Type_convert_subarray(int ndims,
 					  int *array_of_sizes, 
 					  int *array_of_subsizes,
 					  int *array_of_starts,
 					  int order,
 					  MPI_Datatype oldtype, 
 					  MPI_Datatype *newtype);
-int PREPEND_PREFIX(Type_convert_darray)(int size,
+int MPIDU_Type_convert_darray(int size,
 					int rank,
 					int ndims, 
 					int *array_of_gsizes,
@@ -83,13 +83,13 @@ int PREPEND_PREFIX(Type_convert_darray)(int size,
 					MPI_Datatype oldtype, 
 					MPI_Datatype *newtype);
 
-DLOOP_Count PREPEND_PREFIX(Type_indexed_count_contig)(DLOOP_Count count,
+DLOOP_Count MPIDU_Type_indexed_count_contig(DLOOP_Count count,
                                                       const DLOOP_Count *blocklength_array,
                                                       const void *displacement_array,
                                                       int dispinbytes,
                                                       DLOOP_Offset old_extent);
 
-DLOOP_Count PREPEND_PREFIX(Type_blockindexed_count_contig)(DLOOP_Count count,
+DLOOP_Count MPIDU_Type_blockindexed_count_contig(DLOOP_Count count,
                                                            DLOOP_Count blklen,
                                                            const void *disp_array,
                                                            int dispinbytes,

--- a/src/mpid/common/datatype/dataloop/dataloop_create_blockindexed.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create_blockindexed.c
@@ -31,7 +31,7 @@ static void DLOOP_Type_blockindexed_array_copy(DLOOP_Count count,
 .N Errors
 .N Returns 0 on success, -1 on failure.
 @*/
-int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
+int MPIDU_Dataloop_create_blockindexed(DLOOP_Count icount,
 						 DLOOP_Count iblklen,
 						 const void *disp_array,
 						 int dispinbytes,
@@ -55,7 +55,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
     /* if count or blklen are zero, handle with contig code, call it a int */
     if (count == 0 || blklen == 0)
     {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(0,
+	err = MPIDU_Dataloop_create_contiguous(0,
 							 MPI_INT,
 							 dlp_p,
 							 dlsz_p,
@@ -77,7 +77,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
 	DLOOP_Handle_get_loopdepth_macro(oldtype, old_loop_depth, flag);
     }
 
-    contig_count = PREPEND_PREFIX(Type_blockindexed_count_contig)(count,
+    contig_count = MPIDU_Type_blockindexed_count_contig(count,
                                                                   blklen,
                                                                   disp_array,
                                                                   dispinbytes,
@@ -92,7 +92,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
 	((!dispinbytes && ((int *) disp_array)[0] == 0) ||
 	 (dispinbytes && ((MPI_Aint *) disp_array)[0] == 0)))
     {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(icount * iblklen,
+	err = MPIDU_Dataloop_create_contiguous(icount * iblklen,
 							 oldtype,
 							 dlp_p,
 							 dlsz_p,
@@ -142,7 +142,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
 	}
 	if (is_vectorizable)
 	{
-	    err = PREPEND_PREFIX(Dataloop_create_vector)(count,
+	    err = MPIDU_Dataloop_create_vector(count,
 							 blklen,
 							 last_stride,
 							 1, /* strideinbytes */
@@ -175,7 +175,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
 
     if (is_builtin)
     {
-	PREPEND_PREFIX(Dataloop_alloc)(DLOOP_KIND_BLOCKINDEXED,
+	MPIDU_Dataloop_alloc(DLOOP_KIND_BLOCKINDEXED,
 				       count,
 				       &new_dlp,
 				       &new_loop_sz);
@@ -207,7 +207,7 @@ int PREPEND_PREFIX(Dataloop_create_blockindexed)(DLOOP_Count icount,
 	DLOOP_Handle_get_loopptr_macro(oldtype, old_loop_ptr, flag);
 	DLOOP_Handle_get_loopsize_macro(oldtype, old_loop_sz, flag);
 
-	PREPEND_PREFIX(Dataloop_alloc_and_copy)(DLOOP_KIND_BLOCKINDEXED,
+	MPIDU_Dataloop_alloc_and_copy(DLOOP_KIND_BLOCKINDEXED,
 						count,
 						old_loop_ptr,
 						old_loop_sz,
@@ -275,7 +275,7 @@ static void DLOOP_Type_blockindexed_array_copy(DLOOP_Count count,
     return;
 }
 
-DLOOP_Count PREPEND_PREFIX(Type_blockindexed_count_contig)(DLOOP_Count count,
+DLOOP_Count MPIDU_Type_blockindexed_count_contig(DLOOP_Count count,
                                                            DLOOP_Count blklen,
                                                            const void *disp_array,
                                                            int dispinbytes,

--- a/src/mpid/common/datatype/dataloop/dataloop_create_contig.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create_contig.c
@@ -25,7 +25,7 @@
 .N Errors
 .N Returns 0 on success, -1 on failure.
 @*/
-int PREPEND_PREFIX(Dataloop_create_contiguous)(DLOOP_Count icount,
+int MPIDU_Dataloop_create_contiguous(DLOOP_Count icount,
 					       DLOOP_Type oldtype,
 					       DLOOP_Dataloop **dlp_p,
 					       DLOOP_Size *dlsz_p,
@@ -76,7 +76,7 @@ int PREPEND_PREFIX(Dataloop_create_contiguous)(DLOOP_Count icount,
     {
 	DLOOP_Offset basic_sz = 0;
 
-	PREPEND_PREFIX(Dataloop_alloc)(DLOOP_KIND_CONTIG,
+	MPIDU_Dataloop_alloc(DLOOP_KIND_CONTIG,
 				       count,
 				       &new_dlp,
 				       &new_loop_sz);
@@ -115,7 +115,7 @@ int PREPEND_PREFIX(Dataloop_create_contiguous)(DLOOP_Count icount,
 	if (apply_contig_coalescing)
 	{
 	    /* make a copy of the old loop and multiply the count */
-	    PREPEND_PREFIX(Dataloop_dup)(old_loop_ptr,
+	    MPIDU_Dataloop_dup(old_loop_ptr,
 					 old_loop_sz,
 					 &new_dlp);
 	    /* --BEGIN ERROR HANDLING-- */
@@ -130,7 +130,7 @@ int PREPEND_PREFIX(Dataloop_create_contiguous)(DLOOP_Count icount,
 	else
 	{
 	    /* allocate space for new loop including copy of old */
-	    PREPEND_PREFIX(Dataloop_alloc_and_copy)(DLOOP_KIND_CONTIG,
+	    MPIDU_Dataloop_alloc_and_copy(DLOOP_KIND_CONTIG,
 						    count,
 						    old_loop_ptr,
 						    old_loop_sz,

--- a/src/mpid/common/datatype/dataloop/dataloop_create_indexed.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create_indexed.c
@@ -36,7 +36,7 @@ static void DLOOP_Type_indexed_array_copy(DLOOP_Count count,
 .N Returns 0 on success, -1 on error.
 @*/
 
-int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
+int MPIDU_Dataloop_create_indexed(DLOOP_Count icount,
 					    const DLOOP_Size *blocklength_array,
 					    const void *displacement_array,
 					    int dispinbytes,
@@ -62,7 +62,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
     /* if count is zero, handle with contig code, call it an int */
     if (count == 0)
     {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(0,
+	err = MPIDU_Dataloop_create_contiguous(0,
 							 MPI_INT,
 							 dlp_p,
 							 dlsz_p,
@@ -95,7 +95,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
 	old_type_count += (DLOOP_Count) blocklength_array[i];
     }
 
-    contig_count = PREPEND_PREFIX(Type_indexed_count_contig)(count,
+    contig_count = MPIDU_Type_indexed_count_contig(count,
                                                              blocklength_array,
                                                              displacement_array,
                                                              dispinbytes,
@@ -104,7 +104,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
     /* if contig_count is zero (no data), handle with contig code */
     if (contig_count == 0)
     {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(0,
+	err = MPIDU_Dataloop_create_contiguous(0,
 							 MPI_INT,
 							 dlp_p,
 							 dlsz_p,
@@ -122,7 +122,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
 	((!dispinbytes && ((int *) displacement_array)[first] == 0) ||
 	 (dispinbytes && ((MPI_Aint *) displacement_array)[first] == 0)))
     {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(old_type_count,
+	err = MPIDU_Dataloop_create_contiguous(old_type_count,
 							 oldtype,
 							 dlp_p,
 							 dlsz_p,
@@ -144,7 +144,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
             disp_arr_tmp = &(((const MPI_Aint *)displacement_array)[first]);
         else
             disp_arr_tmp = &(((const int *)displacement_array)[first]);
-	err = PREPEND_PREFIX(Dataloop_create_blockindexed)(1,
+	err = MPIDU_Dataloop_create_blockindexed(1,
 							   old_type_count,
 							   disp_arr_tmp,
 							   dispinbytes,
@@ -178,7 +178,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
             disp_arr_tmp = &(((const MPI_Aint *)displacement_array)[first]);
         else
             disp_arr_tmp = &(((const int *)displacement_array)[first]);
-	err = PREPEND_PREFIX(Dataloop_create_blockindexed)(icount-first,
+	err = MPIDU_Dataloop_create_blockindexed(icount-first,
 							   blksz,
 							   disp_arr_tmp,
 							   dispinbytes,
@@ -203,7 +203,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
 
     if (is_builtin)
     {
-	PREPEND_PREFIX(Dataloop_alloc)(DLOOP_KIND_INDEXED,
+	MPIDU_Dataloop_alloc(DLOOP_KIND_INDEXED,
 				       count,
 				       &new_dlp,
 				       &new_loop_sz);
@@ -235,7 +235,7 @@ int PREPEND_PREFIX(Dataloop_create_indexed)(DLOOP_Count icount,
 	DLOOP_Handle_get_loopptr_macro(oldtype, old_loop_ptr, flag);
 	DLOOP_Handle_get_loopsize_macro(oldtype, old_loop_sz, flag);
 
-	PREPEND_PREFIX(Dataloop_alloc_and_copy)(DLOOP_KIND_INDEXED,
+	MPIDU_Dataloop_alloc_and_copy(DLOOP_KIND_INDEXED,
 						contig_count,
 						old_loop_ptr,
 						old_loop_sz,
@@ -385,7 +385,7 @@ static void DLOOP_Type_indexed_array_copy(DLOOP_Count count,
  *
  * Extent passed in is for the original type.
  */
-DLOOP_Count PREPEND_PREFIX(Type_indexed_count_contig)(DLOOP_Count count,
+DLOOP_Count MPIDU_Type_indexed_count_contig(DLOOP_Count count,
                                                       const DLOOP_Count *blocklength_array,
                                                       const void *displacement_array,
                                                       int dispinbytes,

--- a/src/mpid/common/datatype/dataloop/dataloop_create_pairtype.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create_pairtype.c
@@ -36,7 +36,7 @@
    This same function could be used to create dataloops for any type
    that actually consists of two distinct elements.
 @*/
-int PREPEND_PREFIX(Dataloop_create_pairtype)(MPI_Datatype type,
+int MPIDU_Dataloop_create_pairtype(MPI_Datatype type,
 					     DLOOP_Dataloop **dlp_p,
 					     MPI_Aint *dlsz_p,
 					     int *dldepth_p,
@@ -63,7 +63,7 @@ int PREPEND_PREFIX(Dataloop_create_pairtype)(MPI_Datatype type,
     if (type == MPI_2INT)
 	PAIRTYPE_CONTENTS(MPI_INT, int, MPI_INT, int);
 
-    return PREPEND_PREFIX(Dataloop_create_struct)(2,
+    return MPIDU_Dataloop_create_struct(2,
 						  blocks,
 						  disps,
 						  types,

--- a/src/mpid/common/datatype/dataloop/dataloop_create_vector.c
+++ b/src/mpid/common/datatype/dataloop/dataloop_create_vector.c
@@ -24,7 +24,7 @@
    Returns 0 on success, -1 on failure.
 
 @*/
-int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count icount,
+int MPIDU_Dataloop_create_vector(DLOOP_Count icount,
 					   DLOOP_Size iblocklength,
 					   MPI_Aint astride,
 					   int strideinbytes,
@@ -52,7 +52,7 @@ int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count icount,
     if (count == 0 || blocklength == 0)
     {
 
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(0,
+	err = MPIDU_Dataloop_create_contiguous(0,
 							 MPI_INT,
 							 dlp_p,
 							 dlsz_p,
@@ -66,7 +66,7 @@ int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count icount,
      * if count == 1, store as a contiguous rather than a vector dataloop.
      */
     if (count == 1) {
-	err = PREPEND_PREFIX(Dataloop_create_contiguous)(iblocklength,
+	err = MPIDU_Dataloop_create_contiguous(iblocklength,
 							 oldtype,
 							 dlp_p,
 							 dlsz_p,
@@ -97,7 +97,7 @@ int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count icount,
     if (is_builtin) {
 	DLOOP_Offset basic_sz = 0;
 
-	PREPEND_PREFIX(Dataloop_alloc)(DLOOP_KIND_VECTOR,
+	MPIDU_Dataloop_alloc(DLOOP_KIND_VECTOR,
 				       count,
 				       &new_dlp,
 				       &new_loop_sz);
@@ -136,7 +136,7 @@ int PREPEND_PREFIX(Dataloop_create_vector)(DLOOP_Count icount,
 	DLOOP_Handle_get_loopptr_macro(oldtype, old_loop_ptr, flag);
 	DLOOP_Handle_get_loopsize_macro(oldtype, old_loop_sz, flag);
 
-	PREPEND_PREFIX(Dataloop_alloc_and_copy)(DLOOP_KIND_VECTOR,
+	MPIDU_Dataloop_alloc_and_copy(DLOOP_KIND_VECTOR,
 						count,
 						old_loop_ptr,
 						old_loop_sz,

--- a/src/mpid/common/datatype/dataloop/dataloop_parts.h
+++ b/src/mpid/common/datatype/dataloop/dataloop_parts.h
@@ -9,10 +9,6 @@
 #define DATALOOP_PARTS_H
 
 /* Check that all the appropriate defines are present */
-#ifndef PREPEND_PREFIX
-#error "PREPEND_PREFIX must be defined before dataloop_parts.h is included."
-#endif
-
 #ifndef DLOOP_Offset
 #error "DLOOP_Offset must be defined before dataloop_parts.h is included."
 #endif
@@ -38,15 +34,15 @@
 #endif
 
 /* Redefine all of the internal structures in terms of the prefix */
-#define DLOOP_Dataloop              PREPEND_PREFIX(Dataloop)
-#define DLOOP_Dataloop_contig       PREPEND_PREFIX(Dataloop_contig)
-#define DLOOP_Dataloop_vector       PREPEND_PREFIX(Dataloop_vector)
-#define DLOOP_Dataloop_blockindexed PREPEND_PREFIX(Dataloop_blockindexed)
-#define DLOOP_Dataloop_indexed      PREPEND_PREFIX(Dataloop_indexed)
-#define DLOOP_Dataloop_struct       PREPEND_PREFIX(Dataloop_struct)
-#define DLOOP_Dataloop_common       PREPEND_PREFIX(Dataloop_common)
-#define DLOOP_Segment               PREPEND_PREFIX(Segment)
-#define DLOOP_Dataloop_stackelm     PREPEND_PREFIX(Dataloop_stackelm)
+#define DLOOP_Dataloop              MPIDU_Dataloop
+#define DLOOP_Dataloop_contig       MPIDU_Dataloop_contig
+#define DLOOP_Dataloop_vector       MPIDU_Dataloop_vector
+#define DLOOP_Dataloop_blockindexed MPIDU_Dataloop_blockindexed
+#define DLOOP_Dataloop_indexed      MPIDU_Dataloop_indexed
+#define DLOOP_Dataloop_struct       MPIDU_Dataloop_struct
+#define DLOOP_Dataloop_common       MPIDU_Dataloop_common
+#define DLOOP_Segment               MPIDU_Segment
+#define DLOOP_Dataloop_stackelm     MPIDU_Dataloop_stackelm
 
 /* These flags are used at creation time to specify what types of
  * optimizations may be applied. They are also passed in at Segment_init
@@ -318,52 +314,52 @@ typedef struct DLOOP_Segment {
 } DLOOP_Segment;
 
 /* Dataloop functions (dataloop.c) */
-void PREPEND_PREFIX(Dataloop_copy)(void *dest,
+void MPIDU_Dataloop_copy(void *dest,
 				   void *src,
 				   DLOOP_Size size);
-void PREPEND_PREFIX(Dataloop_update)(DLOOP_Dataloop *dataloop,
+void MPIDU_Dataloop_update(DLOOP_Dataloop *dataloop,
 				     DLOOP_Offset ptrdiff);
 DLOOP_Offset
-PREPEND_PREFIX(Dataloop_stream_size)(DLOOP_Dataloop *dl_p,
+MPIDU_Dataloop_stream_size(DLOOP_Dataloop *dl_p,
 				     DLOOP_Offset (*sizefn)(DLOOP_Type el_type));
-void PREPEND_PREFIX(Dataloop_print)(DLOOP_Dataloop *dataloop,
+void MPIDU_Dataloop_print(DLOOP_Dataloop *dataloop,
 				    int depth);
 
-void PREPEND_PREFIX(Dataloop_alloc)(int kind,
+void MPIDU_Dataloop_alloc(int kind,
 				    DLOOP_Count count,
 				    DLOOP_Dataloop **new_loop_p,
 				    DLOOP_Size *new_loop_sz_p);
-void PREPEND_PREFIX(Dataloop_alloc_and_copy)(int kind,
+void MPIDU_Dataloop_alloc_and_copy(int kind,
 					     DLOOP_Count count,
 					     DLOOP_Dataloop *old_loop,
 					     DLOOP_Size old_loop_sz,
 					     DLOOP_Dataloop **new_loop_p,
 					     DLOOP_Size *new_loop_sz_p);
-void PREPEND_PREFIX(Dataloop_struct_alloc)(DLOOP_Count count,
+void MPIDU_Dataloop_struct_alloc(DLOOP_Count count,
 					   DLOOP_Size old_loop_sz,
 					   int basic_ct,
 					   DLOOP_Dataloop **old_loop_p,
 					   DLOOP_Dataloop **new_loop_p,
 					   DLOOP_Size *new_loop_sz_p);
-void PREPEND_PREFIX(Dataloop_dup)(DLOOP_Dataloop *old_loop,
+void MPIDU_Dataloop_dup(DLOOP_Dataloop *old_loop,
 				  DLOOP_Size old_loop_sz,
 				  DLOOP_Dataloop **new_loop_p);
 
-void PREPEND_PREFIX(Dataloop_free)(DLOOP_Dataloop **dataloop);
+void MPIDU_Dataloop_free(DLOOP_Dataloop **dataloop);
 
 /* Segment functions (segment.c) */
-DLOOP_Segment * PREPEND_PREFIX(Segment_alloc)(void);
+DLOOP_Segment * MPIDU_Segment_alloc(void);
 
-void PREPEND_PREFIX(Segment_free)(DLOOP_Segment *segp);
+void MPIDU_Segment_free(DLOOP_Segment *segp);
 
-int PREPEND_PREFIX(Segment_init)(const DLOOP_Buffer buf,
+int MPIDU_Segment_init(const DLOOP_Buffer buf,
 				 DLOOP_Count count,
 				 DLOOP_Handle handle,
 				 DLOOP_Segment *segp,
 				 int hetero);
 
 void
-PREPEND_PREFIX(Segment_manipulate)(DLOOP_Segment *segp,
+MPIDU_Segment_manipulate(DLOOP_Segment *segp,
 				   DLOOP_Offset first, 
 				   DLOOP_Offset *lastp, 
 				   int (*piecefn) (DLOOP_Offset *blocks_p,
@@ -399,11 +395,11 @@ PREPEND_PREFIX(Segment_manipulate)(DLOOP_Segment *segp,
 				   void *pieceparams);
 
 /* Common segment operations (segment_ops.c) */
-void PREPEND_PREFIX(Segment_count_contig_blocks)(DLOOP_Segment *segp,
+void MPIDU_Segment_count_contig_blocks(DLOOP_Segment *segp,
 						 DLOOP_Offset first,
 						 DLOOP_Offset *lastp,
 						 DLOOP_Count *countp);
-void PREPEND_PREFIX(Segment_mpi_flatten)(DLOOP_Segment *segp,
+void MPIDU_Segment_mpi_flatten(DLOOP_Segment *segp,
 					 DLOOP_Offset first,
 					 DLOOP_Offset *lastp,
 					 DLOOP_Size *blklens,
@@ -413,28 +409,28 @@ void PREPEND_PREFIX(Segment_mpi_flatten)(DLOOP_Segment *segp,
 #define DLOOP_M2M_TO_USERBUF   0
 #define DLOOP_M2M_FROM_USERBUF 1
 
-struct PREPEND_PREFIX(m2m_params) {
+struct MPIDU_m2m_params {
     int direction; /* M2M_TO_USERBUF or M2M_FROM_USERBUF */
     char *streambuf;
     char *userbuf;
 };
 
-void PREPEND_PREFIX(Segment_pack)(struct DLOOP_Segment *segp,
+void MPIDU_Segment_pack(struct DLOOP_Segment *segp,
 				  DLOOP_Offset   first,
 				  DLOOP_Offset  *lastp,
 				  void *streambuf);
-void PREPEND_PREFIX(Segment_unpack)(struct DLOOP_Segment *segp,
+void MPIDU_Segment_unpack(struct DLOOP_Segment *segp,
 				    DLOOP_Offset   first,
 				    DLOOP_Offset  *lastp,
 				    void *streambuf);
 
 /* Segment piece functions that are used in specific cases elsewhere */
-int PREPEND_PREFIX(Segment_contig_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_contig_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Type el_type,
 				       DLOOP_Offset rel_off,
 				       void *bufp, /* unused */
 				       void *v_paramp);
-int PREPEND_PREFIX(Segment_vector_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_vector_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Count count, /* unused */
 				       DLOOP_Count blksz,
 				       DLOOP_Offset stride,
@@ -442,7 +438,7 @@ int PREPEND_PREFIX(Segment_vector_m2m)(DLOOP_Offset *blocks_p,
 				       DLOOP_Offset rel_off,
 				       void *bufp, /* unused */
 				       void *v_paramp);
-int PREPEND_PREFIX(Segment_blkidx_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_blkidx_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Count count,
 				       DLOOP_Count blocklen,
 				       DLOOP_Offset *offsetarray,
@@ -450,7 +446,7 @@ int PREPEND_PREFIX(Segment_blkidx_m2m)(DLOOP_Offset *blocks_p,
 				       DLOOP_Offset rel_off,
 				       void *bufp, /*unused */
 				       void *v_paramp);
-int PREPEND_PREFIX(Segment_index_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_index_m2m(DLOOP_Offset *blocks_p,
 				      DLOOP_Count count,
 				      DLOOP_Count *blockarray,
 				      DLOOP_Offset *offsetarray,

--- a/src/mpid/common/datatype/dataloop/segment.c
+++ b/src/mpid/common/datatype/dataloop/segment.c
@@ -12,16 +12,12 @@
 
 #undef DLOOP_DEBUG_MANIPULATE
 
-#ifndef PREPEND_PREFIX
-#error "You must explicitly include a header that sets the PREPEND_PREFIX and includes dataloop_parts.h"
-#endif
-
 /* Notes on functions:
  *
  * There are a few different sets of functions here:
  * - DLOOP_Segment_manipulate() - uses a "piece" function to perform operations
  *   using segments (piece functions defined elsewhere)
- * - PREPEND_PREFIX functions - these define the externally visible interface
+ * - MPIDU functions - these define the externally visible interface
  *   to segment functionality
  */
 
@@ -46,7 +42,7 @@ static inline void DLOOP_Stackelm_load(struct DLOOP_Dataloop_stackelm *elmp,
  *   indicate HETEROGENEOUS.
  *
  */
-int PREPEND_PREFIX(Segment_init)(const DLOOP_Buffer buf,
+int MPIDU_Segment_init(const DLOOP_Buffer buf,
 				 DLOOP_Count count,
 				 DLOOP_Handle handle,
 				 struct DLOOP_Segment *segp,
@@ -221,7 +217,7 @@ int PREPEND_PREFIX(Segment_init)(const DLOOP_Buffer buf,
 /* Segment_alloc
  *
  */
-struct DLOOP_Segment * PREPEND_PREFIX(Segment_alloc)(void)
+struct DLOOP_Segment * MPIDU_Segment_alloc(void)
 {
     return (struct DLOOP_Segment *) DLOOP_Malloc(sizeof(struct DLOOP_Segment));
 }
@@ -231,7 +227,7 @@ struct DLOOP_Segment * PREPEND_PREFIX(Segment_alloc)(void)
  * Input Parameters:
  * segp - pointer to segment
  */
-void PREPEND_PREFIX(Segment_free)(struct DLOOP_Segment *segp)
+void MPIDU_Segment_free(struct DLOOP_Segment *segp)
 {
     DLOOP_Free(segp);
     return;
@@ -325,7 +321,7 @@ void PREPEND_PREFIX(Segment_free)(struct DLOOP_Segment *segp)
 #define DLOOP_STACKELM_STRUCT_DATALOOP(elmp_, curcount_) \
 (elmp_)->loop_p->loop_params.s_t.dataloop_array[(curcount_)]
 
-void PREPEND_PREFIX(Segment_manipulate)(struct DLOOP_Segment *segp,
+void MPIDU_Segment_manipulate(struct DLOOP_Segment *segp,
 					DLOOP_Offset first,
 					DLOOP_Offset *lastp,
 					int (*contigfn) (DLOOP_Offset *blocks_p,
@@ -392,7 +388,7 @@ void PREPEND_PREFIX(Segment_manipulate)(struct DLOOP_Segment *segp,
 	    /* use manipulate function with a NULL piecefn to advance
 	     * stream offset
 	     */
-	    PREPEND_PREFIX(Segment_manipulate)(segp,
+	    MPIDU_Segment_manipulate(segp,
 					       stream_off,
 					       &tmp_last,
 					       NULL, /* contig fn */

--- a/src/mpid/common/datatype/dataloop/segment_count.c
+++ b/src/mpid/common/datatype/dataloop/segment_count.c
@@ -44,7 +44,7 @@ static int DLOOP_Leaf_index_count_block(DLOOP_Offset *blocks_p,
 					void *bufp,
 					void *v_paramp);
 
-struct PREPEND_PREFIX(contig_blocks_params) {
+struct MPIDU_contig_blocks_params {
     DLOOP_Count  count;
     DLOOP_Offset last_loc;
 };
@@ -53,12 +53,12 @@ struct PREPEND_PREFIX(contig_blocks_params) {
  *
  * Count number of contiguous regions in segment between first and last.
  */
-void PREPEND_PREFIX(Segment_count_contig_blocks)(DLOOP_Segment *segp,
+void MPIDU_Segment_count_contig_blocks(DLOOP_Segment *segp,
 						 DLOOP_Offset first,
 						 DLOOP_Offset *lastp,
 						 DLOOP_Count *countp)
 {
-    struct PREPEND_PREFIX(contig_blocks_params) params;
+    struct MPIDU_contig_blocks_params params;
 
     params.count    = 0;
     params.last_loc = 0;
@@ -67,7 +67,7 @@ void PREPEND_PREFIX(Segment_count_contig_blocks)(DLOOP_Segment *segp,
      * optimize the count by coalescing contiguous segments, while
      * functions using the count do not optimize in the same way
      * (e.g., flatten code) */
-    PREPEND_PREFIX(Segment_manipulate)(segp,
+    MPIDU_Segment_manipulate(segp,
 				       first,
 				       lastp,
 				       DLOOP_Leaf_contig_count_block,
@@ -95,7 +95,7 @@ static int DLOOP_Leaf_contig_count_block(DLOOP_Offset *blocks_p,
 					 void *v_paramp)
 {
     DLOOP_Offset size, el_size;
-    struct PREPEND_PREFIX(contig_blocks_params) *paramp = v_paramp;
+    struct MPIDU_contig_blocks_params *paramp = v_paramp;
 
     DLOOP_Assert(*blocks_p > 0);
 
@@ -146,7 +146,7 @@ static int DLOOP_Leaf_vector_count_block(DLOOP_Offset *blocks_p,
 {
     DLOOP_Count new_blk_count;
     DLOOP_Offset size, el_size;
-    struct PREPEND_PREFIX(contig_blocks_params) *paramp = v_paramp;
+    struct MPIDU_contig_blocks_params *paramp = v_paramp;
 
     DLOOP_Assert(count > 0 && blksz > 0 && *blocks_p > 0);
 
@@ -184,7 +184,7 @@ static int DLOOP_Leaf_blkidx_count_block(DLOOP_Offset *blocks_p,
 {
     DLOOP_Count i, new_blk_count;
     DLOOP_Offset size, el_size, last_loc;
-    struct PREPEND_PREFIX(contig_blocks_params) *paramp = v_paramp;
+    struct MPIDU_contig_blocks_params *paramp = v_paramp;
 
     DLOOP_Assert(count > 0 && blksz > 0 && *blocks_p > 0);
 
@@ -226,7 +226,7 @@ static int DLOOP_Leaf_index_count_block(DLOOP_Offset *blocks_p,
 {
     DLOOP_Count new_blk_count;
     DLOOP_Offset el_size, last_loc;
-    struct PREPEND_PREFIX(contig_blocks_params) *paramp = v_paramp;
+    struct MPIDU_contig_blocks_params *paramp = v_paramp;
 
     DLOOP_Assert(count > 0 && *blocks_p > 0);
 

--- a/src/mpid/common/datatype/dataloop/segment_flatten.c
+++ b/src/mpid/common/datatype/dataloop/segment_flatten.c
@@ -44,7 +44,7 @@ static int DLOOP_Leaf_index_mpi_flatten(DLOOP_Offset *blocks_p,
 					void *bufp,
 					void *v_paramp);
 
-struct PREPEND_PREFIX(mpi_flatten_params) {
+struct MPIDU_mpi_flatten_params {
     int       index;
     MPI_Aint  length;
     MPI_Aint  last_end;
@@ -70,14 +70,14 @@ struct PREPEND_PREFIX(mpi_flatten_params) {
  * lengthp - in/out parameter describing length of array (and afterwards
  *           the amount of the array that has actual data)
  */
-void PREPEND_PREFIX(Segment_mpi_flatten)(DLOOP_Segment *segp,
+void MPIDU_Segment_mpi_flatten(DLOOP_Segment *segp,
 					 DLOOP_Offset first,
 					 DLOOP_Offset *lastp,
 					 DLOOP_Size *blklens,
 					 MPI_Aint *disps,
 					 DLOOP_Size *lengthp)
 {
-    struct PREPEND_PREFIX(mpi_flatten_params) params;
+    struct MPIDU_mpi_flatten_params params;
 
     DLOOP_Assert(*lengthp > 0);
 
@@ -86,7 +86,7 @@ void PREPEND_PREFIX(Segment_mpi_flatten)(DLOOP_Segment *segp,
     params.blklens = blklens;
     params.disps   = disps;
 
-    PREPEND_PREFIX(Segment_manipulate)(segp,
+    MPIDU_Segment_manipulate(segp,
 				       first,
 				       lastp,
 				       DLOOP_Leaf_contig_mpi_flatten,
@@ -116,7 +116,7 @@ static int DLOOP_Leaf_contig_mpi_flatten(DLOOP_Offset *blocks_p,
     DLOOP_Offset size;
     DLOOP_Offset el_size;
     char *last_end = NULL;
-    struct PREPEND_PREFIX(mpi_flatten_params) *paramp = v_paramp;
+    struct MPIDU_mpi_flatten_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     size = *blocks_p * el_size;
@@ -191,7 +191,7 @@ static int DLOOP_Leaf_vector_mpi_flatten(DLOOP_Offset *blocks_p,
     int i;
     DLOOP_Size size, blocks_left;
     DLOOP_Offset el_size;
-    struct PREPEND_PREFIX(mpi_flatten_params) *paramp = v_paramp;
+    struct MPIDU_mpi_flatten_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     blocks_left = *blocks_p;
@@ -286,7 +286,7 @@ static int DLOOP_Leaf_blkidx_mpi_flatten(DLOOP_Offset *blocks_p,
     int i;
     DLOOP_Size blocks_left, size;
     DLOOP_Offset el_size;
-    struct PREPEND_PREFIX(mpi_flatten_params) *paramp = v_paramp;
+    struct MPIDU_mpi_flatten_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     blocks_left = *blocks_p;
@@ -369,7 +369,7 @@ static int DLOOP_Leaf_index_mpi_flatten(DLOOP_Offset *blocks_p,
     int i;
     DLOOP_Size size, blocks_left;
     DLOOP_Offset el_size;
-    struct PREPEND_PREFIX(mpi_flatten_params) *paramp = v_paramp;
+    struct MPIDU_mpi_flatten_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     blocks_left = *blocks_p;

--- a/src/mpid/common/datatype/dataloop/segment_packunpack.c
+++ b/src/mpid/common/datatype/dataloop/segment_packunpack.c
@@ -35,12 +35,12 @@ static void setPrint( void ) {
 #define DBG_SEGMENT(_a)
 #endif
 
-void PREPEND_PREFIX(Segment_pack)(DLOOP_Segment *segp,
+void MPIDU_Segment_pack(DLOOP_Segment *segp,
 				  DLOOP_Offset   first,
 				  DLOOP_Offset  *lastp,
 				  void *streambuf)
 {
-    struct PREPEND_PREFIX(m2m_params) params; /* defined in dataloop_parts.h */
+    struct MPIDU_m2m_params params; /* defined in dataloop_parts.h */
 
     DBG_SEGMENT(printf( "Segment_pack...\n" ));
     /* experimenting with discarding buf value in the segment, keeping in
@@ -51,22 +51,22 @@ void PREPEND_PREFIX(Segment_pack)(DLOOP_Segment *segp,
     params.streambuf = streambuf;
     params.direction = DLOOP_M2M_FROM_USERBUF;
 
-    PREPEND_PREFIX(Segment_manipulate)(segp, first, lastp,
-				       PREPEND_PREFIX(Segment_contig_m2m),
-				       PREPEND_PREFIX(Segment_vector_m2m),
-				       PREPEND_PREFIX(Segment_blkidx_m2m),
-				       PREPEND_PREFIX(Segment_index_m2m),
+    MPIDU_Segment_manipulate(segp, first, lastp,
+				       MPIDU_Segment_contig_m2m,
+				       MPIDU_Segment_vector_m2m,
+				       MPIDU_Segment_blkidx_m2m,
+				       MPIDU_Segment_index_m2m,
 				       NULL, /* size fn */
 				       &params);
     return;
 }
 
-void PREPEND_PREFIX(Segment_unpack)(DLOOP_Segment *segp,
+void MPIDU_Segment_unpack(DLOOP_Segment *segp,
 				    DLOOP_Offset   first,
 				    DLOOP_Offset  *lastp,
 				    void *streambuf)
 {
-    struct PREPEND_PREFIX(m2m_params) params;
+    struct MPIDU_m2m_params params;
 
     DBG_SEGMENT(printf( "Segment_unpack...\n" ));
     /* experimenting with discarding buf value in the segment, keeping in
@@ -77,11 +77,11 @@ void PREPEND_PREFIX(Segment_unpack)(DLOOP_Segment *segp,
     params.streambuf = streambuf;
     params.direction = DLOOP_M2M_TO_USERBUF;
 
-    PREPEND_PREFIX(Segment_manipulate)(segp, first, lastp,
-				       PREPEND_PREFIX(Segment_contig_m2m),
-				       PREPEND_PREFIX(Segment_vector_m2m),
-				       PREPEND_PREFIX(Segment_blkidx_m2m),
-				       PREPEND_PREFIX(Segment_index_m2m),
+    MPIDU_Segment_manipulate(segp, first, lastp,
+				       MPIDU_Segment_contig_m2m,
+				       MPIDU_Segment_vector_m2m,
+				       MPIDU_Segment_blkidx_m2m,
+				       MPIDU_Segment_index_m2m,
 				       NULL, /* size fn */
 				       &params);
     return;
@@ -89,7 +89,7 @@ void PREPEND_PREFIX(Segment_unpack)(DLOOP_Segment *segp,
 
 /* PIECE FUNCTIONS BELOW */
 
-int PREPEND_PREFIX(Segment_contig_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_contig_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Type el_type,
 				       DLOOP_Offset rel_off,
 				       void *bufp ATTRIBUTE((unused)),
@@ -97,7 +97,7 @@ int PREPEND_PREFIX(Segment_contig_m2m)(DLOOP_Offset *blocks_p,
 {
     DLOOP_Offset el_size; /* DLOOP_Count? */
     DLOOP_Offset size;
-    struct PREPEND_PREFIX(m2m_params) *paramp = v_paramp;
+    struct MPIDU_m2m_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     size = *blocks_p * el_size;
@@ -140,7 +140,7 @@ int PREPEND_PREFIX(Segment_contig_m2m)(DLOOP_Offset *blocks_p,
  * Note: this is only called when the starting position is at the beginning
  * of a whole block in a vector type.
  */
-int PREPEND_PREFIX(Segment_vector_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_vector_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Count count ATTRIBUTE((unused)),
 				       DLOOP_Count blksz,
 				       DLOOP_Offset stride,
@@ -151,7 +151,7 @@ int PREPEND_PREFIX(Segment_vector_m2m)(DLOOP_Offset *blocks_p,
 {
     DLOOP_Count i;
     DLOOP_Offset el_size, whole_count, blocks_left;
-    struct PREPEND_PREFIX(m2m_params) *paramp = v_paramp;
+    struct MPIDU_m2m_params *paramp = v_paramp;
     char *cbufp;
 
     /* Ensure that pointer increment fits in a pointer */
@@ -273,7 +273,7 @@ int PREPEND_PREFIX(Segment_vector_m2m)(DLOOP_Offset *blocks_p,
 
 /* MPIDU_Segment_blkidx_m2m
  */
-int PREPEND_PREFIX(Segment_blkidx_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_blkidx_m2m(DLOOP_Offset *blocks_p,
 				       DLOOP_Count count,
 				       DLOOP_Count blocklen,
 				       DLOOP_Offset *offsetarray,
@@ -286,7 +286,7 @@ int PREPEND_PREFIX(Segment_blkidx_m2m)(DLOOP_Offset *blocks_p,
     DLOOP_Offset el_size;
     DLOOP_Offset blocks_left = *blocks_p;
     char *cbufp;
-    struct PREPEND_PREFIX(m2m_params) *paramp = v_paramp;
+    struct MPIDU_m2m_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     DBG_SEGMENT( printf("blkidx m2m: elsize = %ld, count = %ld, blocklen = %ld,"
@@ -353,7 +353,7 @@ int PREPEND_PREFIX(Segment_blkidx_m2m)(DLOOP_Offset *blocks_p,
 
 /* MPIDU_Segment_index_m2m
  */
-int PREPEND_PREFIX(Segment_index_m2m)(DLOOP_Offset *blocks_p,
+int MPIDU_Segment_index_m2m(DLOOP_Offset *blocks_p,
 				      DLOOP_Count count,
 				      DLOOP_Count *blockarray,
 				      DLOOP_Offset *offsetarray,
@@ -366,7 +366,7 @@ int PREPEND_PREFIX(Segment_index_m2m)(DLOOP_Offset *blocks_p,
     DLOOP_Offset el_size;
     DLOOP_Offset cur_block_sz, blocks_left = *blocks_p;
     char *cbufp;
-    struct PREPEND_PREFIX(m2m_params) *paramp = v_paramp;
+    struct MPIDU_m2m_params *paramp = v_paramp;
 
     DLOOP_Handle_get_size_macro(el_type, el_size);
     DBG_SEGMENT(printf( "index m2m: elsize = %d, count = %d\n", (int)el_size, (int)count ));

--- a/src/mpid/common/datatype/dataloop/subarray_support.c
+++ b/src/mpid/common/datatype/dataloop/subarray_support.c
@@ -9,10 +9,10 @@
 
 #include "dataloop.h"
 #undef FUNCNAME
-#define FUNCNAME PREPEND_PREFIX(Type_convert_subarray)
+#define FUNCNAME MPIDU_Type_convert_subarray
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int PREPEND_PREFIX(Type_convert_subarray)(int ndims,
+int MPIDU_Type_convert_subarray(int ndims,
 					  int *array_of_sizes,
 					  int *array_of_subsizes,
 					  int *array_of_starts,

--- a/src/mpid/common/datatype/dataloop/typesize_support.c
+++ b/src/mpid/common/datatype/dataloop/typesize_support.c
@@ -135,8 +135,7 @@ static int DLOOP_Structalign_llint_position(void);
 	}								\
     }
 
-void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
-					 DLOOP_Type_footprint *tfp)
+void MPIDU_Type_calc_footprint(MPI_Datatype type, DLOOP_Type_footprint *tfp)
 {
     int mpi_errno;
     int nr_ints, nr_aints, nr_types, combiner;
@@ -184,7 +183,7 @@ void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
     }
 
     /* get access to contents; need it immediately to check for zero count */
-    PREPEND_PREFIX(Type_access_contents)(type, &ints, &aints, &types);
+    MPIDU_Type_access_contents(type, &ints, &aints, &types);
 
     /* knock out all the zero count cases */
     if ((combiner == MPI_COMBINER_CONTIGUOUS ||
@@ -209,7 +208,7 @@ void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
     {
 	DLOOP_Type_footprint cfp;
 
-	PREPEND_PREFIX(Type_calc_footprint)(types[0], &cfp);
+	MPIDU_Type_calc_footprint(types[0], &cfp);
 	size    = cfp.size;
 	lb      = cfp.lb;
 	ub      = cfp.ub;
@@ -382,20 +381,20 @@ void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
 	    break;
 	case MPI_COMBINER_SUBARRAY:
 	    ndims = ints[0];
-	    PREPEND_PREFIX(Type_convert_subarray)(ndims,
+	    MPIDU_Type_convert_subarray(ndims,
 						  &ints[1] /* sizes */,
 						  &ints[1+ndims] /* subsz */,
 						  &ints[1+2*ndims] /* strts */,
 						  ints[1+3*ndims] /* order */,
 						  types[0],
 						  &tmptype);
-	    PREPEND_PREFIX(Type_calc_footprint)(tmptype, tfp);
+	    MPIDU_Type_calc_footprint(tmptype, tfp);
 	    MPIR_Type_free_impl(&tmptype);
 	    break;
 	case MPI_COMBINER_DARRAY:
 	    ndims = ints[2];
 
-	    PREPEND_PREFIX(Type_convert_darray)(ints[0] /* size */,
+	    MPIDU_Type_convert_darray(ints[0] /* size */,
 						ints[1] /* rank */,
 						ndims,
 						&ints[3] /* gsizes */,
@@ -406,7 +405,7 @@ void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
 						types[0],
 						&tmptype);
 
-	    PREPEND_PREFIX(Type_calc_footprint)(tmptype, tfp);
+	    MPIDU_Type_calc_footprint(tmptype, tfp);
 	    MPIR_Type_free_impl(&tmptype);
 	    break;
 	case MPI_COMBINER_F90_REAL:
@@ -418,7 +417,7 @@ void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
     }
 
  clean_exit:
-    PREPEND_PREFIX(Type_release_contents)(type, &ints, &aints, &types);
+    MPIDU_Type_release_contents(type, &ints, &aints, &types);
     return;
 }
 
@@ -462,7 +461,7 @@ static void DLOOP_Type_calc_footprint_struct(MPI_Datatype type,
 
 	/* opt: could just inline assignments for combiner == NAMED case */
 
-	PREPEND_PREFIX(Type_calc_footprint)(types[i], &cfp);
+	MPIDU_Type_calc_footprint(types[i], &cfp);
 	size      = cfp.size;
 	lb        = cfp.lb;
 	ub        = cfp.ub;

--- a/src/mpid/common/datatype/dataloop/typesize_support.h
+++ b/src/mpid/common/datatype/dataloop/typesize_support.h
@@ -8,9 +8,9 @@
 
 #include "dataloop.h"
 
-#define DLOOP_Type_footprint PREPEND_PREFIX(Type_footprint)
+#define DLOOP_Type_footprint MPIDU_Type_footprint
 
-typedef struct PREPEND_PREFIX(Type_footprint_s) {
+typedef struct MPIDU_Type_footprint_s {
     DLOOP_Offset size, extent;
 
     /* these are only needed for calculating footprint of types
@@ -22,7 +22,6 @@ typedef struct PREPEND_PREFIX(Type_footprint_s) {
     int has_sticky_ub;
 } DLOOP_Type_footprint;
 
-void PREPEND_PREFIX(Type_calc_footprint)(MPI_Datatype type,
-					 DLOOP_Type_footprint *tfp);
+void MPIDU_Type_calc_footprint(MPI_Datatype type, DLOOP_Type_footprint *tfp);
 
 #endif

--- a/src/mpid/common/datatype/mpidu_dataloop.h
+++ b/src/mpid/common/datatype/mpidu_dataloop.h
@@ -11,11 +11,6 @@
 #include <mpi.h>
 #include <mpl.h>
 
-/* Note: this is where you define the prefix that will be prepended on
- * all externally visible generic dataloop and segment functions.
- */
-#define PREPEND_PREFIX(fn) MPIDU_ ## fn
-
 /* These following dataloop-specific types will be used throughout the DLOOP
  * instance:
  */


### PR DESCRIPTION
Remove another unnecessary indirection macro that makes
grep'ing/ctag'ing the code hard.