### PR TITLE
hwloc : support for v2.0.0rc2

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -337,7 +337,6 @@ int MPIR_Init_thread(int * argc, char ***argv, int required, int * provided)
 #ifdef HAVE_HWLOC
     MPIR_Process.bindset = hwloc_bitmap_alloc();
     hwloc_topology_init(&MPIR_Process.topology);
-    hwloc_topology_set_flags(MPIR_Process.topology, HWLOC_TOPOLOGY_FLAG_WHOLE_IO|HWLOC_TOPOLOGY_FLAG_IO_BRIDGES);
     MPIR_Process.bindset_is_valid = 0;
     if (!hwloc_topology_load(MPIR_Process.topology)) {
         MPIR_Process.bindset_is_valid =

--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -424,9 +424,6 @@ HYD_status HYDT_topo_hwloc_init(const char *binding, const char *mapping, const 
     else if (!strncmp(membind, "interleave:", strlen("interleave:"))) {
         HYDT_topo_hwloc_info.membind = HWLOC_MEMBIND_INTERLEAVE;
     }
-    else if (!strncmp(membind, "replicate:", strlen("replicate:"))) {
-        HYDT_topo_hwloc_info.membind = HWLOC_MEMBIND_REPLICATE;
-    }
     else {
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
                             "unrecognized membind policy \"%s\"\n", membind);

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -940,7 +940,6 @@ static void bind_to_help_fn(void)
     printf("            nexttouch         -- closest to process that next touches memory\n");
     printf("            bind:<list>       -- bind to memory node list\n");
     printf("            interleave:<list> -- interleave among memory node list\n");
-    printf("            replicate:<list>  -- replicate among memory node list\n");
 }
 
 static HYD_status bind_to_fn(char *arg, char ***argv)


### PR DESCRIPTION
changes for hwloc's newer version, requires that netloc build references be removed. working on exposing netloc as a library. need the code changes to be reviewed in the meantime.