### PR TITLE
CH4/OFI: Create one VNI by default

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -233,7 +233,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_OFI_MAX_VNIS
       category    : CH4_OFI
       type        : int
-      default     : -1
+      default     : 1
       class       : device
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL


### PR DESCRIPTION
Currently MPIR_CVAR_CH4_OFI_MAX_VNIS is set to -1 by default,
meaning it would claim all avaialable contexts from the provider.
This patch sets it to 1 by default.

This was supposed to be fixed in 8f103d7 but this part was missing.