### PR TITLE
hcoll: Disable hcoll when MPICH is multi-threaded

### DIFF
--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -91,7 +91,7 @@ int hcoll_initialize(void)
     hcoll_init_opts_t *init_opts;
     mpi_errno = MPI_SUCCESS;
 
-    hcoll_enable = MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL;
+    hcoll_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) && !MPIR_ThreadInfo.isThreaded;
     if (0 >= hcoll_enable) {
         goto fn_exit;
     }


### PR DESCRIPTION
We are seeing deadlocks when using hcoll collectives in
MPI_THREAD_MULTIPLE programs. Issue has been reported upstream, and we
can try again when HPC-X version 2.0 is released. For now, we disable
hcoll when using MPI_THREAD_MULTIPLE.