### PR TITLE
Add a batch-waitall in MPI_Waitall to reduce cache misses

### DIFF
--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,8 +10,8 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm *comm_ptr, MPI_Request *request);
-int MPIR_Test_impl(MPI_Request *request, int *flag, MPI_Status *status);
-int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
+int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
+int MPIR_Testall_impl(int count, MPIR_Request *array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status);
 int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -13,8 +13,13 @@ int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest
 int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
 int MPIR_Testall_impl(int count, MPIR_Request *array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
-int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status);
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
+int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status);
+int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
                       MPI_Status array_of_statuses[]);
+
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request *request_ptrs[],
+                      MPI_Status array_of_statuses[]);
+int MPIR_Waitany_impl(int count, MPIR_Request *request_ptrs[], int *indx, MPI_Status *status);
 
 #endif /* MPIR_PT2PT_H_INCLUDED */

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -737,12 +737,10 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPI_Request request_ptr_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
-    MPI_Request *request_ptrs = request_ptr_array;
     MPI_Status status_static_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
     MPI_Status *status_array = statuses;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_WAITALL);
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIC_WAITALL);
 
@@ -753,7 +751,6 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
     }
 
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno, "request pointers", MPL_MEM_BUFFER);
         MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno, "status objects", MPL_MEM_BUFFER);
     }
 
@@ -763,12 +760,14 @@ int MPIC_Waitall(int numreq, MPIR_Request *requests[], MPI_Status statuses[], MP
         tag fields here. */
         status_array[i].MPI_TAG = 0;
         status_array[i].MPI_SOURCE = MPI_PROC_NULL;
-
-        /* Convert the MPIR_Request objects to MPI_Request objects */
-        request_ptrs[i] = requests[i]->handle;
     }
 
-    mpi_errno = MPIR_Waitall_impl(numreq, request_ptrs, status_array);
+    mpi_errno = MPIR_Waitall_impl(numreq, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
+    mpi_errno = MPIR_Waitall_post(numreq, NULL, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
 
     /* The errflag value here is for all requests, not just a single one.  If
      * in the future, this function is used for multiple collectives at a

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -468,7 +468,6 @@ static int MPIR_Bsend_check_active( void )
 
     MPL_DBG_MSG_P(MPIR_DBG_BSEND,TYPICAL,"Checking active starting at %p", active);
     while (active) {
-	MPI_Request r = active->request->handle;
 	int         flag;
 	
 	next_active = active->next;
@@ -483,7 +482,7 @@ static int MPIR_Bsend_check_active( void )
 	    flag = 0;
             /* XXX DJG FIXME-MT should we be checking this? */
 	    if (MPIR_Object_get_ref(active->request) == 1) {
-		mpi_errno = MPIR_Test_impl(&r, &flag, MPI_STATUS_IGNORE );
+                mpi_errno = MPIR_Test_impl(active->request, &flag, MPI_STATUS_IGNORE );
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    } else {
 		/* We need to invoke the progress engine in case we 
@@ -495,11 +494,16 @@ static int MPIR_Bsend_check_active( void )
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    }
 	} else {
-	    mpi_errno = MPIR_Test_impl( &r, &flag, MPI_STATUS_IGNORE );
+            mpi_errno = MPIR_Test_impl( active->request, &flag, MPI_STATUS_IGNORE );
             if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	}
 	if (flag) {
 	    /* We're done.  Remove this segment */
+        if (MPIR_Request_is_complete(active->request)) {
+            mpi_errno = MPIR_Request_complete(NULL, active->request, MPI_STATUS_IGNORE,
+                              &flag);
+            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        }
 	    MPL_DBG_MSG_P(MPIR_DBG_BSEND,TYPICAL,"Removing segment %p", active);
 	    MPIR_Bsend_free_segment( active );
 	}

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -180,9 +180,12 @@ int MPIR_Bsend_detach( void *bufferp, int *size )
 	MPII_Bsend_data_t *p = BsendBuffer.active;
 
 	while (p) {
-	    MPI_Request r = p->request->handle;
-	    mpi_errno = MPIR_Wait_impl( &r, MPI_STATUS_IGNORE );
-	    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPI_Request r = p->request->handle;
+            int active_flag;
+            mpi_errno = MPIR_Wait_impl( p->request, MPI_STATUS_IGNORE );
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+            MPIR_Request_complete(&r, p->request, MPI_STATUS_IGNORE, &active_flag);
 	    p = p->next;
 	}
     }

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -482,7 +482,7 @@ static int MPIR_Bsend_check_active( void )
 	    flag = 0;
             /* XXX DJG FIXME-MT should we be checking this? */
 	    if (MPIR_Object_get_ref(active->request) == 1) {
-                mpi_errno = MPIR_Test_impl(active->request, &flag, MPI_STATUS_IGNORE );
+                mpi_errno = MPID_Test(active->request, &flag, MPI_STATUS_IGNORE );
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    } else {
 		/* We need to invoke the progress engine in case we 
@@ -494,7 +494,7 @@ static int MPIR_Bsend_check_active( void )
                 if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	    }
 	} else {
-            mpi_errno = MPIR_Test_impl( active->request, &flag, MPI_STATUS_IGNORE );
+            mpi_errno = MPID_Test( active->request, &flag, MPI_STATUS_IGNORE );
             if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 	}
 	if (flag) {

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -61,6 +61,7 @@ PMPI_LOCAL int MPIR_Ibsend_cancel( void *extra, int complete )
     MPI_Status status;
     MPIR_Request *req = ibsend_info->req;
     MPI_Request req_hdl = req->handle;
+    int active_flag;
 
     /* FIXME: There should be no unreferenced args! */
     /* Note that this value should always be 1 because 
@@ -72,8 +73,11 @@ PMPI_LOCAL int MPIR_Ibsend_cancel( void *extra, int complete )
     /* Try to cancel the underlying request */
     mpi_errno = MPIR_Cancel_impl(req);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl( &req_hdl, &status );
+    mpi_errno = MPIR_Wait_impl( req, &status );
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_complete(&req_hdl, req, &status, &active_flag);
+    MPIR_Assert(!mpi_errno);
+
     ibsend_info->cancelled = MPIR_STATUS_GET_CANCEL_BIT(status);
 
     /* If the cancelation is successful, free the memory in the

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -43,15 +43,13 @@ int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
 
     if (request_ptr->kind == MPIR_REQUEST_KIND__GREQUEST &&
         request_ptr->u.ureq.greq_fns != NULL &&
-        request_ptr->u.ureq.greq_fns->poll_fn != NULL)
-    {
+        request_ptr->u.ureq.greq_fns->poll_fn != NULL) {
         mpi_errno = (request_ptr->u.ureq.greq_fns->poll_fn)(request_ptr->u.ureq.greq_fns->grequest_extra_state, status);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
 
-    if (MPIR_Request_is_complete(request_ptr)) {
-	*flag = TRUE;
-    }
+    if (MPIR_Request_is_complete(request_ptr))
+        *flag = TRUE;
 
  fn_exit:
     return mpi_errno;
@@ -93,10 +91,10 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
     int mpi_errno = MPI_SUCCESS;
     int active_flag;
     MPIR_Request *request_ptr = NULL;
-   MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TEST);
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TEST);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TEST);
 
@@ -105,30 +103,29 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
-	    MPIR_ERRTEST_REQUEST_OR_NULL(*request, mpi_errno);
-	}
+            MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
+            MPIR_ERRTEST_REQUEST_OR_NULL(*request, mpi_errno);
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
-    MPIR_Request_get_ptr( *request, request_ptr );
-    
+
+    MPIR_Request_get_ptr(*request, request_ptr);
+
    /* Validate parameters and objects (post conversion) */
 #   ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    if (*request != MPI_REQUEST_NULL)
-	    {
-		/* Validate request_ptr */
-		MPIR_Request_valid_ptr( request_ptr, mpi_errno );
+            if (*request != MPI_REQUEST_NULL) {
+                /* Validate request_ptr */
+                MPIR_Request_valid_ptr(request_ptr, mpi_errno);
                 if (mpi_errno) goto fn_fail;
-	    }
-	    
-	    MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
-	    /* NOTE: MPI_STATUS_IGNORE != NULL */
-	    MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            }
+
+            MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
+            /* NOTE: MPI_STATUS_IGNORE != NULL */
+            MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -145,7 +142,7 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
 
     mpi_errno = MPIR_Test_impl(request_ptr, flag, status);
     if (mpi_errno) goto fn_fail;
-    
+
     if (MPIR_Request_is_complete(request_ptr)) {
         mpi_errno = MPIR_Request_complete(request, request_ptr, status,
                                           &active_flag);
@@ -161,24 +158,24 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
         goto fn_fail;
     }
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-	MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TEST);
-	MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-	return mpi_errno;
-    
+        MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TEST);
+        MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+        return mpi_errno;
+
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
 #   ifdef HAVE_ERROR_CHECKING
     {
-	mpi_errno = MPIR_Err_create_code(
-	    mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, 
-	    "**mpi_test",
-	    "**mpi_test %p %p %p", request, flag, status);
+        mpi_errno = MPIR_Err_create_code(
+            mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER,
+            "**mpi_test",
+            "**mpi_test %p %p %p", request, flag, status);
     }
 #   endif
-    mpi_errno = MPIR_Err_return_comm(request_ptr ? request_ptr->comm : NULL, 
-				     FCNAME, mpi_errno);
+    mpi_errno = MPIR_Err_return_comm(request_ptr ? request_ptr->comm : NULL,
+                                     FCNAME, mpi_errno);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -29,7 +29,7 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status) __attribute__(
 #define FUNCNAME MPIR_Test_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Test_impl(MPI_Request *request, int *flag, MPI_Status *status)
+int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -143,7 +143,7 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
 
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Test_impl(request, flag, status);
+    mpi_errno = MPIR_Test_impl(request_ptr, flag, status);
     if (mpi_errno) goto fn_fail;
     
     if (MPIR_Request_is_complete(request_ptr)) {

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -32,19 +32,8 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status) __attribute__(
 int MPIR_Test_impl(MPI_Request *request, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int active_flag;
-    MPIR_Request *request_ptr = NULL;
 
-    /* If this is a null request handle, then return an empty status */
-    if (*request == MPI_REQUEST_NULL) {
-	MPIR_Status_set_empty(status);
-	*flag = TRUE;
-	goto fn_exit;
-    }
-    
     *flag = FALSE;
-
-    MPIR_Request_get_ptr( *request, request_ptr );
 
     /* If the request is already completed AND we want to avoid calling
      the progress engine, we could make the call to MPID_Progress_test
@@ -61,19 +50,9 @@ int MPIR_Test_impl(MPI_Request *request, int *flag, MPI_Status *status)
     }
 
     if (MPIR_Request_is_complete(request_ptr)) {
-	mpi_errno = MPIR_Request_complete(request, request_ptr, status,
-					  &active_flag);
 	*flag = TRUE;
-	if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-	/* Fall through to the exit */
-    } else if (unlikely(
-                MPIR_CVAR_ENABLE_FT &&
-                MPID_Request_is_anysource(request_ptr) &&
-                !MPID_Comm_AS_enabled(request_ptr->comm))) {
-        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-        if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
-        goto fn_fail;
     }
+
  fn_exit:
     return mpi_errno;
  fn_fail:
@@ -112,6 +91,7 @@ Output Parameters:
 int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int active_flag;
     MPIR_Request *request_ptr = NULL;
    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TEST);
 
@@ -154,11 +134,32 @@ int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status)
     }
 #   endif /* HAVE_ERROR_CHECKING */
 
+    /* If this is a null request handle, then return an empty status */
+    if (*request == MPI_REQUEST_NULL) {
+        MPIR_Status_set_empty(status);
+        *flag = TRUE;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Test_impl(request, flag, status);
     if (mpi_errno) goto fn_fail;
     
+    if (MPIR_Request_is_complete(request_ptr)) {
+        mpi_errno = MPIR_Request_complete(request, request_ptr, status,
+                                          &active_flag);
+        *flag = TRUE;
+        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        /* Fall through to the exit */
+    } else if (unlikely(
+                MPIR_CVAR_ENABLE_FT &&
+                MPID_Request_is_anysource(request_ptr) &&
+                !MPID_Comm_AS_enabled(request_ptr->comm))) {
+        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+        if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
+        goto fn_fail;
+    }
     /* ... end of body of routine ... */
     
   fn_exit:

--- a/src/mpi/request/testall.c
+++ b/src/mpi/request/testall.c
@@ -38,6 +38,80 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
 int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
                       MPI_Status array_of_statuses[])
 {
+    int i;
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPID_Progress_test();
+    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+
+    for (i = 0; i < count; i++)
+    {
+        if (request_ptrs[i] != NULL &&
+                request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
+                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
+        {
+            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
+                    &(array_of_statuses[i]));
+            if (mpi_errno != MPI_SUCCESS) goto fn_fail;
+        }
+    }
+
+ fn_exit:
+    return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
+#endif
+
+#undef FUNCNAME
+#define FUNCNAME MPI_Testall
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+/*@
+    MPI_Testall - Tests for the completion of all previously initiated
+    requests
+
+Input Parameters:
++ count - lists length (integer) 
+- array_of_requests - array of requests (array of handles) 
+
+Output Parameters:
++ flag - True if all requests have completed; false otherwise (logical) 
+- array_of_statuses - array of status objects (array of Status).  May be
+ 'MPI_STATUSES_IGNORE'.
+
+Notes:
+  'flag' is true only if all requests have completed.  Otherwise, flag is
+  false and neither the 'array_of_requests' nor the 'array_of_statuses' is
+  modified.
+
+If one or more of the requests completes with an error, 'MPI_ERR_IN_STATUS' is
+returned.  An error value will be present is elements of 'array_of_status'
+associated with the requests.  Likewise, the 'MPI_ERROR' field in the status
+elements associated with requests that have successfully completed will be
+'MPI_SUCCESS'.  Finally, those requests that have not completed will have a 
+value of 'MPI_ERR_PENDING'.
+
+While it is possible to list a request handle more than once in the
+'array_of_requests', such an action is considered erroneous and may cause the
+program to unexecpectedly terminate or produce incorrect results.
+
+.N ThreadSafe
+
+.N waitstatus
+
+.N Fortran
+
+.N Errors
+.N MPI_SUCCESS
+.N MPI_ERR_IN_STATUS
+.N MPI_ERR_REQUEST
+.N MPI_ERR_ARG
+@*/
+int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, 
+		MPI_Status array_of_statuses[])
+{
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
     MPI_Status * status_ptr;
@@ -47,6 +121,38 @@ int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
     int rc = MPI_SUCCESS;
     int proc_failure = FALSE;
     int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTALL);
+
+    MPIR_ERRTEST_INITIALIZED_ORDIE();
+    
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TESTALL);
+
+    /* Check the arguments */
+#   ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+        int i = 0;
+
+	    MPIR_ERRTEST_COUNT(count, mpi_errno);
+
+	    if (count != 0) {
+		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+		/* NOTE: MPI_STATUSES_IGNORE != NULL */
+		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
+	    }
+	    MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
+
+	    for (i = 0; i < count; i++) {
+		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+	    }
+	}
+        MPID_END_ERROR_CHECKS;
+    }
+#   endif /* HAVE_ERROR_CHECKING */
+
+    /* ... body of routine ...  */
     MPIR_CHKLMEM_DECL(1);
 
     /* Convert MPI request handles to a request object pointers */
@@ -86,14 +192,6 @@ int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
 
     for (i = 0; i < count; i++)
     {
-        if (request_ptrs[i] != NULL &&
-                request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-        {
-            mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
-                    &(array_of_statuses[i]));
-            if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-        }
         if (request_ptrs[i] != NULL)
         {
             if (MPIR_Request_is_complete(request_ptrs[i]))
@@ -171,107 +269,13 @@ int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
 
     *flag = (n_completed == count) ? TRUE : FALSE;
 
- fn_exit:
+    /* ... end of body of routine ... */
+    
+  fn_exit:
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
         MPIR_CHKLMEM_FREEALL();
     }
-
-    return mpi_errno;
- fn_fail:
-    goto fn_exit;
-}
-
-#endif
-
-#undef FUNCNAME
-#define FUNCNAME MPI_Testall
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-/*@
-    MPI_Testall - Tests for the completion of all previously initiated
-    requests
-
-Input Parameters:
-+ count - lists length (integer) 
-- array_of_requests - array of requests (array of handles) 
-
-Output Parameters:
-+ flag - True if all requests have completed; false otherwise (logical) 
-- array_of_statuses - array of status objects (array of Status).  May be
- 'MPI_STATUSES_IGNORE'.
-
-Notes:
-  'flag' is true only if all requests have completed.  Otherwise, flag is
-  false and neither the 'array_of_requests' nor the 'array_of_statuses' is
-  modified.
-
-If one or more of the requests completes with an error, 'MPI_ERR_IN_STATUS' is
-returned.  An error value will be present is elements of 'array_of_status'
-associated with the requests.  Likewise, the 'MPI_ERROR' field in the status
-elements associated with requests that have successfully completed will be
-'MPI_SUCCESS'.  Finally, those requests that have not completed will have a 
-value of 'MPI_ERR_PENDING'.
-
-While it is possible to list a request handle more than once in the
-'array_of_requests', such an action is considered erroneous and may cause the
-program to unexecpectedly terminate or produce incorrect results.
-
-.N ThreadSafe
-
-.N waitstatus
-
-.N Fortran
-
-.N Errors
-.N MPI_SUCCESS
-.N MPI_ERR_IN_STATUS
-.N MPI_ERR_REQUEST
-.N MPI_ERR_ARG
-@*/
-int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, 
-		MPI_Status array_of_statuses[])
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTALL);
-
-    MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TESTALL);
-
-    /* Check the arguments */
-#   ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-        int i = 0;
-
-	    MPIR_ERRTEST_COUNT(count, mpi_errno);
-
-	    if (count != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		/* NOTE: MPI_STATUSES_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
-
-	    for (i = 0; i < count; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
-        MPID_END_ERROR_CHECKS;
-    }
-#   endif /* HAVE_ERROR_CHECKING */
-
-    /* ... body of routine ...  */
-
-    mpi_errno = MPIR_Testall_impl(count, array_of_requests, flag, array_of_statuses);
-    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-
-    /* ... end of body of routine ... */
-    
-  fn_exit:
     
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TESTALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);

--- a/src/mpi/request/testall.c
+++ b/src/mpi/request/testall.c
@@ -44,12 +44,10 @@ int MPIR_Testall_impl(int count, MPIR_Request *request_ptrs[], int *flag,
     mpi_errno = MPID_Progress_test();
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 
-    for (i = 0; i < count; i++)
-    {
+    for (i = 0; i < count; i++) {
         if (request_ptrs[i] != NULL &&
                 request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-        {
+                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
             mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
                     &(array_of_statuses[i]));
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
@@ -109,8 +107,8 @@ program to unexecpectedly terminate or produce incorrect results.
 .N MPI_ERR_REQUEST
 .N MPI_ERR_ARG
 @*/
-int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, 
-		MPI_Status array_of_statuses[])
+int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
+                MPI_Status array_of_statuses[])
 {
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
@@ -124,7 +122,7 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TESTALL);
 
@@ -133,21 +131,21 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-        int i = 0;
+            int i = 0;
 
-	    MPIR_ERRTEST_COUNT(count, mpi_errno);
+            MPIR_ERRTEST_COUNT(count, mpi_errno);
 
-	    if (count != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		/* NOTE: MPI_STATUSES_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
+            if (count != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                /* NOTE: MPI_STATUSES_IGNORE != NULL */
+                MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
+            }
+            MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
 
-	    for (i = 0; i < count; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
+            for (i = 0; i < count; i++) {
+                MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+            }
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
@@ -156,32 +154,28 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     MPIR_CHKLMEM_DECL(1);
 
     /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **,
                 count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_completed = 0;
-    for (i = 0; i < count; i++)
-    {
-        if (array_of_requests[i] != MPI_REQUEST_NULL)
-        {
+    for (i = 0; i < count; i++) {
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
             MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
             /* Validate object pointers if error checking is enabled */
 #           ifdef HAVE_ERROR_CHECKING
             {
                 MPID_BEGIN_ERROR_CHECKS;
                 {
-                    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
                     if (mpi_errno) goto fn_fail;
                 }
                 MPID_END_ERROR_CHECKS;
             }
 #           endif
         }
-        else
-        {
+        else {
             request_ptrs[i] = NULL;
             n_completed += 1;
         }
@@ -190,24 +184,19 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     mpi_errno = MPID_Testall(count, request_ptrs, flag, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 
-    for (i = 0; i < count; i++)
-    {
-        if (request_ptrs[i] != NULL)
-        {
-            if (MPIR_Request_is_complete(request_ptrs[i]))
-            {
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] != NULL) {
+            if (MPIR_Request_is_complete(request_ptrs[i])) {
                 n_completed++;
                 rc = MPIR_Request_get_error(request_ptrs[i]);
-                if (rc != MPI_SUCCESS)
-                {
+                if (rc != MPI_SUCCESS) {
                     if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc) || MPIX_ERR_PROC_FAILED_PENDING == MPIR_ERR_GET_CLASS(rc))
                         proc_failure = TRUE;
                     mpi_errno = MPI_ERR_IN_STATUS;
                 }
             } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm)))
-            {
+                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
                 mpi_errno = MPI_ERR_IN_STATUS;
                 MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                 status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
@@ -217,51 +206,34 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
         }
     }
 
-    if (n_completed == count || mpi_errno == MPI_ERR_IN_STATUS)
-    {
+    if (n_completed == count || mpi_errno == MPI_ERR_IN_STATUS) {
         n_completed = 0;
-        for (i = 0; i < count; i++)
-        {
-            if (request_ptrs[i] != NULL)
-            {
-                if (MPIR_Request_is_complete(request_ptrs[i]))
-                {
+        for (i = 0; i < count; i++) {
+            if (request_ptrs[i] != NULL) {
+                if (MPIR_Request_is_complete(request_ptrs[i])) {
                     n_completed ++;
                     status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
                     rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
-                    if (mpi_errno == MPI_ERR_IN_STATUS && status_ptr != MPI_STATUS_IGNORE)
-                    {
+                    if (mpi_errno == MPI_ERR_IN_STATUS && status_ptr != MPI_STATUS_IGNORE) {
                         if (active_flag)
-                        {
                             status_ptr->MPI_ERROR = rc;
-                        }
                         else
-                        {
                             status_ptr->MPI_ERROR = MPI_SUCCESS;
-                        }
                     }
-                }
-                else
-                {
-                    if (mpi_errno == MPI_ERR_IN_STATUS && array_of_statuses != MPI_STATUSES_IGNORE)
-                    {
+                } else {
+                    if (mpi_errno == MPI_ERR_IN_STATUS && array_of_statuses != MPI_STATUSES_IGNORE) {
                         if (!proc_failure)
                             array_of_statuses[i].MPI_ERROR = MPI_ERR_PENDING;
                         else
                             array_of_statuses[i].MPI_ERROR = MPIX_ERR_PROC_FAILED_PENDING;
                     }
                 }
-            }
-            else
-            {
+            } else {
                 n_completed ++;
-                if (array_of_statuses != MPI_STATUSES_IGNORE)
-                {
+                if (array_of_statuses != MPI_STATUSES_IGNORE) {
                     MPIR_Status_set_empty(&array_of_statuses[i]);
                     if (mpi_errno == MPI_ERR_IN_STATUS)
-                    {
                         array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-                    }
                 }
             }
         }
@@ -270,13 +242,12 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     *flag = (n_completed == count) ? TRUE : FALSE;
 
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_FREEALL();
     }
-    
+
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TESTALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
@@ -285,9 +256,9 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
     /* --BEGIN ERROR HANDLING-- */
 #   ifdef HAVE_ERROR_CHECKING
     {
-	mpi_errno = MPIR_Err_create_code(
-	    mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testall",
-	    "**mpi_testall %d %p %p %p", count, array_of_requests, flag, array_of_statuses);
+        mpi_errno = MPIR_Err_create_code(
+            mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testall",
+            "**mpi_testall %d %p %p %p", count, array_of_requests, flag, array_of_statuses);
     }
 #   endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);

--- a/src/mpi/request/testall.c
+++ b/src/mpi/request/testall.c
@@ -35,7 +35,7 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
 #define FUNCNAME MPIR_Testall_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
+int MPIR_Testall_impl(int count, MPIR_Request *request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[])
 {
     int i;
@@ -187,7 +187,7 @@ int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag,
         }
     }
 
-    mpi_errno = MPID_Progress_test();
+    mpi_errno = MPID_Testall(count, request_ptrs, flag, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
 
     for (i = 0; i < count; i++)

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -188,7 +188,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     *flag = FALSE;
     *indx = MPI_UNDEFINED;
     
-    mpi_errno = MPIR_Testany_impl(count, request_ptrs, flag, indx, status);
+    mpi_errno = MPID_Testany(count, request_ptrs, flag, indx, status);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
     {

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -43,17 +43,13 @@ int MPIR_Testany_impl(int count, MPIR_Request *request_ptrs[], int *indx,
     mpi_errno = MPID_Progress_test();
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
-    {
         goto fn_fail;
-    }
     /* --END ERROR HANDLING-- */
 
-    for (i = 0; i < count; i++)
-    {
+    for (i = 0; i < count; i++) {
         if (request_ptrs[i] != NULL &&
             request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-        {
+            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
             mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
                                                              status);
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
@@ -103,7 +99,7 @@ program to unexecpectedly terminate or produce incorrect results.
 .N MPI_SUCCESS
 @*/
 int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
-		int *flag, MPI_Status *status)
+                int *flag, MPI_Status *status)
 {
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
@@ -116,7 +112,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTANY);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TESTANY);
 
@@ -125,100 +121,85 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_COUNT(count, mpi_errno);
+            MPIR_ERRTEST_COUNT(count, mpi_errno);
 
-	    if (count != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		/* NOTE: MPI_STATUS_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(indx, "indx", mpi_errno);
-	    MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
-	    
-	    for (i = 0; i < count; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
+            if (count != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                /* NOTE: MPI_STATUS_IGNORE != NULL */
+                MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            }
+            MPIR_ERRTEST_ARGNULL(indx, "indx", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(flag, "flag", mpi_errno);
+
+            for (i = 0; i < count; i++) {
+                MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+            }
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
-    
+
     /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_inactive = 0;
-    for (i = 0; i < count; i++)
-    {
-	if (array_of_requests[i] != MPI_REQUEST_NULL)
-	{
-	    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-	    /* Validate object pointers if error checking is enabled */
+    for (i = 0; i < count; i++) {
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
+            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            /* Validate object pointers if error checking is enabled */
 #           ifdef HAVE_ERROR_CHECKING
-	    {
-		MPID_BEGIN_ERROR_CHECKS;
-		{
-		    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-		    if (mpi_errno) goto fn_fail;
-		}
-		MPID_END_ERROR_CHECKS;
-	    }
-#           endif	    
-	}
-	else
-	{
-	    request_ptrs[i] = NULL;
-	    n_inactive += 1;
-	}
+            {
+                MPID_BEGIN_ERROR_CHECKS;
+                {
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
+                    if (mpi_errno) goto fn_fail;
+                }
+                MPID_END_ERROR_CHECKS;
+            }
+#           endif
+        } else {
+            request_ptrs[i] = NULL;
+            n_inactive += 1;
+        }
     }
 
-    if (n_inactive == count)
-    {
-	*flag = TRUE;
-	*indx = MPI_UNDEFINED;
-	if (status != NULL)  /* could be null if count=0 */
-	    MPIR_Status_set_empty(status);
-	goto fn_exit;
+    if (n_inactive == count) {
+        *flag = TRUE;
+        *indx = MPI_UNDEFINED;
+        if (status != NULL)  /* could be null if count=0 */
+            MPIR_Status_set_empty(status);
+        goto fn_exit;
     }
-    
+
     *flag = FALSE;
     *indx = MPI_UNDEFINED;
-    
+
     mpi_errno = MPID_Testany(count, request_ptrs, flag, indx, status);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
-    {
-	goto fn_fail;
-    }
+        goto fn_fail;
     /* --END ERROR HANDLING-- */
-	
-    for (i = 0; i < count; i++)
-    {
-        if (request_ptrs[i] != NULL)
-        {
-            if (MPIR_Request_is_complete(request_ptrs[i]))
-            {
+
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] != NULL) {
+            if (MPIR_Request_is_complete(request_ptrs[i])) {
                 mpi_errno = MPIR_Request_complete(&array_of_requests[i],
                         request_ptrs[i],
                         status, &active_flag);
-                if (active_flag)
-                {
+                if (active_flag) {
                     *flag = TRUE;
                     *indx = i;
                     goto fn_exit;
-                }
-                else
-                {
+                } else {
                     n_inactive += 1;
                 }
             } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm)))
-            {
+                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
                 last_disabled_anysource = i;
             }
         }
@@ -226,27 +207,24 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
 
     /* If none of the requests completed, mark the last anysource request as
      * pending failure. */
-    if (unlikely(last_disabled_anysource != -1))
-    {
+    if (unlikely(last_disabled_anysource != -1)) {
         MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
         if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
         *flag = TRUE;
         goto fn_fail;
     }
-    
-    if (n_inactive == count)
-    {
-	*flag = TRUE;
-	*indx = MPI_UNDEFINED;
-	/* status set to empty by MPIR_Request_complete() */
+
+    if (n_inactive == count) {
+        *flag = TRUE;
+        *indx = MPI_UNDEFINED;
+        /* status set to empty by MPIR_Request_complete() */
     }
-    
+
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_FREEALL();
     }
 
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TESTANY);
@@ -257,9 +235,9 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     /* --BEGIN ERROR HANDLING-- */
 #   ifdef HAVE_ERROR_CHECKING
     {
-	mpi_errno = MPIR_Err_create_code(
-	    mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testany",
-	    "**mpi_testany %d %p %p %p %p", count, array_of_requests, indx, flag, status);
+        mpi_errno = MPIR_Err_create_code(
+            mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testany",
+            "**mpi_testany %d %p %p %p %p", count, array_of_requests, indx, flag, status);
     }
 #   endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);

--- a/src/mpi/request/testsome.c
+++ b/src/mpi/request/testsome.c
@@ -46,12 +46,10 @@ int MPIR_Testsome_impl(int incount, MPIR_Request *request_ptrs[], int *outcount,
         goto fn_fail;
     /* --END ERROR HANDLING-- */
 
-    for (i = 0; i < incount; i++)
-    {
+    for (i = 0; i < incount; i++) {
         if (request_ptrs[i] != NULL &&
             request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-        {
+            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
             mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state,
                                                              array_of_statuses);
             if (mpi_errno != MPI_SUCCESS) goto fn_fail;
@@ -101,8 +99,8 @@ program to unexecpectedly terminate or produce incorrect results.
 .N MPI_ERR_IN_STATUS
 
 @*/
-int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, 
-		 int array_of_indices[], MPI_Status array_of_statuses[])
+int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
+                 int array_of_indices[], MPI_Status array_of_statuses[])
 {
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
@@ -117,7 +115,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TESTSOME);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_TESTSOME);
 
@@ -126,108 +124,90 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_COUNT(incount, mpi_errno);
+            MPIR_ERRTEST_COUNT(incount, mpi_errno);
 
-	    if (incount != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		MPIR_ERRTEST_ARGNULL(array_of_indices, "array_of_indices", mpi_errno);
-		/* NOTE: MPI_STATUSES_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(outcount, "outcount", mpi_errno);
- 
-	    for (i = 0; i < incount; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
+            if (incount != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                MPIR_ERRTEST_ARGNULL(array_of_indices, "array_of_indices", mpi_errno);
+                /* NOTE: MPI_STATUSES_IGNORE != NULL */
+                MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
+            }
+            MPIR_ERRTEST_ARGNULL(outcount, "outcount", mpi_errno);
+
+            for (i = 0; i < incount; i++) {
+                MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+            }
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* ... body of routine ... */
-    
+
     *outcount = 0;
-    
+
     /* Convert MPI request handles to a request object pointers */
-    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
     n_inactive = 0;
-    for (i = 0; i < incount; i++)
-    {
-	if (array_of_requests[i] != MPI_REQUEST_NULL)
-	{
-	    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-	    /* Validate object pointers if error checking is enabled */
+    for (i = 0; i < incount; i++) {
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
+            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            /* Validate object pointers if error checking is enabled */
 #           ifdef HAVE_ERROR_CHECKING
-	    {
-		MPID_BEGIN_ERROR_CHECKS;
-		{
-		    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-		    if (mpi_errno) goto fn_fail;
-		}
-		MPID_END_ERROR_CHECKS;
-	    }
-#           endif	    
-	}
-	else
-	{
-	    request_ptrs[i] = NULL;
-	    n_inactive += 1;
-	}
+            {
+                MPID_BEGIN_ERROR_CHECKS;
+                {
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
+                    if (mpi_errno) goto fn_fail;
+                }
+                MPID_END_ERROR_CHECKS;
+            }
+#           endif
+        } else {
+            request_ptrs[i] = NULL;
+            n_inactive += 1;
+        }
     }
 
-    if (n_inactive == incount)
-    {
-	*outcount = MPI_UNDEFINED;
-	goto fn_exit;
+    if (n_inactive == incount) {
+        *outcount = MPI_UNDEFINED;
+        goto fn_exit;
     }
-    
+
     n_active = 0;
-    
+
     mpi_errno = MPID_Testsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
-	goto fn_fail;
+        goto fn_fail;
     /* --END ERROR HANDLING-- */
 
-    for (i = 0; i < incount; i++)
-    {
+    for (i = 0; i < incount; i++) {
         status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
-        if (request_ptrs[i] != NULL)
-        {
-            if (MPIR_Request_is_complete(request_ptrs[i]))
-            {
+        if (request_ptrs[i] != NULL) {
+            if (MPIR_Request_is_complete(request_ptrs[i])) {
                 rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
-                if (active_flag)
-                {
+                if (active_flag) {
                     array_of_indices[n_active] = i;
                     n_active += 1;
 
-                    if (rc == MPI_SUCCESS)
-                    {
+                    if (rc == MPI_SUCCESS) {
                         request_ptrs[i] = NULL;
-                    }
-                    else
-                    {
+                    } else {
                         mpi_errno = MPI_ERR_IN_STATUS;
                         if (status_ptr != MPI_STATUS_IGNORE)
-                        {
                             status_ptr->MPI_ERROR = rc;
-                        }
                     }
-                }
-                else
-                {
+                } else {
                     request_ptrs[i] = NULL;
                     n_inactive += 1;
                 }
             } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm)))
-            {
+                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
                 mpi_errno = MPI_ERR_IN_STATUS;
                 MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                 status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
@@ -236,37 +216,27 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
         }
     }
 
-    if (mpi_errno == MPI_ERR_IN_STATUS)
-    {
-	if (array_of_statuses != MPI_STATUSES_IGNORE)
-	{ 
-	    for (i = 0; i < n_active; i++)
-	    {
-		if (request_ptrs[array_of_indices[i]] == NULL)
-		{ 
-		    array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-		}
-	    }
-	}
-	*outcount = n_active;
-    }
-    else if (n_active > 0)
-    {
-	*outcount = n_active;
-    }
-    else if (n_inactive == incount)
-    {
-	*outcount = MPI_UNDEFINED;
+    if (mpi_errno == MPI_ERR_IN_STATUS) {
+        if (array_of_statuses != MPI_STATUSES_IGNORE) {
+            for (i = 0; i < n_active; i++) {
+                if (request_ptrs[array_of_indices[i]] == NULL)
+                    array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            }
+        }
+        *outcount = n_active;
+    } else if (n_active > 0) {
+        *outcount = n_active;
+    } else if (n_inactive == incount) {
+        *outcount = MPI_UNDEFINED;
     }
 
     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-    
+
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
+    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_FREEALL();
     }
 
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_TESTSOME);
@@ -277,9 +247,9 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     /* --BEGIN ERROR HANDLING-- */
 #   ifdef HAVE_ERROR_CHECKING
     {
-	mpi_errno = MPIR_Err_create_code(
-	    mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testsome",
-	    "**mpi_testsome %d %p %p %p %p", incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
+        mpi_errno = MPIR_Err_create_code(
+            mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, "**mpi_testsome",
+            "**mpi_testsome %d %p %p %p %p", incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
     }
 #   endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);

--- a/src/mpi/request/testsome.c
+++ b/src/mpi/request/testsome.c
@@ -187,7 +187,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
     
     n_active = 0;
     
-    mpi_errno = MPIR_Testsome_impl(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
+    mpi_errno = MPID_Testsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
 	goto fn_fail;

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -28,20 +28,10 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status) __attribute__((weak,alias
 #define FUNCNAME MPIR_Wait_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status)
+int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
     int active_flag;
-    MPIR_Request *request_ptr = NULL;
-
-    /* If this is a null request handle, then return an empty status */
-    if (*request == MPI_REQUEST_NULL)
-    {
-	MPIR_Status_set_empty(status);
-	goto fn_exit;
-    }
-
-    MPIR_Request_get_ptr(*request, request_ptr);
 
     if (!MPIR_Request_is_complete(request_ptr))
     {
@@ -95,9 +85,6 @@ int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status)
 	}
 	MPID_Progress_end(&progress_state);
     }
-
-    mpi_errno = MPIR_Request_complete(request, request_ptr, status, &active_flag);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     
  fn_exit:
     return mpi_errno;
@@ -138,6 +125,7 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     MPIR_Request * request_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm * comm_ptr = NULL;
+    int active_flag;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAIT);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -186,8 +174,10 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     /* save copy of comm because request will be freed */
     if (request_ptr)
         comm_ptr = request_ptr->comm;
-    mpi_errno = MPIR_Wait_impl(request, status);
+    mpi_errno = MPIR_Wait_impl(request_ptr, status);
     if (mpi_errno) goto fn_fail;
+    mpi_errno = MPIR_Request_complete(request, request_ptr, status, &active_flag);
+    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     /* ... end of body of routine ... */
     

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -33,9 +33,8 @@ int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status)
     int mpi_errno = MPI_SUCCESS;
     int active_flag;
 
-    if (!MPIR_Request_is_complete(request_ptr))
-    {
-	MPID_Progress_state progress_state;
+    if (!MPIR_Request_is_complete(request_ptr)) {
+        MPID_Progress_state progress_state;
 
         /* If this is an anysource request including a communicator with
          * anysource disabled, convert the call to an MPI_Test instead so we
@@ -47,30 +46,28 @@ int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status)
             goto fn_exit;
         }
 
-	MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(request_ptr))
-	{
-	    mpi_errno = MPIR_Grequest_progress_poke(1, &request_ptr, status);
-	    if (request_ptr->kind == MPIR_REQUEST_KIND__GREQUEST &&
-                request_ptr->u.ureq.greq_fns->wait_fn != NULL)
-	    {
-		if (mpi_errno) {
-		    /* --BEGIN ERROR HANDLING-- */
-		    MPID_Progress_end(&progress_state);
+        MPID_Progress_start(&progress_state);
+        while (!MPIR_Request_is_complete(request_ptr)) {
+            mpi_errno = MPIR_Grequest_progress_poke(1, &request_ptr, status);
+            if (request_ptr->kind == MPIR_REQUEST_KIND__GREQUEST &&
+                request_ptr->u.ureq.greq_fns->wait_fn != NULL) {
+                if (mpi_errno) {
+                    /* --BEGIN ERROR HANDLING-- */
+                    MPID_Progress_end(&progress_state);
                     MPIR_ERR_POP(mpi_errno);
                     /* --END ERROR HANDLING-- */
-		}
-		continue; /* treating UREQUEST like normal request means we'll
-			     poll indefinitely. skip over progress_wait */
-	    }
+                }
+                continue; /* treating UREQUEST like normal request means we'll
+                             poll indefinitely. skip over progress_wait */
+            }
 
-	    mpi_errno = MPID_Progress_wait(&progress_state);
-	    if (mpi_errno) {
-		/* --BEGIN ERROR HANDLING-- */
-		MPID_Progress_end(&progress_state);
+            mpi_errno = MPID_Progress_wait(&progress_state);
+            if (mpi_errno) {
+                /* --BEGIN ERROR HANDLING-- */
+                MPID_Progress_end(&progress_state);
                 MPIR_ERR_POP(mpi_errno);
-		/* --END ERROR HANDLING-- */
-	    }
+                /* --END ERROR HANDLING-- */
+            }
 
             if (unlikely(
                         MPIR_CVAR_ENABLE_FT &&
@@ -82,10 +79,10 @@ int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status)
                 if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
                 goto fn_fail;
             }
-	}
-	MPID_Progress_end(&progress_state);
+        }
+        MPID_Progress_end(&progress_state);
     }
-    
+
  fn_exit:
     return mpi_errno;
  fn_fail:
@@ -102,7 +99,7 @@ int MPIR_Wait_impl(MPIR_Request *request_ptr, MPI_Status *status)
     MPI_Wait - Waits for an MPI request to complete
 
 Input Parameters:
-. request - request (handle) 
+. request - request (handle)
 
 Output Parameters:
 . status - status object (Status).  May be 'MPI_STATUS_IGNORE'.
@@ -129,7 +126,7 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAIT);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAIT);
 
@@ -138,31 +135,30 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
-	    /* NOTE: MPI_STATUS_IGNORE != NULL */
-	    MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
-	    MPIR_ERRTEST_REQUEST_OR_NULL(*request, mpi_errno);
-	}
+            MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
+            /* NOTE: MPI_STATUS_IGNORE != NULL */
+            MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            MPIR_ERRTEST_REQUEST_OR_NULL(*request, mpi_errno);
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* If this is a null request handle, then return an empty status */
-    if (*request == MPI_REQUEST_NULL)
-    {
-	MPIR_Status_set_empty(status);
-	goto fn_exit;
+    if (*request == MPI_REQUEST_NULL) {
+        MPIR_Status_set_empty(status);
+        goto fn_exit;
     }
-    
+
     /* Convert MPI request handle to a request object pointer */
     MPIR_Request_get_ptr(*request, request_ptr);
-    
+
     /* Validate object pointers if error checking is enabled */
 #   ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Request_valid_ptr( request_ptr, mpi_errno );
+            MPIR_Request_valid_ptr(request_ptr, mpi_errno);
             if (mpi_errno) goto fn_fail;
         }
         MPID_END_ERROR_CHECKS;
@@ -180,19 +176,19 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
 
     /* ... end of body of routine ... */
-    
+
   fn_exit:
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAIT);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
-	
+
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
-    mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, 
-				     FCNAME, __LINE__, MPI_ERR_OTHER,
-				     "**mpi_wait", "**mpi_wait %p %p", 
-				     request, status);
+    mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE,
+                                     FCNAME, __LINE__, MPI_ERR_OTHER,
+                                     "**mpi_wait", "**mpi_wait %p %p",
+                                     request, status);
 #endif
     mpi_errno = MPIR_Err_return_comm(comm_ptr, FCNAME, mpi_errno);
     goto fn_exit;

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -174,7 +174,7 @@ int MPI_Wait(MPI_Request *request, MPI_Status *status)
     /* save copy of comm because request will be freed */
     if (request_ptr)
         comm_ptr = request_ptr->comm;
-    mpi_errno = MPIR_Wait_impl(request_ptr, status);
+    mpi_errno = MPID_Wait(request_ptr, status);
     if (mpi_errno) goto fn_fail;
     mpi_errno = MPIR_Request_complete(request, request_ptr, status, &active_flag);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -53,7 +53,7 @@ int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status)
         if (unlikely(MPIR_CVAR_ENABLE_FT &&
                     MPID_Request_is_anysource(request_ptr) &&
                     !MPID_Comm_AS_enabled(request_ptr->comm))) {
-            mpi_errno = MPIR_Test_impl(request, &active_flag, status);
+            mpi_errno = MPIR_Test_impl(request_ptr, &active_flag, status);
             goto fn_exit;
         }
 

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -53,7 +53,7 @@ int MPIR_Wait_impl(MPI_Request *request, MPI_Status *status)
         if (unlikely(MPIR_CVAR_ENABLE_FT &&
                     MPID_Request_is_anysource(request_ptr) &&
                     !MPID_Comm_AS_enabled(request_ptr->comm))) {
-            mpi_errno = MPIR_Test_impl(request_ptr, &active_flag, status);
+            mpi_errno = MPID_Test(request_ptr, &active_flag, status);
             goto fn_exit;
         }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -170,12 +170,12 @@ int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
   Setting statuses, freeing requests objects, etc.
 */
 #undef FUNCNAME
-#define FUNCNAME MPIR_Waitall_post
+#define FUNCNAME do_waitall_post
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
-                      MPIR_Request *request_ptrs[],
-                      MPI_Status array_of_statuses[])
+MPL_STATIC_INLINE_PREFIX int do_waitall_post(int count, MPI_Request array_of_requests[],
+                                             MPIR_Request *request_ptrs[],
+                                             MPI_Status array_of_statuses[])
 {
     int i, j;
     int mpi_errno = MPI_SUCCESS;
@@ -235,6 +235,18 @@ int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
     }
 
     return mpi_errno;
+}
+
+/* External entry point of do_waitall_post for users outside of this compile unit */
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitall_post
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request *request_ptrs[],
+                      MPI_Status array_of_statuses[])
+{
+    return do_waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
 }
 
 #undef FUNCNAME
@@ -387,7 +399,7 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     }
 
     /* ------ "slow" code path below ------ */
-    mpi_errno = MPIR_Waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
+    mpi_errno = do_waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
     if (mpi_errno)
         goto fn_fail;
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -147,7 +147,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
     }
 
     if (unlikely(disabled_anysource)) {
-        mpi_errno = MPIR_Testall_impl(count, array_of_requests, &disabled_anysource, array_of_statuses);
+        mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -67,57 +67,25 @@ static inline int request_complete_fastpath(MPI_Request *request, MPIR_Request *
 #define FUNCNAME MPIR_Waitall_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
+int MPIR_Waitall_impl(int count, MPIR_Request *request_ptrs[],
                       MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
-    MPIR_Request ** request_ptrs = request_ptr_array;
-    MPI_Status * status_ptr = NULL;
+    MPI_Status * status_ptr;
     MPID_Progress_state progress_state;
-    int i, j;
+    int i;
     int n_completed;
-    int active_flag;
     int rc = MPI_SUCCESS;
     int n_greqs;
-    int proc_failure = FALSE;
     int disabled_anysource = FALSE;
     const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
-    int optimize = ignoring_statuses; /* see NOTE-O1 */
-    MPIR_CHKLMEM_DECL(1);
-
-    /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
-    }
 
     n_greqs = 0;
     n_completed = 0;
     for (i = 0; i < count; i++)
     {
-	if (array_of_requests[i] != MPI_REQUEST_NULL)
+        if (request_ptrs[i] != NULL)
 	{
-	    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-	    /* Validate object pointers if error checking is enabled */
-#           ifdef HAVE_ERROR_CHECKING
-	    {
-		MPID_BEGIN_ERROR_CHECKS;
-		{
-		    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-                    MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
-                                         mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d", i);
-		}
-		MPID_END_ERROR_CHECKS;
-	    }
-#           endif
-            if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
-                request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND)
-            {
-                optimize = FALSE;
-            }
-
             if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST)
                 ++n_greqs;
 
@@ -133,11 +101,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
 	}
 	else
 	{
-	    status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
-	    MPIR_Status_set_empty(status_ptr);
-	    request_ptrs[i] = NULL;
 	    n_completed += 1;
-            optimize = FALSE;
 	}
     }
     
@@ -150,43 +114,6 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
         mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
-
-    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
-     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
-     * out as many unnecessary jumps and error handling as possible.
-     *
-     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
-     * additional branch inside the for-loop below. */
-    if (optimize) {
-        MPID_Progress_start(&progress_state);
-        for (i = 0; i < count; ++i) {
-            while (!MPIR_Request_is_complete(request_ptrs[i])) {
-                mpi_errno = MPID_Progress_wait(&progress_state);
-                /* must check and handle the error, can't guard with HAVE_ERROR_CHECKING, but it's
-                 * OK for the error case to be slower */
-                if (unlikely(mpi_errno)) {
-                    /* --BEGIN ERROR HANDLING-- */
-                    if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                MPID_Request_is_anysource(request_ptrs[i]) &&
-                                !MPIR_Request_is_complete(request_ptrs[i]) &&
-                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                        MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
-                    }
-                    MPID_Progress_end(&progress_state);
-                    MPIR_ERR_POP(mpi_errno);
-                    /* --END ERROR HANDLING-- */
-                }
-            }
-            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        }
-
-        MPID_Progress_end(&progress_state);
-
-        goto fn_exit;
-    }
-
-    /* ------ "slow" code path below ------ */
 
     /* Grequest_waitall may run the progress engine - thus, we don't 
        invoke progress_start until after running Grequest_waitall */
@@ -229,15 +156,55 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
                 MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                 status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
                 if (status_ptr != MPI_STATUS_IGNORE) status_ptr->MPI_ERROR = mpi_errno;
-                proc_failure = TRUE;
-                break;
+                mpi_errno = rc;
+                goto fn_fail;
             }
         }
+    }
+    MPID_Progress_end(&progress_state);
 
-        if (MPIR_Request_is_complete(request_ptrs[i])) {
+ fn_exit:
+
+   return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
+#endif
+
+/*
+  Post-processing of MPI_Waitall
+  Setting statuses, freeing requests objects, etc.
+*/
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitall_post
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request *request_ptrs[],
+                      MPI_Status array_of_statuses[])
+{
+    int i, j;
+    int mpi_errno = MPI_SUCCESS;
+    int rc = MPI_SUCCESS;
+    const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
+    MPI_Status *status_ptr;
+    MPI_Request *req_hndl_ptr;
+
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] == NULL) {
+            if (!ignoring_statuses)
+                array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            continue;
+        }
+
+        if (MPIR_Request_is_complete(request_ptrs[i]))
+        {
+            int active_flag;
             /* complete the request and check the status */
             status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
-            rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
+            req_hndl_ptr = array_of_requests ? &array_of_requests[i] : NULL;
+            rc = MPIR_Request_complete(req_hndl_ptr, request_ptrs[i], status_ptr, &active_flag);
         }
 
         if (rc == MPI_SUCCESS)
@@ -248,13 +215,13 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
         }
         else
         {
+            int proc_failure = FALSE;
+
             /* req completed with an error */
             MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
 
-            if (!proc_failure) {
-                if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
-                    proc_failure = TRUE;
-            }
+            if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
+                proc_failure = TRUE;
 
             if (!ignoring_statuses)
             {
@@ -284,20 +251,9 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[],
             break;
         }
     }
-    MPID_Progress_end(&progress_state);
-        
- fn_exit:
-     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
-    }
 
-   return mpi_errno;
- fn_fail:
-    goto fn_exit;
+    return mpi_errno;
 }
-
-#endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitall
@@ -343,6 +299,12 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
 		MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
+    MPIR_Request ** request_ptrs = NULL;
+    MPI_Status *status_ptr;
+    int optimize = (array_of_statuses == MPI_STATUSES_IGNORE); /* see NOTE-O1 */
+    int i;
+    MPIR_CHKLMEM_DECL(1);
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -350,12 +312,18 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITALL);
 
+    /* Convert MPI request handles to a request object pointers */
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
+    } else {
+        request_ptrs = request_ptr_array;
+    }
+
     /* Check the arguments */
 #   ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            int i;
 	    MPIR_ERRTEST_COUNT(count, mpi_errno);
 
 	    if (count != 0) {
@@ -372,15 +340,81 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Waitall_impl(count, array_of_requests, array_of_statuses);
-    if (mpi_errno) goto fn_fail;
+    /* Translate array-of-request-handles to array-of-request-pointers */
+    for (i = 0; i < count; i++) {
+        if (array_of_requests[i] == MPI_REQUEST_NULL) {
+            request_ptrs[i] = NULL;
+            status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
+            MPIR_Status_set_empty(status_ptr);
+            optimize = FALSE;
+            continue;
+        }
+        MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+        /* Validate object pointers if error checking is enabled */
+#       ifdef HAVE_ERROR_CHECKING
+        {
+            MPID_BEGIN_ERROR_CHECKS;
+            {
+                MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
+                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
+                                     mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d", i);
+            }
+            MPID_END_ERROR_CHECKS;
+        }
+#       endif
+
+        /* Message rate optimization applies only to send/recv requests */
+        if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
+            request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND)
+            optimize = FALSE;
+    }
+
+    /* Make progress and wait for completion */
+    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    switch (mpi_errno) {
+    case MPI_SUCCESS:
+        break;
+
+    case MPIX_ERR_PROC_FAILED_PENDING:
+        optimize = FALSE;
+        break;
+
+    default:
+        goto fn_fail;
+    }
+
+    /* Free completed request objects */
+
+    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
+     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
+     * out as many unnecessary jumps and error handling as possible.
+     *
+     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
+     * additional branch inside the for-loop below. */
+    if (optimize) {
+        for (i = 0; i < count; i++) {
+            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+        goto fn_exit;
+    }
+
+    /* ------ "slow" code path below ------ */
+    mpi_errno = MPIR_Waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
+    if (mpi_errno)
+        goto fn_fail;
 
     /* ... end of body of routine ... */
     
  fn_exit:
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
+        MPIR_CHKLMEM_FREEALL();
+
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -374,7 +374,7 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[],
     }
 
     /* Make progress and wait for completion */
-    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    mpi_errno = MPID_Waitall(count, request_ptrs, array_of_statuses);
     switch (mpi_errno) {
     case MPI_SUCCESS:
         break;

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -23,21 +23,17 @@ int MPIR_Waitany_impl(int count, MPIR_Request *request_ptrs[], int *indx, MPI_St
     int i;
 
     MPID_Progress_start(&progress_state);
-    for(;;)
-    {
-        for (i = 0; i < count; i++)
-        {
+    for (;;) {
+        for (i = 0; i < count; i++) {
             if (request_ptrs[i] == NULL)
                 continue;
 
-            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST && request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-            {
+            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST && request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
                 /* this is a generalized request; make progress on it */
                 mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state, status);
                 if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
             }
-            if (MPIR_Request_is_complete(request_ptrs[i]))
-            {
+            if (MPIR_Request_is_complete(request_ptrs[i])) {
                 *indx = i;
                 goto break_l1;
             } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
@@ -49,8 +45,7 @@ int MPIR_Waitany_impl(int count, MPIR_Request *request_ptrs[], int *indx, MPI_St
 
         /* If none of the requests completed, mark the last anysource request
          * as pending failure and break out. */
-        if (unlikely(last_disabled_anysource != -1))
-        {
+        if (unlikely(last_disabled_anysource != -1)) {
             MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
             if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
             goto fn_progress_end_fail;
@@ -100,8 +95,8 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
     MPI_Waitany - Waits for any specified MPI Request to complete
 
 Input Parameters:
-+ count - list length (integer) 
-- array_of_requests - array of requests (array of handles) 
++ count - list length (integer)
+- array_of_requests - array of requests (array of handles)
 
 Output Parameters:
 + indx - index of handle for operation that completed (integer).  In the
@@ -128,7 +123,7 @@ program to unexecpectedly terminate or produce incorrect results.
 .N MPI_ERR_ARG
 @*/
 int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
-		MPI_Status *status)
+                MPI_Status *status)
 {
     static const char FCNAME[] = "MPI_Waitany";
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
@@ -143,7 +138,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITANY);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITANY);
 
@@ -152,15 +147,15 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_COUNT(count, mpi_errno);
+            MPIR_ERRTEST_COUNT(count, mpi_errno);
 
-	    if (count != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		/* NOTE: MPI_STATUS_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(indx, "indx", mpi_errno);
-	}
+            if (count != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                /* NOTE: MPI_STATUS_IGNORE != NULL */
+                MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            }
+            MPIR_ERRTEST_ARGNULL(indx, "indx", mpi_errno);
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
@@ -168,8 +163,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     /* ... body of routine ...  */
 
     /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
@@ -181,15 +175,14 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
         }
         MPID_END_ERROR_CHECKS;
 #endif /* HAVE_ERROR_CHECKING */
-        if (array_of_requests[i] != MPI_REQUEST_NULL)
-        {
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
             MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
             /* Validate object pointers if error checking is enabled */
 #ifdef HAVE_ERROR_CHECKING
             {
                 MPID_BEGIN_ERROR_CHECKS;
                 {
-                    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
                     if (mpi_errno != MPI_SUCCESS) goto fn_fail;
                 }
                 MPID_END_ERROR_CHECKS;
@@ -197,15 +190,13 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
 #endif
             found_nonnull_req = TRUE;
         }
-        else
-        {
+        else {
             request_ptrs[i] = NULL;
             ++n_inactive;
         }
     }
 
-    if (!found_nonnull_req)
-    {
+    if (!found_nonnull_req) {
         /* all requests were NULL */
         *indx = MPI_UNDEFINED;
         if (status != NULL)    /* could be null if count=0 */
@@ -222,18 +213,15 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
         mpi_errno = MPIR_Request_complete(&array_of_requests[i],
                                           request_ptrs[i], status,
                                           &active_flag);
-        if (active_flag)
-        {
+        if (active_flag) {
             *indx = i;
             goto fn_exit;
         }
-        else
-        {
+        else {
             ++n_inactive;
             request_ptrs[i] = NULL;
 
-            if (n_inactive == count)
-            {
+            if (n_inactive == count) {
                 *indx = MPI_UNDEFINED;
                 /* status is set to empty by MPIR_Request_complete */
                 goto fn_exit;
@@ -244,11 +232,10 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     }
 
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_FREEALL();
     }
 
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITANY);
@@ -258,11 +245,11 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
-    mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, 
-				     FCNAME, __LINE__, MPI_ERR_OTHER,
-				     "**mpi_waitany", 
-				     "**mpi_waitany %d %p %p %p", 
-				     count, array_of_requests, indx, status);
+    mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE,
+                                     FCNAME, __LINE__, MPI_ERR_OTHER,
+                                     "**mpi_waitany",
+                                     "**mpi_waitany %d %p %p %p",
+                                     count, array_of_requests, indx, status);
 #endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);
     goto fn_exit;

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -214,7 +214,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     }
 
     for (;;) {
-        mpi_errno = MPIR_Waitany_impl(count - off, request_ptrs + off, indx, status);
+        mpi_errno = MPID_Waitany(count - off, request_ptrs + off, indx, status);
         if (mpi_errno)
             goto fn_fail;
 

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -11,6 +11,68 @@
 #define MPIR_REQUEST_PTR_ARRAY_SIZE 16
 #endif
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitany
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitany_impl(int count, MPIR_Request *request_ptrs[], int *indx, MPI_Status *status)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPID_Progress_state progress_state;
+    int last_disabled_anysource = -1;
+    int i;
+
+    MPID_Progress_start(&progress_state);
+    for(;;)
+    {
+        for (i = 0; i < count; i++)
+        {
+            if (request_ptrs[i] == NULL)
+                continue;
+
+            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST && request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
+            {
+                /* this is a generalized request; make progress on it */
+                mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state, status);
+                if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
+            }
+            if (MPIR_Request_is_complete(request_ptrs[i]))
+            {
+                *indx = i;
+                goto break_l1;
+            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                        MPID_Request_is_anysource(request_ptrs[i]) &&
+                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+                last_disabled_anysource = i;
+            }
+        }
+
+        /* If none of the requests completed, mark the last anysource request
+         * as pending failure and break out. */
+        if (unlikely(last_disabled_anysource != -1))
+        {
+            MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+            if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
+            goto fn_progress_end_fail;
+        }
+
+	mpi_errno = MPID_Progress_test();
+	if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
+        /* Avoid blocking other threads since I am inside an infinite loop */
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    }
+  break_l1:
+    MPID_Progress_end(&progress_state);
+
+  fn_exit:
+    return mpi_errno;
+
+  fn_progress_end_fail:
+    MPID_Progress_end(&progress_state);
+
+    goto fn_exit;
+}
+
 /* -- Begin Profiling Symbol Block for routine MPI_Waitany */
 #if defined(HAVE_PRAGMA_WEAK)
 #pragma weak MPI_Waitany = PMPI_Waitany
@@ -33,7 +95,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitany
-
+#undef FCNAME
 /*@
     MPI_Waitany - Waits for any specified MPI Request to complete
 
@@ -71,14 +133,12 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     static const char FCNAME[] = "MPI_Waitany";
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
-    MPID_Progress_state progress_state;
     int i;
-    int n_inactive;
+    int n_inactive = 0;
     int active_flag;
-    int init_req_array;
-    int found_nonnull_req;
-    int last_disabled_anysource = -1;
+    int found_nonnull_req = FALSE;
     int mpi_errno = MPI_SUCCESS;
+    int off = 0;
     MPIR_CHKLMEM_DECL(1);
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITANY);
 
@@ -104,120 +164,84 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* ... body of routine ...  */
-    
+
     /* Convert MPI request handles to a request object pointers */
     if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
     {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
-    n_inactive = 0;
-    init_req_array = TRUE;
-    found_nonnull_req = FALSE;
-    
-    MPID_Progress_start(&progress_state);
-    for(;;)
-    {
-	for (i = 0; i < count; i++)
-	{
-            if (init_req_array)
-            {   
+    for (i = 0; i < count; i++) {
 #ifdef HAVE_ERROR_CHECKING
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+        }
+        MPID_END_ERROR_CHECKS;
+#endif /* HAVE_ERROR_CHECKING */
+        if (array_of_requests[i] != MPI_REQUEST_NULL)
+        {
+            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            /* Validate object pointers if error checking is enabled */
+#ifdef HAVE_ERROR_CHECKING
+            {
                 MPID_BEGIN_ERROR_CHECKS;
                 {
-                    MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+                    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
+                    if (mpi_errno != MPI_SUCCESS) goto fn_fail;
                 }
                 MPID_END_ERROR_CHECKS;
-#endif /* HAVE_ERROR_CHECKING */
-                if (array_of_requests[i] != MPI_REQUEST_NULL)
-                {
-                    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-                    /* Validate object pointers if error checking is enabled */
-#ifdef HAVE_ERROR_CHECKING
-                    {
-                        MPID_BEGIN_ERROR_CHECKS;
-                        {
-                            MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-                            if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
-                        }
-                        MPID_END_ERROR_CHECKS;
-                    }
-#endif	    
-                }
-                else
-                {
-                    request_ptrs[i] = NULL;
-                    ++n_inactive;
-                }
             }
-            if (request_ptrs[i] == NULL)
-                continue;
-            /* we found at least one non-null request */
+#endif
             found_nonnull_req = TRUE;
-
-            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST && request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL)
-	    {
-                /* this is a generalized request; make progress on it */
-                mpi_errno = (request_ptrs[i]->u.ureq.greq_fns->poll_fn)(request_ptrs[i]->u.ureq.greq_fns->grequest_extra_state, status);
-		if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
-	    }
-            if (MPIR_Request_is_complete(request_ptrs[i]))
-	    {
-		mpi_errno = MPIR_Request_complete(&array_of_requests[i], 
-						  request_ptrs[i], status, 
-						  &active_flag);
-		if (active_flag)
-		{
-		    *indx = i;
-		    goto break_l1;
-		}
-		else
-		{
-		    ++n_inactive;
-		    request_ptrs[i] = NULL;
-
-		    if (n_inactive == count)
-		    {
-			*indx = MPI_UNDEFINED;
-			/* status is set to empty by MPIR_Request_complete */
-			goto break_l1;
-		    }
-		}
-            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                        MPID_Request_is_anysource(request_ptrs[i]) &&
-                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                last_disabled_anysource = i;
-            }
-	}
-        init_req_array = FALSE;
-
-        if (!found_nonnull_req)
-        {
-            /* all requests were NULL */
-            *indx = MPI_UNDEFINED;
-            if (status != NULL)    /* could be null if count=0 */
-                MPIR_Status_set_empty(status);
-            goto break_l1;
         }
-
-        /* If none of the requests completed, mark the last anysource request
-         * as pending failure and break out. */
-        if (unlikely(last_disabled_anysource != -1))
+        else
         {
-            MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-            if (status != MPI_STATUS_IGNORE) status->MPI_ERROR = mpi_errno;
-            goto fn_progress_end_fail;
+            request_ptrs[i] = NULL;
+            ++n_inactive;
         }
-
-	mpi_errno = MPID_Progress_test();
-	if (mpi_errno != MPI_SUCCESS) goto fn_progress_end_fail;
-    /* Avoid blocking other threads since I am inside an infinite loop */
-    MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
-  break_l1:
-    MPID_Progress_end(&progress_state);
+
+    if (!found_nonnull_req)
+    {
+        /* all requests were NULL */
+        *indx = MPI_UNDEFINED;
+        if (status != NULL)    /* could be null if count=0 */
+            MPIR_Status_set_empty(status);
+        goto fn_exit;
+    }
+
+    for (;;) {
+        mpi_errno = MPIR_Waitany_impl(count - off, request_ptrs + off, indx, status);
+        if (mpi_errno)
+            goto fn_fail;
+
+        i = *indx + off;
+        mpi_errno = MPIR_Request_complete(&array_of_requests[i],
+                                          request_ptrs[i], status,
+                                          &active_flag);
+        if (active_flag)
+        {
+            *indx = i;
+            goto fn_exit;
+        }
+        else
+        {
+            ++n_inactive;
+            request_ptrs[i] = NULL;
+
+            if (n_inactive == count)
+            {
+                *indx = MPI_UNDEFINED;
+                /* status is set to empty by MPIR_Request_complete */
+                goto fn_exit;
+            }
+        }
+        off = i + 1;
+        MPIR_Assert(off < count);
+    }
 
     /* ... end of body of routine ... */
     
@@ -230,9 +254,6 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx,
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITANY);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
-
-  fn_progress_end_fail:
-    MPID_Progress_end(&progress_state);
 
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -251,7 +251,7 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
         goto fn_exit;
     }
 
-    mpi_errno = MPIR_Waitsome_impl(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
+    mpi_errno = MPID_Waitsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS)
     {
 	/* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -47,8 +47,7 @@ int MPIR_Waitsome_impl(int incount, MPIR_Request *request_ptrs[], int *outcount,
        therefore, we kick the pipes once and then fall into a loop
        checking for completion and waiting for progress. */
     mpi_errno = MPID_Progress_test();
-    if (mpi_errno != MPI_SUCCESS)
-    {
+    if (mpi_errno != MPI_SUCCESS) {
         /* --BEGIN ERROR HANDLING-- */
         goto fn_fail;
         /* --END ERROR HANDLING-- */
@@ -56,27 +55,20 @@ int MPIR_Waitsome_impl(int incount, MPIR_Request *request_ptrs[], int *outcount,
 
     n_active = 0;
     MPID_Progress_start(&progress_state);
-    for(;;)
-    {
+    for (;;) {
         mpi_errno = MPIR_Grequest_progress_poke(incount,
                                                 request_ptrs, array_of_statuses);
         if (mpi_errno != MPI_SUCCESS) goto fn_fail;
-        for (i = 0; i < incount; i++)
-        {
-                if (request_ptrs[i] != NULL && MPIR_Request_is_complete(request_ptrs[i]))
-                {
-                        n_active += 1;
-                }
+        for (i = 0; i < incount; i++) {
+            if (request_ptrs[i] != NULL && MPIR_Request_is_complete(request_ptrs[i]))
+                n_active += 1;
         }
 
         if (n_active > 0)
-        {
             break;
-        }
 
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS)
-        {
+        if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */
             MPID_Progress_end(&progress_state);
             goto fn_fail;
@@ -131,8 +123,8 @@ However, 'MPI_Waitsome' only guarantees that at least one
 request has completed; there is no guarantee that `all` completed requests 
 will be returned, or that the entries in 'array_of_indices' will be in 
 increasing order. Also, requests that are completed while 'MPI_Waitsome' is
-executing may or may not be returned, depending on the timing of the 
-completion of the message.  
+executing may or may not be returned, depending on the timing of the
+completion of the message.
 
 .N waitstatus
 
@@ -146,9 +138,9 @@ completion of the message.
 .N MPI_ERR_ARG
 .N MPI_ERR_IN_STATUS
 @*/
-int MPI_Waitsome(int incount, MPI_Request array_of_requests[], 
-		 int *outcount, int array_of_indices[],
-		 MPI_Status array_of_statuses[])
+int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
+                 int *outcount, int array_of_indices[],
+                 MPI_Status array_of_statuses[])
 {
     MPIR_Request * request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request ** request_ptrs = request_ptr_array;
@@ -164,7 +156,7 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITSOME);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
-    
+
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITSOME);
 
@@ -173,55 +165,49 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-	    MPIR_ERRTEST_COUNT(incount, mpi_errno);
+            MPIR_ERRTEST_COUNT(incount, mpi_errno);
 
-	    if (incount != 0) {
-		MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
-		MPIR_ERRTEST_ARGNULL(array_of_indices, "array_of_indices", mpi_errno);
-		/* NOTE: MPI_STATUSES_IGNORE != NULL */
-		MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
-	    }
-	    MPIR_ERRTEST_ARGNULL(outcount, "outcount", mpi_errno);
+            if (incount != 0) {
+                MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
+                MPIR_ERRTEST_ARGNULL(array_of_indices, "array_of_indices", mpi_errno);
+                /* NOTE: MPI_STATUSES_IGNORE != NULL */
+                MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
+            }
+            MPIR_ERRTEST_ARGNULL(outcount, "outcount", mpi_errno);
 
-	    for (i = 0; i < incount; i++) {
-		MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
-	    }
-	}
+            for (i = 0; i < incount; i++) {
+                MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+            }
+        }
         MPID_END_ERROR_CHECKS;
     }
 #   endif /* HAVE_ERROR_CHECKING */
-    
+
     /* ... body of routine ...  */
-    
+
     *outcount = 0;
-    
+
     /* Convert MPI request handles to a request object pointers */
-    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
+    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC_ORJUMP(request_ptrs, MPIR_Request **, incount * sizeof(MPIR_Request *), mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
-    
+
     n_inactive = 0;
-    for (i = 0; i < incount; i++)
-    {
-	if (array_of_requests[i] != MPI_REQUEST_NULL)
-	{
-	    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-	    /* Validate object pointers if error checking is enabled */
+    for (i = 0; i < incount; i++) {
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
+            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            /* Validate object pointers if error checking is enabled */
 #           ifdef HAVE_ERROR_CHECKING
-	    {
-		MPID_BEGIN_ERROR_CHECKS;
-		{
-		    MPIR_Request_valid_ptr( request_ptrs[i], mpi_errno );
-		    if (mpi_errno != MPI_SUCCESS)
-		    {
-			goto fn_fail;
-		    }
-		    
-		}
-		MPID_END_ERROR_CHECKS;
-	    }
-#           endif	    
+            {
+                MPID_BEGIN_ERROR_CHECKS;
+                {
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
+                    if (mpi_errno != MPI_SUCCESS)
+                        goto fn_fail;
+                }
+                MPID_END_ERROR_CHECKS;
+            }
+#           endif
 
             /* If one of the requests is an anysource on a communicator that's
              * disabled such communication, convert this operation to a testall
@@ -232,18 +218,16 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
                 disabled_anysource = TRUE;
             }
-	}
-	else
-	{
-	    n_inactive += 1;
-	    request_ptrs[i] = NULL;
-	} 
+        }
+        else {
+            n_inactive += 1;
+            request_ptrs[i] = NULL;
+        }
     }
 
-    if (n_inactive == incount)
-    {
-	*outcount = MPI_UNDEFINED;
-	goto fn_exit;
+    if (n_inactive == incount) {
+        *outcount = MPI_UNDEFINED;
+        goto fn_exit;
     }
 
     if (unlikely(disabled_anysource)) {
@@ -252,85 +236,63 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     }
 
     mpi_errno = MPID_Waitsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
-    if (mpi_errno != MPI_SUCCESS)
-    {
-	/* --BEGIN ERROR HANDLING-- */
-	goto fn_fail;
-	/* --END ERROR HANDLING-- */
+    if (mpi_errno != MPI_SUCCESS) {
+        /* --BEGIN ERROR HANDLING-- */
+        goto fn_fail;
+        /* --END ERROR HANDLING-- */
     }
 
     n_active = 0;
-	for (i = 0; i < incount; i++)
-	{
-            if (request_ptrs[i] != NULL)
-	    {
-                if (MPIR_Request_is_complete(request_ptrs[i]))
-                {
-                    status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
-                    rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
-                    if (active_flag)
-                    {
-                        array_of_indices[n_active] = i;
-                        n_active += 1;
+    for (i = 0; i < incount; i++) {
+        if (request_ptrs[i] != NULL) {
+            if (MPIR_Request_is_complete(request_ptrs[i])) {
+                status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
+                rc = MPIR_Request_complete(&array_of_requests[i], request_ptrs[i], status_ptr, &active_flag);
+                if (active_flag) {
+                    array_of_indices[n_active] = i;
+                    n_active += 1;
 
-                        if (rc == MPI_SUCCESS)
-                        {
-                            request_ptrs[i] = NULL;
-                        }
-                        else
-                        {
-                            mpi_errno = MPI_ERR_IN_STATUS;
-                            if (status_ptr != MPI_STATUS_IGNORE)
-                            {
-                                status_ptr->MPI_ERROR = rc;
-                            }
-                        }
-                    }
-                    else
-                    {
+                    if (rc == MPI_SUCCESS) {
                         request_ptrs[i] = NULL;
-                        n_inactive += 1;
                     }
-                } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                            MPID_Request_is_anysource(request_ptrs[i]) &&
-                            !MPID_Comm_AS_enabled(request_ptrs[i]->comm)))
-                {
-                    mpi_errno = MPI_ERR_IN_STATUS;
-                    MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-                    status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
-                    if (status_ptr != MPI_STATUS_IGNORE) status_ptr->MPI_ERROR = rc;
+                    else {
+                        mpi_errno = MPI_ERR_IN_STATUS;
+                        if (status_ptr != MPI_STATUS_IGNORE)
+                            status_ptr->MPI_ERROR = rc;
+                    }
+                } else {
+                    request_ptrs[i] = NULL;
+                    n_inactive += 1;
                 }
+            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                                MPID_Request_is_anysource(request_ptrs[i]) &&
+                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+                mpi_errno = MPI_ERR_IN_STATUS;
+                MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+                status_ptr = (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
+                if (status_ptr != MPI_STATUS_IGNORE) status_ptr->MPI_ERROR = rc;
             }
-	}
+        }
+    }
 
-	if (mpi_errno == MPI_ERR_IN_STATUS)
-	{
-	    if (array_of_statuses != MPI_STATUSES_IGNORE)
-	    { 
-		for (i = 0; i < n_active; i++)
-		{
-		    if (request_ptrs[array_of_indices[i]] == NULL)
-		    { 
-			array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-		    }
-		}
-	    }
-	    *outcount = n_active;
-	}
-	else if (n_active > 0)
-	{
-	    *outcount = n_active;
-	}
-	else if (n_inactive == incount)
-	{
-	    *outcount = MPI_UNDEFINED;
-	}
+    if (mpi_errno == MPI_ERR_IN_STATUS) {
+        if (array_of_statuses != MPI_STATUSES_IGNORE) {
+            for (i = 0; i < n_active; i++) {
+                if (request_ptrs[array_of_indices[i]] == NULL)
+                    array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            }
+        }
+        *outcount = n_active;
+    } else if (n_active > 0) {
+        *outcount = n_active;
+    } else if (n_inactive == incount) {
+        *outcount = MPI_UNDEFINED;
+    }
     /* ... end of body of routine ... */
-    
+
   fn_exit:
-    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE)
-    {
-	MPIR_CHKLMEM_FREEALL();
+    if (incount > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_FREEALL();
     }
 
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITSOME);
@@ -341,10 +303,10 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
     mpi_errno = MPIR_Err_create_code(
-	mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER, 
-	"**mpi_waitsome", "**mpi_waitsome %d %p %p %p %p",
-	incount, array_of_requests, outcount, array_of_indices, 
-	array_of_statuses);
+        mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, MPI_ERR_OTHER,
+        "**mpi_waitsome", "**mpi_waitsome %d %p %p %p %p",
+        incount, array_of_requests, outcount, array_of_indices,
+        array_of_statuses);
 #endif
     mpi_errno = MPIR_Err_return_comm(NULL, FCNAME, mpi_errno);
     goto fn_exit;

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -180,6 +180,10 @@ static inline int MPID_Progress_test(void)
 /*
  * Device level MPI wait/test functions
  */
+#define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_imp
+#define MPID_Waitany MPIR_Waitany_impl
+#define MPID_Waitsome MPIR_Waitsome_impl
 #define MPID_Test MPIR_Test_impl
 #define MPID_Testall MPIR_Testall_impl
 #define MPID_Testany MPIR_Testany_impl

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -177,6 +177,14 @@ static inline int MPID_Progress_test(void)
 }
 #define MPID_Progress_poke()		     MPIDI_CH3_Progress_poke()
 
+/*
+ * Device level MPI wait/test functions
+ */
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
+
 /* Dynamic process support */
 int MPIDI_GPID_GetAllInComm( MPIR_Comm *comm_ptr, int local_size,
                              MPIDI_Gpid local_gpids[], int *singlePG );

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -727,7 +727,7 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
     win_ptr->at_completion_counter += post_grp_ptr->size;
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
-        MPI_Request *req;
+        MPIR_Request **req_ptrs;
         MPI_Status *status;
         int i, post_grp_size, dst, rank;
         MPIR_Comm *win_comm_ptr;
@@ -745,8 +745,8 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
-        MPIR_CHKLMEM_MALLOC(req, MPI_Request *, post_grp_size * sizeof(MPI_Request),
-                            mpi_errno, "req", MPL_MEM_RMA);
+        MPIR_CHKLMEM_MALLOC(req_ptrs, MPIR_Request **, post_grp_size * sizeof(MPIR_Request *),
+                            mpi_errno, "req_ptrs", MPL_MEM_RMA);
         MPIR_CHKLMEM_MALLOC(status, MPI_Status *, post_grp_size * sizeof(MPI_Status),
                             mpi_errno, "status", MPL_MEM_RMA);
 
@@ -755,19 +755,20 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
             dst = post_ranks_in_win_grp[i];
 
             if (dst != rank) {
-                MPIR_Request *req_ptr;
                 mpi_errno = MPID_Isend(&i, 0, MPI_INT, dst, SYNC_POST_TAG, win_comm_ptr,
-                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptr);
+                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptrs[i]);
                 if (mpi_errno != MPI_SUCCESS)
                     MPIR_ERR_POP(mpi_errno);
-                req[i] = req_ptr->handle;
             }
             else {
-                req[i] = MPI_REQUEST_NULL;
+                req_ptrs[i] = NULL;
             }
         }
 
-        mpi_errno = MPIR_Waitall_impl(post_grp_size, req, status);
+        mpi_errno = MPIR_Waitall_impl(post_grp_size, req_ptrs, status);
+        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIR_Waitall_post(post_grp_size, NULL, req_ptrs, status);
         if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
             MPIR_ERR_POP(mpi_errno);
 
@@ -862,7 +863,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
         int i, intra_cnt;
-        MPI_Request *intra_start_req = NULL;
+        MPIR_Request **intra_start_req = NULL;
         MPI_Status *intra_start_status = NULL;
         MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
         int rank = comm_ptr->rank;
@@ -872,8 +873,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
         /* post IRECVs */
         if (win_ptr->shm_allocated == TRUE) {
             int node_comm_size = comm_ptr->node_comm->local_size;
-            MPIR_CHKLMEM_MALLOC(intra_start_req, MPI_Request *,
-                                node_comm_size * sizeof(MPI_Request), mpi_errno, "intra_start_req", MPL_MEM_RMA);
+            MPIR_CHKLMEM_MALLOC(intra_start_req, MPIR_Request **,
+                                node_comm_size * sizeof(MPIR_Request *), mpi_errno, "intra_start_req", MPL_MEM_RMA);
             MPIR_CHKLMEM_MALLOC(intra_start_status, MPI_Status *,
                                 node_comm_size * sizeof(MPI_Status),
                                 mpi_errno, "intra_start_status", MPL_MEM_RMA);
@@ -895,7 +896,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
                     MPIR_ERR_POP(mpi_errno);
 
                 if (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id) {
-                    intra_start_req[intra_cnt++] = req_ptr->handle;
+                    intra_start_req[intra_cnt++] = req_ptr;
                 }
                 else {
                     if (!MPIR_Request_is_complete(req_ptr)) {
@@ -914,6 +915,10 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
             mpi_errno = MPIR_Waitall_impl(intra_cnt, intra_start_req, intra_start_status);
             if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
                 MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIR_Waitall_post(intra_cnt, NULL, intra_start_req, intra_start_status);
+            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+                MPIR_ERR_POP(mpi_errno);
+
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno == MPI_ERR_IN_STATUS) {
                 for (i = 0; i < intra_cnt; i++) {

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -26,6 +26,11 @@
  *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
  * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
  */
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
+
 #undef FUNCNAME
 #define FUNCNAME MPIDI_Progress_test
 #undef FCNAME
@@ -233,5 +238,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_DEACTIVATE);
     return mpi_errno;
 }
+
+/* Device level wait/test implementations */
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
 
 #endif /* CH4_PROGRESS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -244,5 +244,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
 #define MPID_Testall MPIR_Testall_impl
 #define MPID_Testany MPIR_Testany_impl
 #define MPID_Testsome MPIR_Testsome_impl
+#define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_impl
+#define MPID_Waitany MPIR_Waitany_impl
+#define MPID_Waitsome MPIR_Waitsome_impl
 
 #endif /* CH4_PROGRESS_H_INCLUDED */


### PR DESCRIPTION
This is based on PR #2742.
It improves the performance when dealing with large number of requests (by reducing cache misses with the cost of more instructions). It also removes an memory allocation, because the batch size is set to be the available stack buffers for internal requests.

This is WIP, any feedback to improve is appreciated.
(I also fixed the merge conflicts, see only this 3c7411e commit to track changes vs. original PR)
```
window=8192
<2742>
size | MB/s | Messages/s | TOT_INS | L1_DCM
1 | 0.77 | 772205.74 | 1204033.79 | 5069.38
2 | 1.53 | 766035.08 | 2408041.65 | 10116
4 | 2.98 | 746067.09 | 3612049.53 | 15103.13
8 | 6.10 | 761932.77 | 4816057.53 | 20157.45

<this PR>
size | MB/s | Messages/s | TOT_INS | L1_DCM
1 | 0.80 | 798943.71 | 1230194.72 | 1691.25
2 | 1.59 | 792737.86 | 2460361.73 | 3411.09
4 | 3.15 | 786491.78 | 3690528.71 | 5141.10
8 | 6.34 | 792034.11 | 4920695.91 | 6860.15

<master>
size | MB/s | Messages/s | TOT_INS | L1_DCM
1 | 0.78 | 779323.83 | 1163436.04 | 2781.15
2 | 1.56 | 780292.07 | 2326846.47 | 5629.61
4 | 3.15 | 786695.38 | 3490256.54 | 8484.65
8 | 6.34 | 791960.40 | 4653666.75 | 11321.55

window=64 (minimal difference)
<master>

Size | MB/s | Messages/s | TOT_INS | L1_DCM
1 | 0.89 | 886386.69 | 9940.47 | 23.20
2 | 1.81 | 904826.96 | 19853.69 | 46.15
4 | 3.67 | 917355.87 | 29766.89 | 67.70
8 | 7.30 | 911918.77 | 39680.12 | 88.24

<this PR>
Size | MB/s | Messages/s | TOT_INS | L1_DCM
1 | 0.90 | 900083.26 | 10193.47 | 20.20
2 | 1.78 | 890365.15 | 20359.67 | 40.70
4 | 3.68 | 919155.49 | 30525.87 | 62.06
8 | 7.37 | 921270.72 | 40692.07 | 82.91
```

