### PR TITLE
CH4/OFI: Remove ep_nocmpl from RMA window logic

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -169,7 +169,6 @@ typedef struct {
     struct fid_mr *mr;
     uint64_t mr_key;
     struct fid_ep *ep;          /* EP with counter & completion */
-    struct fid_ep *ep_nocmpl;   /* EP with counter only (no completion) */
     uint64_t *issued_cntr;
     uint64_t issued_cntr_v;     /* main body of an issued counter,
                                  * if we are to use per-window counter */


### PR DESCRIPTION
The ep_nocmpl endpoint stored in RMA windows was being created for RMA
operations that do not need full completions.  However, the implementation
of this was incorrect because a CQ wasn't being bound to it (which is
against the rules in OFI, you need a CQ even if you never read from it for
error reporting). It also is unnecessary, because the normal endpoint within
the window structure is already set to use FI_SELECTIVE_COMPLETION, meaning
no completion event will be generated unless you explicitly pass the
FI_COMPLETION flag.

This commit removes ep_nocmpl in favor of using the normal endpoint without
a FI_COMPLETION flag. Because the two endpoints were bound to the same
counter, the resulting logic is the same.