### PR TITLE
ch4/ofi: Request memory pool abstraction.

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -159,11 +159,16 @@ extern MPIR_Object_alloc_t MPIR_Request_mem;
 /* Preallocated request objects */
 extern MPIR_Request MPIR_Request_direct[];
 
+static inline MPIR_Object_alloc_t *MPIR_Request_mem_ptr()
+{
+    return &MPIR_Request_mem;
+}
+
 static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
 {
     MPIR_Request *req;
 
-    req = MPIR_Handle_obj_alloc(&MPIR_Request_mem);
+    req = MPIR_Handle_obj_alloc(MPIR_Request_mem_ptr());
     if (req != NULL) {
 	MPL_DBG_MSG_P(MPIR_DBG_REQUEST,VERBOSE,
                       "allocated request, handle=0x%08x", req->handle);
@@ -271,7 +276,7 @@ static inline void MPIR_Request_free(MPIR_Request *req)
 
         MPID_Request_destroy_hook(req);
 
-        MPIR_Handle_obj_free(&MPIR_Request_mem, req);
+        MPIR_Handle_obj_free(MPIR_Request_mem_ptr(), req);
     }
 }
 

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -254,7 +254,7 @@ extern MPIDI_Process_t MPIDI_Process;
 
 #  define MPIDI_Request_tls_alloc(req_) \
     do { \
-	(req_) = MPIR_Handle_obj_alloc(&MPIR_Request_mem); \
+	(req_) = MPIR_Handle_obj_alloc(MPIR_Request_mem_ptr()); \
         MPL_DBG_MSG_P(MPIDI_CH3_DBG_CHANNEL,VERBOSE,		\
 	       "allocated request, handle=0x%08x", req_);\
     } while (0)

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -43,7 +43,7 @@
     } while (0)
 
 #define MPIDI_OFI_ssendack_request_t_tls_free(req) \
-  MPIR_Handle_obj_free(&MPIR_Request_mem, (req))
+  MPIR_Handle_obj_free(MPIR_Request_mem_ptr(), (req))
 
 #define MPIDI_OFI_ssendack_request_t_alloc_and_init(req)        \
     do {                                                                \
@@ -311,7 +311,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_reque
         MPIDI_OFI_win_datatype_unmap(&req->noncontig->origin_dt);
         MPIDI_OFI_win_datatype_unmap(&req->noncontig->result_dt);
         MPL_free(req->noncontig);
-        MPIR_Handle_obj_free(&MPIR_Request_mem, (req));
+        MPIR_Handle_obj_free(MPIR_Request_mem_ptr(), (req));
     }
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -69,7 +69,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
         *flag = 0;
 
         if (message)
-            MPIR_Handle_obj_free(&MPIR_Request_mem, rreq);
+            MPIR_Handle_obj_free(MPIR_Request_mem_ptr(), rreq);
 
         goto fn_exit;
         break;


### PR DESCRIPTION
The change allows to redefine the pointer to the memory pool just
in a query function, not changing the code that uses the pointer.