### PR TITLE
pm/hydra: fix kvsname collision when using multiple mpiexecs

### DIFF
--- a/src/pm/hydra/pm/pmiserv/common.c
+++ b/src/pm/hydra/pm/pmiserv/common.c
@@ -122,11 +122,24 @@ char *HYD_pmcd_pmi_find_token_keyval(struct HYD_pmcd_token *tokens, int count, c
 HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs ** kvs, int pgid)
 {
     HYD_status status = HYD_SUCCESS;
+    char hostname[MAX_HOSTNAME_LEN];
+    unsigned int seed;
+    MPL_time_t tv;
+    double secs;
+    int rnd;
 
     HYDU_FUNC_ENTER();
 
+    gethostname(hostname, MAX_HOSTNAME_LEN);
+
+    MPL_wtime(&tv);
+    MPL_wtime_todouble(&tv, &secs);
+    seed = (unsigned int)(secs*1e6);
+    srand(seed);
+    rnd = rand();
+
     HYDU_MALLOC_OR_JUMP(*kvs, struct HYD_pmcd_pmi_kvs *, sizeof(struct HYD_pmcd_pmi_kvs), status);
-    MPL_snprintf((*kvs)->kvsname, PMI_MAXKVSLEN, "kvs_%d_%d", (int) getpid(), pgid);
+    MPL_snprintf((*kvs)->kvsname, PMI_MAXKVSLEN, "kvs_%d_%d_%d_%s", (int) getpid(), pgid, rnd, hostname);
     (*kvs)->key_pair = NULL;
     (*kvs)->tail = NULL;
 


### PR DESCRIPTION
Now hydra kvsname also contains a random
generated number and the hostname

@raffenet 