### PR TITLE
ROMIO: check filetype and etype error

### DIFF
--- a/src/mpi/romio/adio/common/ad_set_view.c
+++ b/src/mpi/romio/adio/common/ad_set_view.c
@@ -45,7 +45,8 @@ int check_type(ADIOI_Flatlist_node * flat_type,
   err_check:
     *error_code = MPIO_Err_create_code(*error_code,
                                        MPIR_ERR_RECOVERABLE, caller,
-                                       __LINE__, MPI_ERR_IO, "**iofiletype", err_msg);
+                                       __LINE__, MPI_ERR_IO, "**iobadoverlap", " **iobadoverlap %s",
+                                       err_msg);
     return 0;
 }
 

--- a/src/mpi/romio/adio/common/ad_set_view.c
+++ b/src/mpi/romio/adio/common/ad_set_view.c
@@ -45,7 +45,7 @@ int check_type(ADIOI_Flatlist_node * flat_type,
   err_check:
     *error_code = MPIO_Err_create_code(*error_code,
                                        MPIR_ERR_RECOVERABLE, caller,
-                                       __LINE__, MPI_ERR_IO, "**iobadoverlap", " **iobadoverlap %s", err_msg);
+                                       __LINE__, MPI_ERR_IO, "**iofiletype", err_msg);
     return 0;
 }
 

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -24,7 +24,7 @@ static ADIOI_Flatlist_node *flatlist_node_new(MPI_Datatype datatype, MPI_Count c
     flat->count = count;
     flat->flag = 0;
 
-    flat->blocklens = (ADIO_Offset *) ADIOI_Malloc(flat->count * sizeof(ADIO_Offset));
+    flat->blocklens = (ADIO_Offset *) ADIOI_Calloc(flat->count, sizeof(ADIO_Offset));
     flat->indices = (ADIO_Offset *) ADIOI_Malloc(flat->count * sizeof(ADIO_Offset));
     return flat;
 }

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -1180,8 +1180,8 @@ void ADIOI_Optimize_flattened(ADIOI_Flatlist_node * flat_type)
     if (opt_blocks == flat_type->count)
         return;
 
-    opt_blocklens = (ADIO_Offset *) ADIOI_Malloc(opt_blocks * sizeof(ADIO_Offset));
-    opt_indices = (ADIO_Offset *) ADIOI_Malloc(opt_blocks * sizeof(ADIO_Offset));
+    opt_blocklens = (ADIO_Offset *) ADIOI_Calloc(opt_blocks * 2, sizeof(ADIO_Offset));
+    opt_indices = opt_blocklens + opt_blocks;
 
     /* fill in new blocklists */
     opt_blocklens[0] = flat_type->blocklens[0];

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -24,8 +24,8 @@ static ADIOI_Flatlist_node *flatlist_node_new(MPI_Datatype datatype, MPI_Count c
     flat->count = count;
     flat->flag = 0;
 
-    flat->blocklens = (ADIO_Offset *) ADIOI_Calloc(flat->count, sizeof(ADIO_Offset));
-    flat->indices = (ADIO_Offset *) ADIOI_Malloc(flat->count * sizeof(ADIO_Offset));
+    flat->blocklens = (ADIO_Offset *) ADIOI_Calloc(flat->count * 2, sizeof(ADIO_Offset));
+    flat->indices = flat->blocklens + flat->count;
     return flat;
 }
 
@@ -1198,7 +1198,6 @@ void ADIOI_Optimize_flattened(ADIOI_Flatlist_node * flat_type)
     }
     flat_type->count = opt_blocks;
     ADIOI_Free(flat_type->blocklens);
-    ADIOI_Free(flat_type->indices);
     flat_type->blocklens = opt_blocklens;
     flat_type->indices = opt_indices;
     return;
@@ -1227,7 +1226,6 @@ int ADIOI_Flattened_type_delete(MPI_Datatype datatype,
 
     if (node->refct <= 0) {
         ADIOI_Free(node->blocklens);
-        ADIOI_Free(node->indices);
         ADIOI_Free(node);
     }
 

--- a/src/mpi/romio/adio/common/utils.c
+++ b/src/mpi/romio/adio/common/utils.c
@@ -94,12 +94,12 @@ int ADIOI_Type_create_hindexed_x(int count,
 
     if (is_big) {
         ret = MPI_Type_create_struct(count, blocklens, array_of_displacements, types, newtype);
+        for (i = 0; i < count; i++)
+            if (types[i] != oldtype)
+                MPI_Type_free(&(types[i]));
     } else {
         ret = MPI_Type_create_hindexed(count, blocklens, array_of_displacements, oldtype, newtype);
     }
-    for (i = 0; i < count; i++)
-        if (types[i] != oldtype)
-            MPI_Type_free(&(types[i]));
     ADIOI_Free(types);
     ADIOI_Free(blocklens);
 

--- a/test/mpi/io/Makefile.am
+++ b/test/mpi/io/Makefile.am
@@ -27,7 +27,7 @@ noinst_PROGRAMS = \
     bigtype       \
     hindexed_io   \
     simple_collective \
-    external32_derived_dtype \
+    external32-derived-dtype \
     tst_fileview
 
 

--- a/test/mpi/io/external32_derived_dtype.c
+++ b/test/mpi/io/external32_derived_dtype.c
@@ -18,6 +18,15 @@
         MPI_Abort(MPI_COMM_WORLD, 1); \
     }
 
+#define HANDLE_ERROR(err) \
+    if (err != MPI_SUCCESS) { \
+        char msg[MPI_MAX_ERROR_STRING]; \
+        int resultlen; \
+        MPI_Error_string(err, msg, &resultlen); \
+        fprintf(stderr, "%s line %d: %s\n", __FILE__, __LINE__, msg); \
+        MPI_Abort(MPI_COMM_WORLD, 1); \
+    }
+
 static void read_file(const char *name, void *buf, MPI_Datatype dt)
 {
     int rank, err;

--- a/test/mpi/io/i_noncontig_coll.c
+++ b/test/mpi/io/i_noncontig_coll.c
@@ -28,7 +28,7 @@
 int main(int argc, char **argv)
 {
     int *buf, i, mynod, nprocs, len, b[3];
-    int errs = 0, err = MPI_SUCCESS;
+    int errs = 0, toterrs, err;
     MPI_Aint d[3];
     MPI_File fh;
     MPI_Request request;
@@ -245,6 +245,15 @@ int main(int argc, char **argv)
 
     err = MPI_File_close(&fh);
     HANDLE_ERROR(err);
+
+    MPI_Allreduce(&errs, &toterrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    if (mynod == 0) {
+        if (toterrs > 0) {
+            fprintf(stderr, "Found %d errors\n", toterrs);
+        } else {
+            fprintf(stdout, " No Errors\n");
+        }
+    }
 
     MPI_Type_free(&newtype);
     free(buf);

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -12,8 +12,8 @@ resized2 1
 bigtype 1
 hindexed_io 1
 tst_fileview 1
-simple_collective 1 arg=simple_collective.testfile
-external32_derived_dtype 1
+simple_collective 1 arg="simple_collective.testfile"
+external32-derived-dtype 1
 i_bigtype 1 mpiversion=3.1
 i_hindexed_io 1 mpiversion=3.1
 i_rdwrord 4 mpiversion=3.1


### PR DESCRIPTION
This PR adds the following checks:
1. File displacements of filetype must be non-negative and in a monotonically nondecreasing order.
2. If the file is opened for writing, neither the etype nor the filetype is permitted to contain overlapping regions.
The above MPI-IO requirement can be found in MPI standard Chapter 13.3.