### PR TITLE
Remove MPL_ namespace from utlist library

### DIFF
--- a/src/include/mpit.h
+++ b/src/include/mpit.h
@@ -44,7 +44,7 @@ static inline cvar_table_entry_t * LOOKUP_CVAR_BY_NAME(const char* cvar_name)
 {
     unsigned cvar_idx;
     name2index_hash_t *hash_entry;
-    MPL_HASH_FIND_STR(cvar_hash, cvar_name, hash_entry);
+    HASH_FIND_STR(cvar_hash, cvar_name, hash_entry);
     MPIR_Assert(hash_entry != NULL);
     cvar_idx = hash_entry->idx;
     return (cvar_table_entry_t *)utarray_eltptr(cvar_table, cvar_idx);

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -58,7 +58,7 @@ typedef struct {
 typedef struct {
     const char *name;
     unsigned idx;
-    MPL_UT_hash_handle hh;  /* Makes this structure hashable */
+    UT_hash_handle hh;  /* Makes this structure hashable */
 } name2index_hash_t;
 
 /* MPI_T control variable (cvar)

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -16,7 +16,7 @@
 #include "mpir_assert.h"
 #include "mpir_pointers.h"
 #include "mpir_utarray.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 #include "mpir_objects.h"
 
 #ifdef HAVE_ERROR_CHECKING

--- a/src/mpi/comm/comm_set_info.c
+++ b/src/mpi/comm/comm_set_info.c
@@ -6,7 +6,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "mpir_info.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_Comm_set_info */

--- a/src/mpi/comm/comm_set_info.c
+++ b/src/mpi/comm/comm_set_info.c
@@ -53,7 +53,7 @@ int MPIR_Comm_set_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
     /* MPIR_Info_set_impl will do an O(n) search to prevent duplicate keys, so
      * this _FOREACH loop will cost O(m*n) time, where "m" is the number of keys
      * in info_ptr and "n" is the number of keys in comm_ptr->info. */
-    MPL_LL_FOREACH(info_ptr, curr_info) {
+    LL_FOREACH(info_ptr, curr_info) {
         /* Have we hit the default, empty info hint? */
         if (curr_info->key == NULL) continue;
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -39,7 +39,7 @@ struct MPIR_Comm_hint_fn_elt {
     char name[MPI_MAX_INFO_KEY];
     MPIR_Comm_hint_fn_t fn;
     void *state;
-    MPL_UT_hash_handle hh;
+    UT_hash_handle hh;
 };
 static struct MPIR_Comm_hint_fn_elt *MPID_hint_fns = NULL;
 
@@ -1106,7 +1106,7 @@ int MPII_Comm_apply_hints(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
 
         strncpy(hint_name, hint->key, MPI_MAX_INFO_KEY);
 
-        MPL_HASH_FIND_STR(MPID_hint_fns, hint_name, hint_fn);
+        HASH_FIND_STR(MPID_hint_fns, hint_name, hint_fn);
 
         /* Skip hints that MPICH doesn't recognize. */
         if (hint_fn) {
@@ -1136,8 +1136,8 @@ static int free_hint_handles(void *ignore)
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_FREE_HINT_HANDLES);
 
     if (MPID_hint_fns) {
-        MPL_HASH_ITER(hh, MPID_hint_fns, curr_hint, tmp) {
-            MPL_HASH_DEL(MPID_hint_fns, curr_hint);
+        HASH_ITER(hh, MPID_hint_fns, curr_hint, tmp) {
+            HASH_DEL(MPID_hint_fns, curr_hint);
             MPL_free(curr_hint);
         }
     }
@@ -1169,7 +1169,7 @@ int MPIR_Comm_register_hint(const char *hint_key, MPIR_Comm_hint_fn_t fn, void *
     hint_elt->state = state;
     hint_elt->fn = fn;
 
-    MPL_HASH_ADD_STR(MPID_hint_fns, name, hint_elt);
+    HASH_ADD_STR(MPID_hint_fns, name, hint_elt);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_REGISTER_HINT);
     return mpi_errno;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -444,7 +444,7 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
 
     mapper->next = NULL;
 
-    MPL_LL_APPEND(newcomm->mapper_head, newcomm->mapper_tail, mapper);
+    LL_APPEND(newcomm->mapper_head, newcomm->mapper_tail, mapper);
 
     if (map)
         *map = mapper;
@@ -479,7 +479,7 @@ int MPIR_Comm_map_dup(MPIR_Comm * newcomm, MPIR_Comm * src_comm, MPIR_Comm_map_d
 
     mapper->next = NULL;
 
-    MPL_LL_APPEND(newcomm->mapper_head, newcomm->mapper_tail, mapper);
+    LL_APPEND(newcomm->mapper_head, newcomm->mapper_tail, mapper);
 
   fn_exit:
     MPIR_CHKPMEM_COMMIT();
@@ -1099,7 +1099,7 @@ int MPII_Comm_apply_hints(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_APPLY_HINTS);
 
-    MPL_LL_FOREACH(info_ptr, hint) {
+    LL_FOREACH(info_ptr, hint) {
         /* Have we hit the default, empty info hint? */
         if (hint->key == NULL)
             continue;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -9,7 +9,7 @@
 #include "mpir_info.h"    /* MPIR_Info_free */
 
 #include "mpl_utlist.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 
 /* This is the utility file for comm that contains the basic comm items
    and storage management */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -8,7 +8,7 @@
 #include "mpicomm.h"
 #include "mpir_info.h"    /* MPIR_Info_free */
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "uthash.h"
 
 /* This is the utility file for comm that contains the basic comm items

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -8,7 +8,7 @@
 #include "mpicomm.h"
 #include "mpir_info.h"    /* MPIR_Info_free */
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===

--- a/src/mpi_t/cat_get_index.c
+++ b/src/mpi_t/cat_get_index.c
@@ -71,7 +71,7 @@ int MPI_T_category_get_index(const char *name, int *cat_index)
     name2index_hash_t *hash_entry;
 
     /* Do hash lookup by the name */
-    MPL_HASH_FIND_STR(cat_hash, name, hash_entry);
+    HASH_FIND_STR(cat_hash, name, hash_entry);
     if (hash_entry != NULL) {
         *cat_index = hash_entry->idx;
     } else {

--- a/src/mpi_t/cvar_get_index.c
+++ b/src/mpi_t/cvar_get_index.c
@@ -71,7 +71,7 @@ int MPI_T_cvar_get_index(const char *name, int *cvar_index)
     name2index_hash_t *hash_entry;
 
     /* Do hash lookup by the name */
-    MPL_HASH_FIND_STR(cvar_hash, name, hash_entry);
+    HASH_FIND_STR(cvar_hash, name, hash_entry);
     if (hash_entry != NULL) {
         *cvar_index = hash_entry->idx;
     } else {

--- a/src/mpi_t/mpit.c
+++ b/src/mpi_t/mpit.c
@@ -94,7 +94,7 @@ static cat_table_entry_t *MPIR_T_cat_create(const char *cat_name)
     /* Need not to Strdup cat_name, since cat_table and cat_hash co-exist */
     hash_entry->name = cat_name;
     hash_entry->idx = cat_idx;
-    MPL_HASH_ADD_KEYPTR(hh, cat_hash, hash_entry->name,
+    HASH_ADD_KEYPTR(hh, cat_hash, hash_entry->name,
                     strlen(hash_entry->name), hash_entry);
 
     return cat;
@@ -115,7 +115,7 @@ int MPIR_T_cat_add_pvar(const char *cat_name, int pvar_index)
     if (cat_name == NULL || *cat_name == '\0')
         goto fn_exit;
 
-    MPL_HASH_FIND_STR(cat_hash, cat_name, hash_entry);
+    HASH_FIND_STR(cat_hash, cat_name, hash_entry);
 
     if (hash_entry != NULL) {
         /* Found it, i.e., category already exists */
@@ -149,7 +149,7 @@ int MPIR_T_cat_add_cvar(const char *cat_name, int cvar_index)
     if (cat_name == NULL || *cat_name == '\0')
         goto fn_exit;
 
-    MPL_HASH_FIND_STR(cat_hash, cat_name, hash_entry);
+    HASH_FIND_STR(cat_hash, cat_name, hash_entry);
 
     if (hash_entry != NULL) {
         /* Found it, i.e., category already exists */
@@ -188,7 +188,7 @@ int MPIR_T_cat_add_subcat(const char *parent_name, const char *child_name)
     }
 
     /* Find or create parent */
-    MPL_HASH_FIND_STR(cat_hash, parent_name, hash_entry);
+    HASH_FIND_STR(cat_hash, parent_name, hash_entry);
     if (hash_entry != NULL) {
         /* Found parent in cat_table */
         parent_index = hash_entry->idx;
@@ -199,7 +199,7 @@ int MPIR_T_cat_add_subcat(const char *parent_name, const char *child_name)
     }
 
     /* Find or create child */
-    MPL_HASH_FIND_STR(cat_hash, child_name, hash_entry);
+    HASH_FIND_STR(cat_hash, child_name, hash_entry);
     if (hash_entry != NULL) {
         /* Found child in cat_table */
         child_index = hash_entry->idx;
@@ -235,7 +235,7 @@ int MPIR_T_cat_add_desc(const char *cat_name, const char *cat_desc)
     MPIR_Assert(cat_name);
     MPIR_Assert(cat_desc);
 
-    MPL_HASH_FIND_STR(cat_hash, cat_name, hash_entry);
+    HASH_FIND_STR(cat_hash, cat_name, hash_entry);
 
     if (hash_entry != NULL) {
         /* Found it, i.e., category already exists */
@@ -284,7 +284,7 @@ void MPIR_T_CVAR_REGISTER_impl(
     int cvar_idx;
 
     /* Check whether this is a replicated cvar, whose name is unique. */
-    MPL_HASH_FIND_STR(cvar_hash, name, hash_entry);
+    HASH_FIND_STR(cvar_hash, name, hash_entry);
 
     if (hash_entry != NULL) {
         /* Found it, the cvar already exists */
@@ -332,7 +332,7 @@ void MPIR_T_CVAR_REGISTER_impl(
         /* Need not to Strdup name, since cvar_table and cvar_hash co-exist */
         hash_entry->name =name;
         hash_entry->idx = cvar_idx;
-        MPL_HASH_ADD_KEYPTR(hh, cvar_hash, hash_entry->name,
+        HASH_ADD_KEYPTR(hh, cvar_hash, hash_entry->name,
                         strlen(hash_entry->name), hash_entry);
 
         /* Add the cvar to a category */
@@ -370,7 +370,7 @@ void MPIR_T_PVAR_REGISTER_impl(
     int seq = varclass - MPIR_T_PVAR_CLASS_FIRST;
 
     /* Check whether this is a replicated pvar, whose name is unique per class */
-    MPL_HASH_FIND_STR(pvar_hashs[seq], name, hash_entry);
+    HASH_FIND_STR(pvar_hashs[seq], name, hash_entry);
 
     if (hash_entry != NULL) {
         /* Found it, the pvar already exists */
@@ -407,7 +407,7 @@ void MPIR_T_PVAR_REGISTER_impl(
         /* Need not to Strdup name, since pvar_table and pvar_hashs co-exist */
         hash_entry->name = name;
         hash_entry->idx = pvar_idx;
-        MPL_HASH_ADD_KEYPTR(hh, pvar_hashs[seq], hash_entry->name,
+        HASH_ADD_KEYPTR(hh, pvar_hashs[seq], hash_entry->name,
                         strlen(hash_entry->name), hash_entry);
 
         /* Add the pvar to a category */

--- a/src/mpi_t/mpit_finalize.c
+++ b/src/mpi_t/mpit_finalize.c
@@ -77,13 +77,13 @@ static void MPIR_T_cat_env_finalize(void)
     if (cat_hash) {
         name2index_hash_t *current, *tmp;
         /* Free all entries */
-        MPL_HASH_ITER(hh, cat_hash, current, tmp) {
-            MPL_HASH_DEL(cat_hash, current);
+        HASH_ITER(hh, cat_hash, current, tmp) {
+            HASH_DEL(cat_hash, current);
             MPL_free(current);
         }
 
         /* Free cat_hash itself */
-        MPL_HASH_CLEAR(hh, cat_hash);
+        HASH_CLEAR(hh, cat_hash);
         cat_hash = NULL;
     }
 }
@@ -113,13 +113,13 @@ static void MPIR_T_cvar_env_finalize(void)
     if (cvar_hash) {
         name2index_hash_t *current, *tmp;
         /* Free all entries */
-        MPL_HASH_ITER(hh, cvar_hash, current, tmp) {
-            MPL_HASH_DEL(cvar_hash, current);
+        HASH_ITER(hh, cvar_hash, current, tmp) {
+            HASH_DEL(cvar_hash, current);
             MPL_free(current);
         }
 
         /* Free cvar_hash itself */
-        MPL_HASH_CLEAR(hh, cvar_hash);
+        HASH_CLEAR(hh, cvar_hash);
         cvar_hash = NULL;
     }
 }
@@ -146,13 +146,13 @@ static void MPIR_T_pvar_env_finalize(void)
         if (pvar_hashs[i]) {
             name2index_hash_t *current, *tmp;
             /* Free all entries */
-            MPL_HASH_ITER(hh, pvar_hashs[i], current, tmp) {
-                MPL_HASH_DEL(pvar_hashs[i], current);
+            HASH_ITER(hh, pvar_hashs[i], current, tmp) {
+                HASH_DEL(pvar_hashs[i], current);
                 MPL_free(current);
             }
 
             /* Free pvar_hashs[i] itself */
-            MPL_HASH_CLEAR(hh, pvar_hashs[i]);
+            HASH_CLEAR(hh, pvar_hashs[i]);
             pvar_hashs[i] = NULL;
         }
     }

--- a/src/mpi_t/pvar_get_index.c
+++ b/src/mpi_t/pvar_get_index.c
@@ -79,7 +79,7 @@ int MPI_T_pvar_get_index(const char *name, int var_class, int *pvar_index)
     name2index_hash_t *hash_entry;
 
     /* Do hash lookup by the name */
-    MPL_HASH_FIND_STR(pvar_hashs[seq], name, hash_entry);
+    HASH_FIND_STR(pvar_hashs[seq], name, hash_entry);
     if (hash_entry != NULL) {
         *pvar_index = hash_entry->idx;
     } else {

--- a/src/mpi_t/pvar_handle_alloc.c
+++ b/src/mpi_t/pvar_handle_alloc.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_handle_alloc */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpi_t/pvar_handle_alloc.c
+++ b/src/mpi_t/pvar_handle_alloc.c
@@ -159,7 +159,7 @@ int MPIR_T_pvar_handle_alloc_impl(MPI_T_pvar_session session, int pvar_index,
     }
 
     /* Link the handle in its session and return it */
-    MPL_DL_APPEND(session->hlist, hnd);
+    DL_APPEND(session->hlist, hnd);
     *handle = hnd;
     *count = cnt;
 

--- a/src/mpi_t/pvar_handle_free.c
+++ b/src/mpi_t/pvar_handle_free.c
@@ -36,7 +36,7 @@ int MPIR_T_pvar_handle_free_impl(MPI_T_pvar_session session, MPI_T_pvar_handle *
     int mpi_errno = MPI_SUCCESS;
     MPIR_T_pvar_handle_t *hnd = *handle;
 
-    MPL_DL_DELETE(session->hlist, hnd);
+    DL_DELETE(session->hlist, hnd);
 
     /* Unlink handle from pvar if it is a watermark */
     if (MPIR_T_pvar_is_watermark(hnd)) {

--- a/src/mpi_t/pvar_handle_free.c
+++ b/src/mpi_t/pvar_handle_free.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_handle_free */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpi_t/pvar_reset.c
+++ b/src/mpi_t/pvar_reset.c
@@ -130,7 +130,7 @@ int MPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
      * Otherwise, do correctness check, then go to impl.
      */
     if (handle == MPI_T_PVAR_ALL_HANDLES) {
-        MPL_DL_FOREACH(session->hlist, hnd) {
+        DL_FOREACH(session->hlist, hnd) {
             if (!MPIR_T_pvar_is_readonly(hnd)) {
                 mpi_errno = MPIR_T_pvar_reset_impl(session, hnd);
                 if (mpi_errno != MPI_SUCCESS) goto fn_fail;

--- a/src/mpi_t/pvar_reset.c
+++ b/src/mpi_t/pvar_reset.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_reset */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpi_t/pvar_session_free.c
+++ b/src/mpi_t/pvar_session_free.c
@@ -42,8 +42,8 @@ int MPIR_T_pvar_session_free_impl(MPI_T_pvar_session *session)
      * outstanding handles attached to this session.  A more relaxed
      * interpretation puts that burden on the user.  We choose the conservative
      * view.*/
-    MPL_DL_FOREACH_SAFE((*session)->hlist, hnd, tmp) {
-        MPL_DL_DELETE((*session)->hlist, hnd);
+    DL_FOREACH_SAFE((*session)->hlist, hnd, tmp) {
+        DL_DELETE((*session)->hlist, hnd);
         MPL_free(hnd);
     }
     MPL_free(*session);

--- a/src/mpi_t/pvar_session_free.c
+++ b/src/mpi_t/pvar_session_free.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_session_free */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpi_t/pvar_start.c
+++ b/src/mpi_t/pvar_start.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "utlist.h" /* For MPL_DL_FOREACH */
+#include "utlist.h" /* For DL_FOREACH */
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_start */
 #if defined(HAVE_PRAGMA_WEAK)
@@ -125,7 +125,7 @@ int MPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
 
     if (handle == MPI_T_PVAR_ALL_HANDLES) {
         MPIR_T_pvar_handle_t *hnd;
-        MPL_DL_FOREACH(session->hlist, hnd) {
+        DL_FOREACH(session->hlist, hnd) {
             if (!MPIR_T_pvar_is_continuous(hnd) && !MPIR_T_pvar_is_started(hnd))
                 mpi_errno = MPIR_T_pvar_start_impl(session, hnd);
         }

--- a/src/mpi_t/pvar_start.c
+++ b/src/mpi_t/pvar_start.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h" /* For MPL_DL_FOREACH */
+#include "utlist.h" /* For MPL_DL_FOREACH */
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_start */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpi_t/pvar_stop.c
+++ b/src/mpi_t/pvar_stop.c
@@ -160,7 +160,7 @@ int MPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
      */
     if (handle == MPI_T_PVAR_ALL_HANDLES) {
         MPIR_T_pvar_handle_t *hnd;
-        MPL_DL_FOREACH(session->hlist, hnd) {
+        DL_FOREACH(session->hlist, hnd) {
             if (!MPIR_T_pvar_is_continuous(hnd) && MPIR_T_pvar_is_started(hnd)) {
                 mpi_errno = MPIR_T_pvar_stop_impl(session, hnd);
                 if (mpi_errno != MPI_SUCCESS) goto fn_fail;

--- a/src/mpi_t/pvar_stop.c
+++ b/src/mpi_t/pvar_stop.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpiimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* -- Begin Profiling Symbol Block for routine MPI_T_pvar_stop */
 #if defined(HAVE_PRAGMA_WEAK)

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -221,7 +221,7 @@ static inline int MPIDI_CH3I_SHM_Wins_append(MPIDI_SHM_Wins_list_t * list, MPIR_
     tmp_ptr->next = NULL;
     tmp_ptr->win = win;
 
-    MPL_DL_APPEND(*list, tmp_ptr);
+    DL_APPEND(*list, tmp_ptr);
 
   fn_exit:
     MPIR_CHKPMEM_COMMIT();
@@ -245,10 +245,10 @@ static inline void MPIDI_CH3I_SHM_Wins_unlink(MPIDI_SHM_Wins_list_t * list, MPIR
     MPIDI_SHM_Win_t *elem = NULL;
     MPIDI_SHM_Win_t *tmp_elem = NULL;
 
-    MPL_LL_SEARCH_SCALAR(*list, elem, win, shm_win);
+    LL_SEARCH_SCALAR(*list, elem, win, shm_win);
     if (elem != NULL) {
         tmp_elem = elem;
-        MPL_DL_DELETE(*list, elem);
+        DL_DELETE(*list, elem);
         MPL_free(tmp_elem);
     }
 }

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -9,7 +9,7 @@
 
 #include "mpidimpl.h"
 #include "mpidu_generic_queue.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 #if defined(HAVE_ASSERT_H)
 #include <assert.h>

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_nm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_nm.c
@@ -5,7 +5,7 @@
  */
 
 #include "ptl_impl.h"
-#include <mpl_utlist.h>
+#include "utlist.h"
 #include "rptl.h"
 
 #define NUM_RECV_BUFS 2

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
@@ -88,7 +88,7 @@ static int find_target(ptl_process_t id, struct rptl_target **target)
     /* if the target does not already exist, create one */
     if (t == NULL) {
         MPIR_CHKPMEM_MALLOC(t, struct rptl_target *, sizeof(struct rptl_target), mpi_errno, "rptl target");
-        MPL_DL_APPEND(rptl_info.target_list, t);
+        DL_APPEND(rptl_info.target_list, t);
 
         t->id = id;
         t->state = RPTL_TARGET_STATE_ACTIVE;
@@ -364,9 +364,9 @@ static int rptl_put(ptl_handle_md_t md_handle, ptl_size_t local_offset, ptl_size
     op->target = target;
 
     if (op->u.put.pt_type == RPTL_PT_DATA)
-        MPL_DL_APPEND(target->data_op_list, op);
+        DL_APPEND(target->data_op_list, op);
     else
-        MPL_DL_APPEND(target->control_op_list, op);
+        DL_APPEND(target->control_op_list, op);
 
     ret = poke_progress();
     RPTLU_ERR_POP(ret, "Error from poke_progress\n");
@@ -431,7 +431,7 @@ int MPID_nem_ptl_rptl_get(ptl_handle_md_t md_handle, ptl_size_t local_offset, pt
     op->events_ready = 0;
     op->target = target;
 
-    MPL_DL_APPEND(target->data_op_list, op);
+    DL_APPEND(target->data_op_list, op);
 
     ret = poke_progress();
     RPTLU_ERR_POP(ret, "Error from poke_progress\n");
@@ -812,7 +812,7 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
             event->user_ptr = op->u.get.user_ptr;
 
             /* GET operations only go into the data op list */
-            MPL_DL_DELETE(op->target->data_op_list, op);
+            DL_DELETE(op->target->data_op_list, op);
             rptli_op_free(op);
         }
 
@@ -830,7 +830,7 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
             if (op->u.put.pt_type == RPTL_PT_CONTROL) {
                 /* drop the ack event */
                 MPL_free(op->u.put.ack);
-                MPL_DL_DELETE(op->target->control_op_list, op);
+                DL_DELETE(op->target->control_op_list, op);
                 rptli_op_free(op);
 
                 /* drop the send event */
@@ -848,7 +848,7 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
                     pending_event_valid = 1;
                 }
                 MPL_free(op->u.put.ack);
-                MPL_DL_DELETE(op->target->data_op_list, op);
+                DL_DELETE(op->target->data_op_list, op);
                 rptli_op_free(op);
             }
         }
@@ -867,7 +867,7 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
             if (op->u.put.pt_type == RPTL_PT_CONTROL) {
                 /* drop the send event */
                 MPL_free(op->u.put.send);
-                MPL_DL_DELETE(op->target->control_op_list, op);
+                DL_DELETE(op->target->control_op_list, op);
                 rptli_op_free(op);
 
                 /* drop the ack event */
@@ -897,7 +897,7 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
                     event->user_ptr = op->u.put.user_ptr;
                 }
                 /* we should be in the data op list */
-                MPL_DL_DELETE(op->target->data_op_list, op);
+                DL_DELETE(op->target->data_op_list, op);
                 rptli_op_free(op);
             }
         }

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_init.c
@@ -115,7 +115,7 @@ int MPID_nem_ptl_rptl_drain_eq(int eq_count, ptl_handle_eq_t *eq)
 
         while (target->op_segment_list) {
             op_segment = target->op_segment_list;
-            MPL_DL_DELETE(target->op_segment_list, op_segment);
+            DL_DELETE(target->op_segment_list, op_segment);
             MPL_free(op_segment);
         }
 
@@ -154,7 +154,7 @@ int MPID_nem_ptl_rptl_ptinit(ptl_handle_ni_t ni_handle, ptl_handle_eq_t eq_handl
     /* setup the parts of rptls that can be done before world size or
      * target information */
     MPIR_CHKPMEM_MALLOC(rptl, struct rptl *, sizeof(struct rptl), mpi_errno, "rptl");
-    MPL_DL_APPEND(rptl_info.rptl_list, rptl);
+    DL_APPEND(rptl_info.rptl_list, rptl);
 
     rptl->local_state = RPTL_LOCAL_STATE_ACTIVE;
     rptl->pause_ack_counter = 0;
@@ -227,7 +227,7 @@ int MPID_nem_ptl_rptl_ptfini(ptl_pt_index_t pt_index)
         MPL_free(rptl->control.me);
     }
 
-    MPL_DL_DELETE(rptl_info.rptl_list, rptl);
+    DL_DELETE(rptl_info.rptl_list, rptl);
     MPL_free(rptl);
 
   fn_exit:

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_op.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl_op.c
@@ -27,14 +27,14 @@ int rptli_op_alloc(struct rptl_op **op, struct rptl_target *target)
     if (target->op_pool == NULL) {
         MPIR_CHKPMEM_MALLOC(op_segment, struct rptl_op_pool_segment *, sizeof(struct rptl_op_pool_segment),
                             mpi_errno, "op pool segment");
-        MPL_DL_APPEND(target->op_segment_list, op_segment);
+        DL_APPEND(target->op_segment_list, op_segment);
 
         for (i = 0; i < RPTL_OP_POOL_SEGMENT_COUNT; i++)
-            MPL_DL_APPEND(target->op_pool, &op_segment->op[i]);
+            DL_APPEND(target->op_pool, &op_segment->op[i]);
     }
 
     *op = target->op_pool;
-    MPL_DL_DELETE(target->op_pool, *op);
+    DL_DELETE(target->op_pool, *op);
 
   fn_exit:
     MPIR_CHKPMEM_COMMIT();
@@ -59,7 +59,7 @@ void rptli_op_free(struct rptl_op *op)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_RPTLI_OP_FREE);
 
-    MPL_DL_APPEND(op->target->op_pool, op);
+    DL_APPEND(op->target->op_pool, op);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_RPTLI_OP_FREE);
 }

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -7,7 +7,7 @@
 #include "mpidi_ch3_impl.h"
 #include "pmi.h"
 #include "mpidu_sock.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 #ifdef HAVE_STRING_H
 #include <string.h>

--- a/src/mpid/ch3/include/mpid_port.h
+++ b/src/mpid/ch3/include/mpid_port.h
@@ -6,7 +6,7 @@
 #ifndef MPID_PORT_H_
 #define MPID_PORT_H_
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 #ifndef MPIDI_CH3_HAS_NO_DYNAMIC_PROCESS
 

--- a/src/mpid/ch3/include/mpid_port.h
+++ b/src/mpid/ch3/include/mpid_port.h
@@ -91,7 +91,7 @@ static inline int MPIDI_CH3I_Port_local_close_vc(MPIDI_VC_t * vc)
 static inline void MPIDI_CH3I_Port_connreq_q_enqueue(MPIDI_CH3I_Port_connreq_q_t * connreq_q,
                                                      MPIDI_CH3I_Port_connreq_t * connreq)
 {
-    MPL_LL_APPEND(connreq_q->head, connreq_q->tail, connreq);
+    LL_APPEND(connreq_q->head, connreq_q->tail, connreq);
     connreq_q->size++;
 }
 
@@ -108,7 +108,7 @@ static inline void MPIDI_CH3I_Port_connreq_q_dequeue(MPIDI_CH3I_Port_connreq_q_t
     if (connreq_q->head != NULL) {
         connreq = connreq_q->head;
 
-        MPL_LL_DELETE(connreq_q->head, connreq_q->tail, connreq);
+        LL_DELETE(connreq_q->head, connreq_q->tail, connreq);
         connreq_q->size--;
     }
 
@@ -122,7 +122,7 @@ static inline void MPIDI_CH3I_Port_connreq_q_dequeue(MPIDI_CH3I_Port_connreq_q_t
 static inline void MPIDI_CH3I_Port_connreq_q_delete(MPIDI_CH3I_Port_connreq_q_t * connreq_q,
                                                     MPIDI_CH3I_Port_connreq_t * connreq)
 {
-    MPL_LL_DELETE(connreq_q->head, connreq_q->tail, connreq);
+    LL_DELETE(connreq_q->head, connreq_q->tail, connreq);
     connreq_q->size--;
 }
 

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -7,7 +7,7 @@
 #if !defined(MPID_RMA_ISSUE_H_INCLUDED)
 #define MPID_RMA_ISSUE_H_INCLUDED
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "mpid_rma_types.h"
 
 /* =========================================================== */

--- a/src/mpid/ch3/include/mpid_rma_lockqueue.h
+++ b/src/mpid/ch3/include/mpid_rma_lockqueue.h
@@ -28,7 +28,7 @@ static inline MPIDI_RMA_Target_lock_entry_t *MPIDI_CH3I_Win_target_lock_entry_al
 
     if (win_ptr->target_lock_entry_pool_head != NULL) {
         new_ptr = win_ptr->target_lock_entry_pool_head;
-        MPL_DL_DELETE(win_ptr->target_lock_entry_pool_head, new_ptr);
+        DL_DELETE(win_ptr->target_lock_entry_pool_head, new_ptr);
     }
 
     if (new_ptr != NULL) {
@@ -62,7 +62,7 @@ static inline int MPIDI_CH3I_Win_target_lock_entry_free(MPIR_Win * win_ptr,
 
     /* use PREPEND when return objects back to the pool
      * in order to improve cache performance */
-    MPL_DL_PREPEND(win_ptr->target_lock_entry_pool_head, target_lock_entry);
+    DL_PREPEND(win_ptr->target_lock_entry_pool_head, target_lock_entry);
 
     return mpi_errno;
 }

--- a/src/mpid/ch3/include/mpid_rma_lockqueue.h
+++ b/src/mpid/ch3/include/mpid_rma_lockqueue.h
@@ -7,7 +7,7 @@
 #if !defined(MPID_RMA_LOCKQUEUE_H_INCLUDED)
 #define MPID_RMA_LOCKQUEUE_H_INCLUDED
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "mpid_rma_types.h"
 
 extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_lockqueue_alloc ATTRIBUTE((unused));

--- a/src/mpid/ch3/include/mpid_rma_oplist.h
+++ b/src/mpid/ch3/include/mpid_rma_oplist.h
@@ -7,7 +7,7 @@
 #if !defined(MPID_RMA_OPLIST_H_INCLUDED)
 #define MPID_RMA_OPLIST_H_INCLUDED
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "mpid_rma_types.h"
 
 int MPIDI_CH3I_RMA_Cleanup_ops_aggressive(MPIR_Win * win_ptr);

--- a/src/mpid/ch3/include/mpid_rma_oplist.h
+++ b/src/mpid/ch3/include/mpid_rma_oplist.h
@@ -125,8 +125,8 @@ static inline int MPIDI_CH3I_Win_set_active(MPIR_Win * win_ptr)
             MPID_Progress_activate_hook(MPIDI_CH3I_RMA_Progress_hook_id);
         }
 
-        MPL_DL_DELETE(MPIDI_RMA_Win_inactive_list_head, win_ptr);
-        MPL_DL_APPEND(MPIDI_RMA_Win_active_list_head, win_ptr);
+        DL_DELETE(MPIDI_RMA_Win_inactive_list_head, win_ptr);
+        DL_APPEND(MPIDI_RMA_Win_active_list_head, win_ptr);
     }
 
   fn_exit:
@@ -146,8 +146,8 @@ static inline int MPIDI_CH3I_Win_set_inactive(MPIR_Win * win_ptr)
 
     if (win_ptr->active == TRUE) {
         win_ptr->active = FALSE;
-        MPL_DL_DELETE(MPIDI_RMA_Win_active_list_head, win_ptr);
-        MPL_DL_APPEND(MPIDI_RMA_Win_inactive_list_head, win_ptr);
+        DL_DELETE(MPIDI_RMA_Win_active_list_head, win_ptr);
+        DL_APPEND(MPIDI_RMA_Win_inactive_list_head, win_ptr);
 
         if (MPIDI_RMA_Win_active_list_head == NULL) {
             /* This is the last active window, de-activate RMA progress */
@@ -178,12 +178,12 @@ static inline MPIDI_RMA_Op_t *MPIDI_CH3I_Win_op_alloc(MPIR_Win * win_ptr)
             return NULL;
         else {
             e = global_rma_op_pool_head;
-            MPL_DL_DELETE(global_rma_op_pool_head, e);
+            DL_DELETE(global_rma_op_pool_head, e);
         }
     }
     else {
         e = win_ptr->op_pool_head;
-        MPL_DL_DELETE(win_ptr->op_pool_head, e);
+        DL_DELETE(win_ptr->op_pool_head, e);
     }
 
     e->single_req = NULL;
@@ -219,9 +219,9 @@ static inline int MPIDI_CH3I_Win_op_free(MPIR_Win * win_ptr, MPIDI_RMA_Op_t * e)
     /* use PREPEND when return objects back to the pool
      * in order to improve cache performance */
     if (e->pool_type == MPIDI_RMA_POOL_WIN)
-        MPL_DL_PREPEND(win_ptr->op_pool_head, e);
+        DL_PREPEND(win_ptr->op_pool_head, e);
     else
-        MPL_DL_PREPEND(global_rma_op_pool_head, e);
+        DL_PREPEND(global_rma_op_pool_head, e);
 
     return mpi_errno;
 }
@@ -242,12 +242,12 @@ static inline MPIDI_RMA_Target_t *MPIDI_CH3I_Win_target_alloc(MPIR_Win * win_ptr
             return NULL;
         else {
             e = global_rma_target_pool_head;
-            MPL_DL_DELETE(global_rma_target_pool_head, e);
+            DL_DELETE(global_rma_target_pool_head, e);
         }
     }
     else {
         e = win_ptr->target_pool_head;
-        MPL_DL_DELETE(win_ptr->target_pool_head, e);
+        DL_DELETE(win_ptr->target_pool_head, e);
     }
 
     e->pending_net_ops_list_head = NULL;
@@ -288,9 +288,9 @@ static inline int MPIDI_CH3I_Win_target_free(MPIR_Win * win_ptr, MPIDI_RMA_Targe
     /* use PREPEND when return objects back to the pool
      * in order to improve cache performance */
     if (e->pool_type == MPIDI_RMA_POOL_WIN)
-        MPL_DL_PREPEND(win_ptr->target_pool_head, e);
+        DL_PREPEND(win_ptr->target_pool_head, e);
     else
-        MPL_DL_PREPEND(global_rma_target_pool_head, e);
+        DL_PREPEND(global_rma_target_pool_head, e);
 
     return mpi_errno;
 }
@@ -319,7 +319,7 @@ static inline int MPIDI_CH3I_Win_create_target(MPIR_Win * win_ptr, int target_ra
     t->target_rank = target_rank;
 
     /* Enqueue target into target list. */
-    MPL_DL_APPEND(slot->target_list_head, t);
+    DL_APPEND(slot->target_list_head, t);
 
     assert(t != NULL);
 
@@ -410,21 +410,21 @@ static inline int MPIDI_CH3I_Win_enqueue_op(MPIR_Win * win_ptr, MPIDI_RMA_Op_t *
             /* Move head element of user pending list to net pending list */
             if (target->pending_net_ops_list_head == NULL)
                 win_ptr->num_targets_with_pending_net_ops++;
-            MPL_DL_DELETE(target->pending_user_ops_list_head, user_op);
-            MPL_DL_APPEND(target->pending_net_ops_list_head, user_op);
+            DL_DELETE(target->pending_user_ops_list_head, user_op);
+            DL_APPEND(target->pending_net_ops_list_head, user_op);
 
             if (target->next_op_to_issue == NULL)
                 target->next_op_to_issue = user_op;
         }
 
         /* Enqueue operation into user pending list. */
-        MPL_DL_APPEND(target->pending_user_ops_list_head, op);
+        DL_APPEND(target->pending_user_ops_list_head, op);
     }
     else {
         /* Enqueue operation into net pending list. */
         if (target->pending_net_ops_list_head == NULL)
             win_ptr->num_targets_with_pending_net_ops++;
-        MPL_DL_APPEND(target->pending_net_ops_list_head, op);
+        DL_APPEND(target->pending_net_ops_list_head, op);
 
         if (target->next_op_to_issue == NULL)
             target->next_op_to_issue = op;
@@ -458,7 +458,7 @@ static inline int MPIDI_CH3I_Win_target_dequeue_and_free(MPIR_Win * win_ptr, MPI
 
     slot = MPIDI_CH3I_RMA_RANK_TO_SLOT(win_ptr, target_rank);
 
-    MPL_DL_DELETE(slot->target_list_head, e);
+    DL_DELETE(slot->target_list_head, e);
 
     mpi_errno = MPIDI_CH3I_Win_target_free(win_ptr, e);
     if (mpi_errno != MPI_SUCCESS)
@@ -541,7 +541,7 @@ static inline void MPIDI_CH3I_RMA_Ops_free_elem(MPIR_Win * win_ptr, MPIDI_RMA_Op
 
     MPIR_Assert(curr_ptr != NULL);
 
-    MPL_DL_DELETE(*list, curr_ptr);
+    DL_DELETE(*list, curr_ptr);
 
     MPIDI_CH3I_Win_op_free(win_ptr, tmp_ptr);
 }

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -7,7 +7,7 @@
 #if !defined(MPID_RMA_SHM_H_INCLUDED)
 #define MPID_RMA_SHM_H_INCLUDED
 
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "mpid_rma_types.h"
 
 static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datatype source_dtp,

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -335,7 +335,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
     if (new_ptr != NULL) {
         MPIDI_RMA_Target_lock_entry_t **head_ptr =
             (MPIDI_RMA_Target_lock_entry_t **) (&(win_ptr->target_lock_queue_head));
-        MPL_DL_APPEND((*head_ptr), new_ptr);
+        DL_APPEND((*head_ptr), new_ptr);
         new_ptr->vc = vc;
     }
     else {
@@ -834,7 +834,7 @@ static inline int acquire_local_lock(MPIR_Win * win_ptr, int lock_type)
                 MPIR_ERR_POP(mpi_errno);
             goto fn_exit;
         }
-        MPL_DL_APPEND((*head_ptr), new_ptr);
+        DL_APPEND((*head_ptr), new_ptr);
         MPIDI_Comm_get_vc_set_active(win_ptr->comm_ptr, win_ptr->comm_ptr->rank, &my_vc);
         new_ptr->vc = my_vc;
 

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -32,9 +32,9 @@ static int comm_created(MPIR_Comm *comm, void *param);
 static int comm_destroyed(MPIR_Comm *comm, void *param);
 
 /* macros and head for list of communicators */
-#define COMM_ADD(comm) MPL_DL_PREPEND_NP(comm_list, comm, dev.next, dev.prev)
-#define COMM_DEL(comm) MPL_DL_DELETE_NP(comm_list, comm, dev.next, dev.prev)
-#define COMM_FOREACH(elt) MPL_DL_FOREACH_NP(comm_list, elt, dev.next, dev.prev)
+#define COMM_ADD(comm) DL_PREPEND_NP(comm_list, comm, dev.next, dev.prev)
+#define COMM_DEL(comm) DL_DELETE_NP(comm_list, comm, dev.next, dev.prev)
+#define COMM_FOREACH(elt) DL_FOREACH_NP(comm_list, elt, dev.next, dev.prev)
 static MPIR_Comm *comm_list = NULL;
 
 typedef struct hook_elt
@@ -200,7 +200,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
     comm->dev.is_disconnected = 0;
 
     /* do some sanity checks */
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->src_comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
             MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
                         mapper->dir == MPIR_COMM_MAP_DIR__L2R);
@@ -212,7 +212,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
     /* First, handle all the mappers that contribute to the local part
      * of the comm */
     vcrt_size = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2R ||
             mapper->dir == MPIR_COMM_MAP_DIR__R2R)
             continue;
@@ -220,7 +220,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
         vcrt_size += map_size(*mapper);
     }
     vcrt_offset = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         src_comm = mapper->src_comm;
 
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2R ||
@@ -259,7 +259,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
     /* Next, handle all the mappers that contribute to the remote part
      * of the comm (only valid for intercomms) */
     vcrt_size = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
             mapper->dir == MPIR_COMM_MAP_DIR__R2L)
             continue;
@@ -267,7 +267,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
         vcrt_size += map_size(*mapper);
     }
     vcrt_offset = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         src_comm = mapper->src_comm;
 
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
@@ -300,7 +300,7 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
         }
     }
 
-    MPL_LL_FOREACH(create_hooks_head, elt) {
+    LL_FOREACH(create_hooks_head, elt) {
         mpi_errno = elt->hook_fn(comm, elt->param);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);;
     }
@@ -324,7 +324,7 @@ int MPIDI_CH3I_Comm_destroy_hook(MPIR_Comm *comm)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3U_COMM_DESTROY_HOOK);
 
-    MPL_LL_FOREACH(destroy_hooks_head, elt) {
+    LL_FOREACH(destroy_hooks_head, elt) {
         mpi_errno = elt->hook_fn(comm, elt->param);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
@@ -363,7 +363,7 @@ int MPIDI_CH3U_Comm_register_create_hook(int (*hook_fn)(struct MPIR_Comm *, void
     elt->hook_fn = hook_fn;
     elt->param = param;
     
-    MPL_LL_PREPEND(create_hooks_head, create_hooks_tail, elt);
+    LL_PREPEND(create_hooks_head, create_hooks_tail, elt);
 
  fn_exit:
     MPIR_CHKPMEM_COMMIT();
@@ -392,7 +392,7 @@ int MPIDI_CH3U_Comm_register_destroy_hook(int (*hook_fn)(struct MPIR_Comm *, voi
     elt->hook_fn = hook_fn;
     elt->param = param;
     
-    MPL_LL_PREPEND(destroy_hooks_head, destroy_hooks_tail, elt);
+    LL_PREPEND(destroy_hooks_head, destroy_hooks_tail, elt);
 
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3U_COMM_REGISTER_DESTROY_HOOK);
@@ -414,13 +414,13 @@ static int register_hook_finalize(void *param)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_REGISTER_HOOK_FINALIZE);
 
-    MPL_LL_FOREACH_SAFE(create_hooks_head, elt, tmp) {
-        MPL_LL_DELETE(create_hooks_head, create_hooks_tail, elt);
+    LL_FOREACH_SAFE(create_hooks_head, elt, tmp) {
+        LL_DELETE(create_hooks_head, create_hooks_tail, elt);
         MPL_free(elt);
     }
     
-    MPL_LL_FOREACH_SAFE(destroy_hooks_head, elt, tmp) {
-        MPL_LL_DELETE(destroy_hooks_head, destroy_hooks_tail, elt);
+    LL_FOREACH_SAFE(destroy_hooks_head, elt, tmp) {
+        LL_DELETE(destroy_hooks_head, destroy_hooks_tail, elt);
         MPL_free(elt);
     }
 

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpidimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 #if defined HAVE_LIBHCOLL
 #include "../../common/hcoll/hcoll.h"
 #endif

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -1949,7 +1949,7 @@ int MPIDI_CH3I_Release_lock(MPIR_Win * win_ptr)
                     }
                     if (MPIDI_CH3I_Try_acquire_win_lock(win_ptr, requested_lock) == 1) {
                         /* dequeue entry from lock queue */
-                        MPL_DL_DELETE(win_ptr->target_lock_queue_head, target_lock_entry);
+                        DL_DELETE(win_ptr->target_lock_queue_head, target_lock_entry);
 
                         /* perform this OP */
                         mpi_errno = perform_op_in_lock_queue(win_ptr, target_lock_entry);
@@ -2050,7 +2050,7 @@ int MPIDI_CH3_ReqHandler_PiggybackLockOpRecvComplete(MPIDI_VC_t * vc,
 
         if (MPIDI_CH3I_Try_acquire_win_lock(win_ptr, requested_lock) == 1) {
             /* dequeue entry from lock queue */
-            MPL_DL_DELETE(win_ptr->target_lock_queue_head, target_lock_queue_entry);
+            DL_DELETE(win_ptr->target_lock_queue_head, target_lock_queue_entry);
 
             /* perform this OP */
             mpi_errno = perform_op_in_lock_queue(win_ptr, target_lock_queue_entry);

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -1557,7 +1557,7 @@ int MPIDI_CH3I_Acceptq_enqueue(MPIDI_VC_t * vc, int port_name_tag )
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_ACCEPTQ_ENQUEUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3I_ACCEPTQ_ENQUEUE);
 
-    MPL_LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
+    LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
 
     /* Find port object by using port_name_tag. */
     mpi_errno = MPIDI_CH3I_Port_connreq_create(vc, &connreq);
@@ -1621,7 +1621,7 @@ int MPIDI_CH3I_Acceptq_dequeue(MPIDI_CH3I_Port_connreq_t ** connreq_ptr, int por
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3I_ACCEPTQ_DEQUEUE);
 
     /* Find port object by using port_name_tag. */
-    MPL_LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
+    LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
     MPIR_Assert(port != NULL);  /* Port is always initialized in open_port. */
 
     MPIDI_CH3I_Port_connreq_q_dequeue(&port->accept_connreq_q, connreq_ptr);
@@ -1649,7 +1649,7 @@ static int MPIDI_CH3I_Acceptq_cleanup(MPIDI_CH3I_Port_connreq_q_t * accept_connr
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_Port_connreq_t *connreq = NULL, *connreq_tmp = NULL;
 
-    MPL_LL_FOREACH_SAFE(accept_connreq_q->head, connreq, connreq_tmp) {
+    LL_FOREACH_SAFE(accept_connreq_q->head, connreq, connreq_tmp) {
         MPIDI_CH3I_Port_connreq_q_delete(accept_connreq_q, connreq);
 
         /* Notify connecting client. */
@@ -1694,7 +1694,7 @@ static int MPIDI_CH3I_Revokeq_cleanup(void)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_Port_connreq_t *connreq = NULL, *connreq_tmp = NULL;
 
-    MPL_LL_FOREACH_SAFE(revoked_connreq_q.head, connreq, connreq_tmp) {
+    LL_FOREACH_SAFE(revoked_connreq_q.head, connreq, connreq_tmp) {
         MPID_Progress_state progress_state;
         MPIDI_CH3I_Port_connreq_q_delete(&revoked_connreq_q, connreq);
 
@@ -1944,7 +1944,7 @@ int MPIDI_CH3I_Port_init(int port_name_tag)
     port->accept_connreq_q.size = 0;
     port->next = NULL;
 
-    MPL_LL_APPEND(active_portq.head, active_portq.tail, port);
+    LL_APPEND(active_portq.head, active_portq.tail, port);
     active_portq.size++;
 
   fn_exit:
@@ -1969,9 +1969,9 @@ int MPIDI_CH3I_Port_destroy(int port_name_tag)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_PORT_DESTROY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3I_PORT_DESTROY);
 
-    MPL_LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
+    LL_SEARCH_SCALAR(active_portq.head, port, port_name_tag, port_name_tag);
     if (port != NULL) {
-        MPL_LL_DELETE(active_portq.head, active_portq.tail, port);
+        LL_DELETE(active_portq.head, active_portq.tail, port);
 
         mpi_errno = MPIDI_CH3I_Acceptq_cleanup(&port->accept_connreq_q);
         if (mpi_errno)
@@ -2009,9 +2009,9 @@ int MPIDI_Port_finalize(void)
     {
         MPIDI_CH3I_Port_t *port = NULL, *port_tmp = NULL;
 
-        MPL_LL_FOREACH_SAFE(active_portq.head, port, port_tmp) {
+        LL_FOREACH_SAFE(active_portq.head, port, port_tmp) {
             /* destroy all opening ports. */
-            MPL_LL_DELETE(active_portq.head, active_portq.tail, port);
+            LL_DELETE(active_portq.head, active_portq.tail, port);
 
             mpi_errno = MPIDI_CH3I_Acceptq_cleanup(&port->accept_connreq_q);
             MPL_free(port);
@@ -2026,7 +2026,7 @@ int MPIDI_Port_finalize(void)
     {
         MPIDI_CH3I_Port_connreq_t *connreq = NULL, *connreq_tmp = NULL;
 
-        MPL_LL_FOREACH_SAFE(unexpt_connreq_q.head, connreq, connreq_tmp) {
+        LL_FOREACH_SAFE(unexpt_connreq_q.head, connreq, connreq_tmp) {
             MPIDI_CH3I_Port_connreq_q_delete(&unexpt_connreq_q, connreq);
             mpi_errno = MPIDI_CH3I_Port_connreq_free(connreq);
             if (mpi_errno)

--- a/src/mpid/ch3/src/ch3u_rma_progress.c
+++ b/src/mpid/ch3/src/ch3u_rma_progress.c
@@ -88,8 +88,8 @@ static inline int check_and_switch_target_state(MPIR_Win * win_ptr, MPIDI_RMA_Ta
             if (target->pending_net_ops_list_head == NULL)
                 win_ptr->num_targets_with_pending_net_ops++;
 
-            MPL_DL_DELETE(target->pending_user_ops_list_head, user_op);
-            MPL_DL_APPEND(target->pending_net_ops_list_head, user_op);
+            DL_DELETE(target->pending_user_ops_list_head, user_op);
+            DL_APPEND(target->pending_net_ops_list_head, user_op);
 
             if (target->next_op_to_issue == NULL)
                 target->next_op_to_issue = user_op;

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -333,7 +333,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     (*win_ptr)->op_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE; i++) {
         (*win_ptr)->op_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
-        MPL_DL_APPEND((*win_ptr)->op_pool_head, &((*win_ptr)->op_pool_start[i]));
+        DL_APPEND((*win_ptr)->op_pool_head, &((*win_ptr)->op_pool_start[i]));
     }
 
     win_target_pool_size =
@@ -344,7 +344,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     (*win_ptr)->target_pool_head = NULL;
     for (i = 0; i < win_target_pool_size; i++) {
         (*win_ptr)->target_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
-        MPL_DL_APPEND((*win_ptr)->target_pool_head, &((*win_ptr)->target_pool_start[i]));
+        DL_APPEND((*win_ptr)->target_pool_head, &((*win_ptr)->target_pool_start[i]));
     }
 
     (*win_ptr)->num_slots = MPL_MIN(MPIR_CVAR_CH3_RMA_SLOTS_SIZE, MPIR_Comm_size(win_comm_ptr));
@@ -361,7 +361,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
                         "RMA lock entry pool");
     (*win_ptr)->target_lock_entry_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE; i++) {
-        MPL_DL_APPEND((*win_ptr)->target_lock_entry_pool_head,
+        DL_APPEND((*win_ptr)->target_lock_entry_pool_head,
                       &((*win_ptr)->target_lock_entry_pool_start[i]));
     }
 
@@ -374,7 +374,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
         }
     }
 
-    MPL_DL_APPEND(MPIDI_RMA_Win_inactive_list_head, (*win_ptr));
+    DL_APPEND(MPIDI_RMA_Win_inactive_list_head, (*win_ptr));
 
     if (MPIDI_CH3U_Win_hooks.win_init != NULL) {
         mpi_errno =

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -101,7 +101,7 @@ int MPIDI_RMA_init(void)
                         mpi_errno, "RMA op pool");
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_GLOBAL_POOL_SIZE; i++) {
         global_rma_op_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
-        MPL_DL_APPEND(global_rma_op_pool_head, &(global_rma_op_pool_start[i]));
+        DL_APPEND(global_rma_op_pool_head, &(global_rma_op_pool_start[i]));
     }
 
     MPIR_CHKPMEM_MALLOC(global_rma_target_pool_start, MPIDI_RMA_Target_t *,
@@ -109,7 +109,7 @@ int MPIDI_RMA_init(void)
                         mpi_errno, "RMA target pool");
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_GLOBAL_POOL_SIZE; i++) {
         global_rma_target_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
-        MPL_DL_APPEND(global_rma_target_pool_head, &(global_rma_target_pool_start[i]));
+        DL_APPEND(global_rma_target_pool_head, &(global_rma_target_pool_start[i]));
     }
 
   fn_exit:
@@ -191,7 +191,7 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
 
     /* dequeue window from the global list */
     MPIR_Assert((*win_ptr)->active == FALSE);
-    MPL_DL_DELETE(MPIDI_RMA_Win_inactive_list_head, (*win_ptr));
+    DL_DELETE(MPIDI_RMA_Win_inactive_list_head, (*win_ptr));
 
     if (MPIDI_RMA_Win_inactive_list_head == NULL && MPIDI_RMA_Win_active_list_head == NULL) {
         /* this is the last window, de-register RMA progress hook */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -21,7 +21,7 @@
 #include "mpid_timers_fallback.h"
 #include "netmodpre.h"
 #include "shmpre.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 #include "ch4_coll_params.h"
 
 typedef struct {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -292,7 +292,7 @@ typedef struct MPIDI_CH4U_win_target {
     MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
     MPIDI_CH4U_win_target_sync_t sync;
     int rank;
-    MPL_UT_hash_handle hash_handle;
+    UT_hash_handle hash_handle;
 } MPIDI_CH4U_win_target_t;
 
 typedef struct MPIDI_CH4U_win_t {

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.h
@@ -12,7 +12,7 @@
 #define OFI_COMM_H_INCLUDED
 
 #include "ofi_impl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 #undef FUNCNAME
 #define FUNCNAME MPIDI_NM_mpi_comm_create_hook

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -15,7 +15,7 @@
 #include "ofi_am_impl.h"
 #include "ofi_am_events.h"
 #include "ofi_control.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc,
                                                       MPIR_Request * req);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -200,13 +200,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
 
         MPL_DBG_MSG_FMT(MPIR_DBG_PT2PT,VERBOSE,(MPL_DBG_FDEST, "SEARCHING HUGE UNEXPECTED LIST: (%d, %d, %llu)", comm_ptr->context_id, MPIDI_OFI_cqe_get_source(wc), (MPIDI_OFI_TAG_MASK & wc->tag)));
 
-        MPL_LL_FOREACH(MPIDI_unexp_huge_recv_head, list_ptr) {
+        LL_FOREACH(MPIDI_unexp_huge_recv_head, list_ptr) {
             if (list_ptr->remote_info.comm_id == comm_ptr->context_id &&
                     list_ptr->remote_info.origin_rank == MPIDI_OFI_cqe_get_source(wc) &&
                     list_ptr->remote_info.tag == (MPIDI_OFI_TAG_MASK & wc->tag)) {
                 MPL_DBG_MSG_FMT(MPIR_DBG_PT2PT,VERBOSE,(MPL_DBG_FDEST, "MATCHED HUGE UNEXPECTED LIST: (%d, %d, %llu, %d)", comm_ptr->context_id, MPIDI_OFI_cqe_get_source(wc), (MPIDI_OFI_TAG_MASK & wc->tag), rreq->handle));
 
-                MPL_LL_DELETE(MPIDI_unexp_huge_recv_head, MPIDI_unexp_huge_recv_tail, list_ptr);
+                LL_DELETE(MPIDI_unexp_huge_recv_head, MPIDI_unexp_huge_recv_tail, list_ptr);
 
                 recv = list_ptr;
                 MPIDI_CH4U_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv);
@@ -232,7 +232,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_huge_event(struct fi_cq_tagged_entry
         list_ptr->tag = (MPIDI_OFI_TAG_MASK & wc->tag);
         list_ptr->rreq = rreq;
 
-        MPL_LL_APPEND(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, list_ptr);
+        LL_APPEND(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, list_ptr);
     }
 
     /* Plug the information for the huge event into the receive request and go

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -140,13 +140,13 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
 
         MPL_DBG_MSG_FMT(MPIR_DBG_PT2PT,VERBOSE,(MPL_DBG_FDEST, "SEARCHING POSTED LIST: (%d, %d, %d)", info->comm_id, info->origin_rank, info->tag));
 
-        MPL_LL_FOREACH(MPIDI_posted_huge_recv_head, list_ptr) {
+        LL_FOREACH(MPIDI_posted_huge_recv_head, list_ptr) {
             if (list_ptr->comm_id == info->comm_id &&
                     list_ptr->rank == info->origin_rank &&
                     list_ptr->tag == info->tag) {
                 MPL_DBG_MSG_FMT(MPIR_DBG_PT2PT,VERBOSE,(MPL_DBG_FDEST, "MATCHED POSTED LIST: (%d, %d, %d, %d)", info->comm_id, info->origin_rank, info->tag, list_ptr->rreq->handle));
 
-                MPL_LL_DELETE(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, list_ptr);
+                LL_DELETE(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, list_ptr);
 
                 recv = (MPIDI_OFI_huge_recv_t *) MPIDI_CH4U_map_lookup(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters,
                             list_ptr->rreq->handle);
@@ -165,7 +165,7 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
         recv = (MPIDI_OFI_huge_recv_t *) MPL_calloc(sizeof(*recv), 1);
         if (!recv) MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-        MPL_LL_APPEND(MPIDI_unexp_huge_recv_head, MPIDI_unexp_huge_recv_tail, recv);
+        LL_APPEND(MPIDI_unexp_huge_recv_head, MPIDI_unexp_huge_recv_tail, recv);
     }
 
     recv->event_id = MPIDI_OFI_EVENT_GET_HUGE;

--- a/src/mpid/ch4/shm/posix/posix_comm.h
+++ b/src/mpid/ch4/shm/posix/posix_comm.h
@@ -11,7 +11,7 @@
 #define POSIX_COMM_H_INCLUDED
 
 #include "posix_impl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 #undef FUNCNAME
 #define FUNCNAME MPIDI_POSIX_mpi_comm_create_hook

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -177,7 +177,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_add(MPIR
     target_ptr->sync.access_epoch_type = MPIDI_CH4U_EPOTYPE_NONE;
     target_ptr->sync.assert_mode = 0;
 
-    MPL_HASH_ADD(hash_handle, MPIDI_CH4U_WIN(win, targets), rank, sizeof(int), target_ptr);
+    HASH_ADD(hash_handle, MPIDI_CH4U_WIN(win, targets), rank, sizeof(int), target_ptr);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_WIN_TARGET_ADD);
     return target_ptr;
@@ -194,7 +194,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_CH4U_win_target_t *MPIDI_CH4U_win_target_find(MPI
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_FIND);
 
     MPIDI_CH4U_win_target_t *target_ptr = NULL;
-    MPL_HASH_FIND(hash_handle, MPIDI_CH4U_WIN(win, targets), &rank, sizeof(int), target_ptr);
+    HASH_FIND(hash_handle, MPIDI_CH4U_WIN(win, targets), &rank, sizeof(int), target_ptr);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_WIN_TARGET_FIND);
     return target_ptr;
@@ -210,7 +210,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_delete(MPIR_Win * win,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_TARGET_DELETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_DELETE);
 
-    MPL_HASH_DELETE(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr);
+    HASH_DELETE(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr);
     MPL_free(target_ptr);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_WIN_TARGET_DELETE);
@@ -226,8 +226,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_target_cleanall(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_TARGET_CLEANALL);
 
     MPIDI_CH4U_win_target_t *target_ptr, *tmp;
-    MPL_HASH_ITER(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr, tmp) {
-        MPL_HASH_DELETE(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr);
+    HASH_ITER(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr, tmp) {
+        HASH_DELETE(hash_handle, MPIDI_CH4U_WIN(win, targets), target_ptr);
         MPL_free(target_ptr);
     }
 
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_win_hash_clear(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_WIN_HASH_CLEAR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_WIN_HASH_CLEAR);
 
-    MPL_HASH_CLEAR(hash_handle, MPIDI_CH4U_WIN(win, targets));
+    HASH_CLEAR(hash_handle, MPIDI_CH4U_WIN(win, targets));
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_WIN_HASH_CLEAR);
 }
@@ -860,7 +860,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_destroy(void *in_map)
 {
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
     MPIDI_CH4U_map_t *map = in_map;
-    MPL_HASH_CLEAR(hh, map->head);
+    HASH_CLEAR(hh, map->head);
     MPL_free(map);
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
 }
@@ -879,7 +879,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_set(void *in_map, uint64_t id, void
     MPIR_Assert(map_entry != NULL);
     map_entry->key = id;
     map_entry->value = val;
-    MPL_HASH_ADD(hh, map->head, key, sizeof(uint64_t), map_entry);
+    HASH_ADD(hh, map->head, key, sizeof(uint64_t), map_entry);
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
 }
 
@@ -893,9 +893,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_map_erase(void *in_map, uint64_t id)
     MPIDI_CH4U_map_entry_t *map_entry;
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
     map = (MPIDI_CH4U_map_t *) in_map;
-    MPL_HASH_FIND(hh, map->head, &id, sizeof(uint64_t), map_entry);
+    HASH_FIND(hh, map->head, &id, sizeof(uint64_t), map_entry);
     MPIR_Assert(map_entry != NULL);
-    MPL_HASH_DELETE(hh, map->head, map_entry);
+    HASH_DELETE(hh, map->head, map_entry);
     MPL_free(map_entry);
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
 }
@@ -912,7 +912,7 @@ MPL_STATIC_INLINE_PREFIX void *MPIDI_CH4U_map_lookup(void *in_map, uint64_t id)
 
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_UTIL_MUTEX);
     map = (MPIDI_CH4U_map_t *) in_map;
-    MPL_HASH_FIND(hh, map->head, &id, sizeof(uint64_t), map_entry);
+    HASH_FIND(hh, map->head, &id, sizeof(uint64_t), map_entry);
     if (map_entry == NULL)
         rc = MPIDI_CH4U_MAP_NOT_FOUND;
     else

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -259,7 +259,7 @@ typedef struct {
 typedef struct {
     uint64_t key;
     void *value;
-    MPL_UT_hash_handle hh;      /* makes this structure hashable */
+    UT_hash_handle hh;      /* makes this structure hashable */
 } MPIDI_CH4U_map_entry_t;
 
 typedef struct MPIDI_CH4U_map_t {

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -7,8 +7,8 @@
 #define CH4I_COMM_H_INCLUDED
 
 #include "ch4_types.h"
-#include "mpl_utlist.h"
 #include "ch4r_comm.h"
+#include "utlist.h"
 
 #undef FUNCNAME
 #define FUNCNAME MPIDI_map_size

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -890,7 +890,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMM_CREATE_RANK_MAP);
 
     /* do some sanity checks */
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->src_comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
             MPIR_Assert(mapper->dir == MPIR_COMM_MAP_DIR__L2L ||
                         mapper->dir == MPIR_COMM_MAP_DIR__L2R);
@@ -905,14 +905,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
     /* First, handle all the mappers that contribute to the local part
      * of the comm */
     total_mapper_size = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2R || mapper->dir == MPIR_COMM_MAP_DIR__R2R)
             continue;
 
         total_mapper_size += MPIDI_map_size(*mapper);
     }
     mapper_offset = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         src_comm = mapper->src_comm;
 
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2R || mapper->dir == MPIR_COMM_MAP_DIR__R2R)
@@ -983,14 +983,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_comm_create_rank_map(MPIR_Comm * comm)
      * of the comm (only valid for intercomms)
      */
     total_mapper_size = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2L || mapper->dir == MPIR_COMM_MAP_DIR__R2L)
             continue;
 
         total_mapper_size += MPIDI_map_size(*mapper);
     }
     mapper_offset = 0;
-    MPL_LL_FOREACH(comm->mapper_head, mapper) {
+    LL_FOREACH(comm->mapper_head, mapper) {
         src_comm = mapper->src_comm;
 
         if (mapper->dir == MPIR_COMM_MAP_DIR__L2L || mapper->dir == MPIR_COMM_MAP_DIR__R2L)

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -41,7 +41,7 @@ static inline int MPIDI_check_cmpl_order(MPIR_Request * req,
     MPIDI_CH4U_REQUEST(req, req->target_cmpl_cb) = (void *) target_cmpl_cb;
     MPIDI_CH4U_REQUEST(req, req->request) = (uint64_t) req;
     /* MPIDI_CS_ENTER(); */
-    MPL_DL_APPEND(MPIDI_CH4_Global.cmpl_list, req->dev.ch4.am.req);
+    DL_APPEND(MPIDI_CH4_Global.cmpl_list, req->dev.ch4.am.req);
     /* MPIDI_CS_EXIT(); */
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CHECK_CMPL_ORDER);
@@ -63,9 +63,9 @@ static inline void MPIDI_progress_cmpl_list(void)
 
     /* MPIDI_CS_ENTER(); */
   do_check_again:
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.cmpl_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.cmpl_list, curr, tmp) {
         if (curr->seq_no == (uint64_t) OPA_load_int(&MPIDI_CH4_Global.exp_seq_no)) {
-            MPL_DL_DELETE(MPIDI_CH4_Global.cmpl_list, curr);
+            DL_DELETE(MPIDI_CH4_Global.cmpl_list, curr);
             req = (MPIR_Request *) curr->request;
             target_cmpl_cb = (MPIDIG_am_target_cmpl_cb) curr->target_cmpl_cb;
             target_cmpl_cb(req);

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -18,7 +18,7 @@
 #include "ch4r_rma_target_callbacks.h"
 #include "ch4r_rma_origin_callbacks.h"
 #include "mpidig.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 
 #undef FUNCNAME
 #define FUNCNAME MPIDI_CH4U_init_comm

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -59,10 +59,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_init_comm(MPIR_Comm * comm)
     uelist = MPIDI_CH4U_context_id_to_uelist(comm->context_id);
     if (*uelist) {
         MPIDI_CH4U_rreq_t *curr, *tmp;
-        MPL_DL_FOREACH_SAFE(*uelist, curr, tmp) {
-            MPL_DL_DELETE(*uelist, curr);
+        DL_FOREACH_SAFE(*uelist, curr, tmp) {
+            DL_DELETE(*uelist, curr);
             MPIR_Comm_add_ref(comm);    /* +1 for each entry in unexp_list */
-            MPL_DL_APPEND(MPIDI_CH4U_COMM(comm, unexp_list), curr);
+            DL_APPEND(MPIDI_CH4U_COMM(comm, unexp_list), curr);
         }
         *uelist = NULL;
     }

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -13,7 +13,7 @@
 
 #include <mpidimpl.h>
 #include "mpidig.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 #include "ch4_impl.h"
 
 extern unsigned PVAR_LEVEL_posted_recvq_length ATTRIBUTE((unused));

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -107,7 +107,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIDI_CH4U_REQUEST(req, req->rreq.request) = (uint64_t) req;
-    MPL_DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
+    DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
 }
@@ -122,7 +122,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIDI_CH4U_REQUEST(req, req->rreq.request) = (uint64_t) req;
-    MPL_DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
+    DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
 }
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
-    MPL_DL_DELETE(*list, &req->dev.ch4.am.req->rreq);
+    DL_DELETE(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
 }
@@ -154,12 +154,12 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_UNEXP_STRICT);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(*list, curr, tmp) {
+    DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
             ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore))) {
-            MPL_DL_DELETE(*list, curr);
+            DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
         }
@@ -183,11 +183,11 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_UNEXP);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(*list, curr, tmp) {
+    DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore)) {
-            MPL_DL_DELETE(*list, curr);
+            DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
         }
@@ -211,7 +211,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_FIND_UNEXP);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(*list, curr, tmp) {
+    DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore)) {
@@ -237,12 +237,12 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_POSTED);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
-    MPL_DL_FOREACH_SAFE(*list, curr, tmp) {
+    DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~(MPIDI_CH4U_REQUEST(req, req->rreq.ignore))) ==
             (MPIDI_CH4U_REQUEST(req, tag) & ~(MPIDI_CH4U_REQUEST(req, req->rreq.ignore)))) {
-            MPL_DL_DELETE(*list, curr);
+            DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
         }
@@ -267,10 +267,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_POSTED);
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
-    MPL_DL_FOREACH_SAFE(*list, curr, tmp) {
+    DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         if (curr == req) {
-            MPL_DL_DELETE(*list, curr);
+            DL_DELETE(*list, curr);
             found = 1;
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
@@ -297,7 +297,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_posted(MPIR_Request * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
     MPIDI_CH4U_REQUEST(req, req->rreq.request) = (uint64_t) req;
-    MPL_DL_APPEND(MPIDI_CH4_Global.posted_list, &req->dev.ch4.am.req->rreq);
+    DL_APPEND(MPIDI_CH4_Global.posted_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_ENQUEUE_POSTED);
 }
@@ -312,7 +312,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_enqueue_unexp(MPIR_Request * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
     MPIDI_CH4U_REQUEST(req, req->rreq.request) = (uint64_t) req;
-    MPL_DL_APPEND(MPIDI_CH4_Global.unexp_list, &req->dev.ch4.am.req->rreq);
+    DL_APPEND(MPIDI_CH4_Global.unexp_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_ENQUEUE_UNEXP);
 }
@@ -325,7 +325,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
-    MPL_DL_DELETE(MPIDI_CH4_Global.unexp_list, &req->dev.ch4.am.req->rreq);
+    DL_DELETE(MPIDI_CH4_Global.unexp_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_DELETE_UNEXP);
 }
@@ -344,12 +344,12 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_UNEXP_STRICT);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
             ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore))) {
-            MPL_DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
+            DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
         }
@@ -373,11 +373,11 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_UNEXP);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore)) {
-            MPL_DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
+            DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
         }
@@ -401,7 +401,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_FIND_UNEXP);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, tag) & ~ignore)) {
@@ -427,12 +427,12 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DEQUEUE_POSTED);
 
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if ((tag & ~MPIDI_CH4U_REQUEST(req, req->rreq.ignore)) ==
             (MPIDI_CH4U_REQUEST(req, tag) & ~MPIDI_CH4U_REQUEST(req, req->rreq.ignore))) {
-            MPL_DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
+            DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
         }
@@ -457,10 +457,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_delete_posted(MPIDI_CH4U_rreq_t * req,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_DELETE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_DELETE_POSTED);
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
-    MPL_DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
+    DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         if (curr == req) {
-            MPL_DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
+            DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
             found = 1;
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -15,7 +15,7 @@
 #include "ch4i_util.h"
 #include <opa_primitives.h>
 #include "mpir_info.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -158,7 +158,7 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
         end = tag_ub / 2;
     }
     if (start != MPI_UNDEFINED) {
-        MPL_DL_FOREACH(all_schedules.head, elt) {
+        DL_FOREACH(all_schedules.head, elt) {
             if (elt->tag >= start && elt->tag < end) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**toomanynbc");
             }
@@ -497,7 +497,7 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
 
         MPID_Progress_activate_hook(nbc_progress_hook_id);
     }
-    MPL_DL_APPEND(all_schedules.head, s);
+    DL_APPEND(all_schedules.head, s);
 
     MPL_DBG_MSG_P(MPIR_DBG_COMM, TYPICAL, "started schedule s=%p\n", s);
     if (MPIR_CVAR_COLL_SCHED_DUMP)
@@ -935,7 +935,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
     if (made_progress)
         *made_progress = FALSE;
 
-    MPL_DL_FOREACH_SAFE(state->head, s, tmp) {
+    DL_FOREACH_SAFE(state->head, s, tmp) {
         if (MPIR_CVAR_COLL_SCHED_DUMP)
 	    sched_dump(s, stderr);
 
@@ -1007,7 +1007,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                              (MPL_DBG_FDEST, "completing and dequeuing s=%p r=%p\n", s, s->req));
 
             /* dequeue this schedule from the state, it's complete */
-            MPL_DL_DELETE(state->head, s);
+            DL_DELETE(state->head, s);
 
             /* TODO refactor into a sched_complete routine? */
             switch (s->req->u.nbc.errflag) {

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -5,7 +5,7 @@
  */
 
 #include "mpidimpl.h"
-#include "mpl_utlist.h"
+#include "utlist.h"
 
 /* A random guess at an appropriate value, we can tune it later.  It could also
  * be a real tunable parameter. */

--- a/src/mpl/Makefile.am
+++ b/src/mpl/Makefile.am
@@ -22,7 +22,7 @@ mpl_headers =               \
     include/mpl.h           \
     include/mpl_base.h      \
     include/mplconfig.h     \
-    include/mpl_utlist.h    \
+    include/utlist.h    \
     include/mpl_valgrind.h  \
     include/mpl_env.h       \
     include/mpl_str.h       \

--- a/src/mpl/include/uthash.h
+++ b/src/mpl/include/uthash.h
@@ -29,8 +29,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef MPL_UTHASH_H
-#define MPL_UTHASH_H
+#ifndef UTHASH_H
+#define UTHASH_H
 
 #include <string.h>   /* memcmp,strlen */
 #include <stddef.h>   /* ptrdiff_t */

--- a/src/mpl/include/utlist.h
+++ b/src/mpl/include/utlist.h
@@ -1,12 +1,10 @@
 /* Argonne changes:
 
- - The file name has been changed to avoid conflicts with any system-installed
-   "utlist.h" header files.
  - some configure-time checking for __typeof() support was added
  - intentionally omitted from "mpl.h" in order to require using code to opt-in
  [goodell@ 2010-12-20]
 
- - Added _N (for MPL_LL_ macros) and _NP (for MPL_DL_ and MPL_CDL_ macros)
+ - Added _N (for LL_ macros) and _NP (for DL_ and CDL_ macros)
    variants to each macro.  Thease take additional parameters to specify the
    next or next and prev fields, respectively.  The field name should be used in
    those parameters.  E.g., say the struct looks like this:
@@ -19,13 +17,13 @@
 
    Then, to append an element "my_element" of type my_struct:
 
-       MPL_DL_APPEND_NP(my_head, my_element, my_next, my_prev);
+       DL_APPEND_NP(my_head, my_element, my_next, my_prev);
 
    For convenience one can define a macro to eliminate the need to specify the
    field names every time:
 
-       #define MY_STRUCT_MPL_DL_APPEND(head, add) \
-           MPL_DL_APPEND_NP(head, add, my_next, my_prev)
+       #define MY_STRUCT_DL_APPEND(head, add) \
+           DL_APPEND_NP(head, add, my_next, my_prev)
 
  [buntinas 12/2/2011]
 */
@@ -53,10 +51,10 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#if !defined(MPL_UTLIST_H_INCLUDED)
-#define MPL_UTLIST_H_INCLUDED
+#if !defined(UTLIST_H_INCLUDED)
+#define UTLIST_H_INCLUDED
 
-#define MPL_UTLIST_VERSION 1.9.5
+#define UTLIST_VERSION 1.9.5
 
 #include "mplconfig.h"
 
@@ -98,60 +96,60 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    or, for VS2008 where neither is available, uses casting workarounds. */
 #ifdef _MSC_VER            /* MS compiler */
 #if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
-#define MPL_LDECLTYPE(x) decltype(x)
+#define LDECLTYPE(x) decltype(x)
 #else                     /* VS2008 or older (or VS2010 in C mode) */
-#define MPL_NO_DECLTYPE
-#define MPL_LDECLTYPE(x) char*
+#define NO_DECLTYPE
+#define LDECLTYPE(x) char*
 #endif
 #else                      /* GNU, Sun and other compilers */
-#define MPL_LDECLTYPE(x) __typeof(x)
+#define LDECLTYPE(x) __typeof(x)
 #endif
 #else /* !MPL_HAVE___TYPEOF */
-#define MPL_NO_DECLTYPE
-#define MPL_LDECLTYPE(x) char*
+#define NO_DECLTYPE
+#define LDECLTYPE(x) char*
 #endif /* !MPL_HAVE___TYPEOF */
 
 /* for VS2008 we use some workarounds to get around the lack of decltype,
  * namely, we always reassign our tmp variable to the list head if we need
  * to dereference its prev/next pointers, and save/restore the real head.*/
-#ifdef MPL_NO_DECLTYPE
-#define MPL__SV(elt,list) _tmp = (char*)(list); {char **_alias = (char**)&(list); *_alias = (elt); }
-#define MPL__NEXT(elt,list,_next) ((char*)((list)->_next))
-#define MPL__NEXTASGN(elt,list,to,_next) { char **_alias = (char**)&((list)->_next); *_alias=(char*)(to); }
-#define MPL__PREV(elt,list,_prev) ((char*)((list)->_prev))
-#define MPL__PREVASGN(elt,list,to,_prev) { char **_alias = (char**)&((list)->_prev); *_alias=(char*)(to); }
-#define MPL__RS(list) { char **_alias = (char**)&(list); *_alias=_tmp; }
-#define MPL__CASTASGN(a,b) { char **_alias = (char**)&(a); *_alias=(char*)(b); }
+#ifdef NO_DECLTYPE
+#define _SV(elt,list) _tmp = (char*)(list); {char **_alias = (char**)&(list); *_alias = (elt); }
+#define _NEXT(elt,list,_next) ((char*)((list)->_next))
+#define _NEXTASGN(elt,list,to,_next) { char **_alias = (char**)&((list)->_next); *_alias=(char*)(to); }
+#define _PREV(elt,list,_prev) ((char*)((list)->_prev))
+#define _PREVASGN(elt,list,to,_prev) { char **_alias = (char**)&((list)->_prev); *_alias=(char*)(to); }
+#define _RS(list) { char **_alias = (char**)&(list); *_alias=_tmp; }
+#define _CASTASGN(a,b) { char **_alias = (char**)&(a); *_alias=(char*)(b); }
 #else
-#define MPL__SV(elt,list)
-#define MPL__NEXT(elt,list,_next) ((elt)->_next)
-#define MPL__NEXTASGN(elt,list,to,_next) ((elt)->_next)=(to)
-#define MPL__PREV(elt,list,_prev) ((elt)->_prev)
-#define MPL__PREVASGN(elt,list,to,_prev) ((elt)->_prev)=(to)
-#define MPL__RS(list)
-#define MPL__CASTASGN(a,b) (a)=(b)
+#define _SV(elt,list)
+#define _NEXT(elt,list,_next) ((elt)->_next)
+#define _NEXTASGN(elt,list,to,_next) ((elt)->_next)=(to)
+#define _PREV(elt,list,_prev) ((elt)->_prev)
+#define _PREVASGN(elt,list,to,_prev) ((elt)->_prev)=(to)
+#define _RS(list)
+#define _CASTASGN(a,b) (a)=(b)
 #endif
 
 /******************************************************************************
  * The sort macro is an adaptation of Simon Tatham's O(n log(n)) mergesort    *
  * Unwieldy variable names used here to avoid shadowing passed-in variables.  *
  *****************************************************************************/
-#define MPL_LL_SORT(list, cmp) MPL_LL_SORT_N(list, cmp, next)
-#define MPL_LL_SORT_N(list, cmp, _next)                                                        \
+#define LL_SORT(list, cmp) LL_SORT_N(list, cmp, next)
+#define LL_SORT_N(list, cmp, _next)                                                        \
 do {                                                                                           \
-  MPL_LDECLTYPE(list) _ls_p;                                                                   \
-  MPL_LDECLTYPE(list) _ls_q;                                                                   \
-  MPL_LDECLTYPE(list) _ls_e;                                                                   \
-  MPL_LDECLTYPE(list) _ls_tail;                                                                \
-  MPL_LDECLTYPE(list) _ls_oldhead;                                                             \
-  MPL_LDECLTYPE(list) _tmp;                                                                    \
+  LDECLTYPE(list) _ls_p;                                                                   \
+  LDECLTYPE(list) _ls_q;                                                                   \
+  LDECLTYPE(list) _ls_e;                                                                   \
+  LDECLTYPE(list) _ls_tail;                                                                \
+  LDECLTYPE(list) _ls_oldhead;                                                             \
+  LDECLTYPE(list) _tmp;                                                                    \
   int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
   if (list) {                                                                                  \
     _ls_insize = 1;                                                                            \
     _ls_looping = 1;                                                                           \
     while (_ls_looping) {                                                                      \
-      MPL__CASTASGN(_ls_p,list);                                                               \
-      MPL__CASTASGN(_ls_oldhead,list);                                                         \
+      _CASTASGN(_ls_p,list);                                                               \
+      _CASTASGN(_ls_oldhead,list);                                                         \
       list = NULL;                                                                             \
       _ls_tail = NULL;                                                                         \
       _ls_nmerges = 0;                                                                         \
@@ -161,30 +159,30 @@ do {                                                                            
         _ls_psize = 0;                                                                         \
         for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
           _ls_psize++;                                                                         \
-          MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list);             \
+          _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list);             \
           if (!_ls_q) break;                                                                   \
         }                                                                                      \
         _ls_qsize = _ls_insize;                                                                \
         while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
           if (_ls_psize == 0) {                                                                \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
           } else if (_ls_qsize == 0 || !_ls_q) {                                               \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
           } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
           } else {                                                                             \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
           }                                                                                    \
           if (_ls_tail) {                                                                      \
-            MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,_ls_e,_next); MPL__RS(list);   \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e,_next); _RS(list);   \
           } else {                                                                             \
-            MPL__CASTASGN(list,_ls_e);                                                         \
+            _CASTASGN(list,_ls_e);                                                         \
           }                                                                                    \
           _ls_tail = _ls_e;                                                                    \
         }                                                                                      \
         _ls_p = _ls_q;                                                                         \
       }                                                                                        \
-      MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,NULL,_next); MPL__RS(list);          \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,NULL,_next); _RS(list);          \
       if (_ls_nmerges <= 1) {                                                                  \
         _ls_looping=0;                                                                         \
       }                                                                                        \
@@ -193,22 +191,22 @@ do {                                                                            
   } else _tmp=NULL; /* quiet gcc unused variable warning */                                    \
 } while (0)
 
-#define MPL_DL_SORT(list, cmp) MPL_DL_SORT_NP(list, cmp, next, prev)
-#define MPL_DL_SORT_NP(list, cmp, _next, _prev)                                                \
+#define DL_SORT(list, cmp) DL_SORT_NP(list, cmp, next, prev)
+#define DL_SORT_NP(list, cmp, _next, _prev)                                                \
 do {                                                                                           \
-  MPL_LDECLTYPE(list) _ls_p;                                                                   \
-  MPL_LDECLTYPE(list) _ls_q;                                                                   \
-  MPL_LDECLTYPE(list) _ls_e;                                                                   \
-  MPL_LDECLTYPE(list) _ls_tail;                                                                \
-  MPL_LDECLTYPE(list) _ls_oldhead;                                                             \
-  MPL_LDECLTYPE(list) _tmp;                                                                    \
+  LDECLTYPE(list) _ls_p;                                                                   \
+  LDECLTYPE(list) _ls_q;                                                                   \
+  LDECLTYPE(list) _ls_e;                                                                   \
+  LDECLTYPE(list) _ls_tail;                                                                \
+  LDECLTYPE(list) _ls_oldhead;                                                             \
+  LDECLTYPE(list) _tmp;                                                                    \
   int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
   if (list) {                                                                                  \
     _ls_insize = 1;                                                                            \
     _ls_looping = 1;                                                                           \
     while (_ls_looping) {                                                                      \
-      MPL__CASTASGN(_ls_p,list);                                                               \
-      MPL__CASTASGN(_ls_oldhead,list);                                                         \
+      _CASTASGN(_ls_p,list);                                                               \
+      _CASTASGN(_ls_oldhead,list);                                                         \
       list = NULL;                                                                             \
       _ls_tail = NULL;                                                                         \
       _ls_nmerges = 0;                                                                         \
@@ -218,32 +216,32 @@ do {                                                                            
         _ls_psize = 0;                                                                         \
         for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
           _ls_psize++;                                                                         \
-          MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list);             \
+          _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list);             \
           if (!_ls_q) break;                                                                   \
         }                                                                                      \
         _ls_qsize = _ls_insize;                                                                \
         while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
           if (_ls_psize == 0) {                                                                \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
           } else if (_ls_qsize == 0 || !_ls_q) {                                               \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
           } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
           } else {                                                                             \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
           }                                                                                    \
           if (_ls_tail) {                                                                      \
-            MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,_ls_e,_next); MPL__RS(list);   \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e,_next); _RS(list);   \
           } else {                                                                             \
-            MPL__CASTASGN(list,_ls_e);                                                         \
+            _CASTASGN(list,_ls_e);                                                         \
           }                                                                                    \
-          MPL__SV(_ls_e,list); MPL__PREVASGN(_ls_e,list,_ls_tail,_prev); MPL__RS(list);        \
+          _SV(_ls_e,list); _PREVASGN(_ls_e,list,_ls_tail,_prev); _RS(list);        \
           _ls_tail = _ls_e;                                                                    \
         }                                                                                      \
         _ls_p = _ls_q;                                                                         \
       }                                                                                        \
-      MPL__CASTASGN(list->_prev, _ls_tail);                                                    \
-      MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,NULL,_next); MPL__RS(list);          \
+      _CASTASGN(list->_prev, _ls_tail);                                                    \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,NULL,_next); _RS(list);          \
       if (_ls_nmerges <= 1) {                                                                  \
         _ls_looping=0;                                                                         \
       }                                                                                        \
@@ -252,23 +250,23 @@ do {                                                                            
   } else _tmp=NULL; /* quiet gcc unused variable warning */                                    \
 } while (0)
 
-#define MPL_CDL_SORT(list, cmp) MPL_CDL_SORT_NP(list, cmp, next, prev)
-#define MPL_CDL_SORT_NP(list, cmp, _next, _prev)                                               \
+#define CDL_SORT(list, cmp) CDL_SORT_NP(list, cmp, next, prev)
+#define CDL_SORT_NP(list, cmp, _next, _prev)                                               \
 do {                                                                                           \
-  MPL_LDECLTYPE(list) _ls_p;                                                                   \
-  MPL_LDECLTYPE(list) _ls_q;                                                                   \
-  MPL_LDECLTYPE(list) _ls_e;                                                                   \
-  MPL_LDECLTYPE(list) _ls_tail;                                                                \
-  MPL_LDECLTYPE(list) _ls_oldhead;                                                             \
-  MPL_LDECLTYPE(list) _tmp;                                                                    \
-  MPL_LDECLTYPE(list) _tmp2;                                                                   \
+  LDECLTYPE(list) _ls_p;                                                                   \
+  LDECLTYPE(list) _ls_q;                                                                   \
+  LDECLTYPE(list) _ls_e;                                                                   \
+  LDECLTYPE(list) _ls_tail;                                                                \
+  LDECLTYPE(list) _ls_oldhead;                                                             \
+  LDECLTYPE(list) _tmp;                                                                    \
+  LDECLTYPE(list) _tmp2;                                                                   \
   int _ls_insize, _ls_nmerges, _ls_psize, _ls_qsize, _ls_i, _ls_looping;                       \
   if (list) {                                                                                  \
     _ls_insize = 1;                                                                            \
     _ls_looping = 1;                                                                           \
     while (_ls_looping) {                                                                      \
-      MPL__CASTASGN(_ls_p,list);                                                               \
-      MPL__CASTASGN(_ls_oldhead,list);                                                         \
+      _CASTASGN(_ls_p,list);                                                               \
+      _CASTASGN(_ls_oldhead,list);                                                         \
       list = NULL;                                                                             \
       _ls_tail = NULL;                                                                         \
       _ls_nmerges = 0;                                                                         \
@@ -278,43 +276,43 @@ do {                                                                            
         _ls_psize = 0;                                                                         \
         for (_ls_i = 0; _ls_i < _ls_insize; _ls_i++) {                                         \
           _ls_psize++;                                                                         \
-          MPL__SV(_ls_q,list);                                                                 \
-          if (MPL__NEXT(_ls_q,list,_next) == _ls_oldhead) {                                    \
+          _SV(_ls_q,list);                                                                 \
+          if (_NEXT(_ls_q,list,_next) == _ls_oldhead) {                                    \
             _ls_q = NULL;                                                                      \
           } else {                                                                             \
-            _ls_q = MPL__NEXT(_ls_q,list,_next);                                               \
+            _ls_q = _NEXT(_ls_q,list,_next);                                               \
           }                                                                                    \
-          MPL__RS(list);                                                                       \
+          _RS(list);                                                                       \
           if (!_ls_q) break;                                                                   \
         }                                                                                      \
         _ls_qsize = _ls_insize;                                                                \
         while (_ls_psize > 0 || (_ls_qsize > 0 && _ls_q)) {                                    \
           if (_ls_psize == 0) {                                                                \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
             if (_ls_q == _ls_oldhead) { _ls_q = NULL; }                                        \
           } else if (_ls_qsize == 0 || !_ls_q) {                                               \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
             if (_ls_p == _ls_oldhead) { _ls_p = NULL; }                                        \
           } else if (cmp(_ls_p,_ls_q) <= 0) {                                                  \
-            _ls_e = _ls_p; MPL__SV(_ls_p,list); _ls_p = MPL__NEXT(_ls_p,list,_next); MPL__RS(list); _ls_psize--; \
+            _ls_e = _ls_p; _SV(_ls_p,list); _ls_p = _NEXT(_ls_p,list,_next); _RS(list); _ls_psize--; \
             if (_ls_p == _ls_oldhead) { _ls_p = NULL; }                                        \
           } else {                                                                             \
-            _ls_e = _ls_q; MPL__SV(_ls_q,list); _ls_q = MPL__NEXT(_ls_q,list,_next); MPL__RS(list); _ls_qsize--; \
+            _ls_e = _ls_q; _SV(_ls_q,list); _ls_q = _NEXT(_ls_q,list,_next); _RS(list); _ls_qsize--; \
             if (_ls_q == _ls_oldhead) { _ls_q = NULL; }                                        \
           }                                                                                    \
           if (_ls_tail) {                                                                      \
-            MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,_ls_e,_next); MPL__RS(list);   \
+            _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_ls_e,_next); _RS(list);   \
           } else {                                                                             \
-            MPL__CASTASGN(list,_ls_e);                                                         \
+            _CASTASGN(list,_ls_e);                                                         \
           }                                                                                    \
-          MPL__SV(_ls_e,list); MPL__PREVASGN(_ls_e,list,_ls_tail,_prev); MPL__RS(list);        \
+          _SV(_ls_e,list); _PREVASGN(_ls_e,list,_ls_tail,_prev); _RS(list);        \
           _ls_tail = _ls_e;                                                                    \
         }                                                                                      \
         _ls_p = _ls_q;                                                                         \
       }                                                                                        \
-      MPL__CASTASGN(list->_prev,_ls_tail);                                                     \
-      MPL__CASTASGN(_tmp2,list);                                                               \
-      MPL__SV(_ls_tail,list); MPL__NEXTASGN(_ls_tail,list,_tmp2,_next); MPL__RS(list);         \
+      _CASTASGN(list->_prev,_ls_tail);                                                     \
+      _CASTASGN(_tmp2,list);                                                               \
+      _SV(_ls_tail,list); _NEXTASGN(_ls_tail,list,_tmp2,_next); _RS(list);         \
       if (_ls_nmerges <= 1) {                                                                  \
         _ls_looping=0;                                                                         \
       }                                                                                        \
@@ -326,8 +324,8 @@ do {                                                                            
 /******************************************************************************
  * singly linked list macros (non-circular)                                   *
  *****************************************************************************/
-#define MPL_LL_PREPEND(head,tail,add) MPL_LL_PREPEND_N(head,tail,add,next)
-#define MPL_LL_PREPEND_N(head,tail,add,_next)                                                  \
+#define LL_PREPEND(head,tail,add) LL_PREPEND_N(head,tail,add,next)
+#define LL_PREPEND_N(head,tail,add,_next)                                                  \
 do {                                                                                           \
   (add)->_next = head;                                                                         \
   head = add;                                                                                  \
@@ -335,8 +333,8 @@ do {                                                                            
     (tail) = (add);                                                                            \
 } while (0)
 
-#define MPL_LL_CONCAT(head1,head2,tail1,tail2) MPL_LL_CONCAT_N(head1,head2,tail1,tail2,next)
-#define MPL_LL_CONCAT_N(head1,head2,tail1,tail2,_next)                                         \
+#define LL_CONCAT(head1,head2,tail1,tail2) LL_CONCAT_N(head1,head2,tail1,tail2,next)
+#define LL_CONCAT_N(head1,head2,tail1,tail2,_next)                                         \
 do {                                                                                           \
   if (tail1) {                                                                                 \
     (tail1)->_next=(head2);                                                                    \
@@ -348,8 +346,8 @@ do {                                                                            
   }                                                                                            \
 } while (0)
 
-#define MPL_LL_APPEND(head,tail,add) MPL_LL_APPEND_N(head,tail,add,next)
-#define MPL_LL_APPEND_N(head,tail,add,_next)                                                   \
+#define LL_APPEND(head,tail,add) LL_APPEND_N(head,tail,add,next)
+#define LL_APPEND_N(head,tail,add,_next)                                                   \
 do {                                                                                           \
   (add)->_next=NULL;                                                                           \
   if (tail) {                                                                                  \
@@ -360,10 +358,10 @@ do {                                                                            
   (tail)=(add);                                                                                \
 } while (0)
 
-#define MPL_LL_DELETE(head,tail,del) MPL_LL_DELETE_N(head,tail,del,next)
-#define MPL_LL_DELETE_N(head,tail,del,_next)                                                   \
+#define LL_DELETE(head,tail,del) LL_DELETE_N(head,tail,del,next)
+#define LL_DELETE_N(head,tail,del,_next)                                                   \
 do {                                                                                           \
-  MPL_LDECLTYPE(head) _tmp;                                                                    \
+  LDECLTYPE(head) _tmp;                                                                    \
   if ((head) == (del)) {                                                                       \
     (head)=(head)->_next;                                                                      \
     if ((tail) == (del))                                                                       \
@@ -381,9 +379,9 @@ do {                                                                            
   }                                                                                            \
 } while (0)
 
-/* Here are VS2008 replacements for MPL_LL_DELETE */
-#define MPL_LL_DELETE_VS2008(head,tail,del) MPL_LL_DELETE_N_VS2008(head,tail,del,next)
-#define MPL_LL_DELETE_N_VS2008(head,tail,del,_next)                                            \
+/* Here are VS2008 replacements for LL_DELETE */
+#define LL_DELETE_VS2008(head,tail,del) LL_DELETE_N_VS2008(head,tail,del,next)
+#define LL_DELETE_N_VS2008(head,tail,del,_next)                                            \
 do {                                                                                           \
   if ((head) == (del)) {                                                                       \
     (head)=(head)->_next;                                                                      \
@@ -405,33 +403,33 @@ do {                                                                            
     }                                                                                          \
   }                                                                                            \
 } while (0)
-#ifdef MPL_NO_DECLTYPE
-#undef MPL_LL_DELETE
-#define MPL_LL_DELETE MPL_LL_DELETE_VS2008
-#undef MPL_DL_CONCAT /* no MPL_DL_CONCAT_VS2008 */
+#ifdef NO_DECLTYPE
+#undef LL_DELETE
+#define LL_DELETE LL_DELETE_VS2008
+#undef DL_CONCAT /* no DL_CONCAT_VS2008 */
 #endif
 /* end VS2008 replacements */
 
-#define MPL_LL_FOREACH(head,el) MPL_LL_FOREACH_N(head,el,next)
-#define MPL_LL_FOREACH_N(head,el,_next)                                                        \
+#define LL_FOREACH(head,el) LL_FOREACH_N(head,el,next)
+#define LL_FOREACH_N(head,el,_next)                                                        \
     for(el=head;el;el=el->_next)
 
-#define MPL_LL_FOREACH_SAFE(head,el,tmp) MPL_LL_FOREACH_SAFE_N(head,el,tmp,next)
-#define MPL_LL_FOREACH_SAFE_N(head,el,tmp,_next)                                               \
+#define LL_FOREACH_SAFE(head,el,tmp) LL_FOREACH_SAFE_N(head,el,tmp,next)
+#define LL_FOREACH_SAFE_N(head,el,tmp,_next)                                               \
     for((el)=(head);(el) && (tmp = (el)->_next, 1); (el) = tmp)
 
-#define MPL_LL_SEARCH_SCALAR(head,out,field,val) MPL_LL_SEARCH_SCALAR_N(head,out,field,val,next)
-#define MPL_LL_SEARCH_SCALAR_N(head,out,field,val,_next)                                       \
+#define LL_SEARCH_SCALAR(head,out,field,val) LL_SEARCH_SCALAR_N(head,out,field,val,next)
+#define LL_SEARCH_SCALAR_N(head,out,field,val,_next)                                       \
 do {                                                                                           \
-    MPL_LL_FOREACH_N(head,out,_next) {                                                         \
+    LL_FOREACH_N(head,out,_next) {                                                         \
       if ((out)->field == (val)) break;                                                        \
     }                                                                                          \
 } while(0)
 
-#define MPL_LL_SEARCH(head,out,elt,cmp) MPL_LL_SEARCH_N(head,out,elt,cmp,next)
-#define MPL_LL_SEARCH_N(head,out,elt,cmp,_next)                                                \
+#define LL_SEARCH(head,out,elt,cmp) LL_SEARCH_N(head,out,elt,cmp,next)
+#define LL_SEARCH_N(head,out,elt,cmp,_next)                                                \
 do {                                                                                           \
-    MPL_LL_FOREACH_N(head,out,_next) {                                                         \
+    LL_FOREACH_N(head,out,_next) {                                                         \
       if ((cmp(out,elt))==0) break;                                                            \
     }                                                                                          \
 } while(0)
@@ -439,8 +437,8 @@ do {                                                                            
 /******************************************************************************
  * doubly linked list macros (non-circular)                                   *
  *****************************************************************************/
-#define MPL_DL_PREPEND(head,add) MPL_DL_PREPEND_NP(head,add,next,prev)
-#define MPL_DL_PREPEND_NP(head,add,_next,_prev)                                                \
+#define DL_PREPEND(head,add) DL_PREPEND_NP(head,add,next,prev)
+#define DL_PREPEND_NP(head,add,_next,_prev)                                                \
 do {                                                                                           \
  (add)->_next = head;                                                                          \
  if (head) {                                                                                   \
@@ -452,8 +450,8 @@ do {                                                                            
  (head) = (add);                                                                               \
 } while (0)
 
-#define MPL_DL_APPEND(head,add) MPL_DL_APPEND_NP(head,add,next,prev)
-#define MPL_DL_APPEND_NP(head,add,_next,_prev)                                                 \
+#define DL_APPEND(head,add) DL_APPEND_NP(head,add,next,prev)
+#define DL_APPEND_NP(head,add,_next,_prev)                                                 \
 do {                                                                                           \
   if (head) {                                                                                  \
       (add)->_prev = (head)->_prev;                                                            \
@@ -467,10 +465,10 @@ do {                                                                            
   }                                                                                            \
 } while (0)
 
-#define MPL_DL_CONCAT(head1,head2) MPL_DL_CONCAT_NP(head1,head2,next,prev)
-#define MPL_DL_CONCAT_NP(head1,head2,_next,_prev)                                              \
+#define DL_CONCAT(head1,head2) DL_CONCAT_NP(head1,head2,next,prev)
+#define DL_CONCAT_NP(head1,head2,_next,_prev)                                              \
 do {                                                                                           \
-  MPL_LDECLTYPE(head1) _tmp;                                                                   \
+  LDECLTYPE(head1) _tmp;                                                                   \
   if (head2) {                                                                                 \
     if (head1) {                                                                               \
         _tmp = (head2)->_prev;                                                                 \
@@ -483,8 +481,8 @@ do {                                                                            
   }                                                                                            \
 } while (0)
 
-#define MPL_DL_DELETE(head,del) MPL_DL_DELETE_NP(head,del,next,prev)
-#define MPL_DL_DELETE_NP(head,del,_next,_prev)                                                 \
+#define DL_DELETE(head,del) DL_DELETE_NP(head,del,next,prev)
+#define DL_DELETE_NP(head,del,_next,_prev)                                                 \
 do {                                                                                           \
   if ((del)->_prev == (del)) {                                                                 \
       (head)=NULL;                                                                             \
@@ -502,26 +500,26 @@ do {                                                                            
 } while (0)
 
 
-#define MPL_DL_FOREACH(head,el) MPL_DL_FOREACH_NP(head,el,next,prev)
-#define MPL_DL_FOREACH_NP(head,el,_next,_prev)                                                 \
+#define DL_FOREACH(head,el) DL_FOREACH_NP(head,el,next,prev)
+#define DL_FOREACH_NP(head,el,_next,_prev)                                                 \
     for(el=head;el;el=el->_next)
 
 /* this version is safe for deleting the elements during iteration */
-#define MPL_DL_FOREACH_SAFE(head,el,tmp) MPL_DL_FOREACH_SAFE_NP(head,el,tmp,next,prev)
-#define MPL_DL_FOREACH_SAFE_NP(head,el,tmp,_next,_prev)                                        \
+#define DL_FOREACH_SAFE(head,el,tmp) DL_FOREACH_SAFE_NP(head,el,tmp,next,prev)
+#define DL_FOREACH_SAFE_NP(head,el,tmp,_next,_prev)                                        \
   for((el)=(head);(el) && (tmp = (el)->_next, 1); (el) = tmp)
 
 /* these are identical to their singly-linked list counterparts */
-#define MPL_DL_SEARCH_SCALAR MPL_LL_SEARCH_SCALAR
-#define MPL_DL_SEARCH_SCALAR_NP(head,out,field,val,_next,_prev) MPL_LL_SEARCH_SCALAR_N(head,out,field,val,_next)
-#define MPL_DL_SEARCH MPL_LL_SEARCH
-#define MPL_DL_SEARCH_NP(head,out,elt,cmp,_next,_prev) MPL_LL_SEARCH_N(head,out,elt,cmp,_next)
+#define DL_SEARCH_SCALAR LL_SEARCH_SCALAR
+#define DL_SEARCH_SCALAR_NP(head,out,field,val,_next,_prev) LL_SEARCH_SCALAR_N(head,out,field,val,_next)
+#define DL_SEARCH LL_SEARCH
+#define DL_SEARCH_NP(head,out,elt,cmp,_next,_prev) LL_SEARCH_N(head,out,elt,cmp,_next)
 
 /******************************************************************************
  * circular doubly linked list macros                                         *
  *****************************************************************************/
-#define MPL_CDL_PREPEND(head,add) MPL_CDL_PREPEND_NP(head,add,next,prev)
-#define MPL_CDL_PREPEND_NP(head,add,_next,_prev)                                               \
+#define CDL_PREPEND(head,add) CDL_PREPEND_NP(head,add,next,prev)
+#define CDL_PREPEND_NP(head,add,_next,_prev)                                               \
 do {                                                                                           \
  if (head) {                                                                                   \
    (add)->_prev = (head)->_prev;                                                               \
@@ -535,8 +533,8 @@ do {                                                                            
 (head)=(add);                                                                                  \
 } while (0)
 
-#define MPL_CDL_DELETE(head,del) MPL_CDL_DELETE_NP(head,del,next,prev)
-#define MPL_CDL_DELETE_NP(head,del,_next,_prev)                                                \
+#define CDL_DELETE(head,del) CDL_DELETE_NP(head,del,next,prev)
+#define CDL_DELETE_NP(head,del,_next,_prev)                                                \
 do {                                                                                           \
   if ( ((head)==(del)) && ((head)->_next == (head))) {                                         \
       (head) = 0L;                                                                             \
@@ -547,30 +545,30 @@ do {                                                                            
   }                                                                                            \
 } while (0)
 
-#define MPL_CDL_FOREACH(head,el) MPL_CDL_FOREACH_NP(head,el,next,prev)
-#define MPL_CDL_FOREACH_NP(head,el,_next,_prev)                                                \
+#define CDL_FOREACH(head,el) CDL_FOREACH_NP(head,el,next,prev)
+#define CDL_FOREACH_NP(head,el,_next,_prev)                                                \
     for(el=head;el;el=(el->_next==head ? 0L : el->_next))
 
-#define MPL_CDL_FOREACH_SAFE(head,el,tmp1,tmp2) MPL_CDL_FOREACH_SAFE_NP(head,el,tmp1,tmp2,next,prev)
-#define MPL_CDL_FOREACH_SAFE_NP(head,el,tmp1,tmp2,_next,_prev)                                 \
+#define CDL_FOREACH_SAFE(head,el,tmp1,tmp2) CDL_FOREACH_SAFE_NP(head,el,tmp1,tmp2,next,prev)
+#define CDL_FOREACH_SAFE_NP(head,el,tmp1,tmp2,_next,_prev)                                 \
   for((el)=(head), ((tmp1)=(head)?((head)->_prev):NULL);                                       \
       (el) && ((tmp2)=(el)->_next, 1);                                                         \
       ((el) = (((el)==(tmp1)) ? 0L : (tmp2))))
 
-#define MPL_CDL_SEARCH_SCALAR(head,out,field,val) MPL_CDL_SEARCH_SCALAR_NP(head,out,field,val,next,prev)
-#define MPL_CDL_SEARCH_SCALAR_NP(head,out,field,val,_next,_prev)                               \
+#define CDL_SEARCH_SCALAR(head,out,field,val) CDL_SEARCH_SCALAR_NP(head,out,field,val,next,prev)
+#define CDL_SEARCH_SCALAR_NP(head,out,field,val,_next,_prev)                               \
 do {                                                                                           \
-    MPL_CDL_FOREACH_NP(head,out,_next,_prev) {                                                 \
+    CDL_FOREACH_NP(head,out,_next,_prev) {                                                 \
       if ((out)->field == (val)) break;                                                        \
     }                                                                                          \
 } while(0)
 
-#define MPL_CDL_SEARCH(head,out,elt,cmp) MPL_CDL_SEARCH_NP(head,out,elt,cmp,next,prev)
-#define MPL_CDL_SEARCH_NP(head,out,elt,cmp,_next,_prev)                                        \
+#define CDL_SEARCH(head,out,elt,cmp) CDL_SEARCH_NP(head,out,elt,cmp,next,prev)
+#define CDL_SEARCH_NP(head,out,elt,cmp,_next,_prev)                                        \
 do {                                                                                           \
-    MPL_CDL_FOREACH_NP(head,out,_next,_prev) {                                                 \
+    CDL_FOREACH_NP(head,out,_next,_prev) {                                                 \
       if ((cmp(out,elt))==0) break;                                                            \
     }                                                                                          \
 } while(0)
 
-#endif /* !defined(MPL_UTLIST_H_INCLUDED) */
+#endif /* !defined(UTLIST_H_INCLUDED) */

--- a/src/mpl/include/utlist.h
+++ b/src/mpl/include/utlist.h
@@ -5,7 +5,7 @@
  - some configure-time checking for __typeof() support was added
  - intentionally omitted from "mpl.h" in order to require using code to opt-in
  [goodell@ 2010-12-20]
- 
+
  - Added _N (for MPL_LL_ macros) and _NP (for MPL_DL_ and MPL_CDL_ macros)
    variants to each macro.  Thease take additional parameters to specify the
    next or next and prev fields, respectively.  The field name should be used in
@@ -18,7 +18,7 @@
        };
 
    Then, to append an element "my_element" of type my_struct:
-       
+
        MPL_DL_APPEND_NP(my_head, my_element, my_next, my_prev);
 
    For convenience one can define a macro to eliminate the need to specify the
@@ -122,7 +122,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MPL__PREVASGN(elt,list,to,_prev) { char **_alias = (char**)&((list)->_prev); *_alias=(char*)(to); }
 #define MPL__RS(list) { char **_alias = (char**)&(list); *_alias=_tmp; }
 #define MPL__CASTASGN(a,b) { char **_alias = (char**)&(a); *_alias=(char*)(b); }
-#else 
+#else
 #define MPL__SV(elt,list)
 #define MPL__NEXT(elt,list,_next) ((elt)->_next)
 #define MPL__NEXTASGN(elt,list,to,_next) ((elt)->_next)=(to)
@@ -574,4 +574,3 @@ do {                                                                            
 } while(0)
 
 #endif /* !defined(MPL_UTLIST_H_INCLUDED) */
-

--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -15,7 +15,7 @@
 #include "hydra_config.h"
 
 #include "mpl.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 
 extern char *HYD_dbg_prefix;
 

--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -372,7 +372,7 @@ struct HYD_proxy {
 
     struct HYD_proxy *next;
 
-    MPL_UT_hash_handle hh;
+    UT_hash_handle hh;
 };
 
 /* Global user parameters */

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -32,7 +32,7 @@ static struct {
 struct cache_elem {
     char *key;
     char *val;
-    MPL_UT_hash_handle hh;
+    UT_hash_handle hh;
 };
 
 static struct cache_elem *cache_get = NULL, *hash_get = NULL;
@@ -410,7 +410,7 @@ static HYD_status fn_get(int fd, char *args[])
         MPL_free(cmd);
     }
     else {
-        MPL_HASH_FIND_STR(hash_get, key, found);
+        HASH_FIND_STR(hash_get, key, found);
         if (found) {
             HYD_STRING_STASH_INIT(stash);
             HYD_STRING_STASH(stash, MPL_strdup("cmd=get_result rc="), status);
@@ -500,18 +500,18 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
 
     /* allocate a larger space for the cached keyvals, copy over the
      * older keyvals and add the new ones in */
-    MPL_HASH_CLEAR(hh, hash_get);
+    HASH_CLEAR(hh, hash_get);
     HYDU_REALLOC_OR_JUMP(cache_get, struct cache_elem *,
                          (sizeof(struct cache_elem) * (num_elems + token_count)), status);
     for (i = 0; i < num_elems; i++) {
         struct cache_elem *elem = cache_get + i;
-        MPL_HASH_ADD_STR(hash_get, key, elem);
+        HASH_ADD_STR(hash_get, key, elem);
     }
     for (; i < num_elems + token_count; i++) {
         struct cache_elem *elem = cache_get + i;
         elem->key = MPL_strdup(tokens[i - num_elems].key);
         elem->val = MPL_strdup(tokens[i - num_elems].val);
-        MPL_HASH_ADD_STR(hash_get, key, elem);
+        HASH_ADD_STR(hash_get, key, elem);
     }
     num_elems += token_count;
 

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -9,7 +9,7 @@
 #include "bsci.h"
 #include "demux.h"
 #include "topo.h"
-#include "mpl_uthash.h"
+#include "uthash.h"
 
 #define debug(...)                              \
     {                                           \

--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -84,7 +84,7 @@ static HYD_status cleanup_proxy(struct HYD_proxy *proxy)
         status = HYDT_dmx_deregister_fd(proxy->control_fd);
         HYDU_ERR_POP(status, "error deregistering fd\n");
         close(proxy->control_fd);
-        MPL_HASH_DEL(HYD_server_info.proxy_hash, proxy);
+        HASH_DEL(HYD_server_info.proxy_hash, proxy);
 
         /* Reset the control fd, so when the fd is reused, we don't
          * find the wrong proxy */
@@ -471,7 +471,7 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 
     /* This will be the control socket for this proxy */
     proxy->control_fd = fd;
-    MPL_HASH_ADD_INT(HYD_server_info.proxy_hash, control_fd, proxy);
+    HASH_ADD_INT(HYD_server_info.proxy_hash, control_fd, proxy);
 
     /* Send out the executable information */
     status = send_exec_info(proxy);

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi.c
@@ -16,7 +16,7 @@ struct HYD_proxy *HYD_pmcd_pmi_find_proxy(int fd)
 {
     struct HYD_proxy *proxy;
 
-    MPL_HASH_FIND_INT(HYD_server_info.proxy_hash, &fd, proxy);
+    HASH_FIND_INT(HYD_server_info.proxy_hash, &fd, proxy);
 
     return proxy;
 }


### PR DESCRIPTION
There is an API change in the latest utlist library version that may also have performance impact, so I didn't update this library from the source.

This PR is to be applied after PR#2808 that updates the uthash library.