### PR TITLE
ch4/ucx: Add support for embedded ucx source

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -167,6 +167,9 @@ externals="src/pm/hydra src/mpi/romio src/openpa"
 if [ -e src/mpid/ch4/netmod/ofi/libfabric ]; then
     externals="${externals} src/mpid/ch4/netmod/ofi/libfabric"
 fi
+if [ -e src/mpid/ch4/netmod/ucx/ucx ]; then
+    externals="${externals} src/mpid/ch4/netmod/ucx/ucx"
+fi
 
 # amdirs are the directories that make use of autoreconf
 amdirs=". src/mpl src/util/logging/rlog"

--- a/maint/release.pl
+++ b/maint/release.pl
@@ -224,6 +224,16 @@ for my $module (@nem_modules) {
 }
 print("done\n");
 
+# Embed external libraries
+
+# UCX
+print("===> Embedding UCX... ");
+chdir("${expdir}/src/mpid/ch4/netmod/ucx");
+run_cmd("git clone -b v1.2.1 git://github.com/openucx/ucx ucx");
+chdir("ucx");
+run_cmd("git am ${expdir}/maint/ucx-embed.patch");
+print("done\n");
+
 # Create configure
 print("===> Creating configure in the main codebase... ");
 chdir($expdir);

--- a/maint/ucx-embed.patch
+++ b/maint/ucx-embed.patch
@@ -1,0 +1,106 @@
+From 1e6ef317f2676d19627a40fe2cd09b1e62934538 Mon Sep 17 00:00:00 2001
+From: Ken Raffenetti <raffenet@mcs.anl.gov>
+Date: Wed, 18 Oct 2017 14:39:34 -0500
+Subject: [PATCH] config: Add embedded mode
+
+Add a configure flag to support building UCX as a subproject of
+another project. When configured for embedded mode, we avoid
+installing any header files.
+---
+ configure.ac        | 5 +++++
+ src/ucm/Makefile.am | 2 ++
+ src/ucp/Makefile.am | 2 ++
+ src/ucs/Makefile.am | 2 ++
+ src/uct/Makefile.am | 2 ++
+ 5 files changed, 13 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 74284add..1a257d64 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -77,6 +77,11 @@ AC_C_RESTRICT
+ m4_include([config/m4/pkg.m4])
+ PKG_PROG_PKG_CONFIG
+ 
++AC_ARG_ENABLE([embedded],
++             [AS_HELP_STRING([--enable-embedded],
++                             [Enable embedded mode @<:@default=no@:>@])
++             ])
++AM_CONDITIONAL([EMBEDDED], [test x"$enable_embedded" = x"yes"])
+ 
+ #
+ # Save config flags for version dump tool
+diff --git a/src/ucm/Makefile.am b/src/ucm/Makefile.am
+index 2215ddd2..d5a59326 100644
+--- a/src/ucm/Makefile.am
++++ b/src/ucm/Makefile.am
+@@ -24,8 +24,10 @@ libucm_la_CFLAGS = \
+ 	$(BASE_CFLAGS) \
+ 	$(CFLAGS_NO_DEPRECATED)
+ 
++if !EMBEDDED
+ nobase_dist_libucm_la_HEADERS = \
+ 	api/ucm.h
++endif
+ 
+ noinst_HEADERS = \
+ 	event/event.h \
+diff --git a/src/ucp/Makefile.am b/src/ucp/Makefile.am
+index 5a2bb6a6..f96a3f48 100644
+--- a/src/ucp/Makefile.am
++++ b/src/ucp/Makefile.am
+@@ -13,11 +13,13 @@ libucp_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
+ libucp_la_LIBADD   = ../ucs/libucs.la ../uct/libuct.la
+ libucp_ladir       = $(includedir)/ucp
+ 
++if !EMBEDDED
+ nobase_dist_libucp_la_HEADERS = \
+ 	api/ucp_compat.h \
+ 	api/ucp_def.h \
+ 	api/ucp_version.h \
+ 	api/ucp.h
++endif
+ 
+ noinst_HEADERS = \
+ 	amo/amo.inl \
+diff --git a/src/ucs/Makefile.am b/src/ucs/Makefile.am
+index de930eee..6b930964 100644
+--- a/src/ucs/Makefile.am
++++ b/src/ucs/Makefile.am
+@@ -17,6 +17,7 @@ libucs_la_LIBADD   = \
+ 	$(LIBM) \
+ 	$(top_builddir)/src/ucm/libucm.la
+ 
++if !EMBEDDED
+ nobase_dist_libucs_la_HEADERS = \
+ 	algorithm/crc.h \
+ 	algorithm/qsort_r.h \
+@@ -55,6 +56,7 @@ nobase_dist_libucs_la_HEADERS = \
+ 	type/status.h \
+ 	type/thread_mode.h \
+ 	type/cpu_set.h
++endif
+ 
+ noinst_HEADERS = \
+ 	datastruct/arbiter.h \
+diff --git a/src/uct/Makefile.am b/src/uct/Makefile.am
+index 930f73b9..9a8f988e 100644
+--- a/src/uct/Makefile.am
++++ b/src/uct/Makefile.am
+@@ -15,11 +15,13 @@ libuct_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
+ libuct_la_LIBADD   = $(LIBM) ../ucs/libucs.la
+ libuct_ladir       = $(includedir)/uct
+ 
++if !EMBEDDED
+ nobase_dist_libuct_la_HEADERS = \
+ 	api/tl.h \
+ 	api/uct_def.h \
+ 	api/uct.h \
+ 	api/version.h
++endif
+ 
+ noinst_HEADERS = \
+ 	base/addr.h \
+-- 
+2.11.0
+

--- a/src/mpid/ch4/netmod/ucx/Makefile.mk
+++ b/src/mpid/ch4/netmod/ucx/Makefile.mk
@@ -12,4 +12,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ucx/func_table.c\
 
 errnames_txt_files += src/mpid/ch4/netmod/ucx/errnames.txt
 
+external_subdirs   += @ucxdir@
+pmpi_convenience_libs += @ucxlib@
+
 endif

--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -49,11 +49,42 @@ AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
 AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
     AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch4:ucx])
 
-    PAC_SET_HEADER_LIB_PATH(ucx)
-    PAC_PUSH_FLAG(LIBS)
-    PAC_CHECK_HEADER_LIB_FATAL(ucx, ucp/api/ucp.h, ucp, ucp_config_read)
-    PAC_POP_FLAG(LIBS)
-    PAC_APPEND_FLAG([-lucp],[WRAPPER_LIBS])
+    ucxdir=""
+    AC_SUBST([ucxdir])
+    ucxlib=""
+    AC_SUBST([ucxlib])
+
+    ucx_embedded=""
+    dnl Use embedded libfabric if we specify to do so or we didn't specify and the source is present
+    if test "${with_ucx}" = "embedded" ; then
+        ucx_embedded="yes"
+    elif test -z ${with_ucx} ; then
+        if test -f ${use_top_srcdir}/src/mpid/ch4/netmod/ucx/ucx/configure ; then
+            ucx_embedded="yes"
+        else
+            ucx_embedded="no"
+            PAC_SET_HEADER_LIB_PATH(ucx)
+        fi
+    else
+        ucx_embedded="no"
+        PAC_SET_HEADER_LIB_PATH(ucx)
+    fi
+
+    if test "${ucx_embedded}" = "yes" ; then
+        PAC_PUSH_FLAG(CPPFLAGS)
+        PAC_CONFIG_SUBDIR_ARGS([src/mpid/ch4/netmod/ucx/ucx],[--disable-static --enable-embedded],[],[AC_MSG_ERROR(ucx configure failed)])
+        PAC_POP_FLAG(CPPFLAGS)
+        PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpid/ch4/netmod/ucx/ucx/src], [CPPFLAGS])
+        PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpid/ch4/netmod/ucx/ucx/src], [CPPFLAGS])
+
+        ucxdir="src/mpid/ch4/netmod/ucx/ucx"
+        ucxlib="src/mpid/ch4/netmod/ucx/ucx/src/ucp/libucp.la"
+    else
+        PAC_PUSH_FLAG(LIBS)
+        PAC_CHECK_HEADER_LIB_FATAL(ucx, ucp/api/ucp.h, ucp, ucp_config_read)
+        PAC_POP_FLAG(LIBS)
+        PAC_APPEND_FLAG([-lucp],[WRAPPER_LIBS])
+    fi
 
 ])dnl end AM_COND_IF(BUILD_CH4_NETMOD_OFI,...)
 ])dnl end _BODY


### PR DESCRIPTION
Build, install and link an embedded copy of the UCX source when
desired. We disable static libraries until support for static linking
is fixed. See openucx/ucx#918.