### PR TITLE
 autogen: Ignore submodule dirs that do not exist

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -116,17 +116,6 @@ done
 
 ########################################################################
 echo
-echo "##########################################"
-echo "## Patching necessary third-party software"
-echo "##########################################"
-echo
-
-# ucx
-( cd src/mpid/ch4/netmod/ucx/ucx && git am --3way ../../../../../../maint/patches/pre/ucx/*.patch )
-
-
-########################################################################
-echo
 echo "####################################"
 echo "## Checking user environment"
 echo "####################################"
@@ -159,14 +148,13 @@ do_genstates=yes
 do_atdir_check=no
 do_atver_check=yes
 do_subcfg_m4=yes
+do_ofi=yes
+do_ucx=yes
 
 export do_build_configure
 
 # Allow MAKE to be set from the environment
 MAKE=${MAKE-make}
-
-# external packages that require autogen.sh to be run for each of them
-externals="src/pm/hydra src/mpi/romio src/openpa src/mpid/ch4/netmod/ucx/ucx src/mpid/ch4/netmod/ofi/libfabric"
 
 # amdirs are the directories that make use of autoreconf
 amdirs=". src/mpl src/util/logging/rlog"
@@ -273,6 +261,14 @@ for arg in "$@" ; do
 	    autotoolsdir=`echo "A$arg" | sed -e 's/.*=//'`
 	    ;;
 
+    -without-ofi|--without-ofi|-without-libfabric|--without-libfabric)
+        do_ofi=no
+        ;;
+
+    -without-ucx|--without-ucx)
+        do_ucx=no
+        ;;
+
 	-help|--help|-usage|--usage)
 	    cat <<EOF
    ./autogen.sh [ --with-autotools=dir ] \\
@@ -318,6 +314,34 @@ EOF
 
     esac
 done
+
+########################################################################
+## Set up external packages
+########################################################################
+
+# external packages that require autogen.sh to be run for each of them
+externals="src/pm/hydra src/mpi/romio src/openpa"
+
+if [ "yes" = "$do_ucx" ] ; then
+    externals="${externals} src/mpid/ch4/netmod/ucx/ucx"
+fi
+
+if [ "yes" = "$do_ofi" ] ; then
+    externals="${externals} src/mpid/ch4/netmod/ofi/libfabric"
+fi
+
+########################################################################
+echo
+echo "##########################################"
+echo "## Patching necessary third-party software"
+echo "##########################################"
+echo
+
+# ucx
+if [ "yes" = "$do_ucx" ] ; then
+( cd src/mpid/ch4/netmod/ucx/ucx && git am --3way ../../../../../../maint/patches/pre/ucx/*.patch )
+fi
+
 
 ########################################################################
 ## Check for the location of autotools


### PR DESCRIPTION
If `src/mpid/ch4/netmod/ucx/ucx` and/or `src/mpid/ch4/netmod/ofi/libfabric/` are empty, don't patch them or run `./autogen.sh` on them.