### PR TITLE
CH4/OFI: MPIDI_OFI_am_repost_event needs to be called with mpi_errno

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -685,7 +685,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_ent
             mpi_errno = MPIDI_OFI_am_recv_event(wc, req);
 
         if (unlikely((wc->flags & FI_MULTI_RECV) && !buffered))
-            MPIDI_OFI_am_repost_event(wc, req);
+            mpi_errno = MPIDI_OFI_am_repost_event(wc, req);
 
         goto fn_exit;
     }


### PR DESCRIPTION
In the MPIDI_OFI_dispatch_function the call to MPIDI_OFI_am_repost_event
for the FI_MULTI_RECV flag needs to be called with mpi_errno to take the
rc.