### PR TITLE
Fix Valgrind errors

### DIFF
--- a/src/mpi/rma/alloc_mem.c
+++ b/src/mpi/rma/alloc_mem.c
@@ -100,6 +100,7 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
     }
     /* --END ERROR HANDLING-- */
 
+    MPL_VG_MEM_INIT(ap, size);
     *(void **)baseptr = ap;
 
     /* ... end of body of routine ... */

--- a/src/mpi/spawn/comm_join.c
+++ b/src/mpi/spawn/comm_join.c
@@ -151,6 +151,8 @@ int MPI_Comm_join(int fd, MPI_Comm *intercomm)
     
     MPIU_CHKLMEM_MALLOC(local_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "local port name");
     MPIU_CHKLMEM_MALLOC(remote_port, char *, MPI_MAX_PORT_NAME, mpi_errno, "remote port name");
+
+    MPL_VG_MEM_INIT(local_port, MPI_MAX_PORT_NAME * sizeof(char));
     
     mpi_errno = MPIR_Open_port_impl(NULL, local_port);
     MPIR_ERR_CHKANDJUMP((mpi_errno != MPI_SUCCESS), mpi_errno, MPI_ERR_OTHER, "**openportfailed");

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -145,6 +145,8 @@ static int MPIR_Topology_copy_fn ( MPI_Comm comm ATTRIBUTE((unused)),
 
     MPIU_CHKPMEM_MALLOC(copy_topology, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "copy_topology");
 
+    MPL_VG_MEM_INIT(copy_topology, sizeof(MPIR_Topology));
+
     /* simplify copying and error handling */
 #define MPIR_ARRAY_COPY_HELPER(kind_,array_field_,count_field_) \
         do { \

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -476,18 +476,7 @@ static int send_id_info(const sockconn_t *const sc)
 /*     FIXME better keep pg_id_len itself as part of MPIDI_Process.my_pg structure to */
 /*     avoid computing the length of string everytime this function is called. */
 
-#if defined(MPL_VG_AVAILABLE)
-    /* Valgrind has a bug
-     * (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=524488) that
-     * causes it to report a warning when we initialize the compiler
-     * adds padding to structures.  Even when we initialize all the
-     * fields, the padding bytes are not initialized.  The idea here
-     * is to detect when we are in "valgrind mode" and in such cases
-     * initialize all bytes of the structure. */
-    if (MPL_VG_RUNNING_ON_VALGRIND()) {
-        memset(&hdr, 0, sizeof(hdr));
-    }
-#endif
+    MPL_VG_MEM_INIT(&hdr, sizeof(hdr));
     
     hdr.pkt_type = MPIDI_NEM_TCP_SOCKSM_PKT_ID_INFO;
     hdr.datalen = sizeof(MPIDI_nem_tcp_idinfo_t) + pg_id_len;    
@@ -545,6 +534,8 @@ static int send_tmpvc_info(const sockconn_t *const sc)
 /*     store ending NULL also */
 /*     FIXME better keep pg_id_len itself as part of MPIDI_Process.my_pg structure to */
 /*     avoid computing the length of string everytime this function is called. */
+
+    MPL_VG_MEM_INIT(&hdr, sizeof(hdr));
     
     hdr.pkt_type = MPIDI_NEM_TCP_SOCKSM_PKT_TMPVC_INFO;
     hdr.datalen = sizeof(MPIDI_nem_tcp_portinfo_t);
@@ -724,18 +715,7 @@ static int send_cmd_pkt(int fd, MPIDI_nem_tcp_socksm_pkt_type_t pkt_type)
 		pkt_type == MPIDI_NEM_TCP_SOCKSM_PKT_TMPVC_NAK ||
                 pkt_type == MPIDI_NEM_TCP_SOCKSM_PKT_CLOSED);
 
-#if defined(MPL_VG_AVAILABLE)
-    /* Valgrind has a bug
-     * (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=524488) that
-     * causes it to report a warning when we initialize the compiler
-     * adds padding to structures.  Even when we initialize all the
-     * fields, the padding bytes are not initialized.  The idea here
-     * is to detect when we are in "valgrind mode" and in such cases
-     * initialize all bytes of the structure. */
-    if (MPL_VG_RUNNING_ON_VALGRIND()) {
-        memset(&pkt, 0, sizeof(pkt));
-    }
-#endif
+    MPL_VG_MEM_INIT(&pkt, sizeof(pkt));
 
     pkt.pkt_type = pkt_type;
     pkt.datalen = 0;

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -124,6 +124,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPIU_Malloc(_total_sz);
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_derived_t");
@@ -142,6 +143,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPIU_Malloc(_total_sz);
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_t");
@@ -159,6 +161,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPIU_Malloc(_total_sz);
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_derived_t");
@@ -438,6 +441,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPID_Win * win_ptr,
              * TODO: support extended header array */
             ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t) + target_dtp_ptr->dataloop_size;
             ext_hdr_ptr = MPIU_Malloc(ext_hdr_sz);
+            MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
             if (!ext_hdr_ptr) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                      "**nomem %s", "MPIDI_CH3_Ext_pkt_put_derived_t");
@@ -943,6 +947,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPID_Win * win_ptr,
          * TODO: support extended header array */
         ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t) + dtp->dataloop_size;
         ext_hdr_ptr = MPIU_Malloc(ext_hdr_sz);
+        MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
         if (!ext_hdr_ptr) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_get_derived_t");

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -256,6 +256,7 @@ int MPIDI_CH3U_Win_allocate_no_shm(MPI_Aint size, int disp_unit, MPID_Info * inf
 
     if (size > 0) {
         MPIU_CHKPMEM_MALLOC(*base_pp, void *, size, mpi_errno, "(*win_ptr)->base");
+        MPL_VG_MEM_INIT(*base_pp, size);
     }
     else if (size == 0) {
         *base_pp = NULL;

--- a/src/mpl/include/mpl_valgrind.h
+++ b/src/mpl/include/mpl_valgrind.h
@@ -138,6 +138,14 @@
 #  define MPL_VG_CREATE_BLOCK(addr_,len_,desc_)       do { (void) VALGRIND_CREATE_BLOCK((addr_),(len_),(desc_)); } while (0)
 #  define MPL_VG_RUNNING_ON_VALGRIND()                RUNNING_ON_VALGRIND
 #  define MPL_VG_PRINTF_BACKTRACE                     VALGRIND_PRINTF_BACKTRACE
+/* Valgrind has a bug
+ * (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=524488) that
+ * causes it to report a warning when the compiler adds padding to
+ * structures.  Even when we initialize all the fields in the
+ * structure, the padding bytes are not initialized.  The idea here is
+ * to detect when we are in "valgrind mode" and in such cases
+ * initialize all bytes of the structure. */
+#  define MPL_VG_MEM_INIT(addr_,len_)                 do { memset(addr_, 0, len_); } while (0)
 
 /* custom allocator client requests, you probably shouldn't use these unless you
  * really know what you are doing */
@@ -154,6 +162,7 @@
 #  define MPL_VG_CHECK_MEM_IS_ADDRESSABLE(addr_,len_) do {} while (0)
 #  define MPL_VG_CREATE_BLOCK(addr_,len_,desc_)       do {} while (0)
 #  define MPL_VG_RUNNING_ON_VALGRIND()                (0)       /*always false */
+#  define MPL_VG_MEM_INIT(addr_,len_)                 do {} while (0)
 #  if defined(MPL_HAVE_MACRO_VA_ARGS)
 #    define MPL_VG_PRINTF_BACKTRACE(...)              do {} while (0)
 #  else

--- a/test/mpi/coll/bcastzerotype.c
+++ b/test/mpi/coll/bcastzerotype.c
@@ -47,6 +47,8 @@ int main(int argc, char *argv[])
         assert(buf[i] == wrank * NELEM + i);
     }
 
+    free(buf);
+
     MPI_Type_free(&type);
     MPI_Finalize();
 

--- a/test/mpi/coll/nonblocking.c
+++ b/test/mpi/coll/nonblocking.c
@@ -204,6 +204,8 @@ int main(int argc, char **argv)
         free(sdispls);
     if (rdispls)
         free(rdispls);
+    if (types)
+        free(types);
 
     if (rank == 0) {
         if (errs)

--- a/test/mpi/coll/opland.c
+++ b/test/mpi/coll/opland.c
@@ -202,6 +202,7 @@ int main(int argc, char *argv[])
     {
         long double ldinbuf[3], ldoutbuf[3];
         /* long double */
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;
         ldinbuf[2] = (rank > 0);

--- a/test/mpi/coll/oplor.c
+++ b/test/mpi/coll/oplor.c
@@ -205,6 +205,7 @@ int main(int argc, char *argv[])
     {
         long double ldinbuf[3], ldoutbuf[3];
         /* long double */
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;
         ldinbuf[2] = (rank > 0);

--- a/test/mpi/coll/oplxor.c
+++ b/test/mpi/coll/oplxor.c
@@ -202,6 +202,7 @@ int main(int argc, char *argv[])
     {
         long double ldinbuf[3], ldoutbuf[3];
         /* long double */
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;
         ldinbuf[2] = (rank > 0);

--- a/test/mpi/coll/opmax.c
+++ b/test/mpi/coll/opmax.c
@@ -115,6 +115,7 @@ int main(int argc, char *argv[])
     {
         long double ldinbuf[3], ldoutbuf[3];
         /* long double */
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;
         ldinbuf[2] = rank;

--- a/test/mpi/coll/opmin.c
+++ b/test/mpi/coll/opmin.c
@@ -115,6 +115,7 @@ int main(int argc, char *argv[])
     {
         long double ldinbuf[3], ldoutbuf[3];
         /* long double */
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;
         ldinbuf[2] = rank;

--- a/test/mpi/coll/opminloc.c
+++ b/test/mpi/coll/opminloc.c
@@ -226,6 +226,7 @@ int main(int argc, char *argv[])
             long double val;
             int loc;
         } cinbuf[3], coutbuf[3];
+        MTEST_VG_MEM_INIT(cinbuf, 3* sizeof(cinbuf[0]));
 
         cinbuf[0].val = 1;
         cinbuf[0].loc = rank;

--- a/test/mpi/coll/opprod.c
+++ b/test/mpi/coll/opprod.c
@@ -138,6 +138,7 @@ int main(int argc, char *argv[])
         int dc;
 #ifdef HAVE_LONG_DOUBLE
         ld_complex ldinbuf[3], ldoutbuf[3];
+        MTEST_VG_MEM_INIT(ldinbuf, 3* sizeof(ldinbuf[0]));
 #endif
         /* Must determine which C type matches this Fortran type */
         MPI_Type_size(MPI_DOUBLE_COMPLEX, &dc);
@@ -257,6 +258,7 @@ int main(int argc, char *argv[])
 #ifdef HAVE_LONG_DOUBLE
     {
         long double ldinbuf[3], ldoutbuf[3];
+        MTEST_VG_MEM_INIT(ldinbuf, 3 * sizeof(ldinbuf[0]));
         /* long double */
         ldinbuf[0] = (rank < maxsize && rank > 0) ? rank : 1;
         ldinbuf[1] = 0;

--- a/test/mpi/coll/opsum.c
+++ b/test/mpi/coll/opsum.c
@@ -127,6 +127,7 @@ int main(int argc, char *argv[])
         int dc;
 #ifdef HAVE_LONG_DOUBLE
         ld_complex ldinbuf[3], ldoutbuf[3];
+        MTEST_VG_MEM_INIT(ldinbuf, 3 * sizeof(ldinbuf[0]));
 #endif
         /* Must determine which C type matches this Fortran type */
         MPI_Type_size(MPI_DOUBLE_COMPLEX, &dc);
@@ -203,6 +204,7 @@ int main(int argc, char *argv[])
 #ifdef HAVE_LONG_DOUBLE
     {
         long double ldinbuf[3], ldoutbuf[3];
+        MTEST_VG_MEM_INIT(ldinbuf, 3 * sizeof(ldinbuf[0]));
         /* long double */
         ldinbuf[0] = 1;
         ldinbuf[1] = 0;

--- a/test/mpi/coll/redscat.c
+++ b/test/mpi/coll/redscat.c
@@ -51,6 +51,9 @@ int main(int argc, char **argv)
     if (rank == 0 && toterr == 0) {
         printf(" No Errors\n");
     }
+
+    free(sendbuf);
+    free(recvcounts);
     MPI_Finalize();
 
     return toterr;

--- a/test/mpi/coll/redscat2.c
+++ b/test/mpi/coll/redscat2.c
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
 
         free(recvbuf);
         free(sendbuf);
+        free(recvcounts);
     }
 
     MPI_Op_free(&left_op);

--- a/test/mpi/coll/scatter3.c
+++ b/test/mpi/coll/scatter3.c
@@ -79,6 +79,8 @@ int main(int argc, char **argv)
         }
     }
 
+    free(vecin);
+    free(vecout);
     MTest_Finalize(errs);
     MPI_Type_free(&vec);
     MPI_Finalize();

--- a/test/mpi/coll/scattern.c
+++ b/test/mpi/coll/scattern.c
@@ -52,6 +52,8 @@ int main(int argc, char **argv)
         else
             printf(" No Errors\n");
     }
+    free(vecin);
+    free(vecout);
     MPI_Type_free(&vec);
     MPI_Finalize();
     return 0;

--- a/test/mpi/comm/comm_create_group.c
+++ b/test/mpi/comm/comm_create_group.c
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
     if (rank == 0)
         printf(" No errors\n");
 
+    free(excl);
     MPI_Finalize();
     return 0;
 }

--- a/test/mpi/comm/comm_group_rand.c
+++ b/test/mpi/comm/comm_group_rand.c
@@ -55,6 +55,8 @@ int main(int argc, char **argv)
     if (rank == 0)
         printf(" No Errors\n");
 
+    free(ranks);
+    free(included);
     MPI_Finalize();
 
     return 0;

--- a/test/mpi/comm/comm_idup_isend.c
+++ b/test/mpi/comm/comm_idup_isend.c
@@ -102,6 +102,7 @@ int main(int argc, char **argv)
         MTestFreeComm(&testcomm);
     }
 
+    free(sreq);
     MTest_Finalize(errs);
     MPI_Finalize();
     return 0;

--- a/test/mpi/cxx/coll/arcomplex.cxx
+++ b/test/mpi/cxx/coll/arcomplex.cxx
@@ -31,6 +31,7 @@ int main( int argc, char **argv )
     complex<double> cd[2], cd_out[2];
 #ifdef HAVE_LONG_DOUBLE
     complex<long double> cld[2], cld_out[2];
+    MTEST_VG_MEM_INIT(cld, 2 * sizeof(complex<long double>));
 #endif
 
     MTest_Init( );

--- a/test/mpi/cxx/comm/commname2.cxx
+++ b/test/mpi/cxx/comm/commname2.cxx
@@ -74,7 +74,7 @@ int main( int argc, char **argv )
 	    errs++;
 	    cout << "comm[" << i << "] gave name " << name << "\n";
 	}
-        MTestFreeComm ( *comm[i] );
+        MTestFreeComm ( comm[i] );
     }
     
     MTest_Finalize( errs );

--- a/test/mpi/cxx/comm/commname2.cxx
+++ b/test/mpi/cxx/comm/commname2.cxx
@@ -74,7 +74,7 @@ int main( int argc, char **argv )
 	    errs++;
 	    cout << "comm[" << i << "] gave name " << name << "\n";
 	}
-        MTestFreeComm ( comm[i] );
+        MTestFreeComm ( *comm[i] );
     }
     
     MTest_Finalize( errs );

--- a/test/mpi/cxx/io/filemiscx.cxx
+++ b/test/mpi/cxx/io/filemiscx.cxx
@@ -38,6 +38,8 @@ int main(int argc, char **argv)
     MPI::Datatype etype, filetype;
     char datarep[25], *filename;
 
+    MTEST_VG_MEM_INIT(buf, 1024 * sizeof(int));
+
     MPI::Init();
 
     try {

--- a/test/mpi/cxx/pt2pt/bsend1cxx.cxx
+++ b/test/mpi/cxx/pt2pt/bsend1cxx.cxx
@@ -103,7 +103,7 @@ int main( int argc, char *argv[] )
 	cerr << "Returned buffer from detach is not the same as the initial buffer\n";
     }
 
-    delete buf;
+    delete[] buf;
 
     MTest_Finalize( errs );
 

--- a/test/mpi/cxx/pt2pt/sendrecvx.cxx
+++ b/test/mpi/cxx/pt2pt/sendrecvx.cxx
@@ -45,6 +45,7 @@ int main( int argc, char *argv[] )
 	int i;
 	for (i=0; i<100; i++) buf[i] = i;
 	MPI::COMM_WORLD.Send( buf, 100, MPI::INT, size-1, 0 );
+    delete[] buf;
     }
     else if (rank == size - 1) {
 	int *buf = new int[100];
@@ -56,6 +57,7 @@ int main( int argc, char *argv[] )
 		cerr << "Error: buf[" << i << "] = " << buf[i] << "\n";
 	    }
 	}
+    delete[] buf;
     }
 
     MTest_Finalize( errs );

--- a/test/mpi/cxx/spawn/selfconaccx.cxx
+++ b/test/mpi/cxx/spawn/selfconaccx.cxx
@@ -26,6 +26,8 @@ int main( int argc, char *argv[] )
     MPI::Status status;
     MPI::Intercomm comm;
 
+    MTEST_VG_MEM_INIT(port, MPI_MAX_PORT_NAME * sizeof(char));
+
     MPI::Init(argc, argv);
 
     size = MPI::COMM_WORLD.Get_size();

--- a/test/mpi/datatype/getpartelm.c
+++ b/test/mpi/datatype/getpartelm.c
@@ -6,6 +6,7 @@
  */
 #include "mpi.h"
 #include <stdio.h>
+#include <string.h>
 #include "mpitest.h"
 
 /*
@@ -40,6 +41,7 @@ int main(int argc, char *argv[])
 
     if (rank == src) {
         int buf[128], position, cnt;
+        MTEST_VG_MEM_INIT(buf, 128 * sizeof(buf[0]));
         /* sender */
 
         /* Create a datatype and send it (multiple of sizeof(int)) */

--- a/test/mpi/datatype/large_type.c
+++ b/test/mpi/datatype/large_type.c
@@ -81,6 +81,8 @@ static MPI_Datatype make_largexfer_type_hindexed(MPI_Offset nbytes)
     MPI_Type_create_hindexed(count, blocklens, disp, MPI_BYTE, &memtype);
     MPI_Type_commit(&memtype);
 
+    free(blocklens);
+    free(disp);
     return memtype;
 }
 

--- a/test/mpi/datatype/large_vec.c
+++ b/test/mpi/datatype/large_vec.c
@@ -74,6 +74,7 @@ int main(int argc, char *argv[])
     }
 
     MPI_Type_free(&dtype);
+    free(cols);
 
     MTest_Finalize(errs);
     MPI_Finalize();

--- a/test/mpi/datatype/simple-pack-external.c
+++ b/test/mpi/datatype/simple-pack-external.c
@@ -178,6 +178,7 @@ int vector_of_vectors_test(void)
         }
     }
 
+    free(buf);
     MPI_Type_free(&inner_vector);
     MPI_Type_free(&outer_vector);
     return errs;
@@ -258,6 +259,7 @@ int optimizable_vector_of_basics_test(void)
         }
     }
 
+    free(buf);
     MPI_Type_free(&parent_type);
     return errs;
 }
@@ -347,6 +349,7 @@ int struct_of_basics_test(void)
         }
     }
 
+    free(buf);
     MPI_Type_free(&parent_type);
     return errs;
 }

--- a/test/mpi/datatype/simple-pack.c
+++ b/test/mpi/datatype/simple-pack.c
@@ -174,6 +174,7 @@ int vector_of_vectors_test(void)
         }
     }
 
+    free(buf);
     MPI_Type_free(&inner_vector);
     MPI_Type_free(&outer_vector);
     return errs;
@@ -248,6 +249,7 @@ int optimizable_vector_of_basics_test(void)
         }
     }
 
+    free(buf);
     MPI_Type_free(&parent_type);
     return errs;
 }

--- a/test/mpi/datatype/structpack2.c
+++ b/test/mpi/datatype/structpack2.c
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
         }
     }
 
+    free(buffer);
     MPI_Type_free(&str);
     MPI_Type_free(&con);
     MTest_Finalize(errs);

--- a/test/mpi/datatype/transpose-pack.c
+++ b/test/mpi/datatype/transpose-pack.c
@@ -84,6 +84,7 @@ int main(int argc, char *argv[])
     else {
         printf(" No Errors\n");
     }
+    free(buffer);
     MPI_Finalize();
     return 0;
 }

--- a/test/mpi/datatype/tresized.c
+++ b/test/mpi/datatype/tresized.c
@@ -70,6 +70,7 @@ int main(int argc, char *argv[])
                 }
             }
         }
+        free(buf);
     }
 
     MPI_Type_free(&newtype);

--- a/test/mpi/datatype/tresized2.c
+++ b/test/mpi/datatype/tresized2.c
@@ -74,6 +74,7 @@ int main(int argc, char *argv[])
                 }
             }
         }
+        free(buf);
     }
     MPI_Type_free(&newtype);
 

--- a/test/mpi/datatype/unpack.c
+++ b/test/mpi/datatype/unpack.c
@@ -99,6 +99,8 @@ int main(int argc, char **argv)
 
     MPI_Type_free(&mem_dtype);
 
+    free(mem_buf);
+    free(unpack_buf);
     MTest_Finalize(errs);
     MPI_Finalize();
 

--- a/test/mpi/errors/coll/bcastlength.c
+++ b/test/mpi/errors/coll/bcastlength.c
@@ -22,6 +22,8 @@ int main(int argc, char *argv[])
     char str[MPI_MAX_ERROR_STRING + 1];
     int slen;
 
+    MTEST_VG_MEM_INIT(buf, 10 * sizeof(int));
+
     MTest_Init(&argc, &argv);
 
     MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);

--- a/test/mpi/errors/coll/noalias2.c
+++ b/test/mpi/errors/coll/noalias2.c
@@ -144,6 +144,8 @@ int main(int argc, char **argv)
         free(sdispls);
     if (rdispls)
         free(rdispls);
+    if (types)
+        free(types);
 
     if (rank == 0) {
         if (errs)

--- a/test/mpi/errors/coll/noalias3.c
+++ b/test/mpi/errors/coll/noalias3.c
@@ -148,6 +148,8 @@ int main(int argc, char **argv)
         free(sdispls);
     if (rdispls)
         free(rdispls);
+    if (types)
+        free(types);
 
     if (rank == 0) {
         if (errs)

--- a/test/mpi/errors/comm/too_many_comms2.c
+++ b/test/mpi/errors/comm/too_many_comms2.c
@@ -73,6 +73,7 @@ int main(int argc, char **argv)
         MPI_Comm_free(&comm_hdls[i]);
 
     free(comm_hdls);
+    free(ranks);
     MPI_Group_free(&world_group);
 
     MTest_Finalize(errors);

--- a/test/mpi/errors/comm/too_many_comms3.c
+++ b/test/mpi/errors/comm/too_many_comms3.c
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
         MPI_Comm_free(&comm_hdls[i]);
 
     free(comm_hdls);
+    free(ranks);
     MPI_Group_free(&world_group);
 
     MTest_Finalize(errors);

--- a/test/mpi/errors/cxx/io/fileerrretx.cxx
+++ b/test/mpi/errors/cxx/io/fileerrretx.cxx
@@ -97,6 +97,7 @@ int main( int argc, char *argv[] )
 	}
     }
 
+    delete[] filename;
     MPI::Finalize();
 
     return 0;

--- a/test/mpi/errors/pt2pt/errinstatta.c
+++ b/test/mpi/errors/pt2pt/errinstatta.c
@@ -22,6 +22,9 @@ int main(int argc, char *argv[])
     int b1[20], b2[20], rank, size, src, dest, i, flag;
     int errval, errclass;
 
+    MTEST_VG_MEM_INIT(b1, 20 * sizeof(int));
+    MTEST_VG_MEM_INIT(b2, 20 * sizeof(int));
+
     MTest_Init(&argc, &argv);
 
     /* Create some receive requests.  tags 0-9 will succeed, tags 10-19

--- a/test/mpi/errors/pt2pt/errinstatts.c
+++ b/test/mpi/errors/pt2pt/errinstatts.c
@@ -23,6 +23,9 @@ int main(int argc, char *argv[])
     int errval, errclass;
     int b1[20], b2[20], rank, size, src, dest, i, j;
 
+    MTEST_VG_MEM_INIT(b1, 20 * sizeof(int));
+    MTEST_VG_MEM_INIT(b2, 20 * sizeof(int));
+
     MTest_Init(&argc, &argv);
 
     /* Create some receive requests.  tags 0-9 will succeed, tags 10-19

--- a/test/mpi/errors/pt2pt/errinstatwa.c
+++ b/test/mpi/errors/pt2pt/errinstatwa.c
@@ -22,6 +22,9 @@ int main(int argc, char *argv[])
     int errval, errclass;
     int b1[20], b2[20], rank, size, src, dest, i;
 
+    MTEST_VG_MEM_INIT(b1, 20 * sizeof(int));
+    MTEST_VG_MEM_INIT(b2, 20 * sizeof(int));
+
     MTest_Init(&argc, &argv);
 
     /* Create some receive requests.  tags 0-9 will succeed, tags 10-19

--- a/test/mpi/errors/pt2pt/errinstatws.c
+++ b/test/mpi/errors/pt2pt/errinstatws.c
@@ -23,6 +23,9 @@ int main(int argc, char *argv[])
     int errval, errclass;
     int b1[20], b2[20], rank, size, src, dest, i, j;
 
+    MTEST_VG_MEM_INIT(b1, 20 * sizeof(int));
+    MTEST_VG_MEM_INIT(b2, 20 * sizeof(int));
+
     MTest_Init(&argc, &argv);
 
     /* Create some receive requests.  tags 0-9 will succeed, tags 10-19

--- a/test/mpi/errors/pt2pt/truncmsg1.c
+++ b/test/mpi/errors/pt2pt/truncmsg1.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
     dest = size - 1;
 
     buf = (int *) malloc(LongLen * sizeof(int));
+    MTEST_VG_MEM_INIT(buf, LongLen * sizeof(int));
     if (!buf) {
         fprintf(stderr, "Unable to allocate communication buffer of size %d\n", LongLen);
         MPI_Abort(MPI_COMM_WORLD, 1);

--- a/test/mpi/errors/rma/win_sync_complete.c
+++ b/test/mpi/errors/rma/win_sync_complete.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     int rank;
     int errors = 0, all_errors = 0;
-    int buf;
+    int buf = 0;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/win_sync_free_at.c
+++ b/test/mpi/errors/rma/win_sync_free_at.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     int rank, nproc, i;
     int errors = 0, all_errors = 0;
-    int buf, *my_buf;
+    int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 

--- a/test/mpi/errors/rma/win_sync_free_pt.c
+++ b/test/mpi/errors/rma/win_sync_free_pt.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     int rank;
     int errors = 0, all_errors = 0;
-    int buf;
+    int buf = 0;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/win_sync_lock_at.c
+++ b/test/mpi/errors/rma/win_sync_lock_at.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     int rank, nproc, i;
     int errors = 0, all_errors = 0;
-    int buf, *my_buf;
+    int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 

--- a/test/mpi/errors/rma/win_sync_lock_fence.c
+++ b/test/mpi/errors/rma/win_sync_lock_fence.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     int rank, nproc;
     int errors = 0, all_errors = 0;
-    int buf, my_buf;
+    int buf = 0, my_buf;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/win_sync_lock_pt.c
+++ b/test/mpi/errors/rma/win_sync_lock_pt.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     int rank;
     int errors = 0, all_errors = 0;
-    int buf;
+    int buf = 0;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/win_sync_nested.c
+++ b/test/mpi/errors/rma/win_sync_nested.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     int rank, nproc, i;
     int errors = 0, all_errors = 0;
-    int buf, *my_buf;
+    int buf = 0, *my_buf;
     MPI_Win win;
     MPI_Group world_group;
 

--- a/test/mpi/errors/rma/win_sync_op.c
+++ b/test/mpi/errors/rma/win_sync_op.c
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
 {
     int rank, nproc;
     int errors = 0, all_errors = 0;
-    int buf, my_buf;
+    int buf = 0, my_buf;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/win_sync_unlock.c
+++ b/test/mpi/errors/rma/win_sync_unlock.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
 {
     int rank;
     int errors = 0, all_errors = 0;
-    int buf;
+    int buf = 0;
     MPI_Win win;
 
     MPI_Init(&argc, &argv);

--- a/test/mpi/errors/rma/winerr.c
+++ b/test/mpi/errors/rma/winerr.c
@@ -41,6 +41,7 @@ int main(int argc, char *argv[])
     MPI_Comm comm;
     MPI_Errhandler newerr, olderr;
 
+    MTEST_VG_MEM_INIT(buf, 2 * sizeof(int));
 
     MTest_Init(&argc, &argv);
     comm = MPI_COMM_WORLD;

--- a/test/mpi/errors/rma/winerr2.c
+++ b/test/mpi/errors/rma/winerr2.c
@@ -64,6 +64,7 @@ int main(int argc, char *argv[])
     MPI_Comm comm;
     MPI_Errhandler newerr1, newerr2, olderr;
 
+    MTEST_VG_MEM_INIT(buf, 2 * sizeof(int));
 
     MTest_Init(&argc, &argv);
     comm = MPI_COMM_WORLD;

--- a/test/mpi/f77/coll/split_typef.f
+++ b/test/mpi/f77/coll/split_typef.f
@@ -19,6 +19,7 @@ C
       call mtest_init( ierr )
 
       call mpi_comm_dup( MPI_COMM_WORLD, comm, ierr )
+      call mpi_comm_rank( comm, rank , ierr )
 
       call mpi_comm_split_type( comm, MPI_COMM_TYPE_SHARED, rank,
      &     MPI_INFO_NULL, newcomm, ierr )

--- a/test/mpi/group/groupcreate.c
+++ b/test/mpi/group/groupcreate.c
@@ -79,6 +79,7 @@ implementation\n");
     }
 
     free(group_array);
+    free(ranks);
 
     MPI_Finalize();
     return 0;

--- a/test/mpi/group/grouptest2.c
+++ b/test/mpi/group/grouptest2.c
@@ -207,6 +207,8 @@ int main(int argc, char **argv)
             printf("Found %d errors in MPI Group routines\n", toterr);
     }
 
+    free(ranks);
+    free(ranks_out);
     MPI_Finalize();
     return toterr;
 }

--- a/test/mpi/impls/mpich/mpi_t/collparmt.c
+++ b/test/mpi/impls/mpich/mpi_t/collparmt.c
@@ -5,8 +5,10 @@
  */
 /* */
 #include <stdio.h>
+#include <string.h>
 #include "mpi.h"
 #include "mpitestconf.h"
+#include "mpitest.h"
 
 int main(int argc, char *argv[])
 {
@@ -22,6 +24,10 @@ int main(int argc, char *argv[])
     int gatherScope, gatherCvar = -1;
     int newval;
     int errs = 0;
+
+    MTEST_VG_MEM_INIT(buf1, 400 * sizeof(char));
+    MTEST_VG_MEM_INIT(buf2, 400 * sizeof(char));
+    MTEST_VG_MEM_INIT(buf3, 400 * sizeof(char));
 
     MPI_Init(&argc, &argv);
     MPI_T_init_thread(MPI_THREAD_SINGLE, &provided);

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -7,6 +7,7 @@
 #ifndef MPITEST_H_INCLUDED
 #define MPITEST_H_INCLUDED
 
+#include <string.h>
 #include "mpitestconf.h"
 
 /*
@@ -126,5 +127,11 @@ void MTestFreeWin(MPI_Win *);
 #define MTEST_HAVE_MIN_MPI_VERSION(major_,minor_) \
     ((MTEST_MPI_VERSION == (major_) && MTEST_MPI_SUBVERSION >= (minor_)) ||   \
     (MTEST_MPI_VERSION > (major_)))
+
+/* useful for avoid valgrind warnings about padding bytes */
+#define MTEST_VG_MEM_INIT(addr_, size_) \
+do {                                    \
+    memset(addr_, 0, size_);            \
+} while (0)
 
 #endif

--- a/test/mpi/include/mpitestcxx.h
+++ b/test/mpi/include/mpitestcxx.h
@@ -10,6 +10,8 @@
 
 #ifndef MTEST_INCLUDED
 #define MTEST_INCLUDED
+
+#include <string.h>
 /*
  * Init and finalize test
  */
@@ -63,5 +65,11 @@ int MTestGetWin(MPI::Win &, bool);
 const char *MTestGetWinName(void);
 void MTestFreeWin(MPI::Win &);
 #endif
+
+/* useful for avoid valgrind warnings about padding bytes */
+#define MTEST_VG_MEM_INIT(addr_, size_) \
+do {                                    \
+    memset(addr_, 0, size_);            \
+} while (0)
 
 #endif

--- a/test/mpi/io/async.c
+++ b/test/mpi/io/async.c
@@ -59,6 +59,7 @@ int main(int argc, char **argv)
                 i++;
                 len = (int) strlen(*argv);
                 filename = (char *) malloc(len + 10);
+                MTEST_VG_MEM_INIT(filename, (len + 10) * sizeof(char));
                 strcpy(filename, *argv);
             }
             else if (strcmp(*argv, "-size") == 0) {
@@ -83,6 +84,7 @@ int main(int argc, char **argv)
             /* Use a default filename of testfile */
             len = 8;
             filename = (char *) malloc(len + 10);
+            MTEST_VG_MEM_INIT(filename, (len + 10) * sizeof(char));
             strcpy(filename, "testfile");
         }
         MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);

--- a/test/mpi/io/async_any.c
+++ b/test/mpi/io/async_any.c
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
             /* Use a default filename of testfile */
             len = 8;
             filename = (char *) malloc(len + 10);
+            memset(filename, 0, (len + 10) * sizeof(char));
             strcpy(filename, "testfile");
             /*
              * fprintf(stderr, "\n*#  Usage: async_any -fname filename\n\n");
@@ -54,6 +55,7 @@ int main(int argc, char **argv)
             argv++;
             len = (int) strlen(*argv);
             filename = (char *) malloc(len + 10);
+            MTEST_VG_MEM_INIT(filename, (len + 10) * sizeof(char));
             strcpy(filename, *argv);
         }
         MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
@@ -62,6 +64,7 @@ int main(int argc, char **argv)
     else {
         MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
         filename = (char *) malloc(len + 10);
+        MTEST_VG_MEM_INIT(filename, (len + 10) * sizeof(char));
         MPI_Bcast(filename, len + 10, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
 

--- a/test/mpi/io/i_hindexed_io.c
+++ b/test/mpi/io/i_hindexed_io.c
@@ -110,5 +110,6 @@ int main(int argc, char **argv)
     MPI_Finalize();
 
     free(data);
+    free(verify);
     return 0;
 }

--- a/test/mpi/pt2pt/bsend1.c
+++ b/test/mpi/pt2pt/bsend1.c
@@ -78,6 +78,8 @@ int main(int argc, char *argv[])
     /* We can't guarantee that messages arrive until the detach */
     MPI_Buffer_detach(&bbuf, &bsize);
 
+    free(buf);
+
     MTest_Finalize(errs);
 
     MPI_Finalize();

--- a/test/mpi/pt2pt/bsendfrag.c
+++ b/test/mpi/pt2pt/bsendfrag.c
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
         MPI_Barrier(comm);
         /* Detach waits until all messages received */
         MPI_Buffer_detach(&buf, &bsize);
+        free(buf);
     }
     else if (rank == dest) {
 

--- a/test/mpi/pt2pt/bsendpending.c
+++ b/test/mpi/pt2pt/bsendpending.c
@@ -83,6 +83,7 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Wrong buffer size returned\n");
                 errs++;
             }
+            free(buf);
         }
         else if (rank == dest) {
             double tstart;

--- a/test/mpi/pt2pt/eagerdt.c
+++ b/test/mpi/pt2pt/eagerdt.c
@@ -51,6 +51,7 @@ int main(int argc, char *argv[])
             fprintf(stderr, "Unable to allocate buffer %d of size %ld\n", i, (long) extent);
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
+        MTEST_VG_MEM_INIT(bufs[i], extent);
     }
     buf = (int *) malloc(10 * 30 * sizeof(int));
 
@@ -69,6 +70,10 @@ int main(int argc, char *argv[])
     }
 
     MPI_Type_free(&dtype);
+    for (i = 0; i < MAX_MSGS; i++) {
+        free(bufs[i]);
+    }
+    free(buf);
     MTest_Finalize(errs);
     MPI_Finalize();
     return 0;

--- a/test/mpi/pt2pt/inactivereq.c
+++ b/test/mpi/pt2pt/inactivereq.c
@@ -95,6 +95,7 @@ int main(int argc, char *argv[])
         MPI_Start(&r);
         MPI_Wait(&r, &s);
         MPI_Waitall(size, rr, MPI_STATUSES_IGNORE);
+        free(rr);
     }
     else {
         MPI_Start(&r);

--- a/test/mpi/pt2pt/isendirecv.c
+++ b/test/mpi/pt2pt/isendirecv.c
@@ -28,6 +28,7 @@ int main(int argc, char *argv[])
     reqs = (MPI_Request *) malloc(2 * nproc * sizeof(MPI_Request));
     in_buf = (float *) malloc(elems * nproc * sizeof(float));
     out_buf = (float *) malloc(elems * nproc * sizeof(float));
+    MTEST_VG_MEM_INIT(out_buf, elems * nproc * sizeof(float));
 
     for (i = 0; i < nproc; i++) {
         MPI_Irecv(&in_buf[elems * i], elems, MPI_FLOAT, i, 0, comm, &reqs[i]);
@@ -39,6 +40,9 @@ int main(int argc, char *argv[])
 
     MPI_Waitall(nproc * 2, reqs, MPI_STATUSES_IGNORE);
 
+    free(reqs);
+    free(in_buf);
+    free(out_buf);
     MTest_Finalize(errors);
     MPI_Finalize();
     return 0;

--- a/test/mpi/pt2pt/rcancel.c
+++ b/test/mpi/pt2pt/rcancel.c
@@ -78,6 +78,9 @@ int main(int argc, char *argv[])
             printf("Incorrectly cancelled Irecv[1]\n");
             fflush(stdout);
         }
+        for (i = 0; i < 4; i++) {
+            free(bufs[i]);
+        }
     }
 
     MTest_Finalize(errs);

--- a/test/mpi/pt2pt/rqfreeb.c
+++ b/test/mpi/pt2pt/rqfreeb.c
@@ -80,6 +80,7 @@ int main(int argc, char *argv[])
 
         /* We can't guarantee that messages arrive until the detach */
         MPI_Buffer_detach(&bbuf, &bsize);
+        free(buf);
     }
 
     if (rank == dest) {

--- a/test/mpi/pt2pt/scancel2.c
+++ b/test/mpi/pt2pt/scancel2.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
     for (cs = 0; cs < 4; cs++) {
         n = bufsizes[cs];
         buf = (char *) malloc(n);
+        MTEST_VG_MEM_INIT(buf, n);
         if (!buf) {
             fprintf(stderr, "Unable to allocate %d bytes\n", n);
             MPI_Abort(MPI_COMM_WORLD, 1);

--- a/test/mpi/pt2pt/sendrecv3.c
+++ b/test/mpi/pt2pt/sendrecv3.c
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
                     fprintf(stderr, "Unable to allocate %d bytes\n", msgSize);
                     MPI_Abort(MPI_COMM_WORLD, 1);
                 }
+                MTEST_VG_MEM_INIT(buf[i], msgSize * sizeof(int));
             }
             partner = (rank + 1) % size;
 

--- a/test/mpi/rma/fetch_and_op.c
+++ b/test/mpi/rma/fetch_and_op.c
@@ -76,6 +76,8 @@ int main(int argc, char **argv)
 
     val_ptr = malloc(sizeof(TYPE_C) * nproc);
     res_ptr = malloc(sizeof(TYPE_C) * nproc);
+    MTEST_VG_MEM_INIT(val_ptr, sizeof(TYPE_C) * nproc);
+    MTEST_VG_MEM_INIT(res_ptr, sizeof(TYPE_C) * nproc);
 
     MPI_Win_create(val_ptr, sizeof(TYPE_C) * nproc, sizeof(TYPE_C), MPI_INFO_NULL, MPI_COMM_WORLD,
                    &win);

--- a/test/mpi/rma/linked_list_bench_lock_all.c
+++ b/test/mpi/rma/linked_list_bench_lock_all.c
@@ -122,6 +122,8 @@ int main(int argc, char **argv)
         llist_ptr_t new_elem_ptr;
         int success = 0;
 
+        MTEST_VG_MEM_INIT(&new_elem_ptr, sizeof(llist_ptr_t));
+
         /* Create a new list element and register it with the window */
         new_elem_ptr.rank = procid;
         new_elem_ptr.disp = alloc_elem(procid, llist_win);

--- a/test/mpi/rma/linked_list_bench_lock_excl.c
+++ b/test/mpi/rma/linked_list_bench_lock_excl.c
@@ -118,6 +118,8 @@ int main(int argc, char **argv)
         llist_ptr_t new_elem_ptr;
         int success = 0;
 
+        MTEST_VG_MEM_INIT(&new_elem_ptr, sizeof(llist_ptr_t));
+
         /* Create a new list element and register it with the window */
         new_elem_ptr.rank = procid;
         new_elem_ptr.disp = alloc_elem(procid, llist_win);

--- a/test/mpi/rma/linked_list_bench_lock_shr.c
+++ b/test/mpi/rma/linked_list_bench_lock_shr.c
@@ -119,6 +119,8 @@ int main(int argc, char **argv)
         llist_ptr_t new_elem_ptr;
         int success = 0;
 
+        MTEST_VG_MEM_INIT(&new_elem_ptr, sizeof(llist_ptr_t));
+
         /* Create a new list element and register it with the window */
         new_elem_ptr.rank = procid;
         new_elem_ptr.disp = alloc_elem(procid, llist_win);

--- a/test/mpi/rma/lockcontention3.c
+++ b/test/mpi/rma/lockcontention3.c
@@ -163,6 +163,7 @@ int main(int argc, char *argv[])
     if (getbuf) {
         free(getbuf);
     }
+    free(srcbuf);
     MPI_Win_free(&win);
     MPI_Type_free(&vectype);
 

--- a/test/mpi/rma/manyget.c
+++ b/test/mpi/rma/manyget.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <mpi.h>
+#include "mpitest.h"
 
 #define BUFSIZE (128*1024)
 
@@ -24,6 +25,7 @@ int main(int argc, char *argv[])
     MPI_Init(&argc, &argv);
 
     buf = malloc(BUFSIZE);
+    MTEST_VG_MEM_INIT(buf, BUFSIZE);
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/test/mpi/rma/strided_getacc_indexed_shared.c
+++ b/test/mpi/rma/strided_getacc_indexed_shared.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank_world);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks_world);
 
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, &shr_comm);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank_world, MPI_INFO_NULL, &shr_comm);
 
     MPI_Comm_rank(shr_comm, &rank);
     MPI_Comm_size(shr_comm, &nranks);

--- a/test/mpi/rma/strided_putget_indexed_shared.c
+++ b/test/mpi/rma/strided_putget_indexed_shared.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank_world);
     MPI_Comm_size(MPI_COMM_WORLD, &nranks_world);
 
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, &shr_comm);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank_world, MPI_INFO_NULL, &shr_comm);
 
     MPI_Comm_rank(shr_comm, &rank);
     MPI_Comm_size(shr_comm, &nranks);

--- a/test/mpi/rma/transpose7.c
+++ b/test/mpi/rma/transpose7.c
@@ -90,6 +90,8 @@ int main(int argc, char *argv[])
             MPI_Win_fence(0, win);
         }
         MPI_Win_free(&win);
+        free(A_data);
+        free(A);
     }
     MPI_Comm_free(&CommDeuce);
     MTest_Finalize(errs);

--- a/test/mpi/spawn/join.c
+++ b/test/mpi/spawn/join.c
@@ -88,6 +88,8 @@ int main(int argc, char *argv[])
         MPI_Send(hostname, namelen + 1, MPI_CHAR, 0, 0, MPI_COMM_WORLD);
         MPI_Send(&port, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
 
+        MPI_Barrier(MPI_COMM_WORLD);
+
         clilen = sizeof(cliaddr);
 
         connfd = accept(listenfd, (struct sockaddr *) &cliaddr, &clilen);
@@ -102,6 +104,8 @@ int main(int argc, char *argv[])
         MPI_Recv(hostname, MPI_MAX_PROCESSOR_NAME, MPI_CHAR, 1, 0,
                  MPI_COMM_WORLD, MPI_STATUS_IGNORE);
         MPI_Recv(&port, 1, MPI_INT, 1, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+        MPI_Barrier(MPI_COMM_WORLD);
 
         h = gethostbyname(hostname);
         if (h == NULL) {

--- a/test/mpi/spawn/multiple_ports.c
+++ b/test/mpi/spawn/multiple_ports.c
@@ -32,6 +32,9 @@ int main(int argc, char *argv[])
     int verbose = 0;
     int data = 0;
 
+    MTEST_VG_MEM_INIT(port1, MPI_MAX_PORT_NAME * sizeof(char));
+    MTEST_VG_MEM_INIT(port2, MPI_MAX_PORT_NAME * sizeof(char));
+
     if (getenv("MPITEST_VERBOSE")) {
         verbose = 1;
     }

--- a/test/mpi/spawn/multiple_ports2.c
+++ b/test/mpi/spawn/multiple_ports2.c
@@ -38,6 +38,10 @@ int main(int argc, char *argv[])
     int verbose = 0;
     int data = 0;
 
+    MTEST_VG_MEM_INIT(port1, MPI_MAX_PORT_NAME * sizeof(char));
+    MTEST_VG_MEM_INIT(port2, MPI_MAX_PORT_NAME * sizeof(char));
+    MTEST_VG_MEM_INIT(port3, MPI_MAX_PORT_NAME * sizeof(char));
+
     if (getenv("MPITEST_VERBOSE")) {
         verbose = 1;
     }

--- a/test/mpi/spawn/selfconacc.c
+++ b/test/mpi/spawn/selfconacc.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "mpitest.h"
 
 void check_error(int, const char *);
 void check_error(int error, const char *fcname)
@@ -29,6 +30,8 @@ int main(int argc, char *argv[])
     MPI_Status status;
     MPI_Comm comm;
     int verbose = 0;
+
+    MTEST_VG_MEM_INIT(port, MPI_MAX_PORT_NAME * sizeof(char));
 
     if (getenv("MPITEST_VERBOSE")) {
         verbose = 1;

--- a/test/mpi/spawn/spawnmanyarg.c
+++ b/test/mpi/spawn/spawnmanyarg.c
@@ -114,6 +114,12 @@ int main(int argc, char *argv[])
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
         }
+        /* free the argument vectors */
+        for (i = 0; i < MAX_ARGV; i++) {
+            free(inargv[i]);
+            free(outargv[i]);
+        }
+
     }
     else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/taskmaster.c
+++ b/test/mpi/spawn/taskmaster.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
     int provided;
     pthread_t *threads = NULL;
 #else
-    MPI_Comm *child;
+    MPI_Comm *child = NULL;
 #endif /* USE_THREADS */
     int can_spawn, errs = 0;
 

--- a/test/mpi/spawn/taskmaster.c
+++ b/test/mpi/spawn/taskmaster.c
@@ -158,6 +158,9 @@ int main(int argc, char *argv[])
 #ifdef USE_THREADS
     if (threads)
         free(threads);
+#else
+    if (child)
+        free(child);
 #endif
     MPI_Finalize();
 

--- a/test/mpi/threads/coll/allred.c
+++ b/test/mpi/threads/coll/allred.c
@@ -37,6 +37,8 @@ MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
     int tid = *(int *) arg;
     int buf[BUF_SIZE];
 
+    MTEST_VG_MEM_INIT(buf, BUF_SIZE * sizeof(int));
+
     if (tid == rank)
         MTestSleep(1);
     MPI_Allreduce(MPI_IN_PLACE, buf, BUF_SIZE, MPI_INT, MPI_BAND, comms[tid]);

--- a/test/mpi/threads/coll/iallred.c
+++ b/test/mpi/threads/coll/iallred.c
@@ -37,6 +37,8 @@ MTEST_THREAD_RETURN_TYPE test_iallred(void *arg)
     int tid = *(int *) arg;
     int buf[BUF_SIZE];
 
+    MTEST_VG_MEM_INIT(buf, BUF_SIZE * sizeof(int));
+
     if (tid == rank)
         MTestSleep(1);
     MPI_Iallreduce(MPI_IN_PLACE, buf, BUF_SIZE, MPI_INT, MPI_BAND, comms[tid], &req);

--- a/test/mpi/threads/comm/ctxdup.c
+++ b/test/mpi/threads/comm/ctxdup.c
@@ -92,6 +92,8 @@ int main(int argc, char *argv[])
     MPI_Ssend(buffer, 0, MPI_INT, rank, 1, MPI_COMM_WORLD);
     MPI_Recv(buffer, 0, MPI_INT, rank, 2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
+    MTest_Join_threads();
+
     MPI_Comm_free(&comm4);
     MPI_Comm_free(&comm1);
     MPI_Comm_free(&comm2);

--- a/test/mpi/threads/comm/idup_nb.c
+++ b/test/mpi/threads/comm/idup_nb.c
@@ -57,6 +57,7 @@ MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
     MPI_Comm parentcomm = parentcomms[tid];
     MPI_Comm nbrcomm = nbrcomms[tid];
 
+    MPI_Comm_rank(parentcomm, &rank);
     for (i = 0; i < NUM_ITER; i++) {
         cnt = 0;
         if (*(int *) arg == rank)
@@ -70,7 +71,6 @@ MTEST_THREAD_RETURN_TYPE test_intracomm(void *arg)
             MPI_Comm_idup(parentcomm, &comms[j], &reqs[cnt++]);
 
         /* Issue an iscan on parent comm to overlap with the pending idups */
-        MPI_Comm_rank(parentcomm, &rank);
         MPI_Iscan(&rank, &ans[0], 1, MPI_INT, MPI_SUM, parentcomm, &reqs[cnt++]);
         expected[0] = rank * (rank + 1) / 2;
         /* Wait for the first child comm to be ready */

--- a/test/mpi/threads/pt2pt/ibsend.c
+++ b/test/mpi/threads/pt2pt/ibsend.c
@@ -50,6 +50,7 @@ void *receiver(void *ptr)
 void *sender_bsend(void *ptr)
 {
     char buffer[MSGSIZE];
+    MTEST_VG_MEM_INIT(buffer, MSGSIZE * sizeof(char));
     MPI_Bsend(buffer, MSGSIZE, MPI_CHAR, (rank + 1) % size, 0, MPI_COMM_WORLD);
 
     return NULL;
@@ -59,6 +60,7 @@ void *sender_ibsend(void *ptr)
 {
     char buffer[MSGSIZE];
     MPI_Request req;
+    MTEST_VG_MEM_INIT(buffer, MSGSIZE * sizeof(char));
     MPI_Ibsend(buffer, MSGSIZE, MPI_CHAR, (rank + 1) % size, 0, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, MPI_STATUS_IGNORE);
 
@@ -69,6 +71,7 @@ void *sender_isend(void *ptr)
 {
     char buffer[MSGSIZE];
     MPI_Request req;
+    MTEST_VG_MEM_INIT(buffer, MSGSIZE * sizeof(char));
     MPI_Isend(buffer, MSGSIZE, MPI_CHAR, (rank + 1) % size, 0, MPI_COMM_WORLD, &req);
     MPI_Wait(&req, MPI_STATUS_IGNORE);
 
@@ -78,6 +81,7 @@ void *sender_isend(void *ptr)
 void *sender_send(void *ptr)
 {
     char buffer[MSGSIZE];
+    MTEST_VG_MEM_INIT(buffer, MSGSIZE * sizeof(char));
     MPI_Send(buffer, MSGSIZE, MPI_CHAR, (rank + 1) % size, 0, MPI_COMM_WORLD);
 
     return NULL;
@@ -89,6 +93,7 @@ int main(int argc, char *argv[])
     int provided, i[2], k;
     char *buffer, *ptr_dt;
     buffer = (char *) malloc(BUFSIZE * sizeof(char));
+    MTEST_VG_MEM_INIT(buffer, BUFSIZE * sizeof(char));
     MPI_Status status;
     pthread_t receiver_thread, sender_thread[NUMSENDS];
     pthread_attr_t attr;

--- a/test/mpi/threads/pt2pt/multisend2.c
+++ b/test/mpi/threads/pt2pt/multisend2.c
@@ -31,6 +31,7 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 
     for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
         buf = (int *) malloc(cnt * sizeof(int));
+        MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
 
         /* Wait for all senders to be ready */
         MTest_thread_barrier(nthreads);
@@ -55,6 +56,7 @@ void run_test_recv(void)
 
     for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
         buf = (int *) malloc(cnt * sizeof(int));
+        MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++)
             MPI_Recv(buf, cnt, MPI_INT, 0, cnt, MPI_COMM_WORLD, &status);

--- a/test/mpi/threads/pt2pt/multisend3.c
+++ b/test/mpi/threads/pt2pt/multisend3.c
@@ -38,6 +38,7 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
     /* Create the buf just once to avoid finding races in malloc instead
      * of the MPI library */
     buf = (int *) malloc(MAX_CNT * sizeof(int));
+    MTEST_VG_MEM_INIT(buf, MAX_CNT * sizeof(int));
     MTestPrintfMsg(1, "buf address %p (size %d)\n", buf, MAX_CNT * sizeof(int));
     MPI_Comm_size(MPI_COMM_WORLD, &wsize);
     if (wsize >= MAX_NTHREAD)
@@ -83,6 +84,7 @@ void run_test_recv(void)
 
     for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
         buf = (int *) malloc(cnt * sizeof(int));
+        MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++)
             MPI_Recv(buf, cnt, MPI_INT, 0, cnt, MPI_COMM_WORLD, &status);

--- a/test/mpi/threads/pt2pt/multisend4.c
+++ b/test/mpi/threads/pt2pt/multisend4.c
@@ -46,6 +46,7 @@ MTEST_THREAD_RETURN_TYPE run_test_sendrecv(void *arg)
 
     for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
         buf = (int *) malloc(2 * cnt * sizeof(int));
+        MTEST_VG_MEM_INIT(buf, 2 * cnt * sizeof(int));
 
         /* Wait for all senders to be ready */
         MTest_thread_barrier(nthreads);

--- a/test/mpi/threads/pt2pt/threaded_sr.c
+++ b/test/mpi/threads/pt2pt/threaded_sr.c
@@ -35,6 +35,7 @@ MTEST_THREAD_RETURN_TYPE send_thread(void *p)
     int rank;
 
     buffer = malloc(sizeof(char) * MSG_SIZE);
+    MTEST_VG_MEM_INIT(buffer, MSG_SIZE * sizeof(char));
     if (buffer == NULL) {
         printf("malloc failed to allocate %d bytes for the send buffer.\n", MSG_SIZE);
         fflush(stdout);
@@ -58,6 +59,7 @@ MTEST_THREAD_RETURN_TYPE send_thread(void *p)
     else {
         sendok = 1;
     }
+    free(buffer);
     return (MTEST_THREAD_RETURN_TYPE) (long) err;
 }
 
@@ -100,6 +102,7 @@ int main(int argc, char *argv[])
     MTestSleep(3);
 
     buffer = malloc(sizeof(char) * MSG_SIZE);
+    MTEST_VG_MEM_INIT(buffer, MSG_SIZE * sizeof(char));
     if (buffer == NULL) {
         printf("malloc failed to allocate %d bytes for the recv buffer.\n", MSG_SIZE);
         fflush(stdout);
@@ -125,6 +128,8 @@ int main(int argc, char *argv[])
         errs++;
     }
 
+    MTest_Join_threads();
+    free(buffer);
     MTest_Finalize(errs);
     MPI_Finalize();
     return 0;

--- a/test/mpi/topo/distgraph1.c
+++ b/test/mpi/topo/distgraph1.c
@@ -213,6 +213,10 @@ static int verify_comm(MPI_Comm comm)
     if (dupcomm != MPI_COMM_NULL)
         MPI_Comm_free(&dupcomm);
 
+    free(sources);
+    free(sweights);
+    free(destinations);
+    free(dweights);
     return local_errs;
 }
 
@@ -563,6 +567,11 @@ int main(int argc, char *argv[])
     for (i = 0; i < size; i++)
         free(layout[i]);
     free(layout);
+    free(sources);
+    free(sweights);
+    free(destinations);
+    free(dweights);
+    free(degrees);
 #endif
 
     MTest_Finalize(errs);

--- a/test/mpi/util/dtypes.c
+++ b/test/mpi/util/dtypes.c
@@ -379,6 +379,7 @@ void MTestDatatype2Free(MPI_Datatype * types, void **inbufs, void **outbufs,
         if (i >= nbasic_types)
             MPI_Type_free(types + i);
     }
+    free(types);
     free(inbufs);
     free(outbufs);
     free(counts);


### PR DESCRIPTION
1. Memory leaks due to missing free or delete.
2. False-positive due to unintialized padding (bug of valgrind). Two
macros are added for mem init in MPI library and test.
3. Uninitialized value in some test.

Signed-off-by: Pavan Balaji <balaji@anl.gov>