### PR TITLE
ch4/ofi: Fix fabric resource leak

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1062,6 +1062,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.p2p_cq->fid), cqclose);
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.rma_cmpl_cntr->fid), cqclose);
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.domain->fid), domainclose);
+    MPIDI_OFI_CALL(fi_close(&MPIDI_Global.fabric->fid), fabricclose);
 
     fi_freeinfo(MPIDI_Global.prov_use);
 


### PR DESCRIPTION
Close the fabric object when finalizing to avoid resource leaks and allow OFI providers to shut down properly.


Since there is an allocated fabric, some OFI providers don't perform finalization correctly. Just skips this step.
E.x. the OFI/psm2 providers complains that there is an opened fabric and doesn't continue a finalization. This is an example of output:

Before applying this patch:
```
libfabric:psm2:core:psmx2_fini():701<info>
libfabric:psm2:core:psmx2_fini():713<info> psmx2_active_fabric != NULL, skip psm2_finalize
```

After applying this patch:
```
libfabric:psm2:core:psmx2_fabric_close():45<info> refcnt=1
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: name_server
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: tagged_rma
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: uuid
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: delay
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: timeout
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: prog_interval
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: prog_affinity
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: inject_size
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: lock_level
libfabric:psm2:core:fi_param_undefine():159<debug> Removing param: lazy_conn
libfabric:psm2:core:psmx2_fini():730<info>
libfabric:ofi_rxm:core:fi_param_undefine():159<debug> Removing param: buffer_size
```