### PR TITLE
CH4/OFI: Simplify scalable endpoint usage

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -168,14 +168,14 @@ static inline int MPIDI_OFI_do_rdma_read(void *dst,
             .msg_iov = &iov,
             .desc = NULL,
             .iov_count = 1,
-            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, MPIDI_OFI_API_TAG),
+            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank),
             .rma_iov = &rma_iov,
             .rma_iov_count = 1,
             .context = &am_req->context,
             .data = 0
         };
 
-        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_EP_TX_RMA(0),
+        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_Global.ctx[0].tx,
                                            &msg,
                                            FI_COMPLETION), FALSE /* no lock */ , read);
 
@@ -420,8 +420,8 @@ static inline int MPIDI_OFI_dispatch_ack(int rank,
     msg.hdr.data_sz = 0;
     msg.hdr.am_type = am_type;
     msg.pyld.sreq_ptr = sreq_ptr;
-    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_EP_TX_MSG(0), &msg, sizeof(msg),
-                                      MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG)),
+    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_Global.ctx[0].tx, &msg, sizeof(msg),
+                                      MPIDI_OFI_comm_to_phys(comm, rank)),
                             FALSE /* no lock */ , inject);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DISPATCH_ACK);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -141,9 +141,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
                                                   MPIDI_OFI_SYNC_SEND_ACK);
         MPIR_Comm *c = MPIDI_OFI_REQUEST(rreq, util_comm);
         int r = rreq->status.MPI_SOURCE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), NULL, 0, NULL,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, NULL, 0, NULL,
                                            MPIDI_OFI_REQUEST(rreq, util_comm->rank),
-                                           MPIDI_OFI_comm_to_phys(c, r, MPIDI_OFI_API_TAG),
+                                           MPIDI_OFI_comm_to_phys(c, r),
                                            ss_bits, NULL, MPIDI_OFI_DO_INJECT,
                                            MPIDI_OFI_CALL_NO_LOCK);
         if (mpi_errno)
@@ -394,11 +394,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry 
             remote_key = recv->remote_info.rma_key;
 
         MPIDI_OFI_cntr_incr();
-        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_EP_TX_RMA(0),    /* endpoint     */
+        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_Global.ctx[0].tx,    /* endpoint     */
                                      (void *) ((uintptr_t) recv->wc.buf + recv->cur_offset),    /* local buffer */
                                      bytesToGet,        /* bytes        */
                                      NULL,      /* descriptor   */
-                                     MPIDI_OFI_comm_to_phys(recv->comm_ptr, recv->remote_info.origin_rank, MPIDI_OFI_API_MSG),  /* Destination  */
+                                     MPIDI_OFI_comm_to_phys(recv->comm_ptr, recv->remote_info.origin_rank),  /* Destination  */
                                      MPIDI_OFI_recv_rbase(recv) + recv->cur_offset,     /* remote maddr */
                                      remote_key,        /* Key          */
                                      (void *) &recv->context), rdma_readfrom,   /* Context */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -307,25 +307,23 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
     }
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank, int ep_family)
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         MPIDI_OFI_addr_t *av = &MPIDI_OFI_AV(MPIDIU_comm_rank_to_av(comm, rank));
         int ep_num = MPIDI_OFI_av_to_ep(av);
-        int offset = MPIDI_Global.ctx[ep_num].ctx_offset;
-        int rx_idx = offset + ep_family;
+        int rx_idx = ep_num;
         return fi_rx_addr(MPIDI_OFI_AV_TO_PHYS(av), rx_idx, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
         return MPIDI_OFI_COMM_TO_PHYS(comm, rank);
     }
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int rank, int ep_family)
+MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_to_phys(int rank)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int ep_num = 0;
-        int offset = MPIDI_Global.ctx[ep_num].ctx_offset;
-        int rx_idx = offset + ep_family;
+        int rx_idx = ep_num;
         return fi_rx_addr(MPIDI_OFI_TO_PHYS(0, rank), rx_idx, MPIDI_OFI_MAX_ENDPOINTS_BITS);
     } else {
         return MPIDI_OFI_TO_PHYS(0, rank);
@@ -533,7 +531,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dynproc_send_disconnect(int conn_id)
         msg.ignore = context_id;
         msg.context = (void *) &req.context;
         msg.data = 0;
-        MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_EP_TX_TAG(0), &msg,
+        MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_Global.ctx[0].tx, &msg,
                                          FI_COMPLETION | FI_TRANSMIT_COMPLETE | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0)),
                              tsendmsg, MPIDI_OFI_CALL_LOCK);
         MPIDI_OFI_PROGRESS_WHILE(!req.done);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -315,7 +315,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
                 conn[j] = MPIDI_Global.conn_mgr.conn_list[i].dest;
                 req[j].done = 0;
                 req[j].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-                MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+                MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                               &close_msg[j],
                                               sizeof(int),
                                               NULL,
@@ -765,16 +765,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* ------------------------------------------------------------------------ */
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        /* Specify the number of TX/RX contexts we want
-
-           Currently, scalable endpoint contexts are created in a "bundle",
-           where each bundle consists of four TX contexts
-           (tagged, msg(untagged), rma-counter, rma-completion)
-           and three RX contexts (tagged, msg, rma.) */
-
-        int n_bundles = 1; /* Tentatively, we are creating only one bundle */
-        prov_use->ep_attr->tx_ctx_cnt = 4 * n_bundles;
-        prov_use->ep_attr->rx_ctx_cnt = 3 * n_bundles;
+        /* Specify the number of TX/RX contexts we want */
+        prov_use->ep_attr->tx_ctx_cnt = 1;
+        prov_use->ep_attr->rx_ctx_cnt = 1;
     }
     MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_create_endpoint(prov_use,
                                                      MPIDI_Global.domain,
@@ -908,7 +901,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIDI_Global.cq_buff_head = MPIDI_Global.cq_buff_tail = 0;
         optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
-        MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_EP_RX_MSG(0)->fid),
+        MPIDI_OFI_CALL(fi_setopt(&(MPIDI_Global.ctx[0].rx->fid),
                                  FI_OPT_ENDPOINT,
                                  FI_OPT_MIN_MULTI_RECV, &optlen, sizeof(optlen)), setopt);
 
@@ -924,7 +917,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
             MPIDI_Global.am_msg[i].addr = FI_ADDR_UNSPEC;
             MPIDI_Global.am_msg[i].context = &MPIDI_Global.am_reqs[i].context;
             MPIDI_Global.am_msg[i].iov_count = 1;
-            MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_EP_RX_MSG(0),
+            MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_Global.ctx[0].rx,
                                             &MPIDI_Global.am_msg[i],
                                             FI_MULTI_RECV | FI_COMPLETION), prepost,
                                  MPIDI_OFI_CALL_LOCK);
@@ -1007,18 +1000,8 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     MPIR_Assert(OPA_load_int(&MPIDI_Global.am_inflight_inject_emus) == 0);
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        if (MPIDI_OFI_ENABLE_TAGGED)
-            MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_TX_TAG(0)), epclose);
-
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_TX_RMA(0)), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_TX_MSG(0)), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_TX_CTR(0)), epclose);
-
-        if (MPIDI_OFI_ENABLE_TAGGED)
-            MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_RX_TAG(0)), epclose);
-
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_RX_RMA(0)), epclose);
-        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_EP_RX_MSG(0)), epclose);
+        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_Global.ctx[0].tx), epclose);
+        MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_Global.ctx[0].rx), epclose);
     }
 
     if (MPIDI_OFI_ENABLE_STX_RMA && MPIDI_Global.stx_ctx != NULL)
@@ -1260,113 +1243,50 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_CREATE_ENDPOINT);
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        int idx_off;
         MPIDI_OFI_CALL(fi_scalable_ep(domain, prov_use, ep, NULL), ep);
         MPIDI_OFI_CALL(fi_scalable_ep_bind(*ep, &av->fid, 0), bind);
 
-        idx_off = index * 4;
-        MPIDI_Global.ctx[index].ctx_offset = idx_off;
-
-        if (MPIDI_OFI_ENABLE_TAGGED) {
-            tx_attr = *prov_use->tx_attr;
-            tx_attr.caps = FI_TAGGED | FI_SEND;
-            tx_attr.op_flags = FI_COMPLETION | FI_INJECT_COMPLETE;
-            MPIDI_OFI_CALL(fi_tx_context(*ep, idx_off, &tx_attr, &MPIDI_OFI_EP_TX_TAG(index), NULL),
-                           ep);
-            MPIDI_OFI_CALL(fi_ep_bind
-                           (MPIDI_OFI_EP_TX_TAG(index), &p2p_cq->fid,
-                            FI_SEND | FI_SELECTIVE_COMPLETION), bind);
-        }
-
         tx_attr = *prov_use->tx_attr;
-        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ;
-        tx_attr.caps |= FI_ATOMICS;
         tx_attr.op_flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
-        MPIDI_OFI_CALL(fi_tx_context(*ep, idx_off + 1, &tx_attr, &MPIDI_OFI_EP_TX_RMA(index), NULL),
-                       ep);
-        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_EP_TX_RMA(index), &rma_ctr->fid, FI_WRITE | FI_READ),
-                       bind);
-        MPIDI_OFI_CALL(fi_ep_bind
-                       (MPIDI_OFI_EP_TX_RMA(index), &p2p_cq->fid,
-                        FI_SEND | FI_SELECTIVE_COMPLETION), bind);
+        tx_attr.caps = 0;
 
-        tx_attr = *prov_use->tx_attr;
-        tx_attr.caps = FI_MSG|FI_SEND;
-        tx_attr.op_flags = FI_COMPLETION | FI_INJECT_COMPLETE;
-        MPIDI_OFI_CALL(fi_tx_context(*ep, idx_off + 2, &tx_attr, &MPIDI_OFI_EP_TX_MSG(index), NULL),
-                       ep);
-        MPIDI_OFI_CALL(fi_ep_bind
-                       (MPIDI_OFI_EP_TX_MSG(index), &p2p_cq->fid,
-                        FI_SEND | FI_SELECTIVE_COMPLETION), bind);
+        if (MPIDI_OFI_ENABLE_TAGGED)
+            tx_attr.caps = FI_TAGGED | FI_SEND;
 
-        tx_attr = *prov_use->tx_attr;
-        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ;
+        /* RMA */
+        tx_attr.caps |= FI_RMA | FI_WRITE | FI_READ;
         tx_attr.caps |= FI_ATOMICS;
-        tx_attr.op_flags = FI_DELIVERY_COMPLETE;
-        MPIDI_OFI_CALL(fi_tx_context(*ep, idx_off + 3, &tx_attr, &MPIDI_OFI_EP_TX_CTR(index), NULL),
-                       ep);
-        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_EP_TX_CTR(index), &rma_ctr->fid, FI_WRITE | FI_READ),
+        /* MSG */
+        tx_attr.caps |= FI_MSG | FI_SEND;
+
+        MPIDI_OFI_CALL(fi_tx_context(*ep, index, &tx_attr, &MPIDI_Global.ctx[index].tx, NULL), ep);
+        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_Global.ctx[index].tx,
+                                  &p2p_cq->fid,
+                                  FI_SEND | FI_SELECTIVE_COMPLETION), bind);
+        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_Global.ctx[index].tx, &rma_ctr->fid, FI_WRITE | FI_READ),
                        bind);
-        /* We need to bind to the CQ if the progress mode is manual.
-         * Otherwise fi_cq_read would not make progress on this context and potentially leads to a deadlock. */
-        if (!MPIDI_OFI_ENABLE_DATA_AUTO_PROGRESS)
-            MPIDI_OFI_CALL(fi_ep_bind
-                           (MPIDI_OFI_EP_TX_CTR(index), &p2p_cq->fid,
-                            FI_SEND | FI_SELECTIVE_COMPLETION), bind);
-
-        if (MPIDI_OFI_ENABLE_TAGGED) {
-            rx_attr = *prov_use->rx_attr;
-            rx_attr.caps = FI_TAGGED | FI_RECV;
-
-            if (MPIDI_OFI_ENABLE_DATA)
-                rx_attr.caps |= FI_DIRECTED_RECV;
-
-            rx_attr.op_flags = 0;
-            MPIDI_OFI_CALL(fi_rx_context(*ep, idx_off, &rx_attr, &MPIDI_OFI_EP_RX_TAG(index), NULL),
-                           ep);
-            MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_EP_RX_TAG(index), &p2p_cq->fid, FI_RECV), bind);
-        }
 
         rx_attr = *prov_use->rx_attr;
-        rx_attr.caps = FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE;
-        rx_attr.caps |= FI_ATOMICS;
-        rx_attr.op_flags = 0;
-        MPIDI_OFI_CALL(fi_rx_context(*ep, idx_off + 1, &rx_attr, &MPIDI_OFI_EP_RX_RMA(index), NULL),
-                       ep);
+        rx_attr.caps = 0;
+        rx_attr.op_flags = FI_MULTI_RECV;
 
-        /* Note:  This bind should cause the "passive target" rx context to never generate an event
-         * We need this bind for manual progress to ensure that progress is made on the
-         * rx_ctr or rma operations during completion queue reads */
-        if (!MPIDI_OFI_ENABLE_DATA_AUTO_PROGRESS)
-            MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_EP_RX_RMA(index), &p2p_cq->fid,
-                                      FI_SEND | FI_RECV | FI_SELECTIVE_COMPLETION), bind);
-
-        rx_attr = *prov_use->rx_attr;
-        rx_attr.caps = FI_MSG | FI_RECV;
-        rx_attr.caps |= FI_MULTI_RECV;
-
+        if (MPIDI_OFI_ENABLE_TAGGED)
+            rx_attr.caps |= FI_TAGGED | FI_RECV;
         if (MPIDI_OFI_ENABLE_DATA)
             rx_attr.caps |= FI_DIRECTED_RECV;
 
-        rx_attr.op_flags = FI_MULTI_RECV;
-        MPIDI_OFI_CALL(fi_rx_context(*ep, idx_off + 2, &rx_attr, &MPIDI_OFI_EP_RX_MSG(index), NULL),
-                       ep);
-        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_EP_RX_MSG(index), &p2p_cq->fid, FI_RECV), bind);
+        rx_attr.caps |= FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE;
+        rx_attr.caps |= FI_ATOMICS;
+        rx_attr.caps |= FI_MSG | FI_RECV;
+        rx_attr.caps |= FI_MULTI_RECV;
+
+        MPIDI_OFI_CALL(fi_rx_context(*ep, index, &rx_attr, &MPIDI_Global.ctx[index].rx, NULL), ep);
+        MPIDI_OFI_CALL(fi_ep_bind(MPIDI_Global.ctx[index].rx, &p2p_cq->fid, FI_RECV), bind);
 
         MPIDI_OFI_CALL(fi_enable(*ep), ep_enable);
 
-        if (MPIDI_OFI_ENABLE_TAGGED)
-            MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_TX_TAG(index)), ep_enable);
-
-        MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_TX_RMA(index)), ep_enable);
-        MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_TX_MSG(index)), ep_enable);
-        MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_TX_CTR(index)), ep_enable);
-
-        if (MPIDI_OFI_ENABLE_TAGGED)
-            MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_RX_TAG(index)), ep_enable);
-
-        MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_RX_RMA(index)), ep_enable);
-        MPIDI_OFI_CALL(fi_enable(MPIDI_OFI_EP_RX_MSG(index)), ep_enable);
+        MPIDI_OFI_CALL(fi_enable(MPIDI_Global.ctx[index].tx), ep_enable);
+        MPIDI_OFI_CALL(fi_enable(MPIDI_Global.ctx[index].rx), ep_enable);
     }
     else {
         /* ---------------------------------------------------------- */
@@ -1382,13 +1302,7 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
 
         /* Copy the normal ep into the first entry for scalable endpoints to
          * allow compile macros to work */
-        MPIDI_Global.ctx[0].tx_tag =
-            MPIDI_Global.ctx[0].tx_rma =
-            MPIDI_Global.ctx[0].tx_msg =
-            MPIDI_Global.ctx[0].tx_ctr =
-            MPIDI_Global.ctx[0].rx_tag =
-            MPIDI_Global.ctx[0].rx_rma =
-            MPIDI_Global.ctx[0].rx_msg = *ep;
+        MPIDI_Global.ctx[0].tx = MPIDI_Global.ctx[0].rx = *ep;
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -37,7 +37,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     if (unlikely(MPI_ANY_SOURCE == source))
         remote_proc = FI_ADDR_UNSPEC;
     else
-        remote_proc = MPIDI_OFI_comm_to_phys(comm, source, MPIDI_OFI_API_TAG);
+        remote_proc = MPIDI_OFI_comm_to_phys(comm, source);
 
     if (message)
         MPIDI_OFI_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__MPROBE);
@@ -60,7 +60,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     msg.data = 0;
 
     MPIDI_OFI_CALL(fi_trecvmsg
-                   (MPIDI_OFI_EP_RX_TAG(0), &msg,
+                   (MPIDI_Global.ctx[0].rx, &msg,
                     peek_flags | FI_PEEK | FI_COMPLETION | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0) ), trecvmsg);
     MPIDI_OFI_PROGRESS_WHILE(MPIDI_OFI_REQUEST(rreq, util_id) == MPIDI_OFI_PEEK_START);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -87,13 +87,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV;
 
     if (!flags) /* Branch should compile out */
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       recv_buf,
                                       data_sz,
                                       NULL,
                                       (MPI_ANY_SOURCE ==
-                                       rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_comm_to_phys(comm, rank,
-                                                                                       MPIDI_OFI_API_TAG),
+                                       rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_comm_to_phys(comm, rank),
                                       match_bits, mask_bits,
                                       (void *) &(MPIDI_OFI_REQUEST(rreq, context))), trecv,
                              MPIDI_OFI_CALL_LOCK);
@@ -110,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.data = 0;
         msg.addr = FI_ADDR_UNSPEC;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_EP_RX_TAG(0), &msg, flags), trecv,
+        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_Global.ctx[0].rx, &msg, flags), trecv,
                              MPIDI_OFI_CALL_LOCK);
     }
 
@@ -283,7 +282,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     }
 
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
-    ret = fi_cancel((fid_t) MPIDI_OFI_EP_RX_TAG(0), &(MPIDI_OFI_REQUEST(rreq, context)));
+    ret = fi_cancel((fid_t) MPIDI_Global.ctx[0].rx, &(MPIDI_OFI_REQUEST(rreq, context)));
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
 
     if (ret == 0) {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -512,7 +512,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
 
     req->event_id = MPIDI_OFI_EVENT_ABORT;
     msg.desc = NULL;
-    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank, MPIDI_OFI_API_RMA);
+    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank);
     msg.context = NULL;
     msg.data = 0;
     req->next = MPIDI_OFI_WIN(win).syncQ;
@@ -615,8 +615,7 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_win_cntr_incr(win),
                               fi_inject_write(MPIDI_OFI_WIN(win).ep_nocmpl,
                                               (char *) origin_addr + origin_true_lb, target_bytes,
-                                              MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank,
-                                                                     MPIDI_OFI_API_RMA),
+                                              MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank),
                                               (uint64_t) MPIDI_OFI_winfo_base(win, target_rank)
                                               + target_disp * MPIDI_OFI_winfo_disp_unit(win,
                                                                                         target_rank)
@@ -673,7 +672,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
     req->event_id = MPIDI_OFI_EVENT_ABORT;
     msg.desc = NULL;
-    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank, MPIDI_OFI_API_RMA);
+    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank);
     msg.context = NULL;
     msg.data = 0;
     req->next = MPIDI_OFI_WIN(win).syncQ;
@@ -783,7 +782,7 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank, MPIDI_OFI_API_RMA);
+        msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -939,7 +938,7 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank, MPIDI_OFI_API_RMA);
+    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, target_rank);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -1088,7 +1087,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
                                req->noncontig->origin_dt.map, req->noncontig->target_dt.map);
 
     msg.desc = NULL;
-    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank, MPIDI_OFI_API_RMA);
+    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank);
     msg.context = NULL;
     msg.data = 0;
     msg.datatype = fi_dt;
@@ -1239,7 +1238,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
                                    req->noncontig->result_dt.map, req->noncontig->target_dt.map);
 
     msg.desc = NULL;
-    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank, MPIDI_OFI_API_RMA);
+    msg.addr = MPIDI_OFI_comm_to_phys(win->comm_ptr, req->target_rank);
     msg.context = NULL;
     msg.data = 0;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -31,8 +31,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     match_bits =
         MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
     mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), buf, data_sz, NULL, comm->rank,
-                               MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG), match_bits,
+        MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, buf, data_sz, NULL, comm->rank,
+                               MPIDI_OFI_comm_to_phys(comm, rank), match_bits,
                                NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -65,8 +65,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
     match_bits =
         MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
     mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), buf, data_sz, NULL, comm->rank,
-                               MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG), match_bits,
+        MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, buf, data_sz, NULL, comm->rank,
+                               MPIDI_OFI_comm_to_phys(comm, rank), match_bits,
                                NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -117,11 +117,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
         ssend_match =
             MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, rank, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),   /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,   /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG),    /* remote proc */
+                                      MPIDI_OFI_comm_to_phys(comm, rank),    /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), trecvsync, MPIDI_OFI_CALL_LOCK);
@@ -147,8 +147,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
 
     if (data_sz <= MPIDI_Global.max_buffered_send) {
         mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG),
+            MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
+                                   MPIDI_OFI_comm_to_phys(comm, rank),
                                    match_bits, NULL, MPIDI_OFI_DO_INJECT,
                                    MPIDI_OFI_CALL_LOCK);
         if (mpi_errno)
@@ -157,8 +157,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
     }
     else if (data_sz <= MPIDI_Global.max_send) {
         mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG),
+            MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
+                                   MPIDI_OFI_comm_to_phys(comm, rank),
                                    match_bits, (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
                                    MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK);
         if (mpi_errno)
@@ -214,11 +214,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
         MPIR_Assert(cntr->counter != USHRT_MAX);
         MPIDI_OFI_REQUEST(sreq, util_comm) = comm;
         MPIDI_OFI_REQUEST(sreq, util_id) = rank;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0), send_buf,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx, send_buf,
                                            MPIDI_Global.max_send,
                                            NULL,
                                            comm->rank,
-                                           MPIDI_OFI_comm_to_phys(comm, rank, MPIDI_OFI_API_TAG),
+                                           MPIDI_OFI_comm_to_phys(comm, rank),
                                            match_bits,
                                            (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
                                            MPIDI_OFI_DO_SEND,

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.h
@@ -250,7 +250,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
         while (req.done != MPIDI_OFI_PEEK_FOUND) {
             req.done = MPIDI_OFI_PEEK_START;
             MPIDI_OFI_CALL(fi_trecvmsg
-                           (MPIDI_OFI_EP_RX_TAG(0), &msg,
+                           (MPIDI_Global.ctx[0].rx, &msg,
                             FI_PEEK | FI_COMPLETION | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0)), trecv);
             do {
                 mpi_errno = MPID_Progress_test();
@@ -273,7 +273,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
         req.done = 0;
         req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       &buf,
                                       sizeof(int),
                                       NULL,
@@ -310,7 +310,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
 
         req.done = 0;
         req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0),
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx,
                                            &buf,
                                            sizeof(int),
                                            NULL,
@@ -383,7 +383,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         while (req[0].done != MPIDI_OFI_PEEK_FOUND) {
             req[0].done = MPIDI_OFI_PEEK_START;
             MPIDI_OFI_CALL(fi_trecvmsg
-                           (MPIDI_OFI_EP_RX_TAG(0), &msg,
+                           (MPIDI_Global.ctx[0].rx, &msg,
                             FI_PEEK | FI_COMPLETION | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0)), trecv);
             MPIDI_OFI_PROGRESS_WHILE(req[0].done == MPIDI_OFI_PEEK_START);
         }
@@ -402,7 +402,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         req[2].done = 0;
         req[2].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       *remote_upid_size,
                                       (*remote_size) * sizeof(size_t),
                                       NULL,
@@ -415,7 +415,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         MPIR_CHKPMEM_MALLOC((*remote_upids), char*, remote_upid_recvsize,
                             mpi_errno, "remote_upids");
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       *remote_upids,
                                       remote_upid_recvsize,
                                       NULL,
@@ -423,7 +423,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
                                       match_bits,
                                       mask_bits, &req[1].context), trecv, MPIDI_OFI_CALL_LOCK);
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_EP_RX_TAG(0),
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_Global.ctx[0].rx,
                                       *remote_node_ids,
                                       (*remote_size) * sizeof(MPID_Node_id_t),
                                       NULL,
@@ -468,7 +468,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         req[1].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
         req[2].done = 0;
         req[2].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0),
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx,
                                            local_upid_size,
                                            local_size * sizeof(size_t),
                                            NULL,
@@ -485,7 +485,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
             MPIR_ERR_POP(mpi_errno);
         }
 
-        MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0),
+        MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx,
                                local_upids,
                                local_upid_sendsize,
                                NULL,
@@ -495,7 +495,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
                                (void *) &req[1].context,
                                MPIDI_OFI_DO_SEND,
                                MPIDI_OFI_CALL_LOCK);
-        MPIDI_OFI_send_handler(MPIDI_OFI_EP_TX_TAG(0),
+        MPIDI_OFI_send_handler(MPIDI_Global.ctx[0].tx,
                                local_node_ids,
                                local_size * sizeof(MPID_Node_id_t),
                                NULL,

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -115,11 +115,6 @@
 #endif
 #define MPIDI_OFI_OP_SIZES 15
 
-#define MPIDI_OFI_API_TAG 0
-#define MPIDI_OFI_API_RMA 1
-#define MPIDI_OFI_API_MSG 2
-#define MPIDI_OFI_API_CTR 3
-
 #define MPIDI_OFI_THREAD_UTIL_MUTEX     MPIDI_Global.mutexes[0].m
 #define MPIDI_OFI_THREAD_PROGRESS_MUTEX MPIDI_Global.mutexes[1].m
 #define MPIDI_OFI_THREAD_FI_MUTEX       MPIDI_Global.mutexes[2].m
@@ -169,13 +164,6 @@ static inline int MPIDI_OFI_comm_to_ep(MPIR_Comm *comm_ptr, int rank)
 #endif
 #endif
 }
-#define MPIDI_OFI_EP_TX_TAG(x) MPIDI_Global.ctx[x].tx_tag
-#define MPIDI_OFI_EP_TX_RMA(x) MPIDI_Global.ctx[x].tx_rma
-#define MPIDI_OFI_EP_TX_MSG(x) MPIDI_Global.ctx[x].tx_msg
-#define MPIDI_OFI_EP_TX_CTR(x) MPIDI_Global.ctx[x].tx_ctr
-#define MPIDI_OFI_EP_RX_TAG(x) MPIDI_Global.ctx[x].rx_tag
-#define MPIDI_OFI_EP_RX_RMA(x) MPIDI_Global.ctx[x].rx_rma
-#define MPIDI_OFI_EP_RX_MSG(x) MPIDI_Global.ctx[x].rx_msg
 
 #define MPIDI_OFI_DO_SEND        0
 #define MPIDI_OFI_DO_INJECT      1
@@ -276,18 +264,8 @@ typedef struct {
 } MPIDI_OFI_atomic_valid_t;
 
 typedef struct {
-    struct fid_ep *tx_tag;
-    struct fid_ep *rx_tag;
-
-    struct fid_ep *tx_rma;
-    struct fid_ep *rx_rma;
-
-    struct fid_ep *tx_msg;
-    struct fid_ep *rx_msg;
-
-    struct fid_ep *tx_ctr;
-
-    int ctx_offset;
+    struct fid_ep *tx;
+    struct fid_ep *rx;
 } MPIDI_OFI_context_t;
 
 typedef union {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -209,8 +209,8 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
       fallback_global:
 
         /* Fallback for the traditional global EP/counter model */
-        MPIDI_OFI_WIN(win).ep = MPIDI_OFI_EP_TX_RMA(0);
-        MPIDI_OFI_WIN(win).ep_nocmpl = MPIDI_OFI_EP_TX_CTR(0);
+        MPIDI_OFI_WIN(win).ep = MPIDI_Global.ctx[0].tx;
+        MPIDI_OFI_WIN(win).ep_nocmpl = MPIDI_Global.ctx[0].tx;
         MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_Global.rma_cmpl_cntr;
         MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_Global.rma_issued_cntr;
     }
@@ -746,9 +746,9 @@ static inline int MPIDI_NM_mpi_win_free(MPIR_Win ** win_ptr)
 
     MPIDI_OFI_index_allocator_free(MPIDI_OFI_COMM(win->comm_ptr).win_id_allocator, window_instance);
     MPIDI_OFI_map_erase(MPIDI_Global.win_map, MPIDI_OFI_WIN(win).win_id);
-    if (MPIDI_OFI_WIN(win).ep_nocmpl != MPIDI_OFI_EP_TX_CTR(0))
+    if (MPIDI_OFI_WIN(win).ep_nocmpl != MPIDI_Global.ctx[0].tx)
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).ep_nocmpl->fid), epclose);
-    if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_EP_TX_RMA(0))
+    if (MPIDI_OFI_WIN(win).ep != MPIDI_Global.ctx[0].tx)
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).ep->fid), epclose);
     if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_Global.rma_cmpl_cntr)
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).cmpl_cntr->fid), cqclose);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -687,7 +687,7 @@ static MPI_Op mpi_ops[] = {
 #define _TBL MPIDI_Global.win_op_table[i][j]
 #define CHECK_ATOMIC(fcn,field1,field2)            \
   atomic_count = 0;                                \
-  ret = fcn(MPIDI_OFI_EP_TX_RMA(0),                          \
+  ret = fcn(MPIDI_Global.ctx[0].tx,                \
     fi_dt,                                 \
     fi_op,                                 \
             &atomic_count);                        \


### PR DESCRIPTION
It turns out the current way of using scalable endpoint (per-capability
context, each for tagged, msg, rma-counter, rma-completion) will be
unlikely to bring any benefits but consume tons of limited HW resources.

This patch removes per-capability contexts and instead introduce
one TX and one RX context per bundle.

Fixes csr/mpich-ofi#632