### PR TITLE
ch4/rma: Implement accumulate ordering on OFI

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -290,6 +290,7 @@ typedef struct MPIDI_CH4U_win_sync {
 typedef struct MPIDI_CH4U_win_target {
     MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */
     MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
+    MPIR_cc_t remote_acc_cmpl_cnts; /* for acc only, increase at OP issuing, decrease at remote completion */
     MPIDI_CH4U_win_target_sync_t sync;
     int rank;
     UT_hash_handle hash_handle;
@@ -303,6 +304,7 @@ typedef struct MPIDI_CH4U_win_t {
     /* per-window OP completion for fence */
     MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */
     MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
+    MPIR_cc_t remote_acc_cmpl_cnts; /* for acc only, increase at OP issuing, decrease at remote completion */
 
     MPI_Aint *sizes;
     MPIDI_CH4U_win_sync_t sync;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -278,6 +278,29 @@ void MPIDI_OFI_index_allocator_destroy(void *_indexmap);
 /* Common Utility functions used by the
  * C and C++ components
  */
+/* Set max size based on OFI acc ordering limit. */
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_check_acc_order_size(MPIR_Win * win, size_t max_size)
+{
+    /* Check ordering limit, a value of -1 guarantees ordering for any data size. */
+    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_WAR)
+        && MPIDI_Global.max_order_war != -1) {
+        /* An order size value of 0 indicates that ordering is not guaranteed. */
+        MPIR_Assert(MPIDI_Global.max_order_war != 0);
+        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_war);
+    }
+    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_WAW)
+        && MPIDI_Global.max_order_waw != -1) {
+        MPIR_Assert(MPIDI_Global.max_order_waw != 0);
+        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_waw);
+    }
+    if ((MPIDI_CH4U_WIN(win, info_args).accumulate_ordering & MPIDI_CH4I_ACCU_ORDER_RAW)
+        && MPIDI_Global.max_order_raw != -1) {
+        MPIR_Assert(MPIDI_Global.max_order_raw != 0);
+        max_size = MPL_MIN(max_size, MPIDI_Global.max_order_raw);
+    }
+    return max_size;
+}
+
 MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_and_init(int extra)
 {
     MPIDI_OFI_win_request_t *req;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -651,6 +651,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIDI_Global.max_buffered_write = prov_use->tx_attr->inject_size;
     MPIDI_Global.max_send = prov_use->ep_attr->max_msg_size;
     MPIDI_Global.max_write = prov_use->ep_attr->max_msg_size;
+    MPIDI_Global.max_order_raw = prov_use->ep_attr->max_order_raw_size;
+    MPIDI_Global.max_order_war = prov_use->ep_attr->max_order_war_size;
+    MPIDI_Global.max_order_waw = prov_use->ep_attr->max_order_waw_size;
     MPIDI_Global.tx_iov_limit = MIN(prov_use->tx_attr->iov_limit, MPIDI_OFI_IOV_MAX);
     MPIDI_Global.rx_iov_limit = MIN(prov_use->rx_attr->iov_limit, MPIDI_OFI_IOV_MAX);
     MPIDI_Global.rma_iov_limit = MIN(prov_use->tx_attr->rma_iov_limit, MPIDI_OFI_IOV_MAX);
@@ -1728,7 +1731,8 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
      * else (AM mode) delivery complete is not required */
     if (MPIDI_OFI_ENABLE_RMA)
         hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
-    hints->tx_attr->msg_order = FI_ORDER_SAS;
+    /* Apply most restricted msg order in hints for RMA.*/
+    hints->tx_attr->msg_order = FI_ORDER_SAS | FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
     hints->tx_attr->comp_order = FI_ORDER_NONE;
     hints->rx_attr->op_flags = FI_COMPLETION;
     hints->rx_attr->total_buffered_recv = 0;    /* FI_RM_ENABLED ensures buffering of unexpected messages */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -362,6 +362,9 @@ typedef struct {
     size_t rx_iov_limit;
     size_t rma_iov_limit;
     int max_ch4_vnis;
+    size_t max_order_raw;
+    size_t max_order_war;
+    size_t max_order_waw;
 
     /* Mutexex and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[4];

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -345,6 +345,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
     MPIDI_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    /* Increase remote completion counter for acc. */
+    MPIDI_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
     MPIDI_CH4U_REQUEST(sreq, req->areq.data_sz) = data_sz;
@@ -504,6 +506,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     /* Increase local and remote completion counters and set the local completion
      * counter in request, thus it can be decreased at request completion. */
     MPIDI_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    /* Increase remote completion counter for acc. */
+    MPIDI_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
     MPIDI_CH4U_REQUEST(sreq, rank) = target_rank;
     MPIDI_CH4U_REQUEST(sreq, req->areq.data_sz) = data_sz;
@@ -947,6 +951,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
     MPIDI_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
+    /* Increase remote completion counter for acc. */
+    MPIDI_win_remote_acc_cmpl_cnt_incr(win, target_rank);
 
     /* FIXIME: we need to choose between NM and SHM */
     mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDI_CH4U_CSWAP_REQ,

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -1241,6 +1241,7 @@ static inline int MPIDI_get_acc_ack_target_cmpl_cb(MPIR_Request * areq)
 
     win = MPIDI_CH4U_REQUEST(areq, req->areq.win_ptr);
     MPIDI_win_remote_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(areq, rank));
+    MPIDI_win_remote_acc_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(areq, rank));
 
     dtype_release_if_not_builtin(MPIDI_CH4U_REQUEST(areq, req->areq.result_datatype));
     MPID_Request_complete(areq);
@@ -1267,6 +1268,7 @@ static inline int MPIDI_cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
 
     win = MPIDI_CH4U_REQUEST(rreq, req->creq.win_ptr);
     MPIDI_win_remote_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(rreq, rank));
+    MPIDI_win_remote_acc_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(rreq, rank));
 
     MPL_free(MPIDI_CH4U_REQUEST(rreq, req->creq.data));
     MPID_Request_complete(rreq);
@@ -1343,6 +1345,7 @@ static inline int MPIDI_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
     }
 
     MPIDI_win_remote_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(areq, rank));
+    MPIDI_win_remote_acc_cmpl_cnt_decr(win, MPIDI_CH4U_REQUEST(areq, rank));
 
     MPID_Request_complete(areq);
 

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -240,6 +240,7 @@ static inline int MPIDI_CH4R_win_init(MPI_Aint length,
 
     MPIR_cc_set(&MPIDI_CH4U_WIN(win, local_cmpl_cnts), 0);
     MPIR_cc_set(&MPIDI_CH4U_WIN(win, remote_cmpl_cnts), 0);
+    MPIR_cc_set(&MPIDI_CH4U_WIN(win, remote_acc_cmpl_cnts), 0);
 
     MPIDI_CH4U_WIN(win, win_id) = MPIDI_CH4U_generate_win_id(comm_ptr);
     MPIDI_CH4U_map_set(MPIDI_CH4_Global.win_map, MPIDI_CH4U_WIN(win, win_id), win, MPL_MEM_RMA);

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -107,8 +107,10 @@ static inline int MPIDI_CH4R_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
         } else if (!strcmp(curr_ptr->key, "accumulate_ordering")) {
             save_ordering = MPIDI_CH4U_WIN(win, info_args).accumulate_ordering;
             MPIDI_CH4U_WIN(win, info_args).accumulate_ordering = 0;
-            if (!strcmp(curr_ptr->value, "none"))
+            if (!strcmp(curr_ptr->value, "none")) {
+                /* For MPI-3, "none" means no ordering and is not default. */
                 goto next;
+            }
             value = curr_ptr->value;
             token = (char *) strtok_r(value, ",", &savePtr);
 

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -145,6 +145,7 @@ noinst_PROGRAMS =          \
     badrma                 \
     nb_test                \
     acc-loc                \
+    acc_ordering           \
     fence_shm              \
     get-struct             \
     rput_local_comp        \

--- a/test/mpi/rma/acc_ordering.c
+++ b/test/mpi/rma/acc_ordering.c
@@ -1,0 +1,275 @@
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* This test checks accumulate ordering in three cases:
+ * 1) Default (most restricted)
+ * 2) None (no ordering)
+ * 3) Mixture of REPLACE and MIN_LOC/MAX_LOC.
+ *    (In CH4/OFI, REPLACE may go through OFI but MIN_LOC/MAX_LOC has to go through active message.)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+#include <limits.h>
+#include "mpitest.h"
+
+typedef struct {
+    int val;
+    int loc;
+} twoint_t;
+
+#define ARRAY_LEN (8192/(sizeof(twoint_t)))
+
+static int errs = 0;
+
+void verify_result(twoint_t *data,
+                  int len,
+                  twoint_t expected,
+                  const char *test_name)
+{
+    int i;
+    for (i = 0; i < len; i++) {
+        if ((data[i].val != expected.val) || (data[i].loc != expected.loc)) {
+            errs++;
+            printf("%s: Expected: { loc = %d, val = %d }  Actual: { loc = %d, val = %d }\n",
+                test_name, expected.loc, expected.val, data[i].loc, data[i].val);
+        }
+    }
+}
+
+/* Check non-deterministic result of none ordering.
+ * Expected result has two possibilities. */
+void verify_nondeterministic_result(twoint_t *data,
+                                   int len,
+                                   twoint_t *expected,
+                                   const char *test_name)
+{
+    int i;
+    for (i = 0; i < len; i++) {
+        if ( ! ((data[i].loc == expected[0].loc && data[0].val == expected[0].val)
+                    || (data[i].loc == expected[1].loc && data[i].val == expected[1].val))) {
+            errs++;
+            printf("%s: Expected: { loc = %d, val = %d } or { loc = %d, val = %d }; Actual: { loc = %d, val = %d }\n",
+                test_name, expected[0].loc, expected[0].val, expected[1].loc, expected[1].val, data[i].loc, data[i].val);
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int me, nproc, i;
+    twoint_t *data, *mine, *mine_plus, *expected;
+    MPI_Win win;
+    MPI_Info info_in;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &me);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    if (nproc < 2) {
+        printf("Run this program with 2 or more processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    data = (twoint_t*)calloc(ARRAY_LEN, sizeof(twoint_t));
+    if (me == 0) {
+        /* length of 2 in order to store all results for none ordering. */
+        expected = (twoint_t*)malloc(2*sizeof(twoint_t));
+    }
+    if (me == nproc -1) {
+        mine = (twoint_t*)malloc(ARRAY_LEN * sizeof(twoint_t));
+        mine_plus = (twoint_t*)malloc(ARRAY_LEN * sizeof(twoint_t));
+        for (i = 0; i < ARRAY_LEN; i++) {
+            mine[i].val = me + 1;
+            mine[i].loc = me;
+            mine_plus[i].val = me + 2;
+            mine_plus[i].loc = me + 1;
+        }
+    }
+
+    /* 1. Default ordering */
+    MPI_Win_create(data, sizeof(twoint_t) * ARRAY_LEN, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+    MPI_Win_fence(0, win);
+
+    /* Rank np-1 performs 2 WRITE to rank 0. */
+    /* 1.a. Single data test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine_plus, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        expected[0].loc = nproc;
+        expected[0].val = nproc + 1;
+        verify_result(data, 1, expected[0], "Single data test case for default ordering");
+    }
+
+    if (me == 0) {
+        data[0].loc = 0;
+        data[0].val = 0;
+    }
+    MPI_Win_fence(0, win);
+    /* 1.b. Large arrary test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine_plus, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        verify_result(data, ARRAY_LEN, expected[0], "Large array test case for default ordering");
+    }
+    /* MPI Implementation may ignore window info changes once created.
+     * Thus we should free current window and create a new window with required info. */
+    MPI_Win_free(&win);
+
+    /* 2. None ordering */
+    if (me == 0) {
+        /* reset data on rank 0. */
+        memset((void*)data, 0, ARRAY_LEN * sizeof(twoint_t));
+    }
+
+    MPI_Info_create(&info_in);
+    MPI_Info_set(info_in, "accumulate_ordering", "none");
+    MPI_Win_create(data, sizeof(twoint_t) * ARRAY_LEN, 1, info_in, MPI_COMM_WORLD, &win);
+    MPI_Info_free(&info_in);
+
+    MPI_Win_fence(0, win);
+
+    /* Rank np-1 performs 2 WRITE to rank 0. */
+    /* 2.a. Single data test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine_plus, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        expected[0].loc = nproc - 1;
+        expected[0].val = nproc;
+        expected[1].loc = nproc;
+        expected[1].val = nproc + 1;
+        verify_nondeterministic_result(data, 1, expected, "Single data test case for none ordering");
+    }
+
+    if (me == 0) {
+        data[0].loc = 0;
+        data[0].val = 0;
+    }
+    MPI_Win_fence(0, win);
+    /* 2.b. Large array test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine_plus, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        verify_nondeterministic_result(data, ARRAY_LEN, expected, "Large array test case for none ordering");
+    }
+
+    MPI_Win_free(&win);
+
+    /* 3. Mix MAX_LOC/MIN_LOC and MPI_REPLACE */
+    if (me == 0) {
+        /* reset data on rank 0. */
+        memset((void*)data, 0, ARRAY_LEN * sizeof(twoint_t));
+    }
+
+    MPI_Win_create(data, sizeof(twoint_t) * ARRAY_LEN, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+
+    MPI_Win_fence(0, win);
+
+    /* Rank np-1 performs 2 WRITE to rank 0. */
+    /* Test MAXLOC */
+    /* 3.a. Single data test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine_plus, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_MAXLOC, win);
+        MPI_Accumulate(mine, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        expected[0].loc = nproc - 1;
+        expected[0].val = nproc;
+        verify_result(data, 1, expected[0], "Single data test case for MAXLOC and REPLACE");
+    }
+
+    if (me == 0) {
+        data[0].loc = 0;
+        data[0].val = 0;
+    }
+    MPI_Win_fence(0, win);
+    /* 3.b. Large array test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine_plus, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_MAXLOC, win);
+        MPI_Accumulate(mine, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        verify_result(data, ARRAY_LEN, expected[0], "Large array test case for MAXLOC and REPLACE");
+    }
+
+    /* Test MINLOC */
+    if (me == 0) {
+        for (i = 0; i < ARRAY_LEN; i++) {
+            data[i].loc = INT_MAX;
+            data[i].val = INT_MAX;
+        }
+    }
+    MPI_Win_fence(0, win);
+    /* Rank np-1 performs 2 WRITE to rank 0. */
+    /* 3.c. Single data test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine_plus, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine, 1, MPI_2INT, 0, 0, 1, MPI_2INT, MPI_MINLOC, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        expected[0].loc = nproc - 1;
+        expected[0].val = nproc;
+        verify_result(data, 1, expected[0], "Single data test case for REPLACE and MINLOC");
+    }
+
+    if (me == 0) {
+        data[0].loc = INT_MAX;
+        data[0].val = INT_MAX;
+    }
+    MPI_Win_fence(0, win);
+    /* 3.d. Large array test */
+    if (me == nproc - 1) {
+        MPI_Accumulate(mine_plus, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_REPLACE, win);
+        MPI_Accumulate(mine, ARRAY_LEN, MPI_2INT, 0, 0, ARRAY_LEN, MPI_2INT, MPI_MINLOC, win);
+    }
+
+    MPI_Win_fence(0, win);
+    if (me == 0) {
+        verify_result(data, ARRAY_LEN, expected[0], "Single data test case for REPLACE and MINLOC");
+    }
+
+    MPI_Win_free(&win);
+    if (me == nproc - 1) {
+        free(mine);
+        free(mine_plus);
+    }
+    if (me == 0)
+        free(expected);
+
+    MTest_Finalize(errs);
+    MPI_Finalize();
+    free(data);
+
+    return errs != 0;
+}

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -132,6 +132,7 @@ mutex_bench_shm_ordered 4 mpiversion=3.0
 rma-contig 2 mpiversion=3.0 timeLimit=720
 badrma 2 mpiversion=3.0
 acc-loc 4
+acc_ordering 2 mpiversion=3.0
 fence_shm 2 mpiversion=3.0
 win_shared_zerobyte 4 mpiversion=3.0
 win_shared_put_flush_get 4 mpiversion=3.0


### PR DESCRIPTION
Accumulate ordering on OFI level is implemented as follows:

- Acc, Get_acc, Fetch_and_op and Compare_and_swap are supported.
- Large message is chunked into smaller messages for which OFI provider
guarantees ordering.
- If max ordering size form OFI provider is smaller than basic data
type, then ordering is not guaranteed.
- In order to handle outstanding active message acc ops: an OFI acc op
cannot be issued until all active message acc ops are done, and vice versa.