### PR TITLE
mtest: fix tag in multisend[2-4]

### DIFF
--- a/test/mpi/threads/pt2pt/multisend2.c
+++ b/test/mpi/threads/pt2pt/multisend2.c
@@ -25,11 +25,11 @@ static int nthreads = -1;
 MTEST_THREAD_RETURN_TYPE run_test_send(void *arg);
 MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 {
-    int cnt, j, *buf;
+    int cnt, j, *buf, tag;
     int thread_num = (int) (long) arg;
     double t;
 
-    for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
+    for (cnt = 1, tag = 1; cnt < MAX_CNT; cnt = 2 * cnt, tag++) {
         buf = (int *) malloc(cnt * sizeof(int));
         MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
 
@@ -38,7 +38,7 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++)
-            MPI_Send(buf, cnt, MPI_INT, thread_num, cnt, MPI_COMM_WORLD);
+            MPI_Send(buf, cnt, MPI_INT, thread_num, tag, MPI_COMM_WORLD);
         t = MPI_Wtime() - t;
         free(buf);
         if (thread_num == 1)
@@ -50,16 +50,16 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 void run_test_recv(void);
 void run_test_recv(void)
 {
-    int cnt, j, *buf;
+    int cnt, j, *buf, tag;
     MPI_Status status;
     double t;
 
-    for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
+    for (cnt = 1, tag = 1; cnt < MAX_CNT; cnt = 2 * cnt, tag++) {
         buf = (int *) malloc(cnt * sizeof(int));
         MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++)
-            MPI_Recv(buf, cnt, MPI_INT, 0, cnt, MPI_COMM_WORLD, &status);
+            MPI_Recv(buf, cnt, MPI_INT, 0, tag, MPI_COMM_WORLD, &status);
         t = MPI_Wtime() - t;
         free(buf);
     }

--- a/test/mpi/threads/pt2pt/multisend3.c
+++ b/test/mpi/threads/pt2pt/multisend3.c
@@ -30,7 +30,7 @@ static int nthreads = -1;
 MTEST_THREAD_RETURN_TYPE run_test_send(void *arg);
 MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 {
-    int cnt, j, *buf, wsize;
+    int cnt, j, *buf, wsize, tag;
     int thread_num = (int) (long) arg;
     double t;
     static MPI_Request r[MAX_NTHREAD];
@@ -47,14 +47,14 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
     if (nthreads != wsize - 1)
         fprintf(stderr, "Panic wsize = %d nthreads = %d\n", wsize, nthreads);
 
-    for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
+    for (cnt = 1, tag = 1; cnt < MAX_CNT; cnt = 2 * cnt, tag++) {
         /* Wait for all senders to be ready */
         MTest_thread_barrier(nthreads);
 
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++) {
             MTest_thread_barrier(nthreads);
-            MPI_Isend(buf, cnt, MPI_INT, thread_num, cnt, MPI_COMM_WORLD, &r[thread_num - 1]);
+            MPI_Isend(buf, cnt, MPI_INT, thread_num, tag, MPI_COMM_WORLD, &r[thread_num - 1]);
             if (ownerWaits) {
                 MPI_Wait(&r[thread_num - 1], MPI_STATUS_IGNORE);
             } else {
@@ -77,16 +77,16 @@ MTEST_THREAD_RETURN_TYPE run_test_send(void *arg)
 void run_test_recv(void);
 void run_test_recv(void)
 {
-    int cnt, j, *buf;
+    int cnt, j, *buf, tag;
     MPI_Status status;
     double t;
 
-    for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
+    for (cnt = 1, tag = 1; cnt < MAX_CNT; cnt = 2 * cnt, tag++) {
         buf = (int *) malloc(cnt * sizeof(int));
         MTEST_VG_MEM_INIT(buf, cnt * sizeof(int));
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++)
-            MPI_Recv(buf, cnt, MPI_INT, 0, cnt, MPI_COMM_WORLD, &status);
+            MPI_Recv(buf, cnt, MPI_INT, 0, tag, MPI_COMM_WORLD, &status);
         t = MPI_Wtime() - t;
         free(buf);
     }

--- a/test/mpi/threads/pt2pt/multisend4.c
+++ b/test/mpi/threads/pt2pt/multisend4.c
@@ -30,7 +30,7 @@ static int nthreads = -1;
 MTEST_THREAD_RETURN_TYPE run_test_sendrecv(void *arg);
 MTEST_THREAD_RETURN_TYPE run_test_sendrecv(void *arg)
 {
-    int cnt, j, *buf, wsize;
+    int cnt, j, *buf, wsize, tag;
     int thread_num = (int) (long) arg;
     double t;
     int myrloc = 2 * thread_num;
@@ -44,7 +44,7 @@ MTEST_THREAD_RETURN_TYPE run_test_sendrecv(void *arg)
     if (nthreads != wsize)
         fprintf(stderr, "Panic wsize = %d nthreads = %d\n", wsize, nthreads);
 
-    for (cnt = 1; cnt < MAX_CNT; cnt = 2 * cnt) {
+    for (cnt = 1, tag = 1; cnt < MAX_CNT; cnt = 2 * cnt, tag++) {
         buf = (int *) malloc(2 * cnt * sizeof(int));
         MTEST_VG_MEM_INIT(buf, 2 * cnt * sizeof(int));
 
@@ -54,8 +54,8 @@ MTEST_THREAD_RETURN_TYPE run_test_sendrecv(void *arg)
         t = MPI_Wtime();
         for (j = 0; j < MAX_LOOP; j++) {
             MTest_thread_barrier(nthreads);
-            MPI_Isend(buf, cnt, MPI_INT, thread_num, cnt, MPI_COMM_WORLD, &r[myrloc]);
-            MPI_Irecv(buf + cnt, cnt, MPI_INT, thread_num, cnt, MPI_COMM_WORLD, &r[myrloc + 1]);
+            MPI_Isend(buf, cnt, MPI_INT, thread_num, tag, MPI_COMM_WORLD, &r[myrloc]);
+            MPI_Irecv(buf + cnt, cnt, MPI_INT, thread_num, tag, MPI_COMM_WORLD, &r[myrloc + 1]);
             /* Wait for all threads to start the sends */
             if (ownerWaits) {
                 MPI_Waitall(2, &r[myrloc], MPI_STATUSES_IGNORE);


### PR DESCRIPTION
Tags used in multisend[2-4] can be as high as up to 660000,
which is beyond what PSM2 can support (max_ub is 128K).
Fix the tests by using the log2 of the count instead of count.

Fixes csr/mpich-ofi#944