### PR TITLE
submodule: Do not ignore a dirty ofi submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "src/mpid/ch4/netmod/ofi/libfabric"]
 	path = src/mpid/ch4/netmod/ofi/libfabric
 	url = https://github.com/ofiwg/libfabric
-	ignore = dirty
 [submodule "src/hwloc"]
 	path = src/hwloc
 	url = https://github.com/pmodels/hwloc


### PR DESCRIPTION
We do not patch ofi when embedded in MPICH, so remove configuration to
ignore when the submodule is dirty. This can helps ensure the correct
version is used.