### PR TITLE
Revert "autogen: Get rid of glibtool checks."

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -304,7 +304,11 @@ if [ -n "$autotoolsdir" ] ; then
         automake=$autotoolsdir/automake
         autom4te=$autotoolsdir/autom4te
         aclocal=$autotoolsdir/aclocal
-        libtoolize=$autotoolsdir/libtoolize
+        if [ -x "$autotoolsdir/glibtoolize" ] ; then
+            libtoolize=$autotoolsdir/glibtoolize
+        else
+            libtoolize=$autotoolsdir/libtoolize
+        fi
 
 	AUTOCONF=$autoconf
 	AUTOHEADER=$autoheader
@@ -332,7 +336,11 @@ else
     autom4te=${AUTOM4TE:-autom4te}
     automake=${AUTOMAKE:-automake}
     aclocal=${ACLOCAL:-aclocal}
-    libtoolize=${LIBTOOLIZE:-libtoolize}
+    if test -z "${LIBTOOLIZE+set}" && ( glibtoolize --version ) >/dev/null 2>&1 ; then
+        libtoolize=glibtoolize
+    else
+        libtoolize=${LIBTOOLIZE:-libtoolize}
+    fi
 fi
 
 ProgHomeDir $autoconf   autoconfdir


### PR DESCRIPTION
This reverts commit a512f954007fefa4b3b218848854481927422fc3, which
broke autogen.sh for some OSX users.