### PR TITLE
autogen: use relative path for cxx.vlist

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -736,7 +736,7 @@ if [ $do_bindings = "yes" ] ; then
     if [ $build_cxx = "yes" ] ; then
 	echo_n "Building C++ interface... "
 	( cd src/binding/cxx && chmod a+x ./buildiface &&
-	  ./buildiface -nosep -initfile=cxx.vlist )
+	  ./buildiface -nosep -initfile=./cxx.vlist )
 	echo "done"
     fi
 fi


### PR DESCRIPTION
This is a follow up patch to 3baf0def6e42.