### PR TITLE
Fix: Load distribution in redscat algorithm

### DIFF
--- a/src/mpi/coll/allreduce.c
+++ b/src/mpi/coll/allreduce.c
@@ -715,9 +715,12 @@ int MPIR_Allreduce_reduce_scatter_allgather(
       MPIR_CHKLMEM_MALLOC(cnts, int *, pof2*sizeof(int), mpi_errno, "counts");
       MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
 
-      for (i=0; i<(pof2-1); i++)
+      for (i=0; i<pof2; i++)
           cnts[i] = count/pof2;
-      cnts[pof2-1] = count - (count/pof2)*(pof2-1);
+      if ((count % pof2) > 0) {
+          for (i=0; i<(count % pof2); i++)
+              cnts[i] += 1;
+      }
 
       disps[0] = 0;
       for (i=1; i<pof2; i++)

--- a/src/mpi/coll/reduce.c
+++ b/src/mpi/coll/reduce.c
@@ -424,9 +424,12 @@ int MPIR_Reduce_redscat_gather (
     MPIR_CHKLMEM_MALLOC(disps, int *, pof2*sizeof(int), mpi_errno, "displacements");
     
     if (newrank != -1) {
-        for (i=0; i<(pof2-1); i++) 
+        for (i=0; i<pof2; i++)
             cnts[i] = count/pof2;
-        cnts[pof2-1] = count - (count/pof2)*(pof2-1);
+        if ((count % pof2) > 0) {
+            for (i=0; i<(count % pof2); i++)
+                cnts[i] += 1;
+        }
         
         disps[0] = 0;
         for (i=1; i<pof2; i++)
@@ -507,9 +510,12 @@ int MPIR_Reduce_redscat_gather (
         if (root % 2 != 0) {
             if (rank == root) {    /* recv */
                 /* initialize the arrays that weren't initialized */
-                for (i=0; i<(pof2-1); i++) 
+                for (i=0; i<pof2; i++)
                     cnts[i] = count/pof2;
-                cnts[pof2-1] = count - (count/pof2)*(pof2-1);
+                if ((count % pof2) > 0) {
+                    for (i=0; i<(count % pof2); i++)
+                        cnts[i] +=1;
+                }
                 
                 disps[0] = 0;
                 for (i=1; i<pof2; i++)


### PR DESCRIPTION
The redscat algorithm in reduce and allreduce needs a load distribution when count is not a multiplier of pof2. This patch reduces the imbalance.