### PR TITLE
CH4/OFI: Update the origin and result iovec limits for rma

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
@@ -88,8 +88,8 @@
 
 #define MPIDI_OFI_UPDATE_IOV_STATE2(var1,var2,var3)                               \
   do {                                                                  \
-    if (*var2## _iovs_nout>=var2## _max_iovs) return MPIDI_OFI_IOV_EAGAIN;   \
-    if (*var3## _iovs_nout>=var3## _max_iovs) return MPIDI_OFI_IOV_EAGAIN;   \
+    if (*var2## _iovs_nout > var2## _max_iovs) return MPIDI_OFI_IOV_EAGAIN;   \
+    if (*var3## _iovs_nout > var3## _max_iovs) return MPIDI_OFI_IOV_EAGAIN;   \
     ((struct iovec*)(&var1## _iov[var1## _idx]))->iov_len += len;            \
     var2## _idx++;                                                      \
     (*var2## _iovs_nout)++;                                             \

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -434,7 +434,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     while (rc == MPIDI_OFI_IOV_EAGAIN) {
         originv = &req->noncontig->buf.iov.put_get.originv[cur_o];
         targetv = &req->noncontig->buf.iov.put_get.targetv[cur_t];
-        omax = MPIDI_Global.tx_iov_limit;
+        omax = MPIDI_Global.rma_iov_limit;
         tmax = MPIDI_Global.rma_iov_limit;
         rc = MPIDI_OFI_merge_iov_list(&req->noncontig->iovs, originv,
                                       omax, targetv, tmax, &oout, &tout);
@@ -595,7 +595,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     while (rc == MPIDI_OFI_IOV_EAGAIN) {
         originv = &req->noncontig->buf.iov.put_get.originv[cur_o];
         targetv = &req->noncontig->buf.iov.put_get.targetv[cur_t];
-        omax = MPIDI_Global.tx_iov_limit;
+        omax = MPIDI_Global.rma_iov_limit;
         tmax = MPIDI_Global.rma_iov_limit;
         rc = MPIDI_OFI_merge_iov_list(&req->noncontig->iovs, originv,
                                       omax, targetv, tmax, &oout, &tout);
@@ -1007,7 +1007,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     while (rc == MPIDI_OFI_IOV_EAGAIN) {
         originv = &req->noncontig->buf.iov.accumulate.originv[cur_o];
         targetv = &req->noncontig->buf.iov.accumulate.targetv[cur_t];
-        omax = MPIDI_Global.tx_iov_limit;
+        omax = MPIDI_Global.rma_iov_limit;
         tmax = MPIDI_Global.rma_iov_limit;
         rc = MPIDI_OFI_merge_iov_list(&req->noncontig->iovs, (struct iovec *) originv, omax,
                                       (struct fi_rma_iov *) targetv, tmax, &oout, &tout);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -1160,7 +1160,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         originv = &req->noncontig->buf.iov.get_accumulate.originv[cur_o];
         targetv = &req->noncontig->buf.iov.get_accumulate.targetv[cur_t];
         resultv = &req->noncontig->buf.iov.get_accumulate.resultv[cur_r];
-        omax = rmax = MPIDI_Global.tx_iov_limit;
+        omax = rmax = MPIDI_OFI_FETCH_ATOMIC_IOVECS < 0 ? MPIDI_Global.rma_iov_limit : MPIDI_OFI_FETCH_ATOMIC_IOVECS;
         tmax = MPIDI_OFI_FETCH_ATOMIC_IOVECS < 0 ? MPIDI_Global.rma_iov_limit : MPIDI_OFI_FETCH_ATOMIC_IOVECS;
 
         if (op != MPI_NO_OP)


### PR DESCRIPTION
Update the origin iovec limits from MPIDI_Global.tx_iov_limit to MPIDI_Global.rma_iov_limit. Besides, FETCH_ATOMIC_IOVEC should be considered for origin/results to set the limit of iovec transfer for two-operation atomics.

Fixes csr/mpich-ofi#625
Related to csr/mpich-ofi#734