### PR TITLE
CH4: Added MPIT_PVARs into active message

### DIFF
--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -230,6 +230,14 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vnis)
 
     MPIDI_CH4_Global.win_hash = NULL;
 
+    mpi_errno = MPIDI_CH4R_RMA_Init_sync_pvars();
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    mpi_errno = MPIDI_CH4R_RMA_Init_targetcb_pvars();
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
     MPIDI_CH4_Global.is_ch4u_initialized = 1;
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_INIT);
 

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -251,6 +251,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPIR_Datatype_init();
     MPIR_Group_init();
 
+    /* setup receive queue statistics */
+    mpi_errno = MPIDI_CH4U_Recvq_init();
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     int i;
     for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -13,6 +13,8 @@
 
 #include "ch4_impl.h"
 
+extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_amhdr_set ATTRIBUTE((unused));
+
 #undef FUNCNAME
 #define FUNCNAME MPIDI_do_put
 #undef FCNAME
@@ -69,6 +71,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->preq.win_ptr) = win;
 
     MPIR_cc_incr(sreq->cc_ptr, &c);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.src_rank = win->comm_ptr->rank;
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
@@ -83,6 +86,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
 
     if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
         am_hdr.n_iov = 0;
+        MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDI_CH4U_REQUEST(sreq, req->preq.dt_iov) = NULL;
 
         /* FIXIME: we need to choose between NM and SHM */
@@ -115,6 +119,7 @@ static inline int MPIDI_do_put(const void *origin_addr,
     am_iov[0].iov_len = sizeof(am_hdr);
     am_iov[1].iov_base = dt_iov;
     am_iov[1].iov_len = sizeof(struct iovec) * am_hdr.n_iov;
+    MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
     MPIDI_CH4U_REQUEST(sreq, req->preq.dt_iov) = dt_iov;
 
@@ -208,6 +213,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
 
     MPIR_cc_incr(sreq->cc_ptr, &c);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
     am_hdr.datatype = target_datatype;
@@ -221,6 +227,7 @@ static inline int MPIDI_do_get(void *origin_addr,
 
     if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
         am_hdr.n_iov = 0;
+        MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDI_CH4U_REQUEST(sreq, req->greq.dt_iov) = NULL;
 
         /* FIXIME: we need to choose between NM and SHM */
@@ -248,6 +255,7 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIDU_Segment_pack_vector(segment_ptr, 0, &last, dt_iov, &n_iov);
     MPIR_Assert(last == (MPI_Aint) data_sz);
     MPL_free(segment_ptr);
+    MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
     MPIDI_CH4U_REQUEST(sreq, req->greq.dt_iov) = dt_iov;
     /* FIXIME: we need to choose between NM and SHM */
@@ -316,6 +324,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->areq.win_ptr) = win;
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
+    MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.req_ptr = (uint64_t) sreq;
     am_hdr.origin_count = origin_count;
 
@@ -343,6 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->areq.data_sz) = data_sz;
     if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
         am_hdr.n_iov = 0;
+        MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDI_CH4U_REQUEST(sreq, req->areq.dt_iov) = NULL;
 
         /* FIXIME: we need to choose between NM and SHM */
@@ -381,6 +391,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     am_iov[0].iov_len = sizeof(am_hdr);
     am_iov[1].iov_base = dt_iov;
     am_iov[1].iov_len = sizeof(struct iovec) * am_hdr.n_iov;
+    MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
     MPIDI_CH4U_REQUEST(sreq, req->areq.dt_iov) = dt_iov;
 
     /* FIXIME: MPIDI_NM_am_hdr_max_sz should be removed */
@@ -474,6 +485,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     /* TODO: have common routine for accumulate/get_accumulate */
+    MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.req_ptr = (uint64_t) sreq;
     am_hdr.origin_count = origin_count;
 
@@ -503,6 +515,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIDI_CH4U_REQUEST(sreq, req->areq.data_sz) = data_sz;
     if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
         am_hdr.n_iov = 0;
+        MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDI_CH4U_REQUEST(sreq, req->areq.dt_iov) = NULL;
 
         /* FIXIME: we need to choose between NM and SHM */
@@ -541,6 +554,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     am_iov[0].iov_len = sizeof(am_hdr);
     am_iov[1].iov_base = dt_iov;
     am_iov[1].iov_len = sizeof(struct iovec) * am_hdr.n_iov;
+    MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
     MPIDI_CH4U_REQUEST(sreq, req->areq.dt_iov) = dt_iov;
 
     /* FIXIME: MPIDI_NM_am_hdr_max_sz should be removed */
@@ -933,11 +947,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
+    MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.target_disp = target_disp;
     am_hdr.datatype = datatype;
     am_hdr.req_ptr = (uint64_t) sreq;
     am_hdr.win_id = MPIDI_CH4U_WIN(win, win_id);
     am_hdr.src_rank = win->comm_ptr->rank;
+    MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
     MPIDI_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
 

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -19,6 +19,219 @@
  * functions are named with suffix "_target_msg_cb", and all handler completion
  * function are named with suffix "_target_cmpl_cb". */
 
+extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_winlock_getlocallock ATTRIBUTE((unused));
+
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_put ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_put_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_cas ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_cas_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_win_ctrl ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_put_iov ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_put_iov_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_put_data ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_iov ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_iov ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_iov_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_iov_ack ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_data ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unused));
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_CH4_RMA_Init_targetcb_pvars
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+static inline int MPIDI_CH4R_RMA_Init_targetcb_pvars(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    /* rma_targetcb_put */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_put,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Put (in seconds)");
+
+    /* rma_targetcb_put_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_put_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Put ACK (in seconds)");
+
+    /* rma_targetcb_get */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Get (in seconds)");
+
+    /* rma_targetcb_get_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Get ACK (in seconds)");
+
+    /* rma_targetcb_cas */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_cas,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Compare-and-swap (in seconds)");
+
+    /* rma_targetcb_cas_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_cas_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Compare-and-swap ACK (in seconds)");
+
+    /* rma_targetcb_acc */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_acc,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Accumulate (in seconds)");
+
+    /* rma_targetcb_get_acc */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_acc,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Get-Accumulate (in seconds)");
+
+    /* rma_targetcb_acc_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_acc_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Accumulate ACK (in seconds)");
+
+    /* rma_targetcb_get_acc_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_acc_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for Get-Accumulate ACK (in seconds)");
+
+    /* rma_targetcb_win_ctrl */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_win_ctrl,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for WIN CTRL (in seconds)");
+
+    /* rma_targetcb_put_iov */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_put_iov,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for PUT IOV (in seconds)");
+
+    /* rma_targetcb_put_iov_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_put_iov_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for PUT IOV ACK (in seconds)");
+
+    /* rma_targetcb_put_data */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_put_data,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for PUT DATA (in seconds)");
+
+    /* rma_targetcb_acc_iov */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_acc_iov,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for ACC IOV (in seconds)");
+
+    /* rma_targetcb_get_acc_iov */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_acc_iov,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for GET ACC IOV (in seconds)");
+
+    /* rma_targetcb_acc_iov_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_acc_iov_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for ACC IOV ACK (in seconds)");
+
+    /* rma_targetcb_get_acc_iov_ack */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_acc_iov_ack,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for GET ACC IOV ACK (in seconds)");
+
+    /* rma_targetcb_acc_data */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_acc_data,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for ACC DATA (in seconds)");
+
+    /* rma_targetcb_get_acc_data */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_targetcb_get_acc_data,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "RMA:TARGETCB for GET ACC DATA (in seconds)");
+
+    return mpi_errno;
+}
+
 #undef FUNCNAME
 #define FUNCNAME MPIDI_ack_put
 #undef FCNAME
@@ -203,6 +416,7 @@ static inline void MPIDI_win_lock_req_proc(int handler_id,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_WIN_LOCK_REQ_PROC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_WIN_LOCK_REQ_PROC);
 
+    MPIR_T_PVAR_TIMER_START(RMA, rma_winlock_getlocallock);
     struct MPIDI_CH4U_win_lock *lock = (struct MPIDI_CH4U_win_lock *)
         MPL_calloc(1, sizeof(struct MPIDI_CH4U_win_lock));
 
@@ -220,6 +434,7 @@ static inline void MPIDI_win_lock_req_proc(int handler_id,
     lock_recvd_q->tail = lock;
 
     MPIDI_win_lock_advance(win);
+    MPIR_T_PVAR_TIMER_END(RMA, rma_winlock_getlocallock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_WIN_LOCK_REQ_PROC);
     return;
 }
@@ -1086,6 +1301,7 @@ static inline int MPIDI_put_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put_ack);
 
     preq = (MPIR_Request *) msg_hdr->preq_ptr;
     win = MPIDI_CH4U_REQUEST(preq, req->preq.win_ptr);
@@ -1103,6 +1319,7 @@ static inline int MPIDI_put_ack_target_msg_cb(int handler_id, void *am_hdr,
     if (target_cmpl_cb)
         *target_cmpl_cb = NULL;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1124,6 +1341,7 @@ static inline int MPIDI_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACC_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACC_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_ack);
 
     areq = (MPIR_Request *) msg_hdr->req_ptr;
     win = MPIDI_CH4U_REQUEST(areq, req->areq.win_ptr);
@@ -1141,6 +1359,7 @@ static inline int MPIDI_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
     if (target_cmpl_cb)
         *target_cmpl_cb = NULL;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACC_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1167,6 +1386,7 @@ static inline int MPIDI_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACC_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACC_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_ack);
 
     areq = (MPIR_Request *) msg_hdr->req_ptr;
 
@@ -1213,6 +1433,7 @@ static inline int MPIDI_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
     *target_cmpl_cb = MPIDI_get_acc_ack_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(areq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACC_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1234,6 +1455,7 @@ static inline int MPIDI_cswap_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CSWAP_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CSWAP_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_cas_ack);
 
     creq = (MPIR_Request *) msg_hdr->req_ptr;
     MPIDI_Datatype_check_size(MPIDI_CH4U_REQUEST(creq, req->creq.datatype), 1, data_sz);
@@ -1245,6 +1467,7 @@ static inline int MPIDI_cswap_ack_target_msg_cb(int handler_id, void *am_hdr,
     *target_cmpl_cb = MPIDI_cswap_ack_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(creq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_cas_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CSWAP_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1266,6 +1489,7 @@ static inline int MPIDI_win_ctrl_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_WIN_CTRL_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_WIN_CTRL_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_win_ctrl);
 
     MPL_HASH_FIND(dev.ch4u.hash_handle, MPIDI_CH4_Global.win_hash,
                   &msg_hdr->win_id, sizeof(uint64_t), win);
@@ -1312,6 +1536,7 @@ static inline int MPIDI_win_ctrl_target_msg_cb(int handler_id, void *am_hdr,
     if (target_cmpl_cb)
         *target_cmpl_cb = NULL;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_win_ctrl);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_WIN_CTRL_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1342,6 +1567,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_put_msg_t *msg_hdr = (MPIDI_CH4U_put_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1413,6 +1639,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
     }
 
   fn_exit:
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1436,6 +1663,7 @@ static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_put_msg_t *msg_hdr = (MPIDI_CH4U_put_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_IOV_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_IOV_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put_iov);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1465,6 +1693,7 @@ static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
     *data = dt_iov;
     *p_data_sz = msg_hdr->n_iov * sizeof(struct iovec);
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_iov);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_IOV_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1488,6 +1717,7 @@ static inline int MPIDI_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_IOV_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_IOV_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put_iov_ack);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1511,6 +1741,7 @@ static inline int MPIDI_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
     *req = NULL;
 
   fn_exit:
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_iov_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_IOV_ACK_TARGET_MSG_CB);
     return mpi_errno;
   fn_fail:
@@ -1536,6 +1767,7 @@ static inline int MPIDI_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACC_IOV_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACC_IOV_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_iov_ack);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1559,6 +1791,7 @@ static inline int MPIDI_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
     *req = NULL;
 
   fn_exit:
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_iov_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACC_IOV_ACK_TARGET_MSG_CB);
     return mpi_errno;
   fn_fail:
@@ -1584,6 +1817,7 @@ static inline int MPIDI_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_h
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACC_IOV_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACC_IOV_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_iov_ack);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1607,6 +1841,7 @@ static inline int MPIDI_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_h
     *req = NULL;
 
   fn_exit:
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_iov_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACC_IOV_ACK_TARGET_MSG_CB);
     return mpi_errno;
   fn_fail:
@@ -1634,6 +1869,7 @@ static inline int MPIDI_put_data_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_DATA_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_DATA_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_put_data);
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
     win = MPIDI_CH4U_REQUEST(rreq, req->preq.win_ptr);
@@ -1650,6 +1886,7 @@ static inline int MPIDI_put_data_target_msg_cb(int handler_id, void *am_hdr,
     *req = rreq;
     *target_cmpl_cb = MPIDI_put_target_cmpl_cb;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1671,6 +1908,7 @@ static inline int MPIDI_acc_data_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACC_DATA_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACC_DATA_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_data);
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
     MPIDI_handle_acc_data(data, p_data_sz, is_contig, rreq);
@@ -1678,6 +1916,7 @@ static inline int MPIDI_acc_data_target_msg_cb(int handler_id, void *am_hdr,
     *req = rreq;
     *target_cmpl_cb = MPIDI_acc_target_cmpl_cb;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACC_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1699,6 +1938,7 @@ static inline int MPIDI_get_acc_data_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACC_DATA_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACC_DATA_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_data);
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
     MPIDI_handle_acc_data(data, p_data_sz, is_contig, rreq);
@@ -1706,6 +1946,7 @@ static inline int MPIDI_get_acc_data_target_msg_cb(int handler_id, void *am_hdr,
     *req = rreq;
     *target_cmpl_cb = MPIDI_get_acc_target_cmpl_cb;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACC_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1734,6 +1975,7 @@ static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_cswap_req_msg_t *msg_hdr = (MPIDI_CH4U_cswap_req_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CSWAP_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CSWAP_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_cas);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1766,6 +2008,7 @@ static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
     *data = p_data;
     MPIDI_CH4U_REQUEST(*req, req->creq.data) = p_data;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_cas);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CSWAP_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1794,6 +2037,7 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_acc_req_msg_t *msg_hdr = (MPIDI_CH4U_acc_req_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACC_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACC_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1850,6 +2094,7 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_REQUEST(rreq, req->areq.dt_iov) = dt_iov;
 
   fn_exit:
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACC_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1870,6 +2115,7 @@ static inline int MPIDI_get_acc_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACC_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACC_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc);
 
     /* the same handling processing as ACC except the completion handler function. */
     mpi_errno =
@@ -1878,6 +2124,7 @@ static inline int MPIDI_get_acc_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_get_acc_target_cmpl_cb;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACC_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1903,6 +2150,7 @@ static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_acc_req_msg_t *msg_hdr = (MPIDI_CH4U_acc_req_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACC_IOV_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACC_IOV_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_iov);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -1940,6 +2188,7 @@ static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
     *target_cmpl_cb = MPIDI_acc_iov_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_iov);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACC_IOV_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1959,6 +2208,7 @@ static inline int MPIDI_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACC_IOV_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACC_IOV_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_iov);
 
     /* the same handling processing as ACC except the completion handler function. */
     mpi_errno = MPIDI_acc_iov_target_msg_cb(handler_id, am_hdr, data,
@@ -1966,6 +2216,7 @@ static inline int MPIDI_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_get_acc_iov_target_cmpl_cb;
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_iov);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACC_IOV_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -1991,6 +2242,7 @@ static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get);
 
     rreq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(rreq);
@@ -2025,6 +2277,7 @@ static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
         MPIDI_CH4U_REQUEST(rreq, req->greq.dt_iov) = iov;
     }
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_TARGET_MSG_CB);
     return mpi_errno;
 }
@@ -2052,6 +2305,7 @@ static inline int MPIDI_get_ack_target_msg_cb(int handler_id, void *am_hdr,
     MPIDI_CH4U_get_ack_msg_t *msg_hdr = (MPIDI_CH4U_get_ack_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACK_TARGET_MSG_CB);
+    MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_ack);
 
     greq = MPIDI_CH4I_am_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_Assert(greq);
@@ -2103,6 +2357,7 @@ static inline int MPIDI_get_ack_target_msg_cb(int handler_id, void *am_hdr,
         MPL_free(segment_ptr);
     }
 
+    MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -20,6 +20,47 @@
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
 
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_winlock_getlocallock ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_wincreate_allgather ATTRIBUTE((unused));
+MPIR_T_pvar_timer_t PVAR_TIMER_rma_amhdr_set ATTRIBUTE((unused));
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_CH4_RMA_Init_sync_pvars
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+static inline int MPIDI_CH4R_RMA_Init_sync_pvars(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    /* rma_winlock_getlocallock */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_winlock_getlocallock,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "WIN_LOCK:Get local lock (in seconds)");
+
+    /* rma_wincreate_allgather */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_wincreate_allgather,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "WIN_CREATE:Allgather (in seconds)");
+
+    /* rma_amhdr_set */
+    MPIR_T_PVAR_TIMER_REGISTER_STATIC(RMA,
+            MPI_DOUBLE,
+            rma_amhdr_set,
+            MPI_T_VERBOSITY_MPIDEV_DETAIL,
+            MPI_T_BIND_NO_OBJECT,
+            MPIR_T_PVAR_FLAG_READONLY,
+            "RMA", "Set fields in AM Handler (in seconds)");
+
+    return mpi_errno;
+}
+
 #undef FUNCNAME
 #define FUNCNAME MPIDI_CH4R_mpi_win_set_info
 #undef FCNAME
@@ -846,6 +887,7 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
                                     MPI_WIN_FLAVOR_SHARED, MPI_WIN_UNIFIED);
 
     win = *win_ptr;
+    MPIR_T_PVAR_TIMER_START(RMA, rma_wincreate_allgather);
     MPIDI_CH4U_WIN(win, shared_table) =
         (MPIDI_CH4U_win_shared_info_t *) MPL_malloc(sizeof(MPIDI_CH4U_win_shared_info_t) *
                                                     comm_ptr->local_size);
@@ -859,6 +901,7 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
                                     shared_table,
                                     sizeof(MPIDI_CH4U_win_shared_info_t),
                                     MPI_BYTE, comm_ptr, &errflag);
+    MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 


### PR DESCRIPTION
By referring to MPIT_PVARs usage in CH3, adding corresponding parts into
CH4 active message level.