### PR TITLE
ROMIO: initialize error_code to MPI_SUCCESS

### DIFF
--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -68,6 +68,7 @@ if (count*datatype_size != (ADIO_Offset)(unsigned)count*(ADIO_Offset)datatype_si
                                               "**dtypenull", 0);    \
         }                                                           \
         else {                                                      \
+            error_code = MPI_SUCCESS;                               \
             MPIO_DATATYPE_ISCOMMITTED(datatype, error_code);        \
         }                                                           \
         if (error_code != MPI_SUCCESS) {                            \

--- a/src/mpi/romio/mpi-io/set_view.c
+++ b/src/mpi/romio/mpi-io/set_view.c
@@ -42,7 +42,7 @@ Input Parameters:
 int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
 		      MPI_Datatype filetype, ROMIO_CONST char *datarep, MPI_Info info)
 {
-    int error_code;
+    int error_code = MPI_SUCCESS;
     MPI_Count filetype_size, etype_size;
     static char myname[] = "MPI_FILE_SET_VIEW";
     ADIO_Offset shared_fp, byte_off;


### PR DESCRIPTION
This patch initializes error_code to MPI_SUCCESS before calling MPIO_DATATYPE_ISCOMMITTED. Without this fix, an error message of "Invalid MPI_Op" appears when ROMIO is built stand-alone. Note in file mpi-io/mpioimpl.h, MPIO_DATATYPE_ISCOMMITTED does nothing when ROMIO_INSIDE_MPICH is not defined. Thus, uninitialized error_code can pass through MPIO_DATATYPE_ISCOMMITTED and is checked against MPI_SUCCESS in a few places, including mpi-io/set_view.c and all files that call MPIO_CHECK_DATATYPE.