### PR TITLE
CH4/OFI: Remove FI_MULTI_RECV for single receive operation

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1322,7 +1322,6 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
 
         rx_attr = *prov_use->rx_attr;
         rx_attr.caps = 0;
-        rx_attr.op_flags = FI_MULTI_RECV;
 
         if (MPIDI_OFI_ENABLE_TAGGED)
             rx_attr.caps |= FI_TAGGED | FI_RECV;


### PR DESCRIPTION
When setting rx_attr.op_flags = FI_MULTI_RECV, every single receive operation will be treated as a FI_MULTI_RECV buffer. This is unnecessary.