### PR TITLE
ch4: Create dup of comm when creating win

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -545,7 +545,7 @@ static inline int MPIDI_NM_mpi_win_create(void *base,
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier_impl(win->comm_ptr, &errflag);
 
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -331,7 +331,7 @@ static inline int MPIDI_NM_mpi_win_create(void *base,
 
 
 
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, &errflag);
+    mpi_errno = MPIR_Barrier_impl(win->comm_ptr, &errflag);
 
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;


### PR DESCRIPTION
To avoid race conditions between windows and their parent communicators,
create a duplicate of the communicator for the new window.

Fixes csr/mpich-ofi#304
Fixes pmodels/mpich#2776