### PR TITLE
Fix CH4 build failure when `--enable-strict=yes`

### DIFF
--- a/src/binding/fortran/mpif_h/mpi_fortimpl.h
+++ b/src/binding/fortran/mpif_h/mpi_fortimpl.h
@@ -120,8 +120,6 @@
 
 /* ------------------------------------------------------------------------- */
 
-/* mpi.h includes the definitions of MPI_Fint */
-#include "mpi.h"
 #include "mpiimpl.h"
 
 /* If there is no MPI I/O support, and we are still using MPIO_Request,

--- a/src/env/mpichversion.c
+++ b/src/env/mpichversion.c
@@ -4,7 +4,6 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include "mpi.h"
 #include "mpiimpl.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/glue/romio/all_romio_symbols
+++ b/src/glue/romio/all_romio_symbols
@@ -72,7 +72,6 @@ print OUTFD <<EOT;
  * have shown up when Fortran support is disabled.
  */
 
-#include "mpi.h"
 #include "mpiimpl.h"
 
 #include <stdio.h>

--- a/src/glue/romio/all_romio_symbols
+++ b/src/glue/romio/all_romio_symbols
@@ -72,9 +72,10 @@ print OUTFD <<EOT;
  * have shown up when Fortran support is disabled.
  */
 
-#include <stdio.h>
 #include "mpi.h"
 #include "mpiimpl.h"
+
+#include <stdio.h>
 
 void MPIR_All_romio_symbols(void);
 void MPIR_All_romio_symbols(void)

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -5,11 +5,11 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "mpiimpl.h"
 
 #undef DEBUG_DLOOP_SIZE
 #undef DLOOP_DEBUG_MEMORY

--- a/src/mpi/datatype/dataloop/dataloop_create.c
+++ b/src/mpi/datatype/dataloop/dataloop_create.c
@@ -5,10 +5,11 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <stdlib.h>
 #include <limits.h>
 
-#include "mpiimpl.h"
 
 static void DLOOP_Dataloop_create_named(MPI_Datatype type,
 					DLOOP_Dataloop **dlp_p,

--- a/src/mpi/datatype/dataloop/dataloop_create_blockindexed.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_blockindexed.c
@@ -5,9 +5,10 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <stdio.h>
 
-#include "mpiimpl.h"
 
 static void DLOOP_Type_blockindexed_array_copy(DLOOP_Count count,
 					       const void *disp_array,

--- a/src/mpi/datatype/dataloop/dataloop_create_indexed.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_indexed.c
@@ -5,9 +5,9 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include <stdlib.h>
-
 #include "mpiimpl.h"
+
+#include <stdlib.h>
 
 static void DLOOP_Type_indexed_array_copy(DLOOP_Count count,
 					  DLOOP_Count contig_count,

--- a/src/mpi/datatype/dataloop/segment.c
+++ b/src/mpi/datatype/dataloop/segment.c
@@ -5,10 +5,10 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <stdio.h>
 #include <stdlib.h>
-
-#include "mpiimpl.h"
 
 #undef DLOOP_DEBUG_MANIPULATE
 

--- a/src/mpi/datatype/dataloop/segment_count.c
+++ b/src/mpi/datatype/dataloop/segment_count.c
@@ -5,12 +5,12 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-
-#include "mpiimpl.h"
 
 /* NOTE: bufp values are unused, ripe for removal */
 

--- a/src/mpi/datatype/dataloop/segment_flatten.c
+++ b/src/mpi/datatype/dataloop/segment_flatten.c
@@ -5,12 +5,12 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpiimpl.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-
-#include "mpiimpl.h"
 
 /* NOTE: I don't think I've removed the need for bufp in here yet! -- RobR */
 

--- a/src/mpi/datatype/ext32_datatype.c
+++ b/src/mpi/datatype/ext32_datatype.c
@@ -5,12 +5,11 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
-#include <mpichconf.h>
 #include <mpiimpl.h>
 #include <mpir_dataloop.h>
+
+#include <stdio.h>
+#include <stdlib.h>
 
 
 typedef struct external32_basic_size

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -4,10 +4,10 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include <strings.h>
-
 #include "mpiimpl.h"
 #include "mpi_init.h"
+
+#include <strings.h>
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===


### PR DESCRIPTION
This PR fixes an issue that CH4 doesn't build when `--enable-strict` is specified.
In short, `mpiimpl.h` has to be included first in order to define necessary macros such as `_GNU_SOURCE` before including others, especially libc header files.

@raffenet since this fixes a very basic build problem, I think it would be nice if we get this in to 3.3b.