### PR TITLE
Introduce MPL_aligned_alloc

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -227,6 +227,18 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         fi
     fi
 
+    # Check for required functions
+
+    # Does MPL provide MPL_aligned_malloc?
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <mplconfig.h>]],
+                                       [[
+                                       #ifndef MPL_DEFINE_ALIGNED_ALLOC
+                                       # error
+                                       #endif
+                                       ]])],
+                                       [],
+                                       [AC_MSG_ERROR(MPL_aligned_alloc is required to build OFI netmod)])
+
 ])dnl end AM_COND_IF(BUILD_CH4_NETMOD_OFI,...)
 ])dnl end _BODY
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -870,6 +870,13 @@ if test "$ac_cv_func_usleep" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <unistd.h>],usleep)
 fi
 
+# Check if we can implement MPL_aligned_alloc
+AC_CHECK_FUNCS(posix_memalign)
+AC_CHECK_FUNCS(aligned_alloc)
+if test "$ac_cv_func_posix_memalign" = "yes" -o "$ac_cv_func_aligned_alloc" = "yes"; then
+   AC_DEFINE([DEFINE_ALIGNED_ALLOC],[1],[Define to 1 if MPL enables MPL_aligned_alloc.])
+fi
+
 AC_CHECK_FUNCS(backtrace_symbols)
 
 # Check for libbacktrace support

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -330,6 +330,7 @@ static void *trmalloc(size_t a, MPL_memory_class class, int lineno, const char f
 
     if (TRhead[0] != TRHEAD_PRESENTINAL || TRhead[2] != TRHEAD_POSTSENTINAL) {
         MPL_error_printf("TRhead corrupted - likely memory overwrite.\n");
+        free(head);
         goto fn_exit;
     }
     if (TRhead[1]) {

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -219,7 +219,6 @@ static void init_classes() {
 void MPL_trinit()
 {
     char *s;
-    int i;
 
     /* FIXME: We should use generalized parameter handling here
      * to allow use of the command line as well as environment


### PR DESCRIPTION
The CH4 OFI netmod relied on an implicit assumption that `malloc(3)` and its family return 16-byte aligned buffer on 64-bit platform. While it was true for glibc malloc, it was not a portably safe thing to assume. Moreover, recent changes in memory tracing (3329c1eea43c0501907701bad546bf2517fe51bc) broke that assumption in tracing-enabled builds.

Therefore this PR introduces an aligned malloc, `MPL_memalign` to fix that problem cleanly.

Currently, I define `MPL_memalign` as follows, following the `posix_memalign(3)` signature:
```
int MPL_memalign(void **ptr, size_t alignment, size_t size);
```
Also, two error codes `MPL_EINVAL` and `MPL_ENOMEM` are defined in MPL to express return value from it.

Initially I was thinking of this signature
```
void *MPL_memalign(size_t alignment, size_t size);
```
to match `malloc(3)` look-and-feel. Either way has pros and cons. Let me know your opinion on this. 

@raffenet could you prioritize this review? It would be better to include this MPL changes sooner than later.
