### PR TITLE
Better error detection for non-contig recv

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -624,7 +624,7 @@ int MPII_Type_zerolen(MPI_Datatype *newtype);
      (type == MPI_LONG_INT) || (type == MPI_SHORT_INT) || \
      (type == MPI_LONG_DOUBLE_INT))
 
-int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *elements);
+int MPIR_Get_elements_x_impl(MPI_Count *bytes, MPI_Datatype datatype, MPI_Count *elements);
 int MPIR_Status_set_elements_x_impl(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
 void MPIR_Type_get_extent_x_impl(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
 void MPIR_Type_get_true_extent_x_impl(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);

--- a/src/mpi/datatype/get_elements.c
+++ b/src/mpi/datatype/get_elements.c
@@ -58,7 +58,7 @@ Output Parameters:
 int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Count count_x;
+    MPI_Count count_x, byte_count;
 
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_GET_ELEMENTS);
 
@@ -104,7 +104,8 @@ int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count
 
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Get_elements_x_impl(status, datatype, &count_x);
+    byte_count = MPIR_STATUS_GET_COUNT(*status);
+    mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, &count_x);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     /* clip the value if it cannot be correctly returned to the user */

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -279,11 +279,21 @@ PMPI_LOCAL MPI_Count MPIR_Type_get_elements(MPI_Count *bytes_p,
 #define FUNCNAME MPIR_Get_elements_x_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *elements)
+/* MPIR_Get_elements_x_impl
+ *
+ * Arguments:
+ * - byte_count - input/output byte count
+ * - datatype - input datatype
+ * - elements - Number of basic elements this byte_count would contain
+ *
+ * Returns number of elements available given the two constraints of number of
+ * bytes and count of types.  Also reduces the byte count by the amount taken
+ * up by the types.
+ */
+int MPIR_Get_elements_x_impl(MPI_Count *byte_count, MPI_Datatype datatype, MPI_Count *elements)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *datatype_ptr = NULL;
-    MPI_Count byte_count;
 
     if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
@@ -297,8 +307,6 @@ int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MP
     if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN ||
         (datatype_ptr->builtin_element_size != -1 && datatype_ptr->size > 0))
     {
-        byte_count = MPIR_STATUS_GET_COUNT(*status);
-
         /* QUESTION: WHAT IF SOMEONE GAVE US AN MPI_UB OR MPI_LB???
          */
 
@@ -308,7 +316,7 @@ int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MP
         if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
             MPI_Datatype basic_type = MPI_DATATYPE_NULL;
             MPIR_Datatype_get_basic_type(datatype_ptr->basic_type, basic_type);
-            *elements = MPIR_Type_get_basic_type_elements(&byte_count,
+            *elements = MPIR_Type_get_basic_type_elements(byte_count,
                                                           -1,
                                                           basic_type);
         }
@@ -316,17 +324,17 @@ int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MP
             /* Behaves just like MPI_Get_Count in the predefined case */
             MPI_Count size;
             MPIR_Datatype_get_size_macro(datatype, size);
-            if ((byte_count % size) != 0)
+            if ((*byte_count % size) != 0)
                 *elements = MPI_UNDEFINED;
             else
-                *elements = MPIR_Type_get_basic_type_elements(&byte_count,
+                *elements = MPIR_Type_get_basic_type_elements(byte_count,
                                                               -1,
                                                               datatype);
         }
-        MPIR_Assert(byte_count >= 0);
+        MPIR_Assert(*byte_count >= 0);
     }
     else if (datatype_ptr->size == 0) {
-        if (MPIR_STATUS_GET_COUNT(*status) > 0) {
+        if (*byte_count > 0) {
             /* --BEGIN ERROR HANDLING-- */
 
             /* datatype size of zero and count > 0 should never happen. */
@@ -345,8 +353,7 @@ int MPIR_Get_elements_x_impl(const MPI_Status *status, MPI_Datatype datatype, MP
     else /* derived type with weird element type or weird size */ {
         MPIR_Assert(datatype_ptr->builtin_element_size == -1);
 
-        byte_count = MPIR_STATUS_GET_COUNT(*status);
-        *elements = MPIR_Type_get_elements(&byte_count, -1, datatype);
+        *elements = MPIR_Type_get_elements(byte_count, -1, datatype);
     }
 
     return mpi_errno;
@@ -381,6 +388,7 @@ Output Parameters:
 int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPI_Count byte_count;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_GET_ELEMENTS_X);
 
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
@@ -423,7 +431,8 @@ int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Coun
 
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Get_elements_x_impl(status, datatype, count);
+    byte_count = MPIR_STATUS_GET_COUNT(*status);
+    mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, count);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     /* ... end of body of routine ... */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -130,8 +130,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
         }
     }
     else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_RECV_NOPACK) && (MPIDI_OFI_REQUEST(rreq, noncontig.nopack))) {
-            last = count;
-            MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack));
+        MPI_Count elements;
+
+        /* Check to see if there are any bytes that don't fit into the datatype basic elements */
+        MPIR_Get_elements_x_impl(((MPI_Count *) &count), MPIDI_OFI_REQUEST(rreq, datatype), &elements);
+        if (count)
+            MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");
+
+        MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack));
     }
 
     dtype_release_if_not_builtin(MPIDI_OFI_REQUEST(rreq, datatype));


### PR DESCRIPTION
Improvements to determining when received non-contig data does not match the type signature specified in the recv call.