### PR TITLE
operate on unsigned before casting to int

### DIFF
--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -546,7 +546,7 @@ fn_fail:
 void MPIDI_PG_IdToNum( MPIDI_PG_t *pg, int *id )
 {
     const char *p = (const char *)pg->id;
-    int pgid = 0;
+    unsigned int pgid = 0;
 
     while (*p) {
         pgid += *p++;


### PR DESCRIPTION
-fsanitize=signed-integer-overflow picks up the math here as an
overflow, but we don't care.  use unsigned as an intermediate value to
get us back into defined behavior and silence the warning here so we
don't miss warnings elsewhere.