### PR TITLE
hwloc: null check for cpuset

### DIFF
--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -154,6 +154,7 @@ static int node_split_processor(MPIR_Comm * comm_ptr, int key, hwloc_obj_type_t 
 
     obj_containing_cpuset =
         hwloc_get_obj_covering_cpuset(MPIR_Process.topology, MPIR_Process.bindset);
+    MPIR_Assert(obj_containing_cpuset != NULL);
     if (obj_containing_cpuset->type == query_obj_type) {
         color = obj_containing_cpuset->logical_index;
     }


### PR DESCRIPTION
node_split_processor method queries for the hwloc object
covering the cpuset of a process. The returned object could be null
if the cpuset is empty or is not covered by the root of the hwloc
topology object. Hence, a null check on the returned hwloc object
of the binding query needs to be performed.