### PR TITLE
CH4: Fix warnings with `--enable-strict`

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -31,7 +31,7 @@ enum {
 #define MPIDI_OFI_MAX_ENDPOINTS_BITS_REGULAR    0
 
 /* This needs to be kept in sync with the order in globals.c */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(char *set_name)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 {
     if (!strcmp("psm", set_name)) {
         return MPIDI_OFI_SET_NUMBER_PSM;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -699,7 +699,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_align_iov_len(size_t len)
 #define FCNAME   MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX void* MPIDI_OFI_aligned_next_iov(void *ptr)
 {
-    return (void *) MPIDI_OFI_align_iov_len((size_t) ptr);
+    return (void *) (uintptr_t) MPIDI_OFI_align_iov_len((size_t) ptr);
 }
 
 #undef  FUNCNAME
@@ -718,7 +718,7 @@ MPL_STATIC_INLINE_PREFIX struct iovec *MPIDI_OFI_request_util_iov(MPIR_Request *
 /* Make sure `p` is properly aligned */
 #define MPIDI_OFI_ASSERT_IOVEC_ALIGN(p)                                 \
     do {                                                                \
-        MPIR_Assert((((uintptr_t)p) & (MPIDI_OFI_IOVEC_ALIGN - 1)) == 0); \
+        MPIR_Assert((((uintptr_t)(void *) p) & (MPIDI_OFI_IOVEC_ALIGN - 1)) == 0); \
     } while (0)
 
 #endif /* OFI_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -252,7 +252,7 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
                                             struct fid_av *av,
                                             struct fid_ep **ep, int index);
 static inline int MPIDI_OFI_application_hints(int rank);
-static inline int MPIDI_OFI_init_global_settings(char *prov_name);
+static inline int MPIDI_OFI_init_global_settings(const char *prov_name);
 static inline int MPIDI_OFI_init_hints(struct fi_info *hints);
 
 #define MPIDI_OFI_CHOOSE_PROVIDER(prov, prov_use,errstr)                          \
@@ -1461,7 +1461,7 @@ static inline int MPIDI_OFI_application_hints(int rank)
     return mpi_errno;
 }
 
-static inline int MPIDI_OFI_init_global_settings(char *prov_name)
+static inline int MPIDI_OFI_init_global_settings(const char *prov_name)
 {
     /* Seed the global settings values for cases where we are using runtime sets */
     MPIDI_Global.settings.enable_data               = MPIR_CVAR_CH4_OFI_ENABLE_DATA != -1 ? MPIR_CVAR_CH4_OFI_ENABLE_DATA :

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -242,7 +242,8 @@ static inline int MPIDI_CH4R_get_symmetric_heap(MPI_Aint size,
             baseP = (void *) -1ULL;
 
             if (comm->rank == maxloc_result.loc) {
-                map_pointer = (uintptr_t) MPIDI_CH4R_generate_random_addr(mapsize);
+                void *p = MPIDI_CH4R_generate_random_addr(mapsize);
+                map_pointer = (uintptr_t) p;
                 baseP = MPL_mmap((void *) map_pointer, mapsize,
                                  PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0, MPL_MEM_RMA);
             }

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -873,6 +873,9 @@ fi
 # Check if we can implement MPL_aligned_alloc
 AC_CHECK_FUNCS(posix_memalign)
 AC_CHECK_FUNCS(aligned_alloc)
+if test "$ac_cv_func_aligned_alloc" = "yes" ; then
+    PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],aligned_alloc)
+fi
 if test "$ac_cv_func_posix_memalign" = "yes" -o "$ac_cv_func_aligned_alloc" = "yes"; then
    AC_DEFINE([DEFINE_ALIGNED_ALLOC],[1],[Define to 1 if MPL enables MPL_aligned_alloc.])
 fi

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -19,6 +19,10 @@ extern char *strdup(const char *);
 char *MPL_strdup(const char *str);
 #endif /* defined(MPL_USE_MEMORY_TRACING) || defined(MPL_HAVE_STRDUP) */
 
+#if defined MPL_NEEDS_ALIGNED_ALLOC_DECL
+extern void *aligned_alloc(size_t alignment, size_t size);
+#endif
+
 typedef enum {
     MPL_MEM_ADDRESS,        /* Address information */
     MPL_MEM_OBJECT,         /* General MPI Objects */


### PR DESCRIPTION
This PR fixes a few warnings from `--enable-strict` + GCC 7.2.1. This fixes the warning pointed out in #2874 after it getting merged, plus few other warnings.