### PR TITLE
test Fortran KIND with requested flags

### DIFF
--- a/confdb/aclocal_romio.m4
+++ b/confdb/aclocal_romio.m4
@@ -579,7 +579,7 @@ if test -z "$FC" ; then
    FC=f90
 fi
 KINDVAL=""
-if $FC -o conftest$EXEEXT conftest.$ac_f90ext >/dev/null 2>&1 ; then
+if $FC -o conftest$EXEEXT conftest.$ac_f90ext $FCFLAGS >/dev/null 2>&1 ; then
     ./conftest$EXEEXT >/dev/null 2>&1
     if test -s conftest.out ; then 
         KINDVAL=`cat conftest.out`
@@ -702,7 +702,7 @@ if test -z "$FC" ; then
    FC=f90
 fi
 KINDVAL=""
-if $FC -o kind$EXEEXT kind.f >/dev/null 2>&1 ; then
+if $FC -o kind$EXEEXT kind.f $FCFLAGS >/dev/null 2>&1 ; then
     ./kind >/dev/null 2>&1
     if test -s k.out ; then 
         KINDVAL=`cat k.out`


### PR DESCRIPTION
We need to use FFLAGS in order to test for "kind-ness" the way the rest
of ROMIO will be built.

Thanks for reporting the bug, Kurt Glaesemann <Kurt.Glaesemann@pnnl.gov>