### PR TITLE
[WIP] New progress implementation

### DIFF
--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,8 +10,8 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm *comm_ptr, MPI_Request *request);
-int MPIR_Test_impl(MPI_Request *request, int *flag, MPI_Status *status);
-int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
+int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
+int MPIR_Testall_impl(int count, MPIR_Request *array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status);
 int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -13,7 +13,7 @@ int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest
 int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
 int MPIR_Testall_impl(int count, MPIR_Request *array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
-int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status);
+int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status);
 int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
                       MPI_Status array_of_statuses[]);
 

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -14,7 +14,11 @@ int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
 int MPIR_Testall_impl(int count, MPIR_Request *array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status);
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
+int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
+                      MPI_Status array_of_statuses[]);
+
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request *request_ptrs[],
                       MPI_Status array_of_statuses[]);
 
 #endif /* MPIR_PT2PT_H_INCLUDED */

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -731,8 +731,6 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPI_Request request_ptr_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
-    MPI_Request *request_ptrs = request_ptr_array;
     MPI_Status status_static_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
     MPI_Status *status_array = statuses;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_WAITALL);
@@ -747,7 +745,6 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
     }
 
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno, "request pointers");
         MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno, "status objects");
     }
 
@@ -757,12 +754,14 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
         tag fields here. */
         status_array[i].MPI_TAG = 0;
         status_array[i].MPI_SOURCE = MPI_PROC_NULL;
-
-        /* Convert the MPIR_Request objects to MPI_Request objects */
-        request_ptrs[i] = requests[i]->handle;
     }
 
-    mpi_errno = MPIR_Waitall_impl(numreq, request_ptrs, status_array);
+    mpi_errno = MPIR_Waitall_impl(numreq, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
+    mpi_errno = MPIR_Waitall_post(numreq, NULL, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
 
     /* The errflag value here is for all requests, not just a single one.  If
      * in the future, this function is used for multiple collectives at a

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -462,7 +462,6 @@ static int MPIR_Bsend_check_active( void )
 
     MPL_DBG_MSG_P(MPIR_DBG_BSEND,TYPICAL,"Checking active starting at %p", active);
     while (active) {
-	MPI_Request r = active->request->handle;
 	int         flag;
 	
 	next_active = active->next;
@@ -477,7 +476,7 @@ static int MPIR_Bsend_check_active( void )
 	    flag = 0;
             /* XXX DJG FIXME-MT should we be checking this? */
 	    if (MPIR_Object_get_ref(active->request) == 1) {
-		mpi_errno = MPIR_Test_impl(&r, &flag, MPI_STATUS_IGNORE );
+		mpi_errno = MPID_Test(active->request, &flag, MPI_STATUS_IGNORE );
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    } else {
 		/* We need to invoke the progress engine in case we 
@@ -489,7 +488,7 @@ static int MPIR_Bsend_check_active( void )
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    }
 	} else {
-	    mpi_errno = MPIR_Test_impl( &r, &flag, MPI_STATUS_IGNORE );
+	    mpi_errno = MPID_Test( active->request, &flag, MPI_STATUS_IGNORE );
             if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	}
 	if (flag) {

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -178,8 +178,11 @@ int MPIR_Bsend_detach( void *bufferp, int *size )
 	MPII_Bsend_data_t *p = BsendBuffer.active;
 
 	while (p) {
-	    MPI_Request r = p->request->handle;
-	    MPIR_Wait_impl( &r, MPI_STATUS_IGNORE );
+            MPI_Request r = p->request->handle;
+            int active_flag;
+	    MPIR_Wait_impl( p->request, MPI_STATUS_IGNORE );
+            MPIR_Request_complete(&r, p->request, MPI_STATUS_IGNORE, &active_flag);
+
 	    p = p->next;
 	}
     }

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -493,6 +493,11 @@ static int MPIR_Bsend_check_active( void )
 	}
 	if (flag) {
 	    /* We're done.  Remove this segment */
+        if (MPIR_Request_is_complete(active->request)) {
+            mpi_errno = MPIR_Request_complete(NULL, active->request, MPI_STATUS_IGNORE,
+                              &flag);
+            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        }
 	    MPL_DBG_MSG_P(MPIR_DBG_BSEND,TYPICAL,"Removing segment %p", active);
 	    MPIR_Bsend_free_segment( active );
 	}

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -61,6 +61,7 @@ PMPI_LOCAL int MPIR_Ibsend_cancel( void *extra, int complete )
     MPI_Status status;
     MPIR_Request *req = ibsend_info->req;
     MPI_Request req_hdl = req->handle;
+    int active_flag;
 
     /* FIXME: There should be no unreferenced args! */
     /* Note that this value should always be 1 because 
@@ -72,8 +73,11 @@ PMPI_LOCAL int MPIR_Ibsend_cancel( void *extra, int complete )
     /* Try to cancel the underlying request */
     mpi_errno = MPIR_Cancel_impl(req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl( &req_hdl, &status );
+    mpi_errno = MPIR_Wait_impl( req, &status );
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req_hdl, req, &status, &active_flag);
+    MPIR_Assert(!mpi_errno);
+
     ibsend_info->cancelled = MPIR_STATUS_GET_CANCEL_BIT(status);
 
     /* If the cancelation is successful, free the memory in the

--- a/src/mpi/pt2pt/test.c
+++ b/src/mpi/pt2pt/test.c
@@ -51,14 +51,8 @@ int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
 
     if (MPIR_Request_is_complete(request_ptr)) {
 	*flag = TRUE;
-    } else if (unlikely(
-                MPIR_CVAR_ENABLE_FT &&
-                MPID_Request_is_anysource(request_ptr) &&
-                !MPID_Comm_AS_enabled(request_ptr->comm))) {
-        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-        if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
-        goto fn_fail;
     }
+
  fn_exit:
     return mpi_errno;
  fn_fail:
@@ -155,7 +149,16 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
     if (MPIR_Request_is_complete(request_ptr)) {
 	mpi_errno = MPIR_Request_complete(request, request_ptr, status,
 					  &active_flag);
+	*flag = TRUE;
 	if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+	/* Fall through to the exit */
+    } else if (unlikely(
+                MPIR_CVAR_ENABLE_FT &&
+                MPID_Request_is_anysource(request_ptr) &&
+                !MPID_Comm_AS_enabled(request_ptr->comm))) {
+        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+        if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
+        goto fn_fail;
     }
     /* ... end of body of routine ... */
     

--- a/src/mpi/pt2pt/test.c
+++ b/src/mpi/pt2pt/test.c
@@ -32,7 +32,6 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status) __attribute__(
 int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int active_flag;
 
     *flag = FALSE;
 
@@ -98,6 +97,7 @@ Output Parameters:
 int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int active_flag;
     MPIR_Request *request_ptr = NULL;
    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TEST);
 
@@ -154,7 +154,7 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
     
     if (MPIR_Request_is_complete(request_ptr)) {
 	mpi_errno = MPIR_Request_complete(request, request_ptr, status,
-					  flag);
+					  &active_flag);
 	if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
     /* ... end of body of routine ... */

--- a/src/mpi/pt2pt/testany.c
+++ b/src/mpi/pt2pt/testany.c
@@ -30,10 +30,48 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx, int *flag
 #undef MPI_Testany
 #define MPI_Testany PMPI_Testany
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Testany_impl
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Testany_impl(int count, MPIR_Request *request_ptrs[], int *indx, 
+		int *flag, MPI_Status *status)
+{
+    int i;
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPID_Progress_test();
+    /* --BEGIN ERROR HANDLING-- */
+    if (mpi_errno != MPI_SUCCESS)
+    {
+	goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+	
+    for (i = 0; i < count; i++)
+    {
+	if (request_ptrs[i] != NULL && 
+            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
+            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
+	{
+            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
+                                                             status);
+	    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+	}
+    }
+
+ fn_exit:
+    return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
 #endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Testany
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 
 /*@
     MPI_Testany - Tests for completion of any previdously initiated 
@@ -67,7 +105,6 @@ program to unexecpectedly terminate or produce incorrect results.
 int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
 		int *flag, MPI_Status *status)
 {
-    static const char FCNAME[] = "MPI_Testany";
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
     int i;
@@ -151,7 +188,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     *flag = FALSE;
     *indx = MPI_UNDEFINED;
     
-    mpi_errno = MPID_Progress_test();
+    mpi_errno = MPID_Testany(count, request_ptrs, flag, indx, status);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
     {
@@ -161,14 +198,6 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
 	
     for (i = 0; i < count; i++)
     {
-	if (request_ptrs[i] != NULL && 
-            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-	{
-            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
-                                                             status);
-	    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-	}
         if (request_ptrs[i] != NULL)
         {
             if (MPIR_Request_is_complete(request_ptrs[i]))

--- a/src/mpi/pt2pt/testsome.c
+++ b/src/mpi/pt2pt/testsome.c
@@ -30,11 +30,46 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
 #undef MPI_Testsome
 #define MPI_Testsome PMPI_Testsome
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Testsome_impl
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Testsome_impl(int incount, MPIR_Request *request_ptrs[], int *outcount, 
+		 int array_of_indices[], MPI_Status array_of_statuses[])
+{
+    int i;
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPID_Progress_test();
+    /* --BEGIN ERROR HANDLING-- */
+    if (mpi_errno != MPI_SUCCESS)
+	goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    for (i = 0; i < incount; i++)
+    {
+	if (request_ptrs[i] != NULL && 
+            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
+            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
+	{
+            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
+                                                             array_of_statuses);
+	    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+	}
+    }
+
+ fn_exit:
+    return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
 #endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Testsome
-
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 /*@
     MPI_Testsome - Tests for some given requests to complete
 
@@ -69,7 +104,6 @@ program to unexecpectedly terminate or produce incorrect results.
 int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, 
 		 int array_of_indices[], MPI_Status array_of_statuses[])
 {
-    static const char FCNAME[] = "MPI_Testsome";
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
     MPI_Status * status_ptr;
@@ -153,7 +187,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     
     n_active = 0;
     
-    mpi_errno = MPID_Progress_test();
+    mpi_errno = MPID_Testsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
 	goto fn_fail;
@@ -161,14 +195,6 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
 
     for (i = 0; i < incount; i++)
     {
-	if (request_ptrs[i] != NULL && 
-            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-	{
-            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
-                                                             array_of_statuses);
-	    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-	}
         status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
         if (request_ptrs[i] != NULL)
         {

--- a/src/mpi/pt2pt/wait.c
+++ b/src/mpi/pt2pt/wait.c
@@ -53,7 +53,7 @@ int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status)
         if (unlikely(MPIR_CVAR_ENABLE_FT &&
                     MPID_Request_is_anysource(request_ptr) &&
                     !MPID_Comm_AS_enabled(request_ptr->comm))) {
-            mpi_errno = MPIR_Test_impl(request, &active_flag, status);
+            mpi_errno = MPID_Test(request_ptr, &active_flag, status);
             goto fn_exit;
         }
 

--- a/src/mpi/pt2pt/wait.c
+++ b/src/mpi/pt2pt/wait.c
@@ -186,7 +186,7 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     /* save copy of comm because request will be freed */
     if (request_ptr)
         comm_ptr = request_ptr->comm;
-    mpi_errno = MPIR_Wait_impl(request, status);
+    mpi_errno = MPID_Wait(request, status);
     if (mpi_errno) goto fn_fail;
 
     /* ... end of body of routine ... */

--- a/src/mpi/pt2pt/waitall.c
+++ b/src/mpi/pt2pt/waitall.c
@@ -147,7 +147,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
     }
 
     if (unlikely(disabled_anysource)) {
-        mpi_errno = MPIR_Testall_impl(count, array_of_requests, &disabled_anysource, array_of_statuses);
+        mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
 

--- a/src/mpi/pt2pt/waitall.c
+++ b/src/mpi/pt2pt/waitall.c
@@ -374,7 +374,7 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     }
 
     /* Make progress and wait for completion */
-    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    mpi_errno = MPID_Waitall(count, request_ptrs, array_of_statuses);
     switch (mpi_errno) {
     case MPI_SUCCESS:
         break;

--- a/src/mpi/pt2pt/waitall.c
+++ b/src/mpi/pt2pt/waitall.c
@@ -82,10 +82,8 @@ int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
 
     n_greqs = 0;
     n_completed = 0;
-    for (i = 0; i < count; i++)
-    {
-	if (request_ptrs[i] != NULL)
-	{
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] != NULL) {
             if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST)
                 ++n_greqs;
 
@@ -98,17 +96,14 @@ int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
                 disabled_anysource = TRUE;
             }
-	}
-	else
-	{
-	    n_completed += 1;
-	}
+        }
+        else {
+            n_completed += 1;
+        }
     }
-    
+
     if (n_completed == count)
-    {
-	goto fn_exit;
-    }
+        goto fn_exit;
 
     if (unlikely(disabled_anysource)) {
         mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
@@ -118,12 +113,11 @@ int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
     /* Grequest_waitall may run the progress engine - thus, we don't 
        invoke progress_start until after running Grequest_waitall */
     /* first, complete any generalized requests */
-    if (n_greqs)
-    {
+    if (n_greqs) {
         mpi_errno = MPIR_Grequest_waitall(count, request_ptrs);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
-    
+
     MPID_Progress_start(&progress_state);
 
     for (i = 0; i < count; i++)
@@ -134,13 +128,12 @@ int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
                 array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
             continue;
         }
-        
+
         /* wait for ith request to complete */
-        while (!MPIR_Request_is_complete(request_ptrs[i]))
-        {
+        while (!MPIR_Request_is_complete(request_ptrs[i])) {
             /* generalized requests should already be finished */
             MPIR_Assert(request_ptrs[i]->kind != MPIR_REQUEST_KIND__GREQUEST);
-            
+
             mpi_errno = MPID_Progress_wait(&progress_state);
             if (mpi_errno != MPI_SUCCESS) {
                 /* --BEGIN ERROR HANDLING-- */
@@ -198,8 +191,7 @@ int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
             continue;
         }
 
-        if (MPIR_Request_is_complete(request_ptrs[i]))
-        {
+        if (MPIR_Request_is_complete(request_ptrs[i])) {
             int active_flag;
             /* complete the request and check the status */
             status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
@@ -207,14 +199,11 @@ int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
             rc = MPIR_Request_complete(req_hndl_ptr, request_ptrs[i], status_ptr, &active_flag);
         }
 
-        if (rc == MPI_SUCCESS)
-        {
+        if (rc == MPI_SUCCESS) {
             request_ptrs[i] = NULL;
             if (!ignoring_statuses)
                 status_ptr->MPI_ERROR = MPI_SUCCESS;
-        }
-        else
-        {
+        } else {
             int proc_failure = FALSE;
 
             /* req completed with an error */
@@ -224,28 +213,21 @@ int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
                 proc_failure = TRUE;
 
             if (!ignoring_statuses)
-            {
-                /* set the error code for this request */
-                status_ptr->MPI_ERROR = rc;
+                break;
 
-                /* set the error codes for the rest of the uncompleted requests to PENDING */
-                for (j = i+1; j < count; ++j)
-                {
-                    if (!ignoring_statuses)
-                    {
-                        if (request_ptrs[j] == NULL)
-                        {
-                            /* either the user specified MPI_REQUEST_NULL, or this is a completed greq */
-                            array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
-                        }
-                        else
-                        {
-                            if (!proc_failure)
-                                array_of_statuses[j].MPI_ERROR = MPI_ERR_PENDING;
-                            else
-                                array_of_statuses[j].MPI_ERROR = MPIX_ERR_PROC_FAILED_PENDING;
-                        }
-                    }
+            /* set the error code for this request */
+            status_ptr->MPI_ERROR = rc;
+
+            /* set the error codes for the rest of the uncompleted requests to PENDING */
+            for (j = i+1; j < count; ++j) {
+                if (request_ptrs[j] == NULL) {
+                    /* either the user specified MPI_REQUEST_NULL, or this is a completed greq */
+                    array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
+                } else {
+                    if (!proc_failure)
+                        array_of_statuses[j].MPI_ERROR = MPI_ERR_PENDING;
+                    else
+                        array_of_statuses[j].MPI_ERROR = MPIX_ERR_PROC_FAILED_PENDING;
                 }
             }
             break;
@@ -295,8 +277,8 @@ program to unexecpectedly terminate or produce incorrect results.
 .N MPI_ERR_ARG
 .N MPI_ERR_IN_STATUS
 @*/
-int MPI_Waitall(int count, MPI_Request array_of_requests[], 
-		MPI_Status array_of_statuses[])
+int MPI_Waitall(int count, MPI_Request array_of_requests[],
+                MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
@@ -308,13 +290,13 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITALL);
 
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
-	MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
     } else {
         request_ptrs = request_ptr_array;
     }
@@ -324,19 +306,19 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_COUNT(count, mpi_errno);
+            MPIR_ERRTEST_COUNT(count, mpi_errno);
 
-	    if (count != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		/* NOTE: MPI_STATUSES_IGNORE != NULL */
-	    
-		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
-	    }
+            if (count != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                /* NOTE: MPI_STATUSES_IGNORE != NULL */
 
-	    for (i = 0; i < count; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
+                MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
+            }
+
+            for (i = 0; i < count; i++) {
+                MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+            }
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
@@ -410,10 +392,10 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
         goto fn_fail;
 
     /* ... end of body of routine ... */
-    
+
  fn_exit:
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-	MPIR_CHKLMEM_FREEALL();
+        MPIR_CHKLMEM_FREEALL();
 
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
@@ -423,11 +405,11 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
     mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE,
-				     FCNAME, __LINE__, MPI_ERR_OTHER,
-				     "**mpi_waitall",
-				     "**mpi_waitall %d %p %p",
-				     count, array_of_requests,
-				     array_of_statuses);
+                                     FCNAME, __LINE__, MPI_ERR_OTHER,
+                                     "**mpi_waitall",
+                                     "**mpi_waitall %d %p %p",
+                                     count, array_of_requests,
+                                     array_of_statuses);
 #endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);
     goto fn_exit;

--- a/src/mpi/pt2pt/waitall.c
+++ b/src/mpi/pt2pt/waitall.c
@@ -67,57 +67,25 @@ static inline int request_complete_fastpath(MPI_Request *request, MPIR_Request *
 #define FUNCNAME MPIR_Waitall_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
+int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
                       MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
-    MPIR_Request ** request_ptrs = request_ptr_array;
     MPI_Status * status_ptr;
     MPID_Progress_state progress_state;
-    int i, j;
+    int i;
     int n_completed;
-    int active_flag;
     int rc = MPI_SUCCESS;
     int n_greqs;
-    int proc_failure = FALSE;
     int disabled_anysource = FALSE;
     const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
-    int optimize = ignoring_statuses; /* see NOTE-O1 */
-    MPIR_CHKLMEM_DECL(1);
-
-    /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
-    }
 
     n_greqs = 0;
     n_completed = 0;
     for (i = 0; i < count; i++)
     {
-	if (array_of_requests[i] != MPI_REQUEST_NULL)
+	if (request_ptrs[i] != NULL)
 	{
-	    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-	    /* Validate object pointers if error checking is enabled */
-#           ifdef HAVE_ERROR_CHECKING
-	    {
-		MPID_BEGIN_ERROR_CHECKS;
-		{
-		    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-                    MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
-                                         mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d", i);
-		}
-		MPID_END_ERROR_CHECKS;
-	    }
-#           endif
-            if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
-                request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND)
-            {
-                optimize = FALSE;
-            }
-
             if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST)
                 ++n_greqs;
 
@@ -133,11 +101,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
 	}
 	else
 	{
-	    status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
-	    MPIR_Status_set_empty(status_ptr);
-	    request_ptrs[i] = NULL;
 	    n_completed += 1;
-            optimize = FALSE;
 	}
     }
     
@@ -150,43 +114,6 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
         mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
-
-    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
-     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
-     * out as many unnecessary jumps and error handling as possible.
-     *
-     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
-     * additional branch inside the for-loop below. */
-    if (optimize) {
-        MPID_Progress_start(&progress_state);
-        for (i = 0; i < count; ++i) {
-            while (!MPIR_Request_is_complete(request_ptrs[i])) {
-                mpi_errno = MPID_Progress_wait(&progress_state);
-                /* must check and handle the error, can't guard with HAVE_ERROR_CHECKING, but it's
-                 * OK for the error case to be slower */
-                if (unlikely(mpi_errno)) {
-                    /* --BEGIN ERROR HANDLING-- */
-                    if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                MPID_Request_is_anysource(request_ptrs[i]) &&
-                                !MPIR_Request_is_complete(request_ptrs[i]) &&
-                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                        MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
-                    }
-                    MPID_Progress_end(&progress_state);
-                    MPIR_ERR_POP(mpi_errno);
-                    /* --END ERROR HANDLING-- */
-                }
-            }
-            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        }
-
-        MPID_Progress_end(&progress_state);
-
-        goto fn_exit;
-    }
-
-    /* ------ "slow" code path below ------ */
 
     /* Grequest_waitall may run the progress engine - thus, we don't 
        invoke progress_start until after running Grequest_waitall */
@@ -229,15 +156,55 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
                 MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                 status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
                 if (status_ptr != MPI_STATUS_IGNORE) status_ptr->MPI_ERROR = mpi_errno;
-                proc_failure = TRUE;
-                break;
+                mpi_errno = rc;
+                goto fn_fail;
             }
         }
+    }
+    MPID_Progress_end(&progress_state);
 
-        if (MPIR_Request_is_complete(request_ptrs[i])) {
+ fn_exit:
+
+   return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
+#endif
+
+/*
+  Post-processing of MPI_Waitall
+  Setting statuses, freeing requests objects, etc.
+*/
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitall_post
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request *request_ptrs[],
+                      MPI_Status array_of_statuses[])
+{
+    int i, j;
+    int mpi_errno = MPI_SUCCESS;
+    int rc = MPI_SUCCESS;
+    const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
+    MPI_Status *status_ptr;
+    MPI_Request *req_hndl_ptr;
+
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] == NULL) {
+            if (!ignoring_statuses)
+                array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            continue;
+        }
+
+        if (MPIR_Request_is_complete(request_ptrs[i]))
+        {
+            int active_flag;
             /* complete the request and check the status */
             status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
-            rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
+            req_hndl_ptr = array_of_requests ? &array_of_requests[i] : NULL;
+            rc = MPIR_Request_complete(req_hndl_ptr, request_ptrs[i], status_ptr, &active_flag);
         }
 
         if (rc == MPI_SUCCESS)
@@ -248,13 +215,13 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
         }
         else
         {
+            int proc_failure = FALSE;
+
             /* req completed with an error */
             MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
 
-            if (!proc_failure) {
-                if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
-                    proc_failure = TRUE;
-            }
+            if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
+                proc_failure = TRUE;
 
             if (!ignoring_statuses)
             {
@@ -284,20 +251,9 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
             break;
         }
     }
-    MPID_Progress_end(&progress_state);
-        
- fn_exit:
-     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
-    }
 
-   return mpi_errno;
- fn_fail:
-    goto fn_exit;
+    return mpi_errno;
 }
-
-#endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitall
@@ -343,6 +299,12 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
 		MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
+    MPIR_Request ** request_ptrs = NULL;
+    MPI_Status *status_ptr;
+    int optimize = (array_of_statuses == MPI_STATUSES_IGNORE); /* see NOTE-O1 */
+    int i;
+    MPIR_CHKLMEM_DECL(1);
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -350,12 +312,18 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITALL);
 
+    /* Convert MPI request handles to a request object pointers */
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+	MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers");
+    } else {
+        request_ptrs = request_ptr_array;
+    }
+
     /* Check the arguments */
 #   ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            int i;
 	    MPIR_ERRTEST_COUNT(count, mpi_errno);
 
 	    if (count != 0) {
@@ -372,15 +340,81 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Waitall_impl(count, array_of_requests, array_of_statuses);
-    if (mpi_errno) goto fn_fail;
+    /* Translate array-of-request-handles to array-of-request-pointers */
+    for (i = 0; i < count; i++) {
+        if (array_of_requests[i] == MPI_REQUEST_NULL) {
+            request_ptrs[i] = NULL;
+            status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
+            MPIR_Status_set_empty(status_ptr);
+            optimize = FALSE;
+            continue;
+        }
+        MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+        /* Validate object pointers if error checking is enabled */
+#       ifdef HAVE_ERROR_CHECKING
+        {
+            MPID_BEGIN_ERROR_CHECKS;
+            {
+                MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
+                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
+                                     mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d", i);
+            }
+            MPID_END_ERROR_CHECKS;
+        }
+#       endif
+
+        /* Message rate optimization applies only to send/recv requests */
+        if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
+            request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND)
+            optimize = FALSE;
+    }
+
+    /* Make progress and wait for completion */
+    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    switch (mpi_errno) {
+    case MPI_SUCCESS:
+        break;
+
+    case MPIX_ERR_PROC_FAILED_PENDING:
+        optimize = FALSE;
+        break;
+
+    default:
+        goto fn_fail;
+    }
+
+    /* Free completed request objects */
+
+    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
+     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
+     * out as many unnecessary jumps and error handling as possible.
+     *
+     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
+     * additional branch inside the for-loop below. */
+    if (optimize) {
+        for (i = 0; i < count; i++) {
+            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+        goto fn_exit;
+    }
+
+    /* ------ "slow" code path below ------ */
+    mpi_errno = MPIR_Waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
+    if (mpi_errno)
+        goto fn_fail;
 
     /* ... end of body of routine ... */
     
  fn_exit:
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
+	MPIR_CHKLMEM_FREEALL();
+
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;

--- a/src/mpi/topo/nhb_allgather.c
+++ b/src/mpi/topo/nhb_allgather.c
@@ -36,11 +36,17 @@ int MPIR_Neighbor_allgather_default(const void *sendbuf, int sendcount, MPI_Data
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req;
+    MPIR_Request *req_ptr;
+    int active_flag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPID_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    MPIR_Assert(req != MPI_REQUEST_NULL);
+    MPIR_Request_get_ptr(req, req_ptr);
+    mpi_errno = MPIR_Wait_impl(req_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 fn_exit:

--- a/src/mpi/topo/nhb_allgatherv.c
+++ b/src/mpi/topo/nhb_allgatherv.c
@@ -38,13 +38,18 @@ int MPIR_Neighbor_allgatherv_default(const void *sendbuf, int sendcount, MPI_Dat
     int mpi_errno = MPI_SUCCESS;
 
     MPI_Request req;
+    MPIR_Request *req_ptr;
+    int active_flag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPID_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcounts, displs, recvtype,
                                                comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    MPIR_Assert(req != MPI_REQUEST_NULL);
+    mpi_errno = MPIR_Wait_impl(req, MPI_STATUS_IGNORE);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 fn_exit:

--- a/src/mpi/topo/nhb_allgatherv.c
+++ b/src/mpi/topo/nhb_allgatherv.c
@@ -47,7 +47,8 @@ int MPIR_Neighbor_allgatherv_default(const void *sendbuf, int sendcount, MPI_Dat
                                                comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     MPIR_Assert(req != MPI_REQUEST_NULL);
-    mpi_errno = MPIR_Wait_impl(req, MPI_STATUS_IGNORE);
+    MPIR_Request_get_ptr(req, req_ptr);
+    mpi_errno = MPIR_Wait_impl(req_ptr, MPI_STATUS_IGNORE);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/topo/nhb_alltoall.c
+++ b/src/mpi/topo/nhb_alltoall.c
@@ -36,13 +36,19 @@ int MPIR_Neighbor_alltoall_default(const void *sendbuf, int sendcount, MPI_Datat
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req;
+    MPIR_Request *req_ptr;
+    int active_flag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPID_Ineighbor_alltoall(sendbuf, sendcount, sendtype,
                                              recvbuf, recvcount, recvtype,
                                              comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_Assert(req != MPI_REQUEST_NULL);
+    MPIR_Request_get_ptr(req, req_ptr);
     mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 fn_exit:

--- a/src/mpi/topo/nhb_alltoallv.c
+++ b/src/mpi/topo/nhb_alltoallv.c
@@ -37,11 +37,17 @@ int MPIR_Neighbor_alltoallv_default(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req;
+    MPIR_Request *req_ptr;
+    int active_flag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPID_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    MPIR_Assert(req != MPI_REQUEST_NULL);
+    MPIR_Request_get_ptr(req, req_ptr);
+    mpi_errno = MPIR_Wait_impl(req_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 fn_exit:

--- a/src/mpi/topo/nhb_alltoallw.c
+++ b/src/mpi/topo/nhb_alltoallw.c
@@ -36,11 +36,17 @@ int MPIR_Neighbor_alltoallw_default(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req;
+    MPIR_Request *req_ptr;
+    int active_flag;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPID_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, &req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    MPIR_Assert(req != MPI_REQUEST_NULL);
+    MPIR_Request_get_ptr(req, req_ptr);
+    mpi_errno = MPIR_Wait_impl(req_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req, req_ptr, MPI_STATUS_IGNORE, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
 fn_exit:

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -178,6 +178,10 @@ int MPIDI_CH3_Comm_connect(char * port_name, int root, MPIR_Comm * comm_ptr,
  * Device level MPI wait/test functions
  */
 #define MPID_Wait MPIR_Wait_impl
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
 
 /* Dynamic process support */
 int MPIDI_GPID_GetAllInComm( MPIR_Comm *comm_ptr, int local_size,

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -174,6 +174,11 @@ int MPIDI_CH3_Comm_connect(char * port_name, int root, MPIR_Comm * comm_ptr,
 #define MPID_Progress_test()                 MPIDI_CH3_Progress_test()
 #define MPID_Progress_poke()		     MPIDI_CH3_Progress_poke()
 
+/*
+ * Device level MPI wait/test functions
+ */
+#define MPID_Wait MPIR_Wait_impl
+
 /* Dynamic process support */
 int MPIDI_GPID_GetAllInComm( MPIR_Comm *comm_ptr, int local_size,
                              MPIDI_Gpid local_gpids[], int *singlePG );

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -178,6 +178,7 @@ int MPIDI_CH3_Comm_connect(char * port_name, int root, MPIR_Comm * comm_ptr,
  * Device level MPI wait/test functions
  */
 #define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_impl
 #define MPID_Test MPIR_Test_impl
 #define MPID_Testall MPIR_Testall_impl
 #define MPID_Testany MPIR_Testany_impl

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -733,7 +733,7 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
     win_ptr->at_completion_counter += post_grp_ptr->size;
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
-        MPI_Request *req;
+        MPIR_Request **req_ptrs;
         MPI_Status *status;
         int i, post_grp_size, dst, rank;
         MPIR_Comm *win_comm_ptr;
@@ -751,8 +751,8 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
-        MPIR_CHKLMEM_MALLOC(req, MPI_Request *, post_grp_size * sizeof(MPI_Request),
-                            mpi_errno, "req");
+        MPIR_CHKLMEM_MALLOC(req_ptrs, MPIR_Request **, post_grp_size * sizeof(MPIR_Request *),
+                            mpi_errno, "req_ptrs");
         MPIR_CHKLMEM_MALLOC(status, MPI_Status *, post_grp_size * sizeof(MPI_Status),
                             mpi_errno, "status");
 
@@ -761,19 +761,20 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
             dst = post_ranks_in_win_grp[i];
 
             if (dst != rank) {
-                MPIR_Request *req_ptr;
                 mpi_errno = MPID_Isend(&i, 0, MPI_INT, dst, SYNC_POST_TAG, win_comm_ptr,
-                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptr);
+                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptrs[i]);
                 if (mpi_errno != MPI_SUCCESS)
                     MPIR_ERR_POP(mpi_errno);
-                req[i] = req_ptr->handle;
             }
             else {
-                req[i] = MPI_REQUEST_NULL;
+                req_ptrs[i] = NULL;
             }
         }
 
-        mpi_errno = MPIR_Waitall_impl(post_grp_size, req, status);
+        mpi_errno = MPIR_Waitall_impl(post_grp_size, req_ptrs, status);
+        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIR_Waitall_post(post_grp_size, NULL, req_ptrs, status);
         if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
             MPIR_ERR_POP(mpi_errno);
 
@@ -867,7 +868,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
         int i, intra_cnt;
-        MPI_Request *intra_start_req = NULL;
+        MPIR_Request **intra_start_req = NULL;
         MPI_Status *intra_start_status = NULL;
         MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
         int rank = comm_ptr->rank;
@@ -877,8 +878,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
         /* post IRECVs */
         if (win_ptr->shm_allocated == TRUE) {
             int node_comm_size = comm_ptr->node_comm->local_size;
-            MPIR_CHKLMEM_MALLOC(intra_start_req, MPI_Request *,
-                                node_comm_size * sizeof(MPI_Request), mpi_errno, "intra_start_req");
+            MPIR_CHKLMEM_MALLOC(intra_start_req, MPIR_Request **,
+                                node_comm_size * sizeof(MPIR_Request *), mpi_errno, "intra_start_req");
             MPIR_CHKLMEM_MALLOC(intra_start_status, MPI_Status *,
                                 node_comm_size * sizeof(MPI_Status),
                                 mpi_errno, "intra_start_status");
@@ -900,7 +901,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
                     MPIR_ERR_POP(mpi_errno);
 
                 if (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id) {
-                    intra_start_req[intra_cnt++] = req_ptr->handle;
+                    intra_start_req[intra_cnt++] = req_ptr;
                 }
                 else {
                     if (!MPIR_Request_is_complete(req_ptr)) {
@@ -919,6 +920,10 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
             mpi_errno = MPIR_Waitall_impl(intra_cnt, intra_start_req, intra_start_status);
             if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
                 MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIR_Waitall_post(intra_cnt, NULL, intra_start_req, intra_start_status);
+            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+                MPIR_ERR_POP(mpi_errno);
+
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno == MPI_ERR_IN_STATUS) {
                 for (i = 0; i < intra_cnt; i++) {

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -208,4 +208,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
     return mpi_errno;
 }
 
+/* Device level wait/test implementations */
+#define MPID_Wait MPIR_Wait_impl
+
 #endif /* CH4_PROGRESS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -13,6 +13,11 @@
 
 #include "ch4_impl.h"
 
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
+
 #undef FUNCNAME
 #define FUNCNAME MPID_Progress_test
 #undef FCNAME

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -215,5 +215,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
 
 /* Device level wait/test implementations */
 #define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_impl
 
 #endif /* CH4_PROGRESS_H_INCLUDED */


### PR DESCRIPTION
**DO NOT MERGE**

This is a demonstration of the new way to handle MPI_Wait/Test functions. MPI layer will call MPID wait/test functions, so a device (or perhaps netmod) can choose how to implement wait/test functions in the best efficient way. If a device does not bother to implement any special functionality, it can simply call MPIR functions (e.g. `MPIR_Wait_impl`), which are the current implementations.

This is just to make sure we agree on the way we are going. Can you take a quick look on this? @raffenet @halimamer @michael-chuvelev
If this makes sense, I'll work on other functions (Waitall, Test, ...) and other CH4 netmods.
