### PR TITLE
hcoll: Do not enable hcoll for internal comms

### DIFF
--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -152,7 +152,9 @@ int hcoll_comm_create(MPID_Comm * comm_ptr, void *param)
         goto fn_exit;
     }
     num_ranks = comm_ptr->local_size;
-    if ((MPID_INTRACOMM != comm_ptr->comm_kind) || (2 > num_ranks)) {
+    if ((MPID_INTRACOMM != comm_ptr->comm_kind) || (2 > num_ranks)
+        || comm_ptr->hierarchy_kind == MPID_HIERARCHY_NODE_ROOTS
+        || comm_ptr->hierarchy_kind == MPID_HIERARCHY_NODE) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }


### PR DESCRIPTION
Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>