### PR TITLE
ch4/ucx: Link with libucs explicitly

### DIFF
--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -83,7 +83,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
         PAC_PUSH_FLAG(LIBS)
         PAC_CHECK_HEADER_LIB_FATAL(ucx, ucp/api/ucp.h, ucp, ucp_config_read)
         PAC_POP_FLAG(LIBS)
-        PAC_APPEND_FLAG([-lucp],[WRAPPER_LIBS])
+        PAC_APPEND_FLAG([-lucp -lucs],[WRAPPER_LIBS])
     fi
 
 ])dnl end AM_COND_IF(BUILD_CH4_NETMOD_OFI,...)


### PR DESCRIPTION
We are directly using UCS datatypes in the UCX netmod, so add a link
to that library for clarity. Fixes a build issue when linking against
UCX as provided by the HPC-X package from Mellanox.