### PR TITLE
ROMIO: fix bug when a write request is larger than INT_MAX (4-byte int)

### DIFF
--- a/src/mpi/romio/adio/common/ad_write_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_write_str_naive.c
@@ -300,6 +300,9 @@ void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, int count,
     		ADIO_Offset new_bwr_size = bwr_size, new_fwr_size = fwr_size;
 
 		size = MPL_MIN(fwr_size, bwr_size);
+                /* keep max of a single read amount <= INT_MAX */
+                size = MPL_MIN(size, INT_MAX);
+
 		if (size) {
 		    req_off = off;
 		    req_len = size;


### PR DESCRIPTION
Assuming ADIO_WriteContig() can only write a maximum of INT_MAX bytes at a time. This small fix makes sure the max does not exceed. Below is a short test program with error message embedded to be run on one MPI process. Similar issue occurs at the read end. I will create a separate pull request for read.
```
#include <stdio.h>
#include <stdlib.h>
#include <mpi.h>

#define ERR if (err != MPI_SUCCESS) { \
        int errorStringLen; \
        char errorString[MPI_MAX_ERROR_STRING]; \
        MPI_Error_string(err, errorString, &errorStringLen); \
        printf("Error at line %d: %s\n",__LINE__, errorString); \
    }

#define TWO_G  2147483648
#define ONE_G  1073741824

int main(int argc, char **argv)
{
    int err, cmode=MPI_MODE_CREATE|MPI_MODE_RDWR;
    char *buf;
    int blocklen[3] = {10, ONE_G-1024, ONE_G+1024};
    MPI_Aint disp[3] = {0, 1024, ONE_G};
    MPI_Datatype dtype;
    MPI_Info info;
    MPI_File fh;
    MPI_Status status;

    MPI_Init(&argc, &argv);
    buf = (char*) calloc(TWO_G+1024,1);

    /* Disable data sieving hint causes MPI_File_write(): Assertion failed in file
     * adio/common/ad_write_str_naive.c at line 308: req_len == (int) req_len
     */
    MPI_Info_create(&info);
    MPI_Info_set(info, "romio_ds_write", "disable");

    err = MPI_File_open(MPI_COMM_WORLD, "testfile", cmode, info, &fh); ERR

    err = MPI_Type_create_hindexed(3, blocklen, disp, MPI_BYTE, &dtype); ERR
    err = MPI_Type_commit(&dtype); ERR

    err = MPI_File_set_view(fh, 0, MPI_BYTE, dtype, "native", MPI_INFO_NULL); ERR
    err = MPI_File_write(fh, buf, 1, dtype, &status); ERR

    err = MPI_File_close(&fh); ERR
    MPI_Type_free(&dtype);
    MPI_Info_free(&info);
    free(buf);

    MPI_Finalize();
    return 0;
}
```