### PR TITLE
CH4/OFI: Create multiple VNIs

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -152,7 +152,7 @@ static inline int MPIDI_OFI_progress_do_queue(int vni_idx)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
 
-    ret = fi_cq_read(MPIDI_Global.p2p_cq, &cq_entry, 1);
+    ret = fi_cq_read(MPIDI_Global.ctx[vni_idx].cq, &cq_entry, 1);
 
     if (unlikely(ret == -FI_EAGAIN))
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -813,7 +813,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
 
     switch (ret) {
     case -FI_EAVAIL:
-        fi_cq_readerr(MPIDI_Global.p2p_cq, &e, 0);
+        fi_cq_readerr(MPIDI_Global.ctx[vni_idx].cq, &e, 0);
 
         switch (e.err) {
         case FI_ETRUNC:

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -32,7 +32,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1, 1);
     else if (likely(1)) {
-        ret = fi_cq_read(MPIDI_Global.p2p_cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
+        ret = fi_cq_read(MPIDI_Global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
             mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret, 0);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -266,6 +266,7 @@ typedef struct {
 typedef struct {
     struct fid_ep *tx;
     struct fid_ep *rx;
+    struct fid_cq *cq;
 } MPIDI_OFI_context_t;
 
 typedef union {
@@ -354,6 +355,7 @@ typedef struct {
     int context_shift;
     size_t iov_limit;
     size_t rma_iov_limit;
+    int max_ch4_vnis;
 
     /* Mutexex and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[4];

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -177,7 +177,7 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
 
         MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_WIN(win).ep, &MPIDI_Global.stx_ctx->fid, 0), bind);
         MPIDI_OFI_CALL(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                  &MPIDI_Global.p2p_cq->fid, FI_TRANSMIT | FI_SELECTIVE_COMPLETION),
+                                  &MPIDI_Global.ctx[0].cq->fid, FI_TRANSMIT | FI_SELECTIVE_COMPLETION),
                        bind);
         MPIDI_OFI_CALL(fi_ep_bind
                        (MPIDI_OFI_WIN(win).ep, &MPIDI_OFI_WIN(win).cmpl_cntr->fid,


### PR DESCRIPTION
This was a part of the threading prototype branch, but I thought it would be easier to get this merged first, as it only depends on the VNI netmod signatures (which is already in master).

This patch enables OFI netmod to create multiple CH4 VNIs
by using scalable endpoints. Each VNI has separate CQ,
so per-VNI CQ creation was also added.

However, note that only VNI#0 is used right now.

Reviewed-by: Wesley Bland <wesley.bland@intel.com>
Reviewed-by: Nusrat Islam <nusrat.islam@intel.com>