### PR TITLE
Commsplit heuristic

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -481,7 +481,7 @@ AC_TYPE_OFF_T
 # Header files
 # Find the CPP before the header check
 AC_PROG_CPP
-AC_CHECK_HEADERS([unistd.h fcntl.h malloc.h stddef.h sys/types.h limits.h time.h])
+AC_CHECK_HEADERS([unistd.h fcntl.h malloc.h stddef.h sys/types.h limits.h time.h dirent.h])
 AC_CHECK_HEADERS(mpix.h,,,[#include <mpi.h>])
 #
 


### PR DESCRIPTION
Turns out we committed the "heuristic"  approach a while back.  This exhaustive approach is killer on parallel file systems, but necessary to detect some topologies like Blue Gene and DataWarp.   I'm making a judgement here that users should opt-in to the expensive algorithm. 