### PR TITLE
ch4/ucx: Allocate static global completed send request

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -220,6 +220,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
 
     MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
 
+    MPIDI_UCX_global.lw_send_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_cc_set(&MPIDI_UCX_global.lw_send_req->cc, 0);
+
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_EXIT);
@@ -290,6 +293,8 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
 
     MPIDIG_finalize();
     PMI_Finalize();
+
+    MPIR_Request_free(MPIDI_UCX_global.lw_send_req);
 
   fn_exit:
     MPL_free(pending);

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -101,8 +101,8 @@ static inline int MPIDI_UCX_send(const void *buf,
         ucp_request->req = req;
         MPIDI_UCX_REQ(req).a.ucp_request = ucp_request;
     } else if (have_request) {
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_cc_set(&req->cc, 0);
+        req = MPIDI_UCX_global.lw_send_req;
+        MPIR_Request_add_ref(req);
     }
     *request = req;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -38,6 +38,7 @@ typedef struct {
     char kvsname[MPIDI_UCX_KVSAPPSTRLEN];
     char pname[MPI_MAX_PROCESSOR_NAME];
     int max_addr_len;
+    MPIR_Request *lw_send_req;
 } MPIDI_UCX_global_t;
 
 #define MPIDI_UCX_AV(av)     ((av)->netmod.ucx)


### PR DESCRIPTION
Use this request for immediately complete ucp_tag_send
operations. Saves a potential call to the MPICH allocator in the
critical path.