### PR TITLE
Use regular patch files instead of git patches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "src/mpid/ch4/netmod/ucx/ucx"]
 	path = src/mpid/ch4/netmod/ucx/ucx
 	url = https://github.com/openucx/ucx
+    ignore = dirty
 [submodule "src/izem"]
 	path = src/izem
 	url = https://github.com/pmodels/izem
 [submodule "src/mpid/ch4/netmod/ofi/libfabric"]
 	path = src/mpid/ch4/netmod/ofi/libfabric
 	url = https://github.com/ofiwg/libfabric
+    ignore = dirty
 [submodule "src/hwloc"]
 	path = src/hwloc
 	url = https://github.com/open-mpi/hwloc
+    ignore = dirty

--- a/autogen.sh
+++ b/autogen.sh
@@ -343,11 +343,11 @@ echo
 
 # ucx
 if [ "yes" = "$do_ucx" ] ; then
-( cd src/mpid/ch4/netmod/ucx/ucx && git am --3way ../../../../../../maint/patches/pre/ucx/*.patch )
+( cd src/mpid/ch4/netmod/ucx/ucx && for i in ../../../../../../maint/patches/pre/ucx/*.patch; do patch -p1 < $i; done )
 fi
 
 # hwloc
-( cd src/hwloc && git am --3way ../../maint/patches/pre/hwloc/*.patch )
+( cd src/hwloc && for i in  ../../maint/patches/pre/hwloc/*.patch; do patch -p1 < $i; done )
 
 
 ########################################################################

--- a/maint/patches/pre/hwloc/0001-hwloc-remove-redundant-pkgconfig-initialization.patch
+++ b/maint/patches/pre/hwloc/0001-hwloc-remove-redundant-pkgconfig-initialization.patch
@@ -1,19 +1,7 @@
-From bb57d00958aea444f6866a11d5539a1985ed6bd4 Mon Sep 17 00:00:00 2001
-From: Pavan Balaji <balaji@anl.gov>
-Date: Fri, 13 Oct 2017 23:00:05 -0500
-Subject: [PATCH 1/3] hwloc: remove redundant pkgconfig initialization.
-
-When hwloc is embedded into mpich, pkgconfig is already initialized.
-Even though the STANDALONE path is never reached, autoreconf still
-complains of a possible reinitialization.
----
- Makefile.am | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
-
-diff --git a/Makefile.am b/Makefile.am
+diff --git c/Makefile.am w/Makefile.am
 index b92ff287de8c..21878c177ab9 100644
---- a/Makefile.am
-+++ b/Makefile.am
+--- c/Makefile.am
++++ w/Makefile.am
 @@ -21,13 +21,13 @@ DIST_SUBDIRS = $(SUBDIRS)
  
  # Only install the pkg file if we're building in standalone mode (and not on Windows)
@@ -31,6 +19,3 @@ index b92ff287de8c..21878c177ab9 100644
  endif
  
  #
--- 
-2.14.2
-

--- a/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
+++ b/maint/patches/pre/hwloc/0002-hwloc-separated-visibility-cflags-for-better-control.patch
@@ -1,16 +1,7 @@
-From 9ef121467a3d187de2e47a7b6def17dbaa9f1e85 Mon Sep 17 00:00:00 2001
-From: Pavan Balaji <balaji@anl.gov>
-Date: Fri, 13 Oct 2017 16:02:08 -0500
-Subject: [PATCH 2/3] hwloc: separated visibility cflags for better control.
-
----
- config/hwloc.m4 | 9 ++++++---
- 1 file changed, 6 insertions(+), 3 deletions(-)
-
-diff --git a/config/hwloc.m4 b/config/hwloc.m4
+diff --git c/config/hwloc.m4 w/config/hwloc.m4
 index cda92d08dfb9..c153e520f888 100644
---- a/config/hwloc.m4
-+++ b/config/hwloc.m4
+--- c/config/hwloc.m4
++++ w/config/hwloc.m4
 @@ -316,9 +316,6 @@ EOF])
      _HWLOC_C_COMPILER_VENDOR([hwloc_c_vendor])
      _HWLOC_CHECK_ATTRIBUTES
@@ -43,6 +34,3 @@ index cda92d08dfb9..c153e520f888 100644
      # Always generate these files
      AC_CONFIG_FILES(
          hwloc_config_prefix[Makefile]
--- 
-2.14.2
-

--- a/maint/patches/pre/hwloc/0003-hwloc-warning-squash.patch
+++ b/maint/patches/pre/hwloc/0003-hwloc-warning-squash.patch
@@ -1,18 +1,7 @@
-From 505392c182729e345a7308db37f6727a74196f10 Mon Sep 17 00:00:00 2001
-From: Pavan Balaji <balaji@anl.gov>
-Date: Fri, 13 Oct 2017 23:16:35 -0500
-Subject: [PATCH 3/3] hwloc: warning squash.
-
----
- src/topology-xml-libxml.c   | 2 +-
- src/topology-xml-nolibxml.c | 2 +-
- src/topology-xml.c          | 2 +-
- 3 files changed, 3 insertions(+), 3 deletions(-)
-
-diff --git a/src/topology-xml-libxml.c b/src/topology-xml-libxml.c
+diff --git c/src/topology-xml-libxml.c w/src/topology-xml-libxml.c
 index ac20d87f21ca..f35eab2795f1 100644
---- a/src/topology-xml-libxml.c
-+++ b/src/topology-xml-libxml.c
+--- c/src/topology-xml-libxml.c
++++ w/src/topology-xml-libxml.c
 @@ -134,7 +134,7 @@ hwloc__libxml_import_get_content(hwloc__xml_import_state_t state,
    if (!child || child->type != XML_TEXT_NODE) {
      if (expected_length)
@@ -22,10 +11,10 @@ index ac20d87f21ca..f35eab2795f1 100644
      return 0;
    }
  
-diff --git a/src/topology-xml-nolibxml.c b/src/topology-xml-nolibxml.c
+diff --git c/src/topology-xml-nolibxml.c w/src/topology-xml-nolibxml.c
 index 147e703cc172..f11ae8cf5ff6 100644
---- a/src/topology-xml-nolibxml.c
-+++ b/src/topology-xml-nolibxml.c
+--- c/src/topology-xml-nolibxml.c
++++ w/src/topology-xml-nolibxml.c
 @@ -222,7 +222,7 @@ hwloc__nolibxml_import_get_content(hwloc__xml_import_state_t state,
    if (nstate->closed) {
      if (expected_length)
@@ -35,10 +24,10 @@ index 147e703cc172..f11ae8cf5ff6 100644
      return 0;
    }
  
-diff --git a/src/topology-xml.c b/src/topology-xml.c
+diff --git c/src/topology-xml.c w/src/topology-xml.c
 index 9eeb85b728a9..1f2a654a37a9 100644
---- a/src/topology-xml.c
-+++ b/src/topology-xml.c
+--- c/src/topology-xml.c
++++ w/src/topology-xml.c
 @@ -673,7 +673,7 @@ hwloc__xml_import_userdata(hwloc_topology_t topology __hwloc_attribute_unused, h
        }
  
@@ -48,6 +37,3 @@ index 9eeb85b728a9..1f2a654a37a9 100644
        if (length) {
  	ret = state->global->get_content(state, &buffer, length);
  	if (ret < 0)
--- 
-2.14.2
-

--- a/maint/patches/pre/ucx/0001-config-Add-embedded-mode.patch
+++ b/maint/patches/pre/ucx/0001-config-Add-embedded-mode.patch
@@ -1,23 +1,7 @@
-From 1e6ef317f2676d19627a40fe2cd09b1e62934538 Mon Sep 17 00:00:00 2001
-From: Ken Raffenetti <raffenet@mcs.anl.gov>
-Date: Wed, 18 Oct 2017 14:39:34 -0500
-Subject: [PATCH] config: Add embedded mode
-
-Add a configure flag to support building UCX as a subproject of
-another project. When configured for embedded mode, we avoid
-installing any header files.
----
- configure.ac        | 5 +++++
- src/ucm/Makefile.am | 2 ++
- src/ucp/Makefile.am | 2 ++
- src/ucs/Makefile.am | 2 ++
- src/uct/Makefile.am | 2 ++
- 5 files changed, 13 insertions(+)
-
-diff --git a/configure.ac b/configure.ac
-index 74284add..1a257d64 100644
---- a/configure.ac
-+++ b/configure.ac
+diff --git c/configure.ac w/configure.ac
+index 74284add87b5..1a257d64b173 100644
+--- c/configure.ac
++++ w/configure.ac
 @@ -77,6 +77,11 @@ AC_C_RESTRICT
  m4_include([config/m4/pkg.m4])
  PKG_PROG_PKG_CONFIG
@@ -30,10 +14,10 @@ index 74284add..1a257d64 100644
  
  #
  # Save config flags for version dump tool
-diff --git a/src/ucm/Makefile.am b/src/ucm/Makefile.am
-index 2215ddd2..d5a59326 100644
---- a/src/ucm/Makefile.am
-+++ b/src/ucm/Makefile.am
+diff --git c/src/ucm/Makefile.am w/src/ucm/Makefile.am
+index 2215ddd21117..d5a5932674da 100644
+--- c/src/ucm/Makefile.am
++++ w/src/ucm/Makefile.am
 @@ -24,8 +24,10 @@ libucm_la_CFLAGS = \
  	$(BASE_CFLAGS) \
  	$(CFLAGS_NO_DEPRECATED)
@@ -45,10 +29,10 @@ index 2215ddd2..d5a59326 100644
  
  noinst_HEADERS = \
  	event/event.h \
-diff --git a/src/ucp/Makefile.am b/src/ucp/Makefile.am
-index 5a2bb6a6..f96a3f48 100644
---- a/src/ucp/Makefile.am
-+++ b/src/ucp/Makefile.am
+diff --git c/src/ucp/Makefile.am w/src/ucp/Makefile.am
+index 5a2bb6a6f4e7..f96a3f488906 100644
+--- c/src/ucp/Makefile.am
++++ w/src/ucp/Makefile.am
 @@ -13,11 +13,13 @@ libucp_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
  libucp_la_LIBADD   = ../ucs/libucs.la ../uct/libuct.la
  libucp_ladir       = $(includedir)/ucp
@@ -63,10 +47,10 @@ index 5a2bb6a6..f96a3f48 100644
  
  noinst_HEADERS = \
  	amo/amo.inl \
-diff --git a/src/ucs/Makefile.am b/src/ucs/Makefile.am
-index de930eee..6b930964 100644
---- a/src/ucs/Makefile.am
-+++ b/src/ucs/Makefile.am
+diff --git c/src/ucs/Makefile.am w/src/ucs/Makefile.am
+index de930eeebefa..6b930964009f 100644
+--- c/src/ucs/Makefile.am
++++ w/src/ucs/Makefile.am
 @@ -17,6 +17,7 @@ libucs_la_LIBADD   = \
  	$(LIBM) \
  	$(top_builddir)/src/ucm/libucm.la
@@ -83,10 +67,10 @@ index de930eee..6b930964 100644
  
  noinst_HEADERS = \
  	datastruct/arbiter.h \
-diff --git a/src/uct/Makefile.am b/src/uct/Makefile.am
-index 930f73b9..9a8f988e 100644
---- a/src/uct/Makefile.am
-+++ b/src/uct/Makefile.am
+diff --git c/src/uct/Makefile.am w/src/uct/Makefile.am
+index 930f73b9b8ba..9a8f988ef495 100644
+--- c/src/uct/Makefile.am
++++ w/src/uct/Makefile.am
 @@ -15,11 +15,13 @@ libuct_la_LDFLAGS  = -ldl -version-info $(SOVERSION)
  libuct_la_LIBADD   = $(LIBM) ../ucs/libucs.la
  libuct_ladir       = $(includedir)/uct
@@ -101,6 +85,3 @@ index 930f73b9..9a8f988e 100644
  
  noinst_HEADERS = \
  	base/addr.h \
--- 
-2.11.0
-


### PR DESCRIPTION
By switching patches for the submodules to regular patch files instead
of git patches, we can avoid accidentally checking in a bad version of a
submodule.

This also changes the submodules definitions to ignore dirty versions of
hydra, ucx, and libfabric.