### PR TITLE
remove obsolete defenitions and rename some structures

### DIFF
--- a/src/mpid/ch4/include/coll_algo_params.h.in
+++ b/src/mpid/ch4/include/coll_algo_params.h.in
@@ -47,12 +47,17 @@ typedef union MPIDI_allreduce_algo_params {
 #define MPIDI_REDUCE_PARAMS_DECL MPIDI_REDUCE_ALGO_params_t reduce_params;
 #define MPIDI_ALLREDUCE_PARAMS_DECL MPIDI_ALLREDUCE_ALGO_params_t allreduce_params;
 
-typedef union MPIDI_coll_algo_params {
+typedef union MPIDI_coll_algo_generic_params {
     MPIDI_BARRIER_PARAMS_DECL;
     MPIDI_BCAST_PARAMS_DECL;
     MPIDI_REDUCE_PARAMS_DECL;
     MPIDI_ALLREDUCE_PARAMS_DECL;
-} MPIDI_COLL_ALGO_params_t;
+} MPIDI_coll_algo_generic_params_t;
+
+typedef struct MPIDI_coll_algo_generic_container {
+    int id;
+    MPIDI_coll_algo_generic_params_t params;
+} MPIDI_coll_algo_generic_container_t;
 
 void *MPIDI_coll_get_next_container(void *container);
 

--- a/src/mpid/ch4/include/netmodpre.h.in
+++ b/src/mpid/ch4/include/netmodpre.h.in
@@ -23,8 +23,5 @@
 #define MPIDI_NM_WIN_DECL        @ch4_netmod_win_decl@
 #define MPIDI_NM_ADDR_DECL    @ch4_netmod_addr_decl@
 #define MPIDI_NM_OP_DECL         @ch4_netmod_op_decl@
-#define MPIDI_NM_BCAST_PARAMS_DECL  @ch4_netmod_bcast_params_decl@
-#define MPIDI_NM_REDUCE_PARAMS_DECL  @ch4_netmod_reduce_params_decl@
-#define MPIDI_NM_ALLREDUCE_PARAMS_DECL  @ch4_netmod_allreduce_params_decl@
 
 #endif /* NETMODPRE_H_INCLUDED */

--- a/src/mpid/ch4/include/shmpre.h.in
+++ b/src/mpid/ch4/include/shmpre.h.in
@@ -17,8 +17,5 @@
 
 #define MPIDI_SHM_REQUEST_DECL       @ch4_shm_request_decl@
 #define MPIDI_SHM_COMM_DECL          @ch4_shm_comm_decl@
-#define MPIDI_SHM_BCAST_PARAMS_DECL  @ch4_shm_bcast_params_decl@
-#define MPIDI_SHM_REDUCE_PARAMS_DECL  @ch4_shm_reduce_params_decl@
-#define MPIDI_SHM_ALLREDUCE_PARAMS_DECL  @ch4_shm_allreduce_params_decl@
 
 #endif /* SHMPRE_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_coll_globals_default.c.in
+++ b/src/mpid/ch4/src/ch4_coll_globals_default.c.in
@@ -3,7 +3,7 @@
 #include "ch4_impl.h"
 
 /* container traverse function to be implemented  */
-/* e.g. return ((void *) ((char *)container) + sizeof(MPIDI_COLL_ALGO_params_t)); */
+/* e.g. return ((void *) ((char *)container) + sizeof(MPIDI_coll_algo_generic_container_t)); */
 void *MPIDI_coll_get_next_container(void *container)
 {
     return NULL;


### PR DESCRIPTION
This PR is polishing to collective selection infrastructure: remove obsolete definitions and introducing generic containers type 