### PR TITLE
autogen: avoid running find on the whole tree

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -589,7 +589,7 @@ fi
 ########################################################################
 
 echo_n "Checking for UNIX find... "
-find . -name 'configure.ac' > /dev/null 2>&1
+find ./maint -name 'configure.ac' > /dev/null 2>&1
 if [ $? = 0 ] ; then
     echo "done"
 else
@@ -603,17 +603,17 @@ fi
 ########################################################################
 
 echo_n "Checking if xargs rm -rf works... "
-if [ -d "`find . -name __random_dir__`" ] ; then
+if [ -d "`find ./maint -name __random_dir__`" ] ; then
     error "found a directory named __random_dir__"
     exit 1
 else
-    mkdir __random_dir__
-    find . -name __random_dir__ | xargs rm -rf > /dev/null 2>&1
+    mkdir ./maint/__random_dir__
+    find ./maint -name __random_dir__ | xargs rm -rf > /dev/null 2>&1
     if [ $? = 0 ] ; then
 	echo "yes"
     else
 	echo "no (error)"
-	rm -rf __random_dir__
+	rm -rf ./maint/__random_dir__
 	exit 1
     fi
 fi


### PR DESCRIPTION
In order to detect whether find and xargs are supported on the target
platform, autogen.sh runs the find command on the whole MPICH
directory ("."). This is overfill as we only want to detect that those
features exist. On some platforms (e.g., with NFS), this step can take
very a long time. This patch solves this issue by reducing the scope
of find to the ./maint directory.