### PR TITLE
pm/hydra: unset O_NONBLOCK on stdout, stderr during finalize

### DIFF
--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -597,6 +597,7 @@ HYD_status HYDU_sock_read(int fd, void *buf, int maxlen, int *recvd, int *closed
 HYD_status HYDU_sock_write(int fd, const void *buf, int maxlen, int *sent, int *closed,
                            enum HYDU_sock_comm_flag flag);
 HYD_status HYDU_sock_set_nonblock(int fd);
+HYD_status HYDU_sock_set_block(int fd);
 HYD_status HYDU_sock_forward_stdio(int in, int out, int *closed);
 void HYDU_sock_finalize(void);
 HYD_status HYDU_sock_get_iface_ip(char *iface, char **ip);

--- a/src/pm/hydra/tools/bootstrap/src/bsci_finalize.c
+++ b/src/pm/hydra/tools/bootstrap/src/bsci_finalize.c
@@ -24,6 +24,12 @@ HYD_status HYDT_bsci_finalize(void)
         HYDU_ERR_POP(status, "RMK returned error while finalizing\n");
     }
 
+    /* unset O_NONBLOCK on stdout, stderr */
+    status = HYDU_sock_set_block(STDOUT_FILENO);
+    HYDU_ERR_POP(status, "error while finalizing stdout\n");
+    status = HYDU_sock_set_block(STDERR_FILENO);
+    HYDU_ERR_POP(status, "error while finalizing stderr\n");
+
   fn_exit:
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/utils/sock/sock.c
+++ b/src/pm/hydra/utils/sock/sock.c
@@ -331,6 +331,28 @@ HYD_status HYDU_sock_set_nonblock(int fd)
     goto fn_exit;
 }
 
+HYD_status HYDU_sock_set_block(int fd)
+{
+    int flags;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
+
+    if ((flags = fcntl(fd, F_GETFL, 0)) == -1)
+        flags = 0;
+#if defined O_NONBLOCK
+    if (fcntl(fd, F_SETFL, flags & ~O_NONBLOCK) < 0)
+        HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "fcntl failed on %d\n", fd);
+#endif /* O_NONBLOCK */
+
+  fn_exit:
+    HYDU_FUNC_EXIT();
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 static HYD_status alloc_fwd_hash(struct fwd_hash **fwd_hash, int in, int out)
 {
     HYD_status status = HYD_SUCCESS;


### PR DESCRIPTION
HYD_pmci_launch_procs
  -> HYD_pmcd_pmiserv_proxy_init_cb
  -> HYDU_sock_forward_stdio
  -> alloc_fwd_hash
  -> HYDU_sock_set_nonblock

sets O_NONBLOCK on STDOUT, STDERR, causing problems for commands subsequent to mpiexec.

This patch unsets O_NONBLOCK on STDOUT, STDERR during bsci_finalize

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>