### PR TITLE
Revert "operate on unsigned before casting to int"

### DIFF
--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -546,7 +546,7 @@ fn_fail:
 void MPIDI_PG_IdToNum( MPIDI_PG_t *pg, int *id )
 {
     const char *p = (const char *)pg->id;
-    unsigned int pgid = 0;
+    int pgid = 0;
 
     while (*p) {
         pgid += *p++;


### PR DESCRIPTION
Reverts pmodels/mpich#2705, change not signed off