### PR TITLE
ROMIO: ADIO_Open should not free cb_config_list if NULL for open error

### DIFF
--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -203,7 +203,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
         }
 	ADIOI_Free(fd->filename);
 	ADIOI_Free(fd->hints->ranklist);
-	ADIOI_Free(fd->hints->cb_config_list);
+	if ( fd->hints->cb_config_list != NULL ) ADIOI_Free(fd->hints->cb_config_list);
 	ADIOI_Free(fd->hints);
 	if (fd->info != MPI_INFO_NULL) MPI_Info_free(&(fd->info));
 	ADIOI_Free(fd->io_buf);


### PR DESCRIPTION
Not all platforms (eg BlueGene) allocate the fd->hints->cb_config_list.
However, in the ADIO_Open it attempts to free it without first checking
for NULL in the case of an error.  The fix is to first check for NULL before
doing the free.