### PR TITLE
ch4/ofi: Allocate static global completed send request

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -217,8 +217,8 @@
 
 #define MPIDI_OFI_SEND_REQUEST_CREATE_LW(req)                   \
     do {                                                                \
-        (req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);           \
-        MPIR_cc_set(&(req)->cc, 0);                                     \
+        (req) = MPIDI_Global.lw_send_req;                               \
+        MPIR_Request_add_ref((req));                                    \
     } while (0)
 
 #define MPIDI_OFI_SSEND_ACKREQUEST_CREATE(req)            \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -937,6 +937,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_Datatype_init_names();
     MPIDI_OFI_index_datatypes();
 
+    MPIDI_Global.lw_send_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_cc_set(&MPIDI_Global.lw_send_req->cc, 0);
+
     /* -------------------------------- */
     /* Initialize Dynamic Tasking       */
     /* -------------------------------- */
@@ -1050,6 +1053,8 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_FI_MUTEX, &thr_err);
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_SPAWN_MUTEX, &thr_err);
+
+    MPIR_Request_free(MPIDI_Global.lw_send_req);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_FINALIZE);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -395,6 +395,9 @@ typedef struct {
     /* Communication info for dynamic processes */
     MPIDI_OFI_conn_manager_t conn_mgr;
 
+    /* complete request used for lightweight sends */
+    MPIR_Request *lw_send_req;
+
     /* Capability settings */
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS
     MPIDI_OFI_capabilities_t settings;


### PR DESCRIPTION
Use a pre-allocated complete request for immediately complete fi_tinject
operations. Saves a call to the MPICH allocator.