### PR TITLE
ch4/ofi: Fix race condition in progress on NBC

### DIFF
--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -31,7 +31,10 @@ int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
 
 int MPIDI_OFI_progress_test_no_inline()
 {
-    return MPID_Progress_test();
+    /* We do not call progress on hooks form netmod level
+     * because it is not reentrant safe.
+     */
+    return MPIDI_Progress_test(MPIDI_PROGRESS_NM|MPIDI_PROGRESS_SHM);
 }
 
 typedef struct MPIDI_OFI_index_allocator_t {

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -13,18 +13,31 @@
 
 #include "ch4_impl.h"
 
+#define MPIDI_PROGRESS_HOOKS  (1)
+#define MPIDI_PROGRESS_NM     (1<<1)
+#define MPIDI_PROGRESS_SHM    (1<<2)
+
+#define MPIDI_PROGRESS_ALL (MPIDI_PROGRESS_HOOKS|MPIDI_PROGRESS_NM|MPIDI_PROGRESS_SHM)
+
+/* Flags argument allows to control execution of different parts of progress function,
+ * for aims of prioritization of different transports and reentrant-safety of progress call.
+ *
+ * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internaly,
+ *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
+ * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
+ */
 #undef FUNCNAME
-#define FUNCNAME MPID_Progress_test
+#define FUNCNAME MPIDI_Progress_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 {
     int mpi_errno, made_progress, i;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROGRESS_TEST);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROGRESS_TEST);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PROGRESS_TEST);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PROGRESS_TEST);
 
-    if (OPA_load_int(&MPIDI_CH4_Global.active_progress_hooks)) {
+    if (OPA_load_int(&MPIDI_CH4_Global.active_progress_hooks) && (flags & MPIDI_PROGRESS_HOOKS)) {
         MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_PROGRESS_MUTEX);
         for (i = 0; i < MAX_PROGRESS_HOOKS; i++) {
             if (MPIDI_CH4_Global.progress_hooks[i].active == TRUE) {
@@ -39,22 +52,36 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
         MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_PROGRESS_MUTEX);
     }
     /* todo: progress unexp_list */
-    mpi_errno = MPIDI_NM_progress(0, 0);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
+
+    if (flags & MPIDI_PROGRESS_NM) {
+        mpi_errno = MPIDI_NM_progress(0, 0);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
     }
 #ifdef MPIDI_CH4_EXCLUSIVE_SHM
-    mpi_errno = MPIDI_SHM_progress(0, 0);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
+    if (flags & MPIDI_PROGRESS_SHM) {
+        mpi_errno = MPIDI_SHM_progress(0, 0);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
     }
 #endif
     MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_TEST);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PROGRESS_TEST);
     return mpi_errno;
   fn_fail:
     goto fn_exit;;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPID_Progress_test
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
+{
+    return MPIDI_Progress_test(MPIDI_PROGRESS_ALL);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_poke(void)


### PR DESCRIPTION
FI_EAGAIN returned by fi_tinject during NBC-schedule execution leads to deadlock

Signed-off-by: Sannikov, Alexander <alexander.sannikov@intel.com>