### PR TITLE
WIP [DO NOT MERGE]: Topology-aware Comm_split_type

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "src/mpid/ch4/netmod/ofi/libfabric"]
 	path = src/mpid/ch4/netmod/ofi/libfabric
 	url = https://github.com/ofiwg/libfabric
+[submodule "src/hwloc"]
+	path = src/hwloc
+	url = https://github.com/open-mpi/hwloc

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,11 +49,11 @@ pkgconfigdir = @pkgconfigdir@
 # to build src/mpi/errhan/defmsg.h
 errnames_txt_files = 
 
-external_subdirs = @mplsrcdir@ @opasrcdir@
-external_ldflags = @mpllibdir@ @opalibdir@
+external_subdirs = @mplsrcdir@ @opasrcdir@ @hwlocsrcdir@
+external_ldflags = @mpllibdir@ @opalibdir@ @hwloclibdir@
 external_libs = @WRAPPER_LIBS@
 mpi_convenience_libs =
-pmpi_convenience_libs = @opalib@ @mpllib@
+pmpi_convenience_libs = @opalib@ @mpllib@ @hwloclib@
 
 # NOTE on our semi-unconventional usage of DIST_SUBDIRS:
 # The automake manual recommends thinking of DIST_SUBDIRS as the list of all

--- a/autogen.sh
+++ b/autogen.sh
@@ -124,6 +124,9 @@ echo
 # ucx
 ( cd src/mpid/ch4/netmod/ucx/ucx && git am --3way ../../../../../../maint/patches/pre/ucx/*.patch )
 
+# hwloc
+( cd src/hwloc && git am --3way ../../maint/patches/pre/hwloc/*.patch )
+
 
 ########################################################################
 echo

--- a/autogen.sh
+++ b/autogen.sh
@@ -166,7 +166,7 @@ export do_build_configure
 MAKE=${MAKE-make}
 
 # external packages that require autogen.sh to be run for each of them
-externals="src/pm/hydra src/mpi/romio src/openpa src/mpid/ch4/netmod/ucx/ucx src/mpid/ch4/netmod/ofi/libfabric"
+externals="src/pm/hydra src/mpi/romio src/openpa src/hwloc src/mpid/ch4/netmod/ucx/ucx src/mpid/ch4/netmod/ofi/libfabric"
 
 # amdirs are the directories that make use of autoreconf
 amdirs=". src/mpl src/util/logging/rlog"

--- a/configure.ac
+++ b/configure.ac
@@ -1290,6 +1290,26 @@ else
 fi
 
 
+# Set NEEDSPLIB to yes if link commands need both -l$MPILIBNAME
+# and -lp$MPILIBNAME.
+NEEDSPLIB=yes
+if test $enable_weak_symbols = yes ; then
+    # Turn off weak symbols if they aren't available
+    PAC_PROG_C_WEAK_SYMBOLS(,enable_weak_symbols=no)
+fi
+if test $enable_weak_symbols = "yes" ; then
+    AC_DEFINE(USE_WEAK_SYMBOLS,1,[Define if weak symbols should be used])
+    NEEDSPLIB=no
+    # Check for the ability to support multiple weak symbols
+    if test "$pac_cv_prog_c_weak_symbols" = "pragma weak" ; then
+       PAC_PROG_C_MULTIPLE_WEAK_SYMBOLS(AC_DEFINE(HAVE_MULTIPLE_PRAGMA_WEAK,1,[Define if multiple weak symbols may be defined]))
+    fi
+fi
+export NEEDSPLIB
+
+AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "$NEEDSPLIB" = "yes"])
+
+
 # ----------------------------------------------------------------------------
 # HWLOC
 # ----------------------------------------------------------------------------
@@ -1329,6 +1349,10 @@ if test "$with_hwloc_prefix" = "embedded" ; then
       CFLAGS="$HWLOC_EMBEDDED_CFLAGS $CFLAGS"
       CPPFLAGS="$HWLOC_EMBEDDED_CPPFLAGS $CPPFLAGS"
       LIBS="$HWLOC_EMBEDDED_LIBS $LIBS"
+      # disable visibility if building profiling library
+      if test "$NEEDSPLIB" != "yes" ; then
+         CFLAGS="$HWLOC_EMBEDDED_VISIBILITY_CFLAGS $CFLAGS"
+      fi
       hwlocsrcdir="src/hwloc"
       hwloclib="src/hwloc/src/libhwloc_embedded.la"
    fi
@@ -1832,25 +1856,6 @@ if test -n "$MPI_DEFAULT_COPTS" ; then
         CFLAGS="$CFLAGS $MPI_DEFAULT_COPTS"
     fi
 fi
-
-# Set NEEDSPLIB to yes if link commands need both -l$MPILIBNAME
-# and -lp$MPILIBNAME.
-NEEDSPLIB=yes
-if test $enable_weak_symbols = yes ; then
-    # Turn off weak symbols if they aren't available
-    PAC_PROG_C_WEAK_SYMBOLS(,enable_weak_symbols=no)
-fi
-if test $enable_weak_symbols = "yes" ; then
-    AC_DEFINE(USE_WEAK_SYMBOLS,1,[Define if weak symbols should be used])
-    NEEDSPLIB=no
-    # Check for the ability to support multiple weak symbols
-    if test "$pac_cv_prog_c_weak_symbols" = "pragma weak" ; then
-       PAC_PROG_C_MULTIPLE_WEAK_SYMBOLS(AC_DEFINE(HAVE_MULTIPLE_PRAGMA_WEAK,1,[Define if multiple weak symbols may be defined]))
-    fi
-fi
-export NEEDSPLIB
-
-AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "$NEEDSPLIB" = "yes"])
 
 # ---------------------------------------------------------------------------
 # determine rpath and other shared library flags for CC

--- a/configure.ac
+++ b/configure.ac
@@ -602,6 +602,8 @@ AC_ARG_ENABLE(dbg-nolocal, AC_HELP_STRING([--enable-dbg-nolocal], [enables debug
 AC_ARG_ENABLE(dbg-localoddeven, AC_HELP_STRING([--enable-dbg-localoddeven], [enables debugging mode where shared-memory communication is enabled only between even processes or odd processes on a node]),
     AC_DEFINE(ENABLED_ODD_EVEN_CLIQUES, 1, [Define to enable debugging mode where shared-memory communication is done only between even procs or odd procs]))
 
+AC_CANONICAL_TARGET
+
 # Find a C compiler.
 # We also need to do this before the F77 and FC test to ensure that we
 # find the C preprocessor reliably.
@@ -619,6 +621,10 @@ if test "$pac_cross_compiling" = "yes" -a "$ac_cv_prog_cc_cross" = "no" ; then
     ac_cv_prog_cxx_cross=yes
 fi
 PAC_POP_FLAG([CFLAGS])
+
+# also needed by hwloc in embedded mode, must also come early for expansion
+# ordering reasons
+AC_USE_SYSTEM_EXTENSIONS
 
 dnl now that autoconf and core compilers are setup, init automake and libtool
 dnl
@@ -1282,6 +1288,86 @@ else
     fi
     PAC_APPEND_FLAG([-L${with_openpa_prefix}/lib],[WRAPPER_LDFLAGS])
 fi
+
+
+# ----------------------------------------------------------------------------
+# HWLOC
+# ----------------------------------------------------------------------------
+# Allow the user to override the hwloc location (from embedded to user
+# path)
+# HWLOC
+AC_ARG_WITH([hwloc-prefix],
+            [AS_HELP_STRING([[--with-hwloc-prefix[=DIR]]],
+                            [use the HWLOC library installed in DIR,
+                             rather than the one included in src/hwloc.  Pass
+                             "embedded" to force usage of the HWLOC source
+                             distributed with MPICH.])],
+            [],dnl action-if-given
+            [with_hwloc_prefix=embedded]) dnl action-if-not-given
+hwlocsrcdir=""
+AC_SUBST([hwlocsrcdir])
+hwloclibdir=""
+AC_SUBST([hwloclibdir])
+hwloclib=""
+AC_SUBST([hwloclib])
+
+# Unconditionally include the hwloc macros, even if we are using an
+# external hwloc (or hwloc is disabled). This is needed for the
+# AM_CONDITIONALS that we will set later.
+m4_include([src/hwloc/config/hwloc.m4])
+m4_include([src/hwloc/config/hwloc_check_attributes.m4])
+m4_include([src/hwloc/config/hwloc_check_visibility.m4])
+m4_include([src/hwloc/config/hwloc_check_vendor.m4])
+m4_include([src/hwloc/config/hwloc_components.m4])
+m4_include([src/hwloc/config/hwloc_pkg.m4])
+
+if test "$with_hwloc_prefix" = "embedded" ; then
+   HWLOC_SETUP_CORE([src/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
+   # Only build hwloc in embedded mode
+   if test "$have_hwloc" = "yes" ; then
+      use_embedded_hwloc=yes
+      CFLAGS="$HWLOC_EMBEDDED_CFLAGS $CFLAGS"
+      CPPFLAGS="$HWLOC_EMBEDDED_CPPFLAGS $CPPFLAGS"
+      LIBS="$HWLOC_EMBEDDED_LIBS $LIBS"
+      hwlocsrcdir="src/hwloc"
+      hwloclib="src/hwloc/src/libhwloc_embedded.la"
+   fi
+else
+   AC_CHECK_HEADERS([hwloc.h])
+   # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our
+   # minimum required version
+   AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
+   AC_MSG_CHECKING([if non-embedded hwloc works])
+   if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
+      have_hwloc=yes
+   else
+      have_hwloc=no
+   fi
+   AC_MSG_RESULT([$have_hwloc])
+
+   # FIXME: Disable hwloc on Cygwin for now. The hwloc package,
+   # atleast as of 1.0.2, does not install correctly on Cygwin
+   AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
+
+   if test "$have_hwloc" = "yes" ; then
+      hwloclib="-lhwloc"
+      if test -d ${with_hwloc_prefix}/lib64 ; then
+         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
+         hwloclibdir="-L${with_hwloc_prefix}/lib64"
+      else
+	 hwloclibdir="-L${with_hwloc_prefix}/lib"
+      fi
+   fi
+fi
+
+if test "$have_hwloc" = "yes" ; then
+   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+fi
+
+HWLOC_DO_AM_CONDITIONALS
+AM_CONDITIONAL([have_hwloc], [test "${have_hwloc}" = "yes"])
+AM_CONDITIONAL([use_embedded_hwloc], [test "${use_embedded_hwloc}" = "yes"])
+
 
 # ----------------------------------------------------------------------------
 # Threads

--- a/maint/patches/pre/hwloc/0001-hwloc-remove-redundant-pkgconfig-initialization.patch
+++ b/maint/patches/pre/hwloc/0001-hwloc-remove-redundant-pkgconfig-initialization.patch
@@ -1,0 +1,36 @@
+From bb57d00958aea444f6866a11d5539a1985ed6bd4 Mon Sep 17 00:00:00 2001
+From: Pavan Balaji <balaji@anl.gov>
+Date: Fri, 13 Oct 2017 23:00:05 -0500
+Subject: [PATCH 1/3] hwloc: remove redundant pkgconfig initialization.
+
+When hwloc is embedded into mpich, pkgconfig is already initialized.
+Even though the STANDALONE path is never reached, autoreconf still
+complains of a possible reinitialization.
+---
+ Makefile.am | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index b92ff287de8c..21878c177ab9 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -21,13 +21,13 @@ DIST_SUBDIRS = $(SUBDIRS)
+ 
+ # Only install the pkg file if we're building in standalone mode (and not on Windows)
+ if HWLOC_BUILD_STANDALONE
+-pkgconfigdir = $(libdir)/pkgconfig
+-pkgconfig_DATA = hwloc.pc
++# pkgconfigdir = $(libdir)/pkgconfig
++# pkgconfig_DATA = hwloc.pc
+ endif
+ 
+ # Only install the valgrind suppressions file if we're building in standalone mode
+ if HWLOC_BUILD_STANDALONE
+-dist_pkgdata_DATA = contrib/hwloc-valgrind.supp
++# dist_pkgdata_DATA = contrib/hwloc-valgrind.supp
+ endif
+ 
+ #
+-- 
+2.14.2
+

--- a/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
+++ b/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
@@ -1,0 +1,48 @@
+From 9ef121467a3d187de2e47a7b6def17dbaa9f1e85 Mon Sep 17 00:00:00 2001
+From: Pavan Balaji <balaji@anl.gov>
+Date: Fri, 13 Oct 2017 16:02:08 -0500
+Subject: [PATCH 2/3] hwloc: separated visibility cflags for better control.
+
+---
+ config/hwloc.m4 | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/config/hwloc.m4 b/config/hwloc.m4
+index cda92d08dfb9..c153e520f888 100644
+--- a/config/hwloc.m4
++++ b/config/hwloc.m4
+@@ -316,9 +316,6 @@ EOF])
+     _HWLOC_C_COMPILER_VENDOR([hwloc_c_vendor])
+     _HWLOC_CHECK_ATTRIBUTES
+     _HWLOC_CHECK_VISIBILITY
+-    HWLOC_CFLAGS="$HWLOC_FLAGS $HWLOC_VISIBILITY_CFLAGS"
+-    AS_IF([test "$HWLOC_VISIBILITY_CFLAGS" != ""],
+-          [AC_MSG_WARN(["$HWLOC_VISIBILITY_CFLAGS" has been added to the hwloc CFLAGS])])
+ 
+     # Make sure the compiler returns an error code when function arg
+     # count is wrong, otherwise sched_setaffinity checks may fail.
+@@ -1179,15 +1176,21 @@ EOF])
+ 
+     AS_IF([test "$hwloc_mode" = "embedded"],
+           [HWLOC_EMBEDDED_CFLAGS=$HWLOC_CFLAGS
++           HWLOC_EMBEDDED_VISIBILITY_CFLAGS=$HWLOC_VISIBILITY_CFLAGS
+            HWLOC_EMBEDDED_CPPFLAGS=$HWLOC_CPPFLAGS
+            HWLOC_EMBEDDED_LDADD='$(HWLOC_top_builddir)/src/libhwloc_embedded.la'
+            HWLOC_EMBEDDED_LIBS=$HWLOC_LIBS
+            HWLOC_LIBS=])
+     AC_SUBST(HWLOC_EMBEDDED_CFLAGS)
++    AC_SUBST(HWLOC_EMBEDDED_VISIBILITY_CFLAGS)
+     AC_SUBST(HWLOC_EMBEDDED_CPPFLAGS)
+     AC_SUBST(HWLOC_EMBEDDED_LDADD)
+     AC_SUBST(HWLOC_EMBEDDED_LIBS)
+ 
++    HWLOC_CFLAGS="$HWLOC_FLAGS $HWLOC_VISIBILITY_CFLAGS $HWLOC_CFLAGS"
++    AS_IF([test "$HWLOC_VISIBILITY_CFLAGS" != ""],
++          [AC_MSG_WARN(["$HWLOC_VISIBILITY_CFLAGS" has been added to the hwloc CFLAGS])])
++
+     # Always generate these files
+     AC_CONFIG_FILES(
+         hwloc_config_prefix[Makefile]
+-- 
+2.14.2
+

--- a/maint/patches/pre/hwloc/0003-hwloc-warning-squash.patch
+++ b/maint/patches/pre/hwloc/0003-hwloc-warning-squash.patch
@@ -1,0 +1,53 @@
+From 505392c182729e345a7308db37f6727a74196f10 Mon Sep 17 00:00:00 2001
+From: Pavan Balaji <balaji@anl.gov>
+Date: Fri, 13 Oct 2017 23:16:35 -0500
+Subject: [PATCH 3/3] hwloc: warning squash.
+
+---
+ src/topology-xml-libxml.c   | 2 +-
+ src/topology-xml-nolibxml.c | 2 +-
+ src/topology-xml.c          | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/topology-xml-libxml.c b/src/topology-xml-libxml.c
+index ac20d87f21ca..f35eab2795f1 100644
+--- a/src/topology-xml-libxml.c
++++ b/src/topology-xml-libxml.c
+@@ -134,7 +134,7 @@ hwloc__libxml_import_get_content(hwloc__xml_import_state_t state,
+   if (!child || child->type != XML_TEXT_NODE) {
+     if (expected_length)
+       return -1;
+-    *beginp = "";
++    *beginp = (char *) "";
+     return 0;
+   }
+ 
+diff --git a/src/topology-xml-nolibxml.c b/src/topology-xml-nolibxml.c
+index 147e703cc172..f11ae8cf5ff6 100644
+--- a/src/topology-xml-nolibxml.c
++++ b/src/topology-xml-nolibxml.c
+@@ -222,7 +222,7 @@ hwloc__nolibxml_import_get_content(hwloc__xml_import_state_t state,
+   if (nstate->closed) {
+     if (expected_length)
+       return -1;
+-    *beginp = "";
++    *beginp = (char *) "";
+     return 0;
+   }
+ 
+diff --git a/src/topology-xml.c b/src/topology-xml.c
+index 9eeb85b728a9..1f2a654a37a9 100644
+--- a/src/topology-xml.c
++++ b/src/topology-xml.c
+@@ -673,7 +673,7 @@ hwloc__xml_import_userdata(hwloc_topology_t topology __hwloc_attribute_unused, h
+       }
+ 
+   } else { /* always handle length==0 in the non-encoded case */
+-      char *buffer = "";
++      char *buffer = (char *) "";
+       if (length) {
+ 	ret = state->global->get_content(state, &buffer, length);
+ 	if (ret < 0)
+-- 
+2.14.2
+

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -309,8 +309,8 @@ int MPIR_Comm_remote_group_impl(MPIR_Comm *comm_ptr, MPIR_Group **group_ptr);
 int MPIR_Comm_group_failed_impl(MPIR_Comm *comm, MPIR_Group **failed_group_ptr);
 int MPIR_Comm_remote_group_failed_impl(MPIR_Comm *comm, MPIR_Group **failed_group_ptr);
 int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **newcomm_ptr);
-int MPIR_Comm_split_type_self(MPIR_Comm *comm_ptr, int key, MPIR_Comm **newcomm_ptr);
-int MPIR_Comm_split_type_node(MPIR_Comm *comm_ptr, int key, MPIR_Comm **newcomm_ptr);
+int MPIR_Comm_split_type_self(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
+int MPIR_Comm_split_type_node(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,
                          MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type_impl(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -311,6 +311,8 @@ int MPIR_Comm_remote_group_failed_impl(MPIR_Comm *comm, MPIR_Group **failed_grou
 int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type_self(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type_node(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
+int MPIR_Comm_split_type_node_topo(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info * info_ptr,
+                                   MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,
                          MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type_impl(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -8,6 +8,10 @@
 #ifndef MPIR_PROCESS_H_INCLUDED
 #define MPIR_PROCESS_H_INCLUDED
 
+#ifdef HAVE_HWLOC
+#include "hwloc.h"
+#endif
+
 /* Per process data */
 typedef struct PreDefined_attrs {
     int appnum;          /* Application number provided by mpiexec (MPI-2) */
@@ -33,6 +37,12 @@ typedef struct MPIR_Process_t {
     PreDefined_attrs  attrs;            /* Predefined attribute values */
     int               tagged_coll_mask; /* Tag space mask for tagged collectives */
 
+#ifdef HAVE_HWLOC
+    hwloc_topology_t topology; /* HWLOC topology */
+    hwloc_cpuset_t bindset; /* process binding */
+    int bindset_is_valid; /* Flag to indicate if the bind set of the process is valid:
+                           * 0 if invalid, 1 if valid */
+#endif
     /* The topology routines dimsCreate is independent of any communicator.
        If this pointer is null, the default routine is used */
     int (*dimsCreate)( int, int, int *);

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -150,20 +150,16 @@ int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
 
 	    MPIR_Comm_get_ptr(dummycomm, dummycomm_ptr);
 	    *newcomm_ptr = dummycomm_ptr;
-
-	    goto fn_exit;
 #endif
-	    /* fall through to the "not supported" case if ROMIO was not
-	     * enabled for some reason */
 	}
-
-	/* In the mean time, the user passed in COMM_TYPE_NEIGHBORHOOD
-	 * but did not give us an info we know how to work with.
-	 * Throw up our hands and treat it like UNDEFINED.  This will
-	 * result in MPI_COMM_NULL being returned to the user. */
-        mpi_errno = MPIR_Comm_split_impl(comm_ptr, MPI_UNDEFINED, key, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        else {
+            /* In the mean time, the user passed in
+             * COMM_TYPE_NEIGHBORHOOD but did not give us an info we
+             * know how to work with.  Throw up our hands and treat it
+             * like UNDEFINED.  This will result in MPI_COMM_NULL
+             * being returned to the user. */
+            *newcomm_ptr = NULL;
+        }
     }
     else {
         MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**splittype");

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -33,6 +33,7 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
 int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key, MPIR_Comm ** newcomm_ptr)
 {
     MPIR_Comm *comm_ptr = NULL;
+    MPIR_Comm *comm_self_ptr;
     int mpi_errno = MPI_SUCCESS;
 
     /* split out the undefined processes */
@@ -46,10 +47,8 @@ int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key
         goto fn_exit;
     }
 
-    /* The default implementation is to either pass MPI_UNDEFINED or
-     * the local rank as the color (in which case a dup of
-     * MPI_COMM_SELF is returned) */
-    mpi_errno = MPIR_Comm_split_impl(comm_ptr, comm_ptr->rank, key, newcomm_ptr);
+    MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
+    mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, newcomm_ptr);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/comm/errnames.txt
+++ b/src/mpi/comm/errnames.txt
@@ -1,0 +1,1 @@
+**splittype: MPI split type is not defined

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -142,6 +142,12 @@ int MPI_Finalize( void )
 {
     static const char FCNAME[] = "MPI_Finalize";
     int mpi_errno = MPI_SUCCESS;
+
+#ifdef HAVE_HWLOC
+    hwloc_topology_destroy(MPIR_Process.topology);
+    hwloc_bitmap_free(MPIR_Process.bindset);
+#endif
+
 #if defined(HAVE_USLEEP) && defined(USE_COVERAGE)
     int rank=0;
 #endif

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -324,6 +324,14 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
     int exit_init_cs_on_failure = 0;
     MPIR_Info *info_ptr;
 
+#ifdef HAVE_HWLOC
+    MPIR_Process.bindset = hwloc_bitmap_alloc();
+    hwloc_topology_init(&MPIR_Process.topology);
+    hwloc_topology_set_flags(MPIR_Process.topology, HWLOC_TOPOLOGY_FLAG_WHOLE_IO|HWLOC_TOPOLOGY_FLAG_IO_BRIDGES);
+    hwloc_topology_load(MPIR_Process.topology);
+    MPIR_Process.bindset_is_valid = !hwloc_get_proc_cpubind(MPIR_Process.topology, getpid(),
+                                                            MPIR_Process.bindset, HWLOC_CPUBIND_PROCESS);
+#endif
     /* For any code in the device that wants to check for runtime 
        decisions on the value of isThreaded, set a provisional
        value here. We could let the MPID_Init routine override this */

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -47,7 +47,7 @@ static int split_type(MPIR_Comm * user_comm_ptr, int stype, int key,
     }
 
     if (MPIDI_CH3I_Shm_supported()) {
-        mpi_errno = MPIR_Comm_split_type_node(comm_ptr, stype, key, newcomm_ptr);
+        mpi_errno = MPIR_Comm_split_type_node_topo(comm_ptr, stype, key, info_ptr, newcomm_ptr);
     }
     else {
         mpi_errno = MPIR_Comm_split_type_self(comm_ptr, stype, key, newcomm_ptr);

--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -12,10 +12,16 @@
 /* FIXME: This test only checks that the MPI_Comm_split_type routine
    doesn't fail.  It does not check for correct behavior */
 
+
+static const char *split_topo[] = { "numanode", "socket", "package", "core", "pu", "l1cache",
+    "l2cache", "l3cache", "machine", "hwthread", "l1ucache", "l1dcache", "l1icache", "l2ucache",
+    "l2dcache", "l2icache", "l3ucache", "l3icache", "l3dcache", "bridge", "pci", NULL
+};
+
 int main(int argc, char *argv[])
 {
     int rank, size, verbose = 0, errs = 0, tot_errs = 0;
-    int wrank;
+    int wrank, i;
     MPI_Comm comm;
     MPI_Info info;
 
@@ -39,6 +45,79 @@ int main(int argc, char *argv[])
             printf("Created shared subcommunicator of size %d\n", size);
         MPI_Comm_free(&comm);
     }
+
+
+    /* test for topology hints: pass a valid info value, but do not
+     * expect that the MPI implementation will respect it.  */
+    for (i = 0; split_topo[i]; i++) {
+        MPI_Info_create(&info);
+        MPI_Info_set(info, "shmem_topo", split_topo[i]);
+        MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &comm);
+        if (comm == MPI_COMM_NULL) {
+            printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
+            errs++;
+        }
+        else {
+            int newsize;
+            MPI_Comm_size(comm, &newsize);
+            if (newsize > size) {
+                printf("Expected comm size to be smaller than node size\n");
+                errs++;
+            }
+            MPI_Comm_free(&comm);
+        }
+        MPI_Info_free(&info);
+    }
+
+    /*
+     * test for topology hints: pass different info values from
+     * different processes, the hint must be ignored then
+     */
+    MPI_Info_create(&info);
+    if (rank == 0) {
+        MPI_Info_set(info, "shmem_topo", split_topo[0]);
+    }
+    else {
+        MPI_Info_set(info, "shmem_topo", split_topo[1]);
+    }
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &comm);
+    if (comm == MPI_COMM_NULL) {
+        printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
+        errs++;
+    }
+    else {
+        int newsize;
+        MPI_Comm_size(comm, &newsize);
+        if (newsize > size) {
+            printf("Expected comm size to be smaller than node size\n");
+            errs++;
+        }
+        MPI_Comm_free(&comm);
+    }
+    MPI_Info_free(&info);
+
+
+    /* test for topology hints: pass an invalid info value and make
+     * sure the behavior is as if no info key was passed.  */
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "shmem_topo", "__garbage_value__");
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, info, &comm);
+    if (comm == MPI_COMM_NULL) {
+        printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
+        errs++;
+    }
+    else {
+        int newsize;
+
+        MPI_Comm_size(comm, &newsize);
+        if (newsize != size) {
+            printf("Expected comm size to be the same as node size\n");
+            errs++;
+        }
+        MPI_Comm_free(&comm);
+    }
+    MPI_Info_free(&info);
+
 
 #if defined(MPIX_COMM_TYPE_NEIGHBORHOOD) && defined(HAVE_MPI_IO)
     /* the MPICH-specific MPIX_COMM_TYPE_NEIGHBORHOOD */

--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -14,7 +14,7 @@
 
 int main(int argc, char *argv[])
 {
-    int rank, size, verbose = 0, errs=0, tot_errs=0;
+    int rank, size, verbose = 0, errs = 0, tot_errs = 0;
     int wrank;
     MPI_Comm comm;
     MPI_Info info;
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
     MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &comm);
     if (comm == MPI_COMM_NULL) {
         printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
-	errs++;
+        errs++;
     }
     else {
         MPI_Comm_rank(comm, &rank);
@@ -41,19 +41,18 @@ int main(int argc, char *argv[])
     }
 
 #if defined(MPIX_COMM_TYPE_NEIGHBORHOOD) && defined(HAVE_MPI_IO)
-    /* the MPICH-specific MPIX_COMM_TYPE_NEIGHBORHOOD*/
+    /* the MPICH-specific MPIX_COMM_TYPE_NEIGHBORHOOD */
     /* test #1: expected behavior -- user provided a directory, and we
      * determine which processes share access to it */
     MPI_Info_create(&info);
     if (argc == 2)
-	    MPI_Info_set(info, "nbhd_common_dirname", argv[1]);
+        MPI_Info_set(info, "nbhd_common_dirname", argv[1]);
     else
-	MPI_Info_set(info, "nbhd_common_dirname", ".");
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPIX_COMM_TYPE_NEIGHBORHOOD, 0,
-	    info, &comm);
+        MPI_Info_set(info, "nbhd_common_dirname", ".");
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPIX_COMM_TYPE_NEIGHBORHOOD, 0, info, &comm);
     if (comm == MPI_COMM_NULL) {
         printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
-	errs++;
+        errs++;
     }
     else {
         MPI_Comm_rank(comm, &rank);
@@ -66,11 +65,10 @@ int main(int argc, char *argv[])
     /* test #2: a hint we don't know about */
     MPI_Info_delete(info, "nbhd_common_dirname");
     MPI_Info_set(info, "mpix_tooth_fairy", "enable");
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPIX_COMM_TYPE_NEIGHBORHOOD, 0,
-	    info, &comm);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPIX_COMM_TYPE_NEIGHBORHOOD, 0, info, &comm);
     if (comm != MPI_COMM_NULL) {
         printf("Expected a NULL communicator, but got something else\n");
-	errs++;
+        errs++;
         MPI_Comm_free(&comm);
     }
     else {
@@ -83,17 +81,17 @@ int main(int argc, char *argv[])
 #endif
 
     /* Check to see if MPI_UNDEFINED is respected */
-    MPI_Comm_split_type(MPI_COMM_WORLD, (wrank % 2 == 0) ? MPI_COMM_TYPE_SHARED : MPI_UNDEFINED,
-                        0, MPI_INFO_NULL, &comm);
+    MPI_Comm_split_type(MPI_COMM_WORLD, (wrank % 2 == 0) ? MPI_COMM_TYPE_SHARED : MPI_UNDEFINED, 0,
+                        MPI_INFO_NULL, &comm);
     if ((wrank % 2) && (comm != MPI_COMM_NULL)) {
         printf("Expected MPI_COMM_NULL, but did not get one\n");
-	errs++;
+        errs++;
     }
     if (wrank % 2 == 0) {
         if (comm == MPI_COMM_NULL) {
             printf("Expected a non-null communicator, but got MPI_COMM_NULL\n");
-	    errs++;
-	}
+            errs++;
+        }
         else {
             MPI_Comm_rank(comm, &rank);
             MPI_Comm_size(comm, &size);


### PR DESCRIPTION
Allow for hwloc integration and using it to create communicators based on on-node topology information.