### PR TITLE
Fix description of recvcount for Igather.

### DIFF
--- a/src/mpi/coll/igather.c
+++ b/src/mpi/coll/igather.c
@@ -566,7 +566,7 @@ Input Parameters:
 + sendbuf - starting address of the send buffer (choice)
 . sendcount - number of elements in send buffer (non-negative integer)
 . sendtype - data type of send buffer elements (handle)
-. recvcount - number of elements in receive buffer (significant only at root) (non-negative integer)
+. recvcount - number of elements for any single receive (non-negative integer, significant only at root)
 . recvtype - data type of receive buffer elements (significant only at root) (handle)
 . root - rank of receiving process (integer)
 - comm - communicator (handle)


### PR DESCRIPTION
The description of recvcount in the doc is different from the MPI standard.

Fixes pmodels/mpich#2793