### PR TITLE
ch4: Change count type to MPI_Aint in send/recv functions

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -20,7 +20,7 @@
 #define FUNCNAME MPIDI_prepare_recv_req
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_prepare_recv_req(void *buf, int count, MPI_Datatype datatype,
+static inline int MPIDI_prepare_recv_req(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                          MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -40,7 +40,7 @@ static inline int MPIDI_prepare_recv_req(void *buf, int count, MPI_Datatype data
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_handle_unexpected(void *buf,
-                                          int count,
+                                          MPI_Aint count,
                                           MPI_Datatype datatype,
                                           MPIR_Comm * comm, int context_offset, MPIR_Request * rreq)
 {
@@ -115,7 +115,7 @@ static inline int MPIDI_handle_unexpected(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_do_irecv(void *buf,
-                                 int count,
+                                 MPI_Aint count,
                                  MPI_Datatype datatype,
                                  int rank,
                                  int tag,
@@ -214,7 +214,7 @@ static inline int MPIDI_do_irecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
@@ -282,7 +282,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv_init(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -335,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mrecv(void *buf,
-                                          int count,
+                                          MPI_Aint count,
                                           MPI_Datatype datatype,
                                           MPIR_Request * message, MPI_Status * status)
 {
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mrecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDI_am_isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_am_isend(const void *buf, int count, MPI_Datatype datatype,
+static inline int MPIDI_am_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                  int rank, int tag, MPIR_Comm * comm, int context_offset,
                                  MPIR_Request ** request, int is_blocking, int type)
 {
@@ -121,7 +121,7 @@ static inline int MPIDI_psend_init(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag, MPIR_Comm * comm, int context_offset,
@@ -143,7 +143,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
@@ -166,7 +166,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag, MPIR_Comm * comm, int context_offset,
@@ -211,7 +211,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irsend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_issend(const void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag, MPIR_Comm * comm, int context_offset,

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -36,13 +36,13 @@ MPIDI_CH4I_API(int, Finalize, void);
 MPIDI_CH4I_API(int, Get_universe_size, int *);
 MPIDI_CH4I_API(int, Get_processor_name, char *, int, int *);
 MPIDI_CH4I_API(int, Iprobe, int, int, MPIR_Comm *, int, int *, MPI_Status *);
-MPIDI_CH4I_API(int, Irecv, void *, int, MPI_Datatype, int, int, MPIR_Comm *, int, MPIR_Request **);
-MPIDI_CH4I_API(int, Isend, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Irecv, void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int, MPIR_Request **);
+MPIDI_CH4I_API(int, Isend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Issend, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Issend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Mrecv, void *, int, MPI_Datatype, MPIR_Request *, MPI_Status *);
-MPIDI_CH4I_API(int, Imrecv, void *, int, MPI_Datatype, MPIR_Request *, MPIR_Request **);
+MPIDI_CH4I_API(int, Mrecv, void *, MPI_Aint, MPI_Datatype, MPIR_Request *, MPI_Status *);
+MPIDI_CH4I_API(int, Imrecv, void *, MPI_Aint, MPI_Datatype, MPIR_Request *, MPIR_Request **);
 MPIDI_CH4I_API(int, Open_port, MPIR_Info *, char *);
 MPIDI_CH4I_API(int, Close_port, const char *);
 MPIDI_CH4I_API(int, Comm_accept, const char *, MPIR_Info *, int, MPIR_Comm *, MPIR_Comm **);
@@ -59,20 +59,20 @@ MPIDI_CH4I_API(int, Progress_register, int (*progress_fn) (int *), int *id);
 MPIDI_CH4I_API(int, Progress_deregister, int id);
 MPIDI_CH4I_API(int, Progress_activate, int id);
 MPIDI_CH4I_API(int, Progress_deactivate, int id);
-MPIDI_CH4I_API(int, Recv, void *, int, MPI_Datatype, int, int, MPIR_Comm *, int, MPI_Status *,
+MPIDI_CH4I_API(int, Recv, void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int, MPI_Status *,
                MPIR_Request **);
 MPIDI_CH4I_API(int, Recv_init, void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
 MPIDI_CH4I_API(void, Request_set_completed, MPIR_Request *);
 MPIDI_CH4I_API(int, Request_complete, MPIR_Request *);
 MPIDI_CH4I_API(int, Request_is_anysource, MPIR_Request *);
-MPIDI_CH4I_API(int, Send, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Send, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Ssend, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Ssend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Rsend, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Rsend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Irsend, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
+MPIDI_CH4I_API(int, Irsend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
 MPIDI_CH4I_API(int, Send_init, const void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -57,10 +57,10 @@ typedef int (*MPIDI_NM_mpi_comm_create_hook_t) (MPIR_Comm * comm);
 typedef int (*MPIDI_NM_mpi_comm_free_hook_t) (MPIR_Comm * comm);
 typedef void (*MPIDI_NM_am_request_init_t) (MPIR_Request * req);
 typedef void (*MPIDI_NM_am_request_finalize_t) (MPIR_Request * req);
-typedef int (*MPIDI_NM_mpi_send_t) (const void *buf, int count, MPI_Datatype datatype, int rank,
+typedef int (*MPIDI_NM_mpi_send_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                     int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                     MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_ssend_t) (const void *buf, int count, MPI_Datatype datatype, int rank,
+typedef int (*MPIDI_NM_mpi_ssend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                      int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                      MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_startall_t) (int count, MPIR_Request * requests[]);
@@ -76,22 +76,22 @@ typedef int (*MPIDI_NM_mpi_rsend_init_t) (const void *buf, int count, MPI_Dataty
 typedef int (*MPIDI_NM_mpi_bsend_init_t) (const void *buf, int count, MPI_Datatype datatype,
                                           int rank, int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                           MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_isend_t) (const void *buf, int count, MPI_Datatype datatype, int rank,
+typedef int (*MPIDI_NM_mpi_isend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                      int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                      MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_issend_t) (const void *buf, int count, MPI_Datatype datatype, int rank,
+typedef int (*MPIDI_NM_mpi_issend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                       int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                       MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_cancel_send_t) (MPIR_Request * sreq);
 typedef int (*MPIDI_NM_mpi_recv_init_t) (void *buf, int count, MPI_Datatype datatype, int rank,
                                          int tag, MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                          MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_recv_t) (void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+typedef int (*MPIDI_NM_mpi_recv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                     MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr, MPI_Status * status,
                                     MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                      MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request);
-typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, int count, MPI_Datatype datatype,
+typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       MPIR_Request * message, MPIR_Request ** rreqp);
 typedef int (*MPIDI_NM_mpi_cancel_recv_t) (MPIR_Request * rreq);
 typedef void *(*MPIDI_NM_mpi_alloc_mem_t) (size_t size, MPIR_Info * info_ptr, MPL_memory_class class);
@@ -649,11 +649,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm) MPL_S
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request *
                                                            req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t *addr,
                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
@@ -680,11 +680,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
                                                      MPIR_Comm * comm, int context_offset, MPIDI_av_entry_t *addr,
                                                      MPIR_Request **
                                                      request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIDI_av_entry_t *addr,
                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
@@ -694,15 +694,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Da
                                                     int context_offset, MPIDI_av_entry_t *addr,
                                                     MPIR_Request **
                                                     request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t *addr, MPI_Status * status,
                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message,
                                                  MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -349,7 +349,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_REQUEST_FINALIZE);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request)
 {
@@ -365,7 +365,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, int count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request)
 {
@@ -462,7 +462,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request)
 {
@@ -478,7 +478,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, int count, MPI_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request)
 {
@@ -523,7 +523,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf, int count, MPI_Da
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t *addr, MPI_Status * status,
                                                MPIR_Request ** request)
@@ -540,7 +540,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, int count, MPI_Datatyp
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t *addr, MPIR_Request ** request)
 {
@@ -556,7 +556,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, int count, MPI_Dataty
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -21,7 +21,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
-                                                int count,
+                                                MPI_Aint count,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
@@ -253,7 +253,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag,
@@ -335,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
-                                                 int count,
+                                                 MPI_Aint count,
                                                  MPI_Datatype datatype,
                                                  MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -369,7 +369,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
-                                                int count,
+                                                MPI_Aint count,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -83,7 +83,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
 #define FUNCNAME MPIDI_OFI_send_normal
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                    int rank, int tag, MPIR_Comm *comm, int context_offset,
                                                    MPIDI_av_entry_t *addr, MPIR_Request **request,
                                                    int dt_contig,
@@ -363,7 +363,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, int count, M
 #define FUNCNAME MPIDI_OFI_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, int count, MPI_Datatype datatype, int rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                             int tag, MPIR_Comm *comm, int context_offset, MPIDI_av_entry_t *addr,
                                             MPIR_Request **request, int noreq, uint64_t syncflag)
 {
@@ -435,7 +435,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_persistent_send(const void *buf, int coun
 #define FUNCNAME MPIDI_NM_mpi_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                                MPIR_Comm *comm, int context_offset, MPIDI_av_entry_t *addr,
                                                MPIR_Request **request)
 {
@@ -460,7 +460,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, int count, MPI_D
 #define FUNCNAME MPIDI_NM_mpi_ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm *comm, int context_offset, MPIDI_av_entry_t *addr,
                                                 MPIR_Request **request)
 {
@@ -487,7 +487,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, int count, MPI_
 #define FUNCNAME MPIDI_NM_mpi_isend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm *comm, int context_offset, MPIDI_av_entry_t *addr,
                                                 MPIR_Request **request)
 {
@@ -512,7 +512,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, int count, MPI_
 #define FUNCNAME MPIDI_NM_mpi_issend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, int count, MPI_Datatype datatype, int rank, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm *comm, int context_offset, MPIDI_av_entry_t *addr,
                                                  MPIR_Request **request)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_am_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_recv.h
@@ -14,7 +14,7 @@
 #include "ucx_impl.h"
 
 static inline int MPIDI_NM_mpi_recv(void *buf,
-                                    int count,
+                                    MPI_Aint count,
                                     MPI_Datatype datatype,
                                     int rank,
                                     int tag,
@@ -53,7 +53,7 @@ static inline int MPIDI_NM_mpi_recv_init(void *buf,
 }
 
 static inline int MPIDI_NM_mpi_imrecv(void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -69,7 +69,7 @@ static inline int MPIDI_NM_mpi_imrecv(void *buf,
 }
 
 static inline int MPIDI_NM_mpi_irecv(void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,

--- a/src/mpid/ch4/netmod/ucx/ucx_am_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_send.h
@@ -14,7 +14,7 @@
 #include "ucx_impl.h"
 
 static inline int MPIDI_NM_mpi_send(const void *buf,
-                                    int count,
+                                    MPI_Aint count,
                                     MPI_Datatype datatype,
                                     int rank,
                                     int tag,
@@ -24,7 +24,7 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
 }
 
 static inline int MPIDI_NM_mpi_ssend(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -83,7 +83,7 @@ static inline int MPIDI_NM_mpi_rsend_init(const void *buf,
 }
 
 static inline int MPIDI_NM_mpi_isend(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -93,7 +93,7 @@ static inline int MPIDI_NM_mpi_isend(const void *buf,
 }
 
 static inline int MPIDI_NM_mpi_issend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -98,7 +98,7 @@ static inline void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_t status,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_UCX_recv(void *buf,
-                                 int count,
+                                 MPI_Aint count,
                                  MPI_Datatype datatype,
                                  int rank,
                                  int tag, MPIR_Comm * comm,
@@ -160,7 +160,7 @@ static inline int MPIDI_UCX_recv(void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
-                                                 int count,
+                                                 MPI_Aint count,
                                                  MPI_Datatype datatype,
                                                  MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -219,7 +219,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag,
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
-                                                int count,
+                                                MPI_Aint count,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -38,7 +38,7 @@ static inline void MPIDI_UCX_send_cmpl_cb(void *request, ucs_status_t status)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_UCX_send(const void *buf,
-                                 int count,
+                                 MPI_Aint count,
                                  MPI_Datatype datatype,
                                  int rank,
                                  int tag,
@@ -123,7 +123,7 @@ static inline int MPIDI_UCX_send(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_send(const void *buf,
-                                    int count,
+                                    MPI_Aint count,
                                     MPI_Datatype datatype,
                                     int rank,
                                     int tag,
@@ -139,7 +139,7 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ssend(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -228,7 +228,7 @@ static inline int MPIDI_NM_mpi_rsend_init(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_isend(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -244,7 +244,7 @@ static inline int MPIDI_NM_mpi_isend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_issend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,

--- a/src/mpid/ch4/shm/glue/shm_p2p.h
+++ b/src/mpid/ch4/shm/glue/shm_p2p.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIR_Request ** request)
 {
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, int count, MPI_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIR_Request ** request)
@@ -122,7 +122,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIR_Request ** request)
 {
@@ -137,7 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, int count, MPI
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count,
                                                   MPI_Datatype datatype, int rank, int tag,
                                                   MPIR_Comm * comm, int context_offset,
                                                   MPIR_Request ** request)
@@ -181,7 +181,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_D
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPI_Status * status,
                                                 MPIR_Request ** request)
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, int count, MPI_Dataty
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIR_Request ** request)
 {
@@ -213,7 +213,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, int count, MPI_Datat
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                   MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int ret;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -83,11 +83,11 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request *
                                                         req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request *
                                                             req) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, int count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
@@ -114,11 +114,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count
                                                       MPIR_Comm * comm, int context_offset,
                                                       MPIR_Request **
                                                       request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset,
                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                   int rank, int tag, MPIR_Comm * comm,
                                                   int context_offset,
                                                   MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
@@ -129,15 +129,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv_init(void *buf, int count, MPI_D
                                                      int context_offset,
                                                      MPIR_Request **
                                                      request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPI_Status * status,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset,
                                                  MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, int count, MPI_Datatype datatype,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                   MPIR_Request * message,
                                                   MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request *

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -26,7 +26,7 @@ extern MPIDI_POSIX_request_queue_t MPIDI_POSIX_recvq_unexpected;
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_do_irecv)
 static inline int MPIDI_POSIX_do_irecv(void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        int rank,
                                        int tag,
@@ -95,7 +95,7 @@ static inline int MPIDI_POSIX_do_irecv(void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_mpi_recv)
 static inline int MPIDI_POSIX_mpi_recv(void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -153,7 +153,7 @@ static inline int MPIDI_POSIX_mpi_recv_init(void *buf,
 
 
 static inline int MPIDI_POSIX_mpi_imrecv(void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -297,7 +297,7 @@ static inline int MPIDI_POSIX_mpi_imrecv(void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_mpi_irecv)
 static inline int MPIDI_POSIX_mpi_irecv(void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -28,7 +28,7 @@
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_do_isend)
 static inline int MPIDI_POSIX_do_isend(const void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        int rank,
                                        int tag,
@@ -91,7 +91,7 @@ static inline int MPIDI_POSIX_do_isend(const void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_SEND)
 static inline int MPIDI_POSIX_mpi_send(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -146,7 +146,7 @@ static inline int MPIDI_POSIX_mpi_send(const void *buf,
 
 
 static inline int MPIDI_POSIX_irsend(const void *buf,
-                                   int count,
+                                   MPI_Aint count,
                                    MPI_Datatype datatype,
                                    int rank,
                                    int tag,
@@ -168,7 +168,7 @@ static inline int MPIDI_POSIX_irsend(const void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_SSEND)
 static inline int MPIDI_POSIX_mpi_ssend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,
@@ -395,7 +395,7 @@ static inline int MPIDI_POSIX_mpi_rsend_init(const void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_mpi_isend)
 static inline int MPIDI_POSIX_mpi_isend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,
@@ -415,7 +415,7 @@ static inline int MPIDI_POSIX_mpi_isend(const void *buf,
 }
 
 static inline int MPIDI_POSIX_mpi_issend(const void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        int rank,
                                        int tag,

--- a/src/mpid/ch4/shm/stubshm/stubshm_recv.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_recv.h
@@ -16,7 +16,7 @@
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_STUBSHM_mpi_recv)
 static inline int MPIDI_STUBSHM_mpi_recv(void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -52,7 +52,7 @@ static inline int MPIDI_STUBSHM_mpi_recv_init(void *buf,
 
 
 static inline int MPIDI_STUBSHM_mpi_imrecv(void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -68,7 +68,7 @@ static inline int MPIDI_STUBSHM_mpi_imrecv(void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_STUBSHM_mpi_irecv)
 static inline int MPIDI_STUBSHM_mpi_irecv(void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,

--- a/src/mpid/ch4/shm/stubshm/stubshm_send.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_send.h
@@ -14,7 +14,7 @@
 #include "stubshm_impl.h"
 
 static inline int MPIDI_STUBSHM_mpi_send(const void *buf,
-                                     int count,
+                                     MPI_Aint count,
                                      MPI_Datatype datatype,
                                      int rank,
                                      int tag,
@@ -33,7 +33,7 @@ static inline int MPIDI_STUBSHM_mpi_send(const void *buf,
 
 
 static inline int MPIDI_STUBSHM_irsend(const void *buf,
-                                   int count,
+                                   MPI_Aint count,
                                    MPI_Datatype datatype,
                                    int rank,
                                    int tag,
@@ -49,7 +49,7 @@ static inline int MPIDI_STUBSHM_irsend(const void *buf,
 }
 
 static inline int MPIDI_STUBSHM_mpi_ssend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,
@@ -146,7 +146,7 @@ static inline int MPIDI_STUBSHM_mpi_rsend_init(const void *buf,
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_STUBSHM_mpi_isend)
 static inline int MPIDI_STUBSHM_mpi_isend(const void *buf,
-                                      int count,
+                                      MPI_Aint count,
                                       MPI_Datatype datatype,
                                       int rank,
                                       int tag,
@@ -162,7 +162,7 @@ static inline int MPIDI_STUBSHM_mpi_isend(const void *buf,
 }
 
 static inline int MPIDI_STUBSHM_mpi_issend(const void *buf,
-                                       int count,
+                                       MPI_Aint count,
                                        MPI_Datatype datatype,
                                        int rank,
                                        int tag,

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -18,7 +18,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
-                                        int count,
+                                        MPI_Aint count,
                                         MPI_Datatype datatype,
                                         int rank,
                                         int tag,
@@ -179,7 +179,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype, MPIR_Request * message,
                                          MPI_Status * status)
 {
@@ -228,7 +228,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
-                                          int count,
+                                          MPI_Aint count,
                                           MPI_Datatype datatype,
                                           MPIR_Request * message, MPIR_Request ** rreqp)
 {
@@ -264,7 +264,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -18,7 +18,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
-                                        int count,
+                                        MPI_Aint count,
                                         MPI_Datatype datatype,
                                         int rank,
                                         int tag,
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
@@ -119,7 +119,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
-                                          int count,
+                                          MPI_Aint count,
                                           MPI_Datatype datatype,
                                           int rank,
                                           int tag,
@@ -220,7 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
-                                         int count,
+                                         MPI_Aint count,
                                          MPI_Datatype datatype,
                                          int rank,
                                          int tag,
@@ -270,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
-                                          int count,
+                                          MPI_Aint count,
                                           MPI_Datatype datatype,
                                           int rank,
                                           int tag,

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -57,7 +57,7 @@ static inline int MPIDI_handle_unexp_mrecv(MPIR_Request * rreq)
     size_t data_sz, dt_sz;
     MPIR_Segment *segment_ptr;
     void *buf;
-    int count;
+    MPI_Aint count;
     MPI_Datatype datatype;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_HANDLE_UNEXP_MRECV);


### PR DESCRIPTION
count in send/recv functions is currently of type int in ch4. This is inconsistent with ch3 and also gives errors when handling large count values. Change count type to MPI_Aint.