### PR TITLE
Improve backtrace and unwind library checks

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -125,7 +125,7 @@ if test "$pac_cv_have___typeof" = "yes" ; then
 fi
 
 dnl Check if the necessary headers are available
-AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h backtrace.h libunwind.h unistd.h errno.h windows.h)
+AC_CHECK_HEADERS(stdio.h stdlib.h string.h stdarg.h ctype.h sys/types.h sys/uio.h execinfo.h unistd.h errno.h windows.h)
 
 # A C99 compliant compiler should have inttypes.h for fixed-size int types
 AC_CHECK_HEADERS(inttypes.h stdint.h)
@@ -856,10 +856,45 @@ if test "$ac_cv_func_usleep" = "yes" ; then
 fi
 
 AC_CHECK_FUNCS(backtrace_symbols)
-AC_CHECK_LIB(backtrace, backtrace_create_state)
-AC_CHECK_LIB(unwind, unw_backtrace)
 
-AC_CHECK_DECLS([backtrace_create_state, backtrace_print])
+# Check for libbacktrace support
+PAC_PUSH_FLAG([LIBS])
+LIBS="-lbacktrace"
+AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([
+#include <backtrace.h>
+],[
+backtrace_create_state(0, 0, 0, 0);
+backtrace_print(0, 0, 0);
+])],
+    [ac_cv_lib_backtrace=yes],
+    [ac_cv_lib_backtrace=no]
+)
+PAC_POP_FLAG([LIBS])
+
+if test "$ac_cv_lib_backtrace" = "yes" ; then
+    AC_DEFINE([HAVE_LIBBACKTRACE],[1],[Define to 1 if you have the backtrace header (backtrace.h) and library (-lbacktrace)])
+    PAC_PREPEND_FLAG([-lbacktrace],[LIBS])
+fi
+
+# Check for libunwind support
+PAC_PUSH_FLAG([LIBS])
+LIBS="-lunwind"
+AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([
+#include<libunwind.h>
+],[
+unw_backtrace(0, 0);
+])],
+    [ac_cv_lib_libunwind=yes],
+    [ac_cv_lib_libunwind=no]
+)
+PAC_POP_FLAG([LIBS])
+
+if test "$ac_cv_lib_libunwind" = "yes" ; then
+    AC_DEFINE([HAVE_LIBUNWIND],[1],[Define to 1 if you have the libunwind header (libunwind.h) and library (-lunwind)])
+    PAC_PREPEND_FLAG([-lunwind],[LIBS])
+fi
 
 dnl Check for ATTRIBUTE
 PAC_C_GNU_ATTRIBUTE

--- a/src/mpl/src/bt/mpl_bt.c
+++ b/src/mpl/src/bt/mpl_bt.c
@@ -9,11 +9,11 @@
 #include <execinfo.h>
 #endif
 
-#ifdef MPL_HAVE_BACKTRACE_H
+#ifdef MPL_HAVE_LIBBACKTRACE
 #include <backtrace.h>
 #endif
 
-#ifdef MPL_HAVE_LIBUNWIND_H
+#ifdef MPL_HAVE_LIBUNWIND
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #endif
@@ -48,7 +48,7 @@ static inline void backtrace_libback(FILE *output)
  * context), so tighten up when we take the libunwind path.  Thanks
  * Siegmar.Gross@informatik.hs-fulda.de for the bug report about systems with
  * libunwind libraries but no libunwind development headers */
-#elif defined MPL_HAVE_LIBUNWIND && defined(MPL_HAVE_LIBUNWIND_H)
+#elif defined MPL_HAVE_LIBUNWIND
 static inline void backtrace_libunwind(FILE *output)
 {
     unw_cursor_t cursor;
@@ -122,7 +122,7 @@ void MPL_backtrace_show(FILE *output)
 {
 #ifdef MPL_HAVE_LIBBACKTRACE
     backtrace_libback(output);
-#elif defined MPL_HAVE_LIBUNWIND && defined(MPL_HAVE_LIBUNWIND_H)
+#elif defined MPL_HAVE_LIBUNWIND
     /* libunwind is not able to get line numbers without forking off to
      * addr2line (?)*/
     backtrace_libunwind(output);


### PR DESCRIPTION
Fixes #2354 in which compilation with PGI compiler was failing
because of some unresolved symbols in libbacktrace

@pavanbalaji 
@raffenet