### PR TITLE
romio/adio: add support for DDN's Infinite Memory Engine (IME)

### DIFF
--- a/src/mpi/romio/adio/Makefile.mk
+++ b/src/mpi/romio/adio/Makefile.mk
@@ -35,5 +35,6 @@ include $(top_srcdir)/adio/ad_pvfs2/Makefile.mk
 include $(top_srcdir)/adio/ad_testfs/Makefile.mk
 include $(top_srcdir)/adio/ad_ufs/Makefile.mk
 include $(top_srcdir)/adio/ad_xfs/Makefile.mk
+include $(top_srcdir)/adio/ad_ime/Makefile.mk
 include $(top_srcdir)/adio/common/Makefile.mk
 

--- a/src/mpi/romio/adio/ad_ime/Makefile.mk
+++ b/src/mpi/romio/adio/ad_ime/Makefile.mk
@@ -1,0 +1,25 @@
+## -*- Mode: Makefile; -*-
+## vim: set ft=automake :
+##
+## (C) 2017 by DataDirect Networks
+##     See COPYRIGHT in top-level directory.
+##
+
+if BUILD_AD_IME
+
+noinst_HEADERS += adio/ad_ime/ad_ime.h adio/ad_ime/ad_ime_common.h
+
+romio_other_sources +=                    \
+    adio/ad_ime/ad_ime.c            \
+    adio/ad_ime/ad_ime_close.c      \
+    adio/ad_ime/ad_ime_common.c     \
+    adio/ad_ime/ad_ime_delete.c     \
+    adio/ad_ime/ad_ime_fcntl.c      \
+    adio/ad_ime/ad_ime_flush.c      \
+    adio/ad_ime/ad_ime_io.c         \
+    adio/ad_ime/ad_ime_open.c       \
+    adio/ad_ime/ad_ime_resize.c     \
+    adio/ad_ime/ad_ime_features.c
+
+endif BUILD_AD_IME
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime.c
@@ -1,0 +1,41 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+
+/* adioi.h has the ADIOI_Fns_struct define */
+#include "adioi.h"
+
+struct ADIOI_Fns_struct ADIO_IME_operations = {
+    ADIOI_IME_Open, /* Open */
+    ADIOI_SCALEABLE_OpenColl, /* OpenColl */ /*XXX*/
+    ADIOI_IME_ReadContig, /* ReadContig */
+    ADIOI_IME_WriteContig, /* WriteContig */
+    ADIOI_GEN_ReadStridedColl, /* ReadStridedColl */
+    ADIOI_GEN_WriteStridedColl, /* WriteStridedColl */
+    ADIOI_GEN_SeekIndividual, /* SeekIndividual */
+    ADIOI_IME_Fcntl, /* Fcntl */
+    ADIOI_GEN_SetInfo, /* SetInfo */
+    ADIOI_GEN_ReadStrided, /* ReadStrided */
+    ADIOI_GEN_WriteStrided, /* WriteStrided */
+    ADIOI_IME_Close, /* Close */
+    ADIOI_FAKE_IreadContig, /* IreadContig */
+    ADIOI_FAKE_IwriteContig, /* IwriteContig */
+    ADIOI_FAKE_IODone, /* ReadDone */
+    ADIOI_FAKE_IODone, /* WriteDone */
+    ADIOI_FAKE_IOComplete, /* ReadComplete */
+    ADIOI_FAKE_IOComplete, /* WriteComplete */
+    ADIOI_FAKE_IreadStrided, /* IreadStrided */
+    ADIOI_FAKE_IwriteStrided, /* IwriteStrided */
+    ADIOI_IME_Flush, /* Flush */
+    ADIOI_IME_Resize, /* Resize */
+    ADIOI_IME_Delete, /* Delete */
+    ADIOI_IME_Feature,
+    ADIOI_IME_PREFIX,
+};
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime.h
+++ b/src/mpi/romio/adio/ad_ime/ad_ime.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#ifndef AD_IME_INCLUDE
+#define AD_IME_INCLUDE
+
+#include "adio.h"
+#ifdef HAVE_IME_NATIVE_H
+#include "ime_native.h"
+#endif
+
+#define ADIOI_IME_PREFIX        "ime:"
+#define ADIOI_IME_PREFIX_LEN    (sizeof(ADIOI_IME_PREFIX) - 1)
+
+void ADIOI_IME_Open(ADIO_File fd,
+                   int *error_code);
+
+void ADIOI_IME_Close(ADIO_File fd,
+                    int *error_code);
+
+void ADIOI_IME_ReadContig(ADIO_File fd,
+                         void *buf,
+                         int count,
+                         MPI_Datatype datatype,
+                         int file_ptr_type,
+                         ADIO_Offset offset,
+                         ADIO_Status *status,
+                         int *error_code);
+
+void ADIOI_IME_WriteContig(ADIO_File fd,
+                          const void *buf,
+                          int count,
+                          MPI_Datatype datatype,
+                          int file_ptr_type,
+                          ADIO_Offset offset,
+                          ADIO_Status *status,
+                          int *error_code);
+
+void ADIOI_IME_Fcntl(ADIO_File fd,
+                    int flag,
+                    ADIO_Fcntl_t *fcntl_struct,
+                    int *error_code);
+
+void ADIOI_IME_Flush(ADIO_File fd,
+                    int *error_code);
+
+void ADIOI_IME_Delete(const char *filename,
+                     int *error_code);
+
+void ADIOI_IME_Resize(ADIO_File fd,
+                     ADIO_Offset size,
+                     int *error_code);
+
+void ADIOI_IME_SetInfo(ADIO_File fd,
+                      MPI_Info users_info,
+                      int *error_code);
+
+int  ADIOI_IME_Feature(ADIO_File fd,
+                      int flag);
+#endif

--- a/src/mpi/romio/adio/ad_ime/ad_ime_close.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_close.c
@@ -1,0 +1,47 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "ad_ime_common.h"
+#include <assert.h>
+
+void ADIOI_IME_Close(ADIO_File fd, int *error_code)
+{
+    static char myname[] = "ADIOI_IME_CLOSE";
+    int ret;
+    struct ADIOI_IME_fs_s *ime_fs;
+    int tmp_error_code;
+
+    ret = ime_native_close(fd->fd_sys);
+    if (ret != 0)
+    {
+        tmp_error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                       MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_UNKNOWN,
+                                       "Error in ime_native_close", 0);
+    } else {
+        tmp_error_code = MPI_SUCCESS;
+    }
+
+    if (error_code)
+    {
+    *   error_code = tmp_error_code;
+    }
+
+    ime_fs = (ADIOI_IME_fs *) fd->fs_ptr;
+    assert(ime_fs);
+    ADIOI_Free(ime_fs->ime_filename);
+    ime_fs->ime_filename = NULL;
+    ADIOI_Free(ime_fs);
+
+    /* reset fds */
+    fd->fd_direct = -1;
+    fd->fd_sys = -1;
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_common.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_common.c
@@ -1,0 +1,95 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "ad_ime_common.h"
+#include <unistd.h>
+#include <sys/types.h>
+
+/* keyval hack to both tell us if we've already initialized im and also
+ * close it down when mpi exits */
+int ADIOI_IME_Initialized = MPI_KEYVAL_INVALID;
+
+void ADIOI_IME_End(int *error_code)
+{
+    int ret;
+    static char myname[] = "ADIOI_IME_END";
+
+    ret = ime_native_finalize();
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (ret != 0)
+    {
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                       MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_FILE,
+                                       "Error in ime_native_finalize", 0);
+        return;
+    }
+    /* --END ERROR HANDLING-- */
+
+    *error_code = MPI_SUCCESS;
+}
+
+int ADIOI_IME_End_call(MPI_Comm comm,
+                      int keyval,
+                      void *attribute_val,
+                      void *extra_state)
+{
+    int error_code;
+    ADIOI_IME_End(&error_code);
+    MPI_Keyval_free(&keyval);
+    return error_code;
+}
+
+void ADIOI_IME_Init(int rank, int *error_code )
+{
+    /* do nothing if we've already fired up the im interface */
+    if (ADIOI_IME_Initialized != MPI_KEYVAL_INVALID) {
+        *error_code = MPI_SUCCESS;
+        return;
+    }
+
+    ime_native_init();
+
+    *error_code = MPI_SUCCESS;
+
+    MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_IME_End_call,
+                      &ADIOI_IME_Initialized, (void *)0);
+    /* just like romio does, we make a dummy attribute so we
+     * get cleaned up */
+    MPI_Attr_put(MPI_COMM_SELF, ADIOI_IME_Initialized, (void *)0);
+}
+
+/* Return an IME-compatible filename (add 'ime:' prefix).
+ * New filename must be free'd by the user */
+char *ADIOI_IME_Add_prefix(const char *filename)
+{
+    static char myname[] = "ADIOI_IME_ADD_PREFIX";
+    size_t f_len = strlen(filename) + 1;
+    char *ime_filename = ADIOI_Malloc(f_len + ADIOI_IME_PREFIX_LEN);
+
+    if (!ime_filename)
+    {
+
+        MPIO_Err_create_code(MPI_SUCCESS,
+                 MPIR_ERR_FATAL,
+                 myname, __LINE__,
+                 MPI_ERR_UNKNOWN,
+                 "Error allocating memory", 0);
+
+        return NULL;
+    }
+
+    ADIOI_Strncpy(ime_filename, ADIOI_IME_PREFIX, ADIOI_IME_PREFIX_LEN);
+    ADIOI_Strncpy((ime_filename + ADIOI_IME_PREFIX_LEN),
+        filename, f_len);
+    return ime_filename;
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_common.h
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_common.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#ifndef _AD_IME_COMMON_H
+#define _AD_IME_COMMON_H
+#include "ad_ime.h"
+
+struct ADIOI_IME_fs_s {
+     char *ime_filename;
+} ADIOI_IME_fs_s;
+
+typedef struct ADIOI_IME_fs_s ADIOI_IME_fs;
+
+void ADIOI_IME_Init(int rank,
+                   int *error_code );
+void ADIOI_IME_End(int *error_code);
+int ADIOI_IME_End_call(MPI_Comm comm,
+                      int keyval,
+                      void *attribute_val,
+                      void *extra_state);
+
+char *ADIOI_IME_Add_prefix(const char *filename);
+#endif

--- a/src/mpi/romio/adio/ad_ime/ad_ime_delete.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_delete.c
@@ -1,0 +1,33 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "adio.h"
+
+#include "ad_ime_common.h"
+
+void ADIOI_IME_Delete(const char *filename, int *error_code)
+{
+    int ret;
+    static char myname[] = "ADIOI_IME_DELETE";
+
+    char *ime_filename = ADIOI_IME_Add_prefix(filename);
+    ret = ime_native_unlink(ime_filename);
+    ADIOI_Free(ime_filename);
+    if (ret)
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                 MPIR_ERR_RECOVERABLE,
+                 myname, __LINE__,
+                 MPI_ERR_FILE,
+                 "Error in ime_native_unlink", 0);
+    else
+        *error_code = MPI_SUCCESS;
+
+    return;
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_fcntl.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_fcntl.c
@@ -1,0 +1,63 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "adio_extern.h"
+#include "ad_ime_common.h"
+#include <assert.h>
+
+void ADIOI_IME_Fcntl(ADIO_File fd,
+                    int flag,
+                    ADIO_Fcntl_t *fcntl_struct,
+                            int *error_code)
+{
+    int ret;
+    static char myname[] = "ADIOI_IME_FCNTL";
+
+    switch(flag)
+    {
+        case ADIO_FCNTL_GET_FSIZE:
+        {
+            struct stat stbuf;
+
+            stbuf.st_size = 0;
+            struct ADIOI_IME_fs_s *ime_fs = (ADIOI_IME_fs *) fd->fs_ptr;
+            assert(ime_fs);
+            ret = ime_native_stat(ime_fs->ime_filename, &stbuf);
+
+            if (ret)
+            {
+                *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                    MPIR_ERR_RECOVERABLE,
+                                    myname, __LINE__,
+                                    MPI_ERR_FILE,
+                                    "Error in ime_native_stat", 0);
+                return;
+            }
+
+            fcntl_struct->fsize = stbuf.st_size;
+            *error_code = MPI_SUCCESS;
+            break;
+        }
+        case ADIO_FCNTL_SET_DISKSPACE:
+            ADIOI_GEN_Prealloc(fd,
+                               fcntl_struct->diskspace,
+                               error_code);
+            break;
+
+        case ADIO_FCNTL_SET_ATOMICITY:
+        default:
+            *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                           MPIR_ERR_RECOVERABLE,
+                                           myname, __LINE__,
+                                           MPI_ERR_ARG,
+                                           "**flag", "**flag %d", flag);
+            break;
+    };
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_features.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_features.c
@@ -1,0 +1,23 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+#include "adio.h"
+#include "ad_ime.h"
+
+int ADIOI_IME_Feature(ADIO_File fd, int flag)
+{
+    switch(flag) {
+        case ADIO_SCALABLE_OPEN:
+        case ADIO_SHARED_FP:
+        case ADIO_LOCKS:
+        case ADIO_SEQUENTIAL:
+        case ADIO_DATA_SIEVING_WRITES:
+        default:
+            return 0;
+    }
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_flush.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_flush.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "ad_ime_common.h"
+
+#include <assert.h>
+
+void ADIOI_IME_Flush(ADIO_File fd, int *error_code)
+{
+    int ret;
+    static char myname[] = "ADIOI_IME_FLUSH";
+
+    if (!error_code)
+    {
+        return;
+    }
+
+    if (!fd)
+    {
+        *error_code = MPI_ERR_FILE;
+        return;
+    }
+
+    ret = ime_native_fsync(fd->fd_sys);
+    if (ret != 0)
+    {
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                           MPIR_ERR_RECOVERABLE,
+                                           myname, __LINE__,
+                                           MPI_ERR_FILE,
+                                           "Error in ime_native_fsync", 0);
+        return;
+    }
+
+    *error_code = MPI_SUCCESS;
+
+    return;
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_io.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_io.c
@@ -1,0 +1,129 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*-
+ *
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "adio.h"
+#include "adio_extern.h"
+#include "ad_ime.h"
+
+#include "ad_ime_common.h"
+
+#include <stdint.h>
+
+#define IME_READ 0
+#define IME_WRITE 1
+
+static void IME_IOContig(ADIO_File fd,
+                        void *buf,
+                        int count,
+                        MPI_Datatype datatype,
+                        int file_ptr_type,
+                        ADIO_Offset offset,
+                        ADIO_Status *status,
+                        int io_flag,
+                        int *error_code)
+{
+    ssize_t ret;
+    MPI_Count datatype_size;
+    size_t mem_len;
+    uint64_t file_offset = offset;
+    static char myname[] = "ADIOI_IME_IOCONTIG";
+
+    MPI_Type_size_x(datatype, &datatype_size);
+    mem_len = datatype_size * count;
+
+    if (file_ptr_type == ADIO_INDIVIDUAL)
+            file_offset = fd->fp_ind;
+
+    switch(io_flag)
+    {
+        case IME_READ:
+            ret = ime_native_pread(fd->fd_sys,
+                           buf,
+                           mem_len,
+                           offset);
+            break;
+        case IME_WRITE:
+            ret = ime_native_pwrite(fd->fd_sys,
+                            buf,
+                            mem_len,
+                            offset);
+            break;
+        default:
+            *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                               MPIR_ERR_RECOVERABLE,
+                                               myname,
+                                               __LINE__,
+                                               MPI_ERR_IO,
+                                               "Unknown flag",
+                                               0);
+            goto exit;
+
+            break;
+    };
+
+    /* Let the application decide how to fail */
+    if (ret < 0)
+    {
+        *error_code = MPI_SUCCESS;
+        goto exit;
+    }
+
+    if (file_ptr_type == ADIO_INDIVIDUAL)
+        fd->fp_ind += ret;
+    fd->fp_sys_posn = file_offset + ret;
+
+#ifdef HAVE_STATUS_SET_BYTES
+    MPIR_Status_set_bytes(status, datatype, ret);
+#endif
+
+    *error_code = MPI_SUCCESS;
+
+exit:
+    return;
+}
+
+void ADIOI_IME_ReadContig(ADIO_File fd,
+                         void *buf,
+                         int count,
+                         MPI_Datatype datatype,
+                         int file_ptr_type,
+                         ADIO_Offset offset,
+                         ADIO_Status *status,
+                         int *error_code)
+{
+    IME_IOContig(fd,
+                buf,
+                count,
+                datatype,
+                file_ptr_type,
+                offset,
+                status,
+                IME_READ,
+                error_code);
+}
+
+void ADIOI_IME_WriteContig(ADIO_File fd,
+                          const void *buf,
+                          int count,
+                          MPI_Datatype datatype,
+                          int file_ptr_type,
+                          ADIO_Offset offset,
+                          ADIO_Status *status,
+                          int *error_code)
+{
+    IME_IOContig(fd,
+                (void *)buf,
+                count,
+                datatype,
+                file_ptr_type,
+                offset,
+                status,
+                IME_WRITE,
+                error_code);
+}
+

--- a/src/mpi/romio/adio/ad_ime/ad_ime_open.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_open.c
@@ -1,0 +1,99 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*-
+ *
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "ad_ime_common.h"
+
+#include <assert.h>
+
+void ADIOI_IME_Open(ADIO_File fd,
+                   int *error_code)
+{
+    static char myname[] = "ADIOI_IME_OPEN";
+    struct ADIOI_IME_fs_s *ime_fs;
+    int perm;
+    int amode = 0;
+    int ret;
+    int rank = 0;
+    mode_t old_mask;
+
+    /* validate input args */
+    if (!fd)
+    {
+        *error_code = MPI_ERR_FILE;
+        return;
+    }
+    if (!error_code)
+    {
+        *error_code = MPI_ERR_FILE;
+        return;
+    }
+
+    /* setup file permissions */
+    if (fd->perm == ADIO_PERM_NULL)
+    {
+        old_mask = umask(022);
+        umask(old_mask);
+        perm = old_mask ^ 0666;
+    }
+    else
+        perm = fd->perm;
+
+    /* setup the file access mode */
+    if (fd->access_mode & ADIO_CREATE)
+        amode = amode | O_CREAT;
+    if (fd->access_mode & ADIO_RDONLY)
+        amode = amode | O_RDONLY;
+    if (fd->access_mode & ADIO_WRONLY)
+        amode = amode | O_WRONLY;
+    if (fd->access_mode & ADIO_RDWR)
+        amode = amode | O_RDWR;
+    if (fd->access_mode & ADIO_EXCL)
+        amode = amode | O_EXCL;
+
+    /* XXX no O_APPEND support */
+    assert((fd->access_mode & ADIO_APPEND) == 0);
+
+    /* init IME */
+    MPI_Comm_rank(fd->comm, &rank);
+    ADIOI_IME_Init(rank, error_code);
+    if (*error_code != MPI_SUCCESS)
+        return;
+
+    ime_fs = (ADIOI_IME_fs *) ADIOI_Malloc(sizeof(ADIOI_IME_fs));
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (ime_fs == NULL) {
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                           MPIR_ERR_RECOVERABLE,
+                                           myname, __LINE__,
+                                           MPI_ERR_UNKNOWN,
+                                           "Error allocating memory", 0);
+        return;
+    }
+
+    ime_fs->ime_filename = ADIOI_IME_Add_prefix(fd->filename);
+
+    /* all processes open the file */
+    ret = ime_native_open(ime_fs->ime_filename, amode, perm);
+    if (ret < 0)
+    {
+        *error_code = MPI_ERR_FILE;
+        ADIOI_Free(ime_fs->ime_filename);
+        ADIOI_Free(ime_fs);
+        return;
+    }
+
+    fd->fd_sys = ret;
+    fd->fd_direct = -1;
+    fd->fs_ptr = ime_fs;
+
+    *error_code = MPI_SUCCESS;
+
+    return;
+}

--- a/src/mpi/romio/adio/ad_ime/ad_ime_resize.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_resize.c
@@ -1,0 +1,36 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *   Copyright (C) 1997 University of Chicago.
+ *   Copyright (C) 2017 DataDirect Networks.
+ *   See COPYRIGHT notice in top-level directory.
+ */
+
+#include "ad_ime.h"
+#include "ad_ime_common.h"
+#include <assert.h>
+
+void ADIOI_IME_Resize(ADIO_File fd, ADIO_Offset size, int *error_code)
+{
+    int ret;
+    static char myname[] = "ADIOI_IME_RESIZE";
+
+    if (!error_code)
+        return;
+    if (!fd)
+    {
+        *error_code = MPI_ERR_FILE;
+        return;
+    }
+
+    ret = ime_native_ftruncate(fd->fd_sys, size);
+
+    if (ret != 0)
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                           MPIR_ERR_RECOVERABLE,
+                                           myname, __LINE__,
+                                           MPI_ERR_FILE,
+                                           "Error in ime_native_ftruncate", 0);
+    else
+        *error_code = MPI_SUCCESS;
+}

--- a/src/mpi/romio/adio/common/ad_fstype.c
+++ b/src/mpi/romio/adio/common/ad_fstype.c
@@ -34,6 +34,10 @@
 #include "gpfs.h"
 #endif
 
+#ifdef HAVE_IM_CLIENT_NATIVE2_H
+#include "im_client_native2.h"
+#endif
+
 /* Notes on detection process:
  *
  * There are three more "general" mechanisms that we use for detecting
@@ -538,6 +542,10 @@ static void ADIO_FileSysType_prefix(const char *filename, int *fstype, int *erro
     else if (!strncmp(filename, "pvfs2:", 6)||!strncmp(filename, "PVFS2:", 6)) {
 	*fstype = ADIO_PVFS2;
     } 
+    else if (!strncmp(filename, "ime:", 4)||
+                    !strncmp(filename, "IME:", 4)) {
+            *fstype = ADIO_IME;
+    } 
     else if (!strncmp(filename, "testfs:", 7) 
 	     || !strncmp(filename, "TESTFS:", 7))
     {
@@ -757,6 +765,17 @@ void ADIO_ResolveFileType(MPI_Comm comm, const char *filename, int *fstype,
 	return;
 #else
 	*ops = &ADIO_LUSTRE_operations;
+#endif
+    }
+    if (file_system == ADIO_IME)
+    {
+#ifndef ROMIO_IME
+        *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                           myname, __LINE__, MPI_ERR_IO,
+                                           "**iofstypeunsupported", 0);
+        return;
+#else
+        *ops = &ADIO_IME_operations;
 #endif
     }
     *error_code = MPI_SUCCESS;

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -286,6 +286,7 @@ typedef struct {
 #define ADIO_PANFS               161   /* Panasas FS */
 #define ADIO_LUSTRE              163   /* Lustre */
 #define ADIO_GPFS                  168
+#define ADIO_IME                 169   /* IME burst buffer */
 
 #define ADIO_SEEK_SET            SEEK_SET
 #define ADIO_SEEK_CUR            SEEK_CUR

--- a/src/mpi/romio/adio/include/adioi_errmsg.h
+++ b/src/mpi/romio/adio/include/adioi_errmsg.h
@@ -58,6 +58,7 @@ MPI_ERR_IO
     MPIR_ERR_NO_TESTFS "ROMIO has not been configured to use the TESTFS file system"
     MPIR_ERR_DEFERRED "independent IO attempted even though no_indep_rw hint given"
     MPIR_ERR_NO_GPFS "ROMIO has not been configured to use the GPFS file system"
+    MPIR_ERR_NO_IME "ROMIO has not been configured to use the IME burst buffer"
 
 MPI_ERR_COMM
     MPIR_ERR_COMM_NULL (null communicator. from MPICH)

--- a/src/mpi/romio/adio/include/adioi_fs_proto.h
+++ b/src/mpi/romio/adio/include/adioi_fs_proto.h
@@ -49,4 +49,9 @@ extern struct ADIOI_Fns_struct ADIO_GPFS_operations;
 /* prototypes are in adio/ad_gpfs/ad_gpfs.h */
 #endif
 
+#ifdef ROMIO_IME
+/* prototypes are in adio/ad_im/ad_im.h */
+extern struct ADIOI_Fns_struct ADIO_IME_operations;
+#endif
+
 #endif

--- a/src/mpi/romio/adio/include/mpio_error.h
+++ b/src/mpi/romio/adio/include/mpio_error.h
@@ -59,6 +59,7 @@
 #define MPIR_ERR_NO_TESTFS 36
 #define MPIR_ERR_NO_LUSTRE 37
 #define MPIR_ERR_NO_GPFS 38
+#define MPIR_ERR_NO_IM 39
 
 /* MPI_ERR_COMM */
 #ifndef MPIR_ERR_COMM_NULL

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -185,7 +185,7 @@ dnl An m4 macro for use with m4_foreach_w and friends.  You should modify this
 dnl list if you want to add a known file system.  The list is just whitespace
 dnl separated, so you can use newlines and tabs as well.
 m4_define([known_filesystems_m4_w],
-          [nfs ufs pvfs2 testfs xfs panfs lustre gpfs])dnl
+          [nfs ufs pvfs2 testfs xfs panfs lustre gpfs ime])dnl
 dnl
 dnl An m4 macro for use with m4_foreach and friends.  Expands to a quoted list of
 dnl quoted elements.  A bit easier to use without unintended expansion than the
@@ -926,6 +926,13 @@ int main(int argc, char **argv) {
         AC_MSG_RESULT(assuming 128 for memory alignment)
         CFLAGS="$CFLAGS -DXFS_MEMALIGN=128"
     fi
+fi
+
+if test -n "$file_system_ime"; then
+        AC_CHECK_HEADERS(ime_native.h,
+                AC_DEFINE(ROMIO_IME,1,[Define for ROMIO with IME]),
+                AC_MSG_ERROR([IME support requested but cannot find ime_native.h header file])
+        )
 fi
 
 #


### PR DESCRIPTION
Hi,
This PR adds the support for DDN's Infinite Memory Engine (IME) to romio.
@roblatham00, thank you in advance for taking the time to review my patch.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>