### PR TITLE
Fix deferred open and exclusive access

### DIFF
--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -176,6 +176,16 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
 
     ADIOI_OpenColl(fd, rank, access_mode, error_code);
 
+    /* deferred open consideration: if an independent process lied about
+     * "no_indep_rw" and opens the file later (example: HDF5 uses independent
+     * i/o for metadata), that deferred open will use the access_mode provided
+     * by the user.  CREATE|EXCL only makes sense here -- exclusive access in
+     * the deferred open case is going to fail and surprise the user.  Turn off
+     * the excl amode bit. Save user's ammode for MPI_FILE_GET_AMODE */
+    fd->orig_access_mode = access_mode;
+    if (fd->access_mode & ADIO_EXCL) fd->access_mode ^= ADIO_EXCL;
+
+
     /* for debugging, it can be helpful to see the hints selected. Some file
      * systes set up the hints in the open call (e.g. lustre) */
     p = getenv("ROMIO_PRINT_HINTS");

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -200,7 +200,10 @@ typedef struct ADIOI_FileD {
     int is_agg;              /* bool: if I am an aggregator */
     char *filename;          
     int file_system;         /* type of file system */
-    int access_mode;         /* Access mode (sequential, append, etc.) */
+    int access_mode;         /* Access mode (sequential, append, etc.),
+				possibly modified to deal with
+				data sieving or deferred open*/
+    int orig_access_mode;    /* Access mode provided by user: unmodified */
     ADIO_Offset disp;        /* reqd. for MPI-IO */
     MPI_Datatype etype;      /* reqd. for MPI-IO */
     MPI_Datatype filetype;   /* reqd. for MPI-IO */

--- a/src/mpi/romio/mpi-io/get_amode.c
+++ b/src/mpi/romio/mpi-io/get_amode.c
@@ -48,7 +48,7 @@ int MPI_File_get_amode(MPI_File fh, int *amode)
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
-    *amode = adio_fh->access_mode;
+    *amode = adio_fh->orig_access_mode;
 
 fn_exit:
     return error_code;


### PR DESCRIPTION
The "exclusive" flag makes sense at (collective) open time, but in the
deferred open path the flag will only cause problems -- the independent
process will open a file that definitely exists.  Neeed a bit of extra
work because MPI_FILE_GET_AMODE needs to return the user-provided amode