### PR TITLE
Fixes to MPI_Comm_split_type

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -309,8 +309,8 @@ int MPIR_Comm_remote_group_impl(MPIR_Comm *comm_ptr, MPIR_Group **group_ptr);
 int MPIR_Comm_group_failed_impl(MPIR_Comm *comm, MPIR_Group **failed_group_ptr);
 int MPIR_Comm_remote_group_failed_impl(MPIR_Comm *comm, MPIR_Group **failed_group_ptr);
 int MPIR_Comm_split_impl(MPIR_Comm *comm_ptr, int color, int key, MPIR_Comm **newcomm_ptr);
-int MPIR_Comm_split_type_self(MPIR_Comm *comm_ptr, int key, MPIR_Comm **newcomm_ptr);
-int MPIR_Comm_split_type_node(MPIR_Comm *comm_ptr, int key, MPIR_Comm **newcomm_ptr);
+int MPIR_Comm_split_type_self(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
+int MPIR_Comm_split_type_node(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,
                          MPIR_Comm **newcomm_ptr);
 int MPIR_Comm_split_type_impl(MPIR_Comm *comm_ptr, int split_type, int key, MPIR_Info *info_ptr,

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -150,20 +150,16 @@ int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
 
 	    MPIR_Comm_get_ptr(dummycomm, dummycomm_ptr);
 	    *newcomm_ptr = dummycomm_ptr;
-
-	    goto fn_exit;
 #endif
-	    /* fall through to the "not supported" case if ROMIO was not
-	     * enabled for some reason */
 	}
-
-	/* In the mean time, the user passed in COMM_TYPE_NEIGHBORHOOD
-	 * but did not give us an info we know how to work with.
-	 * Throw up our hands and treat it like UNDEFINED.  This will
-	 * result in MPI_COMM_NULL being returned to the user. */
-        mpi_errno = MPIR_Comm_split_impl(comm_ptr, MPI_UNDEFINED, key, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        else {
+            /* In the mean time, the user passed in
+             * COMM_TYPE_NEIGHBORHOOD but did not give us an info we
+             * know how to work with.  Throw up our hands and treat it
+             * like UNDEFINED.  This will result in MPI_COMM_NULL
+             * being returned to the user. */
+            *newcomm_ptr = NULL;
+        }
     }
     else {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_ARG, "**arg");

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -30,9 +30,21 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
 #define FUNCNAME MPIR_Comm_split_type_self
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Comm_split_type_self(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcomm_ptr)
+int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key, MPIR_Comm ** newcomm_ptr)
 {
+    MPIR_Comm *comm_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
+
+    /* split out the undefined processes */
+    mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
+                                     key, &comm_ptr);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    if (split_type == MPI_UNDEFINED) {
+        *newcomm_ptr = NULL;
+        goto fn_exit;
+    }
 
     /* The default implementation is to either pass MPI_UNDEFINED or
      * the local rank as the color (in which case a dup of
@@ -43,6 +55,8 @@ int MPIR_Comm_split_type_self(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcom
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
+    if (comm_ptr)
+        MPIR_Comm_free_impl(comm_ptr);
     return mpi_errno;
 
   fn_fail:
@@ -53,10 +67,22 @@ int MPIR_Comm_split_type_self(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcom
 #define FUNCNAME MPIR_Comm_split_type_node
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Comm_split_type_node(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcomm_ptr)
+int MPIR_Comm_split_type_node(MPIR_Comm * user_comm_ptr, int split_type, int key, MPIR_Comm ** newcomm_ptr)
 {
+    MPIR_Comm *comm_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
     int color;
+
+    /* split out the undefined processes */
+    mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
+                                     key, &comm_ptr);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    if (split_type == MPI_UNDEFINED) {
+        *newcomm_ptr = NULL;
+        goto fn_exit;
+    }
 
     mpi_errno = MPID_Get_node_id(comm_ptr, comm_ptr->rank, &color);
     if (mpi_errno)
@@ -67,6 +93,8 @@ int MPIR_Comm_split_type_node(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcom
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
+    if (comm_ptr)
+        MPIR_Comm_free_impl(comm_ptr);
     return mpi_errno;
 
   fn_fail:
@@ -77,13 +105,25 @@ int MPIR_Comm_split_type_node(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcom
 #define FUNCNAME MPIR_Comm_split_type
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Comm_split_type(MPIR_Comm * comm_ptr, int split_type, int key,
+int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
                          MPIR_Info * info_ptr, MPIR_Comm ** newcomm_ptr)
 {
+    MPIR_Comm *comm_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
 
+    /* split out the undefined processes */
+    mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
+                                     key, &comm_ptr);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    if (split_type == MPI_UNDEFINED) {
+        *newcomm_ptr = NULL;
+        goto fn_exit;
+    }
+
     if (split_type == MPI_COMM_TYPE_SHARED) {
-        mpi_errno = MPIR_Comm_split_type_self(comm_ptr, key, newcomm_ptr);
+        mpi_errno = MPIR_Comm_split_type_self(comm_ptr, split_type, key, newcomm_ptr);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -126,12 +166,12 @@ int MPIR_Comm_split_type(MPIR_Comm * comm_ptr, int split_type, int key,
             MPIR_ERR_POP(mpi_errno);
     }
     else {
-        mpi_errno = MPIR_Comm_split_impl(comm_ptr, MPI_UNDEFINED, key, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_ARG, "**arg");
     }
 
   fn_exit:
+    if (comm_ptr)
+        MPIR_Comm_free_impl(comm_ptr);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -33,6 +33,7 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
 int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key, MPIR_Comm ** newcomm_ptr)
 {
     MPIR_Comm *comm_ptr = NULL;
+    MPIR_Comm *comm_self_ptr;
     int mpi_errno = MPI_SUCCESS;
 
     /* split out the undefined processes */
@@ -46,10 +47,8 @@ int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key
         goto fn_exit;
     }
 
-    /* The default implementation is to either pass MPI_UNDEFINED or
-     * the local rank as the color (in which case a dup of
-     * MPI_COMM_SELF is returned) */
-    mpi_errno = MPIR_Comm_split_impl(comm_ptr, comm_ptr->rank, key, newcomm_ptr);
+    MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
+    mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, newcomm_ptr);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);


### PR DESCRIPTION
We were relying on the fact that all processes eventually call `MPIR_Comm_split_impl` over the entire communicator, even if the device overrides the function for some processes and hands it off to the upper layer for other processes.
    
For example, with `ch3:nemesis`, in the shared memory case, all processes with `MPI_UNDEFINED` were calling the upper-level `MPIR_Comm_split_impl`, while the processes that gave `MPI_COMM_TYPE_SHARED` would use the nemesis code.  Both the nemesis code and the upper-level code coincidentally happened to call `MPIR_Comm_split_impl` over the user communicator as well, so this bug never surfaced.  But it is easy for us to misstep and create a deadlock in the future.
    
In this patch, we simply split out "UNDEFINED" processes from the parent communicator and handle the rest of the processes together.  If the device overrides `split_type`, it would be responsible for dealing with `MPI_UNDEFINED`.