### PR TITLE
comm: Remove anonymous union/struct and fix types

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -163,19 +163,14 @@ struct MPIR_Comm {
                                     node_roots_comm of rank i in this comm.
                                     It is of size 'local_size'. */
 
-    union {
-        int flags;
-        struct {
-            char is_low_group;/* For intercomms only, this boolean is
-                set for all members of one of the
-                two groups of processes and clear for
-                the other.  It enables certain
-                intercommunicator collective operations
-                that wish to use half-duplex operations
-                to implement a full-duplex operation */
-            char is_single_node;/* if a communicator is inside a single node */
-        };
-    };
+    char is_low_group;/* For intercomms only, this boolean is
+                         set for all members of one of the
+                         two groups of processes and clear for
+                         the other.  It enables certain
+                         intercommunicator collective operations
+                         that wish to use half-duplex operations
+                         to implement a full-duplex operation */
+    char is_single_node;/* if a communicator is inside a single node */
 
     struct MPIR_Comm     *comm_next;/* Provides a chain through all active
 				       communicators */

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -163,14 +163,14 @@ struct MPIR_Comm {
                                     node_roots_comm of rank i in this comm.
                                     It is of size 'local_size'. */
 
-    char is_low_group;/* For intercomms only, this boolean is
-                         set for all members of one of the
-                         two groups of processes and clear for
-                         the other.  It enables certain
-                         intercommunicator collective operations
-                         that wish to use half-duplex operations
-                         to implement a full-duplex operation */
-    char is_single_node;/* if a communicator is inside a single node */
+    int is_low_group;/* For intercomms only, this boolean is
+                        set for all members of one of the
+                        two groups of processes and clear for
+                        the other.  It enables certain
+                        intercommunicator collective operations
+                        that wish to use half-duplex operations
+                        to implement a full-duplex operation */
+    int is_single_node;/* if a communicator is inside a single node */
 
     struct MPIR_Comm     *comm_next;/* Provides a chain through all active
 				       communicators */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -388,9 +388,9 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
 
         /* check whether the communicator resides inside a node */
         if (comm->local_size == num_local) {
-            comm->is_single_node = (char)1;
+            comm->is_single_node = 1;
         } else {
-            comm->is_single_node = (char)0;
+            comm->is_single_node = 0;
         }
         /* if the node_roots_comm and comm would be the same size, then creating
          * the second communicator is useless and wasteful. */
@@ -411,7 +411,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
             comm->node_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
             comm->node_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE;
             comm->node_comm->local_comm = NULL;
-            comm->node_comm->is_single_node = (char)1;
+            comm->node_comm->is_single_node = 1;
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_comm=%p\n", comm->node_comm);
 
             comm->node_comm->local_size = num_local;
@@ -445,7 +445,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
             comm->node_roots_comm->local_comm = NULL;
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_roots_comm=%p\n", comm->node_roots_comm);
 
-            comm->node_roots_comm->is_single_node = (char)0;
+            comm->node_roots_comm->is_single_node = 0;
             comm->node_roots_comm->local_size = num_external;
             comm->node_roots_comm->pof2 = MPL_pof2(comm->node_roots_comm->local_size);
             comm->node_roots_comm->remote_size = num_external;


### PR DESCRIPTION
Partial revert of [a62a1748be01]. Fixes pmodels/mpich#2937.