### PR TITLE
More strict fixes

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -613,7 +613,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIDI_Global.prov_use = fi_dupinfo(prov_use);
     MPIR_Assert(MPIDI_Global.prov_use);
 
-    MPIDI_Global.max_buffered_send = MPL_MIN(prov_use->tx_attr->inject_size, UINT16_MAX);
+    MPIDI_Global.max_buffered_send = prov_use->tx_attr->inject_size;
     MPIDI_Global.max_buffered_write = prov_use->tx_attr->inject_size;
     MPIDI_Global.max_send = prov_use->ep_attr->max_msg_size;
     MPIDI_Global.max_write = prov_use->ep_attr->max_msg_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -347,7 +347,7 @@ typedef struct {
     struct fid_stx *stx_ctx;    /* shared TX context for RMA */
 
     /* Queryable limits */
-    uint16_t max_buffered_send;
+    uint64_t max_buffered_send;
     uint64_t max_buffered_write;
     uint64_t max_send;
     uint64_t max_write;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -126,7 +126,7 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
 {
     int mpi_errno = MPI_SUCCESS;
     uint64_t window_instance;
-    MPIR_Win *win;
+    MPIR_Win *win = NULL;
     struct fi_info *finfo;
     struct fi_cntr_attr cntr_attr;
 

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -822,7 +822,7 @@ static inline int MPIDI_set_map(MPIDI_rank_map_t * src_rmap,
              mapper->src_mapping_size == total_mapper_size) {
         /* check if new comm has the same mapping as src_comm */
         /* detect src_mapping_offset for direct_to_direct and offset_to_offset */
-        int mode_detected, offset, blocksize, stride;
+        int mode_detected, offset = 0, blocksize, stride;
         mode_detected = MPIDI_detect_regular_model(mapper->src_mapping, mapper->src_mapping_size,
                                                    &offset, &blocksize, &stride);
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_MAP, VERBOSE,


### PR DESCRIPTION
Additional fixes for #2927. The most contentious will be the first that changes the active message buffer allocation to use the memory allocation macros instead of relying on the datatype checking.

I'm not sure why we didn't pick this up before, but the compiler didn't go for the hint we were giving it by limiting the size of the array to `uint16_t` so we decided to just switch to using `MPL_CHKLMEM_MALLOC` since this is the active message path.