### PR TITLE
CH4/OFI: iovec alignment fixes

### DIFF
--- a/src/mpid/ch4/include/mpid_ticketlock.h
+++ b/src/mpid/ch4/include/mpid_ticketlock.h
@@ -19,7 +19,7 @@ typedef union MPIDI_CH4_Ticket_lock {
         unsigned short ticket;
         unsigned short clients;
     } s;
-} MPIDI_CH4_Ticket_lock __attribute__ ((aligned(MPIDI_CH4_CACHELINE_SIZE)));
+} MPIDI_CH4_Ticket_lock MPL_ATTR_ALIGNED(MPIDI_CH4_CACHELINE_SIZE);
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_acquire(MPIDI_CH4_Ticket_lock * m)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -952,7 +952,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
             MPIDI_Global.am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
             MPIDI_Global.am_reqs[i].index = i;
             MPIR_Assert(MPIDI_Global.am_bufs[i]);
-            MPIDI_OFI_ASSERT_IOVEC_ALIGN(MPIDI_Global.am_bufs[i]);
+            MPIDI_OFI_ASSERT_IOVEC_ALIGN(&MPIDI_Global.am_iov[i]);
             MPIDI_Global.am_iov[i].iov_base = MPIDI_Global.am_bufs[i];
             MPIDI_Global.am_iov[i].iov_len = MPIDI_OFI_AM_BUFF_SZ;
             MPIDI_Global.am_msg[i].msg_iov = &MPIDI_Global.am_iov[i];

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -101,7 +101,7 @@ typedef struct {
     MPIDI_OFI_am_header_t msg_hdr;
     uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE];
     /* FI_ASYNC_IOV requires an iov storage to be alive until a request completes */
-    struct iovec iov[3];
+    struct iovec iov[3] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
 } MPIDI_OFI_am_request_header_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -374,7 +374,7 @@ typedef struct {
     MPIDI_OFI_atomic_valid_t win_op_table[MPIDI_OFI_DT_SIZES][MPIDI_OFI_OP_SIZES];
 
     /* Active Message Globals */
-    struct iovec am_iov[MPIDI_OFI_NUM_AM_BUFFERS];
+    struct iovec am_iov[MPIDI_OFI_NUM_AM_BUFFERS] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
     struct fi_msg am_msg[MPIDI_OFI_NUM_AM_BUFFERS];
     void *am_bufs[MPIDI_OFI_NUM_AM_BUFFERS];
     MPIDI_OFI_am_repost_request_t am_reqs[MPIDI_OFI_NUM_AM_BUFFERS];

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -274,7 +274,7 @@ typedef struct {
 typedef union {
     MPID_Thread_mutex_t m;
     char cacheline[MPIDI_OFI_CACHELINE_SIZE];
-} MPIDI_OFI_cacheline_mutex_t __attribute__ ((aligned(MPIDI_OFI_CACHELINE_SIZE)));
+} MPIDI_OFI_cacheline_mutex_t MPL_ATTR_ALIGNED(MPIDI_OFI_CACHELINE_SIZE);
 
 typedef struct {
     struct fi_cq_tagged_entry cq_entry;


### PR DESCRIPTION
Small fixes on iovec alignment in the OFI netmod and CH4R which do not require dynamic memory allocation (thus not depend on #2874).