### PR TITLE
CH4/OFI: Create one VNI by default

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -778,9 +778,10 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
 
     MPIDI_Global.max_ch4_vnis = 1;
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        MPIDI_Global.max_ch4_vnis = prov_use->domain_attr->tx_ctx_cnt;
-        if (MPIR_CVAR_CH4_OFI_MAX_VNIS > 0 && MPIDI_Global.max_ch4_vnis > MPIR_CVAR_CH4_OFI_MAX_VNIS)
-            MPIDI_Global.max_ch4_vnis = MPIR_CVAR_CH4_OFI_MAX_VNIS;
+        int max_by_prov = MPL_MIN(prov_use->domain_attr->tx_ctx_cnt,
+                                  prov_use->domain_attr->rx_ctx_cnt);
+        if (MPIR_CVAR_CH4_OFI_MAX_VNIS > 0)
+            MPIDI_Global.max_ch4_vnis = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_VNIS, max_by_prov);
         if (MPIDI_Global.max_ch4_vnis < 1) {
             MPIR_ERR_SETFATALANDJUMP4(mpi_errno,
                                       MPI_ERR_OTHER,


### PR DESCRIPTION
Current logic for determining the number of VNIs created may end up
claiming all available contexts in the hardware.
This patch changes the default number of VNIs to one.
A user may set MPIR_CVAR_CH4_OFI_MAX_VNIS for more VNIs.

Reviewed-by: Rubasri Kalidas <rubasri.kalidas@intel.com>
Reviewed-by: Chongxiao Cao <chongxiao.cao@intel.com>