### PR TITLE
ch4/ofi: Avoid defining values from external header

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -199,7 +199,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_OFI_MAJOR_VERSION
       category    : CH4_OFI
       type        : int
-      default     : FI_MAJOR_VERSION
+      default     : -1
       class       : device
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
@@ -211,7 +211,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_OFI_MINOR_VERSION
       category    : CH4_OFI
       type        : int
-      default     : FI_MINOR_VERSION
+      default     : -1
       class       : device
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
@@ -427,7 +427,10 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* Specify the version of OFI is coded to, the provider will select struct  */
     /* layouts that are compatible with this version.                           */
     /* ------------------------------------------------------------------------ */
-    fi_version = FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
+    if (MPIDI_OFI_MAJOR_VERSION != -1 && MPIDI_OFI_MINOR_VERSION != -1)
+        fi_version = FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
+    else
+        fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 
     MPIDI_OFI_init_hints(hints);
 

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -24,11 +24,6 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     fi
     ])
     AM_CONDITIONAL([BUILD_CH4_NETMOD_OFI],[test "X$build_ch4_netmod_ofi" = "Xyes"])
-
-    if test "x${with_libfabric}" = "x" ; then
-        AC_DEFINE(FI_MAJOR_VERSION, 0, [If not using libfabric, define this macro to avoid compile errors])
-        AC_DEFINE(FI_MINOR_VERSION, 0, [If not using libfabric, define this macro to avoid compile errors])
-    fi
 ])dnl
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[


### PR DESCRIPTION
Instead of directly using values from fabric.h as defaults, use invalid
values. This way, we avoid using the FI_[MAJOR|MINOR]_VERSION values
when we are not building and ofi netmod.

Alternative to pmodels/mpich#2666.