### PR TITLE
mpi: Fix logically dead code

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -525,16 +525,16 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
                                              const MPI_Aint array_of_aints[],
                                              const MPI_Datatype array_of_types[])
 {
-    int i, contents_size, align_sz = 8, epsilon, mpi_errno;
+    int i, contents_size, align_sz, epsilon, mpi_errno;
     int struct_sz, ints_sz, aints_sz, types_sz;
     MPIR_Datatype_contents *cp;
     MPIR_Datatype *old_dtp;
     char *ptr;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8;
 #endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -343,7 +343,7 @@ void MPIR_Dataloop_alloc_and_copy(int kind,
                                   DLOOP_Dataloop ** new_loop_p, DLOOP_Size * new_loop_sz_p)
 {
     DLOOP_Size new_loop_sz = 0;
-    int align_sz = 8;           /* default aligns everything to 8-byte boundaries */
+    int align_sz;
     int epsilon;
     DLOOP_Size loop_sz = sizeof(DLOOP_Dataloop);
     DLOOP_Size off_sz = 0, blk_sz = 0, ptr_sz = 0, extent_sz = 0;
@@ -352,9 +352,9 @@ void MPIR_Dataloop_alloc_and_copy(int kind,
     DLOOP_Dataloop *new_loop;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8; /* default aligns everything to 8-byte boundaries */
 #endif
 
     if (old_loop != NULL) {
@@ -523,7 +523,7 @@ void MPIR_Dataloop_struct_alloc(DLOOP_Count count,
                                 DLOOP_Dataloop ** new_loop_p, DLOOP_Size * new_loop_sz_p)
 {
     DLOOP_Size new_loop_sz = 0;
-    int align_sz = 8;           /* default aligns everything to 8-byte boundaries */
+    int align_sz;
     int epsilon;
     DLOOP_Size loop_sz = sizeof(DLOOP_Dataloop);
     DLOOP_Size off_sz, blk_sz, ptr_sz, extent_sz, basic_sz;
@@ -531,9 +531,9 @@ void MPIR_Dataloop_struct_alloc(DLOOP_Count count,
     DLOOP_Dataloop *new_loop;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8; /* default aligns everything to 8-byte boundaries */
 #endif
 
     /* calculate the space that we actually need for everything */

--- a/src/mpi/datatype/looputil.c
+++ b/src/mpi/datatype/looputil.c
@@ -874,7 +874,7 @@ void MPIR_Type_access_contents(MPI_Datatype type,
                                int **ints_p, MPI_Aint ** aints_p, MPI_Datatype ** types_p)
 {
     int nr_ints, nr_aints, nr_types, combiner;
-    int types_sz, struct_sz, ints_sz, epsilon, align_sz = 8;
+    int types_sz, struct_sz, ints_sz, epsilon, align_sz;
     MPIR_Datatype *dtp;
     MPIR_Datatype_contents *cp;
 
@@ -888,9 +888,9 @@ void MPIR_Type_access_contents(MPI_Datatype type,
     DLOOP_Assert(cp != NULL);
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8;
 #endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -390,13 +390,13 @@ int MPII_Type_zerolen(MPI_Datatype * newtype)
 void MPII_Datatype_get_contents_ints(MPIR_Datatype_contents * cp, int *user_ints)
 {
     char *ptr;
-    int align_sz = 8, epsilon;
+    int align_sz, epsilon;
     int struct_sz, types_sz;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8;
 #endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);
@@ -427,9 +427,9 @@ void MPII_Datatype_get_contents_aints(MPIR_Datatype_contents * cp, MPI_Aint * us
     int struct_sz, ints_sz, types_sz;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8;
 #endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);
@@ -464,9 +464,9 @@ void MPII_Datatype_get_contents_types(MPIR_Datatype_contents * cp, MPI_Datatype 
     int struct_sz;
 
 #ifdef HAVE_MAX_STRUCT_ALIGNMENT
-    if (align_sz > HAVE_MAX_STRUCT_ALIGNMENT) {
-        align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
-    }
+    align_sz = HAVE_MAX_STRUCT_ALIGNMENT;
+#else
+    align_sz = 8;
 #endif
 
     struct_sz = sizeof(MPIR_Datatype_contents);


### PR DESCRIPTION
Fixes coverity issues #174256, #174258 and #174259

The variable HAVE_MAX_STRUCT_ALIGNMENT is set in configure.ac based on "pac_cv_c_max_integer_align".
Max value for this variable is defined as 8.