### PR TITLE
CH4/OFI: Don't allocate RX resources for RMA windows

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -156,6 +156,10 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
 
         finfo = fi_dupinfo(MPIDI_Global.prov_use);
         MPIR_Assert(finfo);
+        finfo->caps = FI_RMA | FI_WRITE | FI_READ;
+        finfo->tx_attr->caps = FI_RMA | FI_WRITE | FI_READ;
+        finfo->rx_attr->caps = 0ULL; /* RX capabilities not needed */
+
         finfo->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT; /* Request a shared context */
         MPIDI_OFI_CALL_RETURN(fi_endpoint(MPIDI_Global.domain,
                                           finfo, &MPIDI_OFI_WIN(win).ep, NULL), ret);


### PR DESCRIPTION
The logic for mapping memory windows to endpoints that share a transmit context
is borrowing the fi_info structure from some earlier point in the code. This
fi_info structure has RX capabilities set, which could cause a provider to
allocate receive resources.

This commit fixes this by modifying the duplicated info structure to only
specify transmit RMA operations.