### PR TITLE
CH4/OFI: Define FI_MAJOR/MINOR_VERSION if unused

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -24,6 +24,11 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     fi
     ])
     AM_CONDITIONAL([BUILD_CH4_NETMOD_OFI],[test "X$build_ch4_netmod_ofi" = "Xyes"])
+
+    if test "x${with_libfabric}" = "x" ; then
+        AC_DEFINE(FI_MAJOR_VERSION, 0, [If not using libfabric, define this macro to avoid compile errors])
+        AC_DEFINE(FI_MINOR_VERSION, 0, [If not using libfabric, define this macro to avoid compile errors])
+    fi
 ])dnl
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[


### PR DESCRIPTION
dca4794ad87da1f94cab5b02e4eace7efbb1cab5 uses `FI_MAJOR_VERSION` and
`FI_MINOR_VERSION` as the seed value for a couple of CVARs which means
that they are required to be defined, even if we're not using libfabric.

If the user doesn't specify that they want to use libfabric, specify
some throwaway values to make sure we can still compile.