### PR TITLE
mtest: Enable spaiccreate2

### DIFF
--- a/test/mpi/spawn/testlist.in
+++ b/test/mpi/spawn/testlist.in
@@ -12,6 +12,7 @@ spaconacc 1
 spaconacc2 1
 selfconacc 2
 spaiccreate 2
+spaiccreate2 2
 taskmaster 1 timeLimit=600
 taskmaster 2 timeLimit=600
 join 2


### PR DESCRIPTION
test/mpi/spawn/spaiccreate2 existed but not listed in testlist.