### PR TITLE
ROMIO: fix bug when a read request is larger than INT_MAX (4-byte int)

### DIFF
--- a/src/mpi/romio/adio/common/ad_read_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_read_str_naive.c
@@ -300,6 +300,9 @@ void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, int count,
     		ADIO_Offset new_brd_size = brd_size, new_frd_size = frd_size;
 
 		size = MPL_MIN(frd_size, brd_size);
+                /* keep max of a single read amount <= INT_MAX */
+                size = MPL_MIN(size, INT_MAX);
+
 		if (size) {
 		    req_off = off;
 		    req_len = size;


### PR DESCRIPTION
Assuming ADIO_ReadContig() can only read a maximum of INT_MAX bytes at a time. This small fix makes sure the max does not exceed. Below is a short test program with error message embedded to be run on one MPI process. Similar issue occurs at the write end (see #2886)
```
#include <stdio.h>
#include <stdlib.h>
#include <mpi.h>

#define ERR if (err != MPI_SUCCESS) { \
        int errorStringLen; \
        char errorString[MPI_MAX_ERROR_STRING]; \
        MPI_Error_string(err, errorString, &errorStringLen); \
        printf("Error at line %d: %s\n",__LINE__, errorString); \
    }

#define TWO_G  2147483648
#define ONE_G  1073741824

/*----< main() >------------------------------------------------------------*/
int main(int argc, char **argv)
{
    int err, cmode=MPI_MODE_CREATE|MPI_MODE_RDWR;
    char *buf;
    int blocklen[3] = {10, ONE_G-1024, ONE_G+1024};
    MPI_Aint disp[3] = {0, 1024, ONE_G};
    MPI_Datatype dtype;
    MPI_Info info;
    MPI_File fh;
    MPI_Status status;

    MPI_Init(&argc, &argv);
    buf = (char*) malloc(TWO_G+1024);
    MPI_Info_create(&info);

    /* This hint below causes MPI_File_read_all(): Assertion failed in file
     * adio/common/ad_read_str_naive.c at line 309: req_len == (int) req_len
     */
    MPI_Info_set(info, "romio_ds_read", "disable");

    err = MPI_Type_create_hindexed(3, blocklen, disp, MPI_BYTE, &dtype); ERR
    err = MPI_Type_commit(&dtype); ERR

    err = MPI_File_open(MPI_COMM_WORLD, "testfile", cmode, info, &fh); ERR

    err = MPI_File_write_all(fh, buf, TWO_G-1024, MPI_BYTE, &status); ERR
    err = MPI_File_write_all(fh, buf, 2048,       MPI_BYTE, &status); ERR

    err = MPI_File_set_view(fh, 0, MPI_BYTE, dtype, "native", MPI_INFO_NULL); ERR
    err = MPI_File_read_all(fh, buf, 1, dtype, &status); ERR

    err = MPI_File_close(&fh); ERR
    MPI_Type_free(&dtype);
    MPI_Info_free(&info);
    free(buf);

    MPI_Finalize();
    return 0;
}
```