### PR TITLE
ROMIO: change buf_idx from int pointer to MPI_Aint pointer

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -448,11 +448,12 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
                             int nprocs,
                             int *count_my_req_procs_ptr,
                             int **count_my_req_per_proc_ptr,
-                            ADIOI_Access ** my_req_ptr, int **buf_idx_ptr)
+                            ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr)
 /* Possibly reconsider if buf_idx's are ok as int's, or should they be aints/offsets?
    They are used as memory buffer indices so it seems like the 2G limit is in effect */
 {
-    int *count_my_req_per_proc, count_my_req_procs, *buf_idx;
+    int *count_my_req_per_proc, count_my_req_procs;
+    MPI_Aint *buf_idx;
     int i, l, proc;
     ADIO_Offset fd_len, rem_len, curr_idx, off;
     ADIOI_Access *my_req;
@@ -468,7 +469,7 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
    I'm allocating memory of size nprocs, so that I can do an
    MPI_Alltoall later on.*/
 
-    buf_idx = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    buf_idx = (MPI_Aint *) ADIOI_Malloc(nprocs * sizeof(MPI_Aint));
 /* buf_idx is relevant only if buftype_is_contig.
    buf_idx[i] gives the index into user_buf where data received
    from proc. i should be placed. This allows receives to be done
@@ -547,8 +548,8 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
 
         /* for each separate contiguous access from this process */
         if (buf_idx[proc] == -1) {
-            ADIOI_Assert(curr_idx == (int) curr_idx);
-            buf_idx[proc] = (int) curr_idx;
+            ADIOI_Assert(curr_idx == (MPI_Aint) curr_idx);
+            buf_idx[proc] = (MPI_Aint) curr_idx;
         }
 
         l = my_req[proc].count;
@@ -572,8 +573,8 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
                                               fd_size, fd_start, fd_end);
 
             if (buf_idx[proc] == -1) {
-                ADIOI_Assert(curr_idx == (int) curr_idx);
-                buf_idx[proc] = (int) curr_idx;
+                ADIOI_Assert(curr_idx == (MPI_Aint) curr_idx);
+                buf_idx[proc] = (MPI_Aint) curr_idx;
             }
 
             l = my_req[proc].count;

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.h
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.h
@@ -52,7 +52,7 @@ void ADIOI_GPFS_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset
                             int nprocs,
                             int *count_my_req_procs_ptr,
                             int **count_my_req_per_proc_ptr,
-                            ADIOI_Access ** my_req_ptr, int **buf_idx_ptr);
+                            ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr);
 
     /*
      * ADIOI_Calc_others_req

--- a/src/mpi/romio/adio/common/ad_aggregate.c
+++ b/src/mpi/romio/adio/common/ad_aggregate.c
@@ -254,11 +254,12 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset * le
                        int nprocs,
                        int *count_my_req_procs_ptr,
                        int **count_my_req_per_proc_ptr,
-                       ADIOI_Access ** my_req_ptr, int **buf_idx_ptr)
+                       ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr)
 /* Possibly reconsider if buf_idx's are ok as int's, or should they be aints/offsets?
    They are used as memory buffer indices so it seems like the 2G limit is in effect */
 {
-    int *count_my_req_per_proc, count_my_req_procs, *buf_idx;
+    int *count_my_req_per_proc, count_my_req_procs;
+    MPI_Aint *buf_idx;
     int i, l, proc;
     ADIO_Offset fd_len, rem_len, curr_idx, off;
     ADIOI_Access *my_req;
@@ -274,7 +275,7 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset * le
    I'm allocating memory of size nprocs, so that I can do an
    MPI_Alltoall later on.*/
 
-    buf_idx = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    buf_idx = (MPI_Aint *) ADIOI_Malloc(nprocs * sizeof(MPI_Aint));
 /* buf_idx is relevant only if buftype_is_contig.
    buf_idx[i] gives the index into user_buf where data received
    from proc. i should be placed. This allows receives to be done
@@ -350,8 +351,8 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset * le
 
         /* for each separate contiguous access from this process */
         if (buf_idx[proc] == -1) {
-            ADIOI_Assert(curr_idx == (int) curr_idx);
-            buf_idx[proc] = (int) curr_idx;
+            ADIOI_Assert(curr_idx == (MPI_Aint) curr_idx);
+            buf_idx[proc] = (MPI_Aint) curr_idx;
         }
 
         l = my_req[proc].count;
@@ -375,8 +376,8 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset * le
                                          fd_size, fd_start, fd_end);
 
             if (buf_idx[proc] == -1) {
-                ADIOI_Assert(curr_idx == (int) curr_idx);
-                buf_idx[proc] = (int) curr_idx;
+                ADIOI_Assert(curr_idx == (MPI_Aint) curr_idx);
+                buf_idx[proc] = (MPI_Aint) curr_idx;
             }
 
             l = my_req[proc].count;

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -59,7 +59,7 @@ struct ADIOI_GEN_IreadStridedColl_vars {
     ADIO_Offset *fd_end;
     ADIO_Offset *end_offsets;
     ADIO_Offset *len_list;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
 };
 
 /* ADIOI_Iread_and_exch */
@@ -82,7 +82,7 @@ struct ADIOI_Iread_and_exch_vars {
     ADIO_Offset fd_size;
     ADIO_Offset *fd_start;
     ADIO_Offset *fd_end;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
 
     /* stack variables */
     int m;
@@ -143,7 +143,7 @@ struct ADIOI_R_Iexchange_data_vars {
     ADIOI_Access *others_req;
     int iter;
     MPI_Aint buftype_extent;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
 
     /* stack variables */
     int nprocs_recv;
@@ -998,7 +998,7 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
     int myrank = vars->myrank;
     ADIOI_Access *others_req = vars->others_req;
     int iter = vars->iter;
-    int *buf_idx = vars->buf_idx;
+    MPI_Aint *buf_idx = vars->buf_idx;
 
     int i, j, k = 0, tmp = 0, nprocs_recv, nprocs_send;
     char **recv_buf = NULL;

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -56,7 +56,7 @@ struct ADIOI_GEN_IwriteStridedColl_vars {
     ADIO_Offset *fd_start;
     ADIO_Offset *fd_end;
     ADIO_Offset *end_offsets;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
     ADIO_Offset *len_list;
     int old_error;
     int tmp_error;
@@ -83,7 +83,7 @@ struct ADIOI_Iexch_and_write_vars {
     ADIO_Offset fd_size;
     ADIO_Offset *fd_start;
     ADIO_Offset *fd_end;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
 
     /* stack variables */
     /* Not convinced end_loc-st_loc couldn't be > int, so make these offsets */
@@ -153,7 +153,7 @@ struct ADIOI_W_Iexchange_data_vars {
     int *hole;
     int iter;
     MPI_Aint buftype_extent;
-    int *buf_idx;
+    MPI_Aint *buf_idx;
 
     /* stack variables */
     int nprocs_recv;
@@ -1154,7 +1154,7 @@ static void ADIOI_W_Iexchange_data_send(ADIOI_NBC_Request * nbc_req, int *error_
     int nprocs = vars->nprocs;
     int myrank = vars->myrank;
     int iter = vars->iter;
-    int *buf_idx = vars->buf_idx;
+    MPI_Aint *buf_idx = vars->buf_idx;
 
     int nprocs_recv = vars->nprocs_recv;
     MPI_Datatype *recv_types = vars->recv_types;

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -24,7 +24,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
                                 ADIO_Offset
                                 min_st_offset, ADIO_Offset fd_size,
                                 ADIO_Offset * fd_start, ADIO_Offset * fd_end,
-                                int *buf_idx, int *error_code);
+                                MPI_Aint * buf_idx, int *error_code);
 static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                                   * flat_buf, ADIO_Offset * offset_list, ADIO_Offset
                                   * len_list, int *send_size, int *recv_size,
@@ -37,7 +37,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                                   ADIO_Offset fd_size,
                                   ADIO_Offset * fd_start, ADIO_Offset * fd_end,
                                   ADIOI_Access * others_req,
-                                  int iter, MPI_Aint buftype_extent, int *buf_idx);
+                                  int iter, MPI_Aint buftype_extent, MPI_Aint * buf_idx);
 void ADIOI_Fill_user_buffer(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                             * flat_buf, char **recv_buf, ADIO_Offset
                             * offset_list, ADIO_Offset * len_list,
@@ -76,7 +76,7 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *fd_start = NULL,
         *fd_end = NULL, *end_offsets = NULL;
     ADIO_Offset *len_list = NULL;
-    int *buf_idx = NULL;
+    MPI_Aint *buf_idx = NULL;
 
 #ifdef HAVE_STATUS_SET_BYTES
     MPI_Count bufsize, size;
@@ -487,7 +487,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
                                 ADIO_Offset * len_list, int contig_access_count, ADIO_Offset
                                 min_st_offset, ADIO_Offset fd_size,
                                 ADIO_Offset * fd_start, ADIO_Offset * fd_end,
-                                int *buf_idx, int *error_code)
+                                MPI_Aint * buf_idx, int *error_code)
 {
 /* Read in sizes of no more than coll_bufsize, an info parameter.
    Send data to appropriate processes.
@@ -766,7 +766,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                                   ADIO_Offset min_st_offset, ADIO_Offset fd_size,
                                   ADIO_Offset * fd_start, ADIO_Offset * fd_end,
                                   ADIOI_Access * others_req,
-                                  int iter, MPI_Aint buftype_extent, int *buf_idx)
+                                  int iter, MPI_Aint buftype_extent, MPI_Aint * buf_idx)
 {
     int i, j, k = 0, tmp = 0, nprocs_recv, nprocs_send;
     char **recv_buf = NULL;

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -20,7 +20,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, void *buf, MPI_Datatype
                                  ADIO_Offset * len_list, int contig_access_count, ADIO_Offset
                                  min_st_offset, ADIO_Offset fd_size,
                                  ADIO_Offset * fd_start, ADIO_Offset * fd_end,
-                                 int *buf_idx, int *error_code);
+                                 MPI_Aint * buf_idx, int *error_code);
 static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
                                   ADIOI_Flatlist_node * flat_buf, ADIO_Offset
                                   * offset_list, ADIO_Offset * len_list, int *send_size,
@@ -34,7 +34,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
                                   ADIOI_Access * others_req,
                                   int *send_buf_idx, int *curr_to_proc,
                                   int *done_to_proc, int *hole, int iter,
-                                  MPI_Aint buftype_extent, int *buf_idx, int *error_code);
+                                  MPI_Aint buftype_extent, MPI_Aint * buf_idx, int *error_code);
 void ADIOI_Fill_send_buffer(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                             * flat_buf, char **send_buf, ADIO_Offset
                             * offset_list, ADIO_Offset * len_list, int *send_size,
@@ -75,7 +75,7 @@ void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     ADIO_Offset orig_fp, start_offset, end_offset, fd_size, min_st_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *fd_start = NULL,
         *fd_end = NULL, *end_offsets = NULL;
-    int *buf_idx = NULL;
+    MPI_Aint *buf_idx = NULL;
     ADIO_Offset *len_list = NULL;
     int old_error, tmp_error;
 
@@ -285,7 +285,7 @@ static void ADIOI_Exch_and_write(ADIO_File fd, void *buf, MPI_Datatype
                                  ADIO_Offset * len_list, int contig_access_count,
                                  ADIO_Offset min_st_offset, ADIO_Offset fd_size,
                                  ADIO_Offset * fd_start, ADIO_Offset * fd_end,
-                                 int *buf_idx, int *error_code)
+                                 MPI_Aint * buf_idx, int *error_code)
 {
 /* Send data to appropriate processes and write in sizes of no more
    than coll_bufsize.
@@ -556,7 +556,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
                                   ADIOI_Access * others_req,
                                   int *send_buf_idx, int *curr_to_proc,
                                   int *done_to_proc, int *hole, int iter,
-                                  MPI_Aint buftype_extent, int *buf_idx, int *error_code)
+                                  MPI_Aint buftype_extent, MPI_Aint * buf_idx, int *error_code)
 {
     int i, j, k, *tmp_len, nprocs_recv, nprocs_send, err;
     char **send_buf = NULL;

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -452,7 +452,7 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                        int nprocs,
                        int *count_my_req_procs_ptr,
                        int **count_my_req_per_proc_ptr,
-                       ADIOI_Access ** my_req_ptr, int **buf_idx_ptr);
+                       ADIOI_Access ** my_req_ptr, MPI_Aint ** buf_idx_ptr);
 void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
                            int *count_my_req_per_proc,
                            ADIOI_Access * my_req,


### PR DESCRIPTION
buf_idx is used to point to various locations inside the user buffer (i.e. a pointer to memory). This PR changes its data type from int to MPI_Aint. Below is a short test program that can cause a core dump if without this PR. The program defines a filetype of size 2GiB+1024 and writes 2GiB+1024 bytes in a single MPI_File_write_all(). The problem was first discovered by @jedwards4b when using PnetCDF. See additional discussions in the [original email](https://lists.mcs.anl.gov/pipermail/parallel-netcdf/2017-December/001991.html).
```
#include <stdio.h>
#include <stdlib.h>
#include <mpi.h>

#define ERR if (err != MPI_SUCCESS) { \
        int errorStringLen; \
        char errorString[MPI_MAX_ERROR_STRING]; \
        MPI_Error_string(err, errorString, &errorStringLen); \
        printf("Error at line %d: %s\n",__LINE__, errorString); \
    }

#define TWO_G  2147483648
#define ONE_G  1073741824

int main(int argc, char **argv)
{
    int err, cmode=MPI_MODE_CREATE|MPI_MODE_RDWR;
    char *buf;
    int blocklen[2] = {ONE_G, ONE_G+1024};
    MPI_Aint disp[2] = {0, ONE_G};
    MPI_Datatype dtype;
    MPI_Info info;
    MPI_File fh;
    MPI_Status status;

    MPI_Init(&argc, &argv);
    buf = (char*) calloc(TWO_G+1024,1);

    /* enable romio_cb_write to force two-phase I/O to trigger the bug when
     * calling MPI_File_write_all below */
    MPI_Info_create(&info);
    MPI_Info_set(info, "romio_cb_write", "enable"); /* force two-phase */

    err = MPI_File_open(MPI_COMM_WORLD, "testfile", cmode, info, &fh); ERR

    err = MPI_Type_create_hindexed(2, blocklen, disp, MPI_BYTE, &dtype); ERR
    err = MPI_Type_commit(&dtype); ERR

    err = MPI_File_set_view(fh, 0, MPI_BYTE, dtype, "native", MPI_INFO_NULL); ERR
    err = MPI_File_write_all(fh, buf, 1, dtype, &status); ERR

    err = MPI_File_close(&fh); ERR
    MPI_Type_free(&dtype);
    MPI_Info_free(&info);
    free(buf);

    MPI_Finalize();
    return 0;
}
```