### PR TITLE
ch3/ofi: Do not refcount temporary request

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
@@ -126,7 +126,8 @@ int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(struct MPIDI_VC *vc,
     if (status != MPI_STATUS_IGNORE)
         *status = rreq->status;
 
-    MPIR_Request_add_ref(rreq);
+    if (rreq_ptr)
+        MPIR_Request_add_ref(rreq);
     *flag = 1;
     END_FUNC_RC(FCNAME);
 }


### PR DESCRIPTION
Probe tests occasionally segfault on an invalid refcount in this
configuration. This can happen because we would unconditionally add a
reference to the request here, despite the fact it may have been
allocated on the stack and thus be not fully initialized. Add a check
to make sure this is a valid request before referencing.