### PR TITLE
Don't use MPL routines in ROMIO tests

### DIFF
--- a/src/mpi/romio/test/async-multiple.c
+++ b/src/mpi/romio/test/async-multiple.c
@@ -35,7 +35,6 @@ int main(int argc, char **argv)
     MPI_Status status[NR_NBOPS];
     MPI_Request request[NR_NBOPS];
     int errcode = 0;
-    size_t filename_sz;
 
     MPI_Init(&argc,&argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -55,7 +54,6 @@ int main(int argc, char **argv)
 	argv++;
 	len = strlen(*argv);
 	filename = (char *) malloc(len+10);
-	filename_sz = sizeof(char)*(len+10);
 	strcpy(filename, *argv);
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
@@ -63,7 +61,6 @@ int main(int argc, char **argv)
     else {
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	filename = (char *) malloc(len+10);
-	filename_sz = sizeof(char)*(len+10);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
 
@@ -75,7 +72,7 @@ int main(int argc, char **argv)
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, filename_sz, "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     errcode = MPI_File_open(MPI_COMM_SELF, filename, 
 		    MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);

--- a/src/mpi/romio/test/async.c
+++ b/src/mpi/romio/test/async.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, sizeof(filename), "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     errcode = MPI_File_open(MPI_COMM_SELF, filename, 
 		    MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);

--- a/src/mpi/romio/test/error.c
+++ b/src/mpi/romio/test/error.c
@@ -18,7 +18,6 @@ int main(int argc, char **argv)
     char *filename, *tmp;
     MPI_File fh;
     char string[MPI_MAX_ERROR_STRING];
-    size_t filename_sz;
 
     MPI_Init(&argc,&argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -45,7 +44,6 @@ int main(int argc, char **argv)
 	argv++;
 	len = strlen(*argv);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	strcpy(filename, *argv);
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
@@ -53,14 +51,13 @@ int main(int argc, char **argv)
     else {
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
     
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, filename_sz, "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     err = MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_CREATE+MPI_MODE_RDWR,
 		        MPI_INFO_NULL, &fh);

--- a/src/mpi/romio/test/file_info.c
+++ b/src/mpi/romio/test/file_info.c
@@ -239,7 +239,7 @@ int main(int argc, char **argv)
     MPI_Info_set(info, "cb_buffer_size", "8388608");
 
     /* number of processes that actually perform I/O in collective I/O */
-    MPL_snprintf(value, sizeof(value), "%d", nprocs/2);
+    sprintf(value, "%d", nprocs/2);
     MPI_Info_set(info, "cb_nodes", value);
 
     /* buffer size for data sieving in independent reads */
@@ -258,11 +258,11 @@ int main(int argc, char **argv)
        accepted only if 0 < value < default_striping_factor; 
        ignored otherwise */
     if (default_striping_factor - 1 > 0) {
-        MPL_snprintf(value, sizeof(value), "%d", default_striping_factor-1);
+        sprintf(value, "%d", default_striping_factor-1);
         MPI_Info_set(info, "striping_factor", value);
     }
     else {
-        MPL_snprintf(value, sizeof(value), "%d", default_striping_factor);
+        sprintf(value, "%d", default_striping_factor);
         MPI_Info_set(info, "striping_factor", value);
     }
 
@@ -277,7 +277,7 @@ int main(int argc, char **argv)
     /* the I/O device number from which to start striping the file.
        accepted only if 0 <= value < default_striping_factor; 
        ignored otherwise */
-    MPL_snprintf(value, sizeof(value), "%d", default_striping_factor-2);
+    sprintf(value, "%d", default_striping_factor-2);
     MPI_Info_set(info, "start_iodevice", value);
 
 

--- a/src/mpi/romio/test/psimple.c
+++ b/src/mpi/romio/test/psimple.c
@@ -24,7 +24,6 @@ int main(int argc, char **argv)
     int errs=0, toterrs;
     MPI_File fh;
     MPI_Status status;
-    int filename_sz;
 
     PMPI_Init(&argc,&argv);
     PMPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -44,7 +43,6 @@ int main(int argc, char **argv)
 	argv++;
 	len = strlen(*argv);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	strcpy(filename, *argv);
 	PMPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	PMPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
@@ -52,7 +50,6 @@ int main(int argc, char **argv)
     else {
 	PMPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	PMPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
     
@@ -64,7 +61,7 @@ int main(int argc, char **argv)
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, filename_sz, "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     PMPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_CREATE | MPI_MODE_RDWR,
 		   MPI_INFO_NULL, &fh);

--- a/src/mpi/romio/test/simple.c
+++ b/src/mpi/romio/test/simple.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
     int  errs = 0, toterrs, errcode;
     MPI_File fh;
     MPI_Status status;
-    size_t filename_sz;
 
     MPI_Init(&argc,&argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -49,7 +48,6 @@ int main(int argc, char **argv)
 	argv++;
 	len = strlen(*argv);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	strcpy(filename, *argv);
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
@@ -57,7 +55,6 @@ int main(int argc, char **argv)
     else {
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
     
@@ -69,7 +66,7 @@ int main(int argc, char **argv)
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, filename_sz, "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     errcode = MPI_File_open(MPI_COMM_SELF, filename, 
 		    MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);

--- a/src/mpi/romio/test/status.c
+++ b/src/mpi/romio/test/status.c
@@ -19,7 +19,6 @@ int main(int argc, char **argv)
     int errs=0, toterrs;
     MPI_File fh;
     MPI_Status status;
-    int filename_sz;
 
     MPI_Init(&argc,&argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -39,7 +38,6 @@ int main(int argc, char **argv)
 	argv++;
 	len = strlen(*argv);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	strcpy(filename, *argv);
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
@@ -47,7 +45,6 @@ int main(int argc, char **argv)
     else {
 	MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	filename = (char *) malloc(len+10);
-	filename_sz = (len+10)*sizeof(char);
 	MPI_Bcast(filename, len+10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
     
@@ -57,7 +54,7 @@ int main(int argc, char **argv)
     /* each process opens a separate file called filename.'myrank' */
     tmp = (char *) malloc(len+10);
     strcpy(tmp, filename);
-    MPL_snprintf(filename, filename_sz, "%s.%d", tmp, rank);
+    sprintf(filename, "%s.%d", tmp, rank);
 
     MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_CREATE | MPI_MODE_RDWR,
 		   MPI_INFO_NULL, &fh);


### PR DESCRIPTION
recent commit got a little aggressive replacing sprintf with MPL_snprintf