### PR TITLE
Infrastructure fix: is_single_node attribute elimination from MPIR_Comm structure

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -170,7 +170,6 @@ struct MPIR_Comm {
                         intercommunicator collective operations
                         that wish to use half-duplex operations
                         to implement a full-duplex operation */
-    int is_single_node;/* if a communicator is inside a single node */
 
     struct MPIR_Comm     *comm_next;/* Provides a chain through all active
 				       communicators */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -386,12 +386,6 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         MPIR_Assert(num_local > 1 || external_rank >= 0);
         MPIR_Assert(external_rank < 0 || external_procs != NULL);
 
-        /* check whether the communicator resides inside a node */
-        if (comm->local_size == num_local) {
-            comm->is_single_node = 1;
-        } else {
-            comm->is_single_node = 0;
-        }
         /* if the node_roots_comm and comm would be the same size, then creating
          * the second communicator is useless and wasteful. */
         if (num_external == comm->remote_size) {
@@ -411,7 +405,6 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
             comm->node_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
             comm->node_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE;
             comm->node_comm->local_comm = NULL;
-            comm->node_comm->is_single_node = 1;
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_comm=%p\n", comm->node_comm);
 
             comm->node_comm->local_size = num_local;
@@ -445,7 +438,6 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
             comm->node_roots_comm->local_comm = NULL;
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_roots_comm=%p\n", comm->node_roots_comm);
 
-            comm->node_roots_comm->is_single_node = 0;
             comm->node_roots_comm->local_size = num_external;
             comm->node_roots_comm->pof2 = MPL_pof2(comm->node_roots_comm->local_size);
             comm->node_roots_comm->remote_size = num_external;

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -82,21 +82,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_composition_beta(MPIR_Comm * comm, MP
     int mpi_errno = MPI_SUCCESS;
     void * barrier_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
-#ifndef MPIDI_BUILD_CH4_SHM
     mpi_errno =
         MPIDI_NM_mpi_barrier(comm, errflag, barrier_container);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-#else
-    if(comm->is_single_node) {
-        mpi_errno =
-            MPIDI_SHM_mpi_barrier(comm, errflag, barrier_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    } else{
-        mpi_errno =
-            MPIDI_NM_mpi_barrier(comm, errflag, barrier_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    }
-#endif/*MPIDI_BUILD_CH4_SHM*/
 
 fn_exit:
     return mpi_errno;
@@ -234,25 +222,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_composition_gamma(void *buffer, int cou
     int mpi_errno = MPI_SUCCESS;
     void * bcast_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
-#ifndef MPIDI_BUILD_CH4_SHM
     mpi_errno =
         MPIDI_NM_mpi_bcast(buffer, count, datatype, root,
                            comm, errflag, bcast_container);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-#else
-    if(comm->is_single_node){
-      mpi_errno =
-          MPIDI_SHM_mpi_bcast(buffer, count, datatype, root,
-                              comm, errflag, bcast_container);
-      if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    }
-    else{
-      mpi_errno =
-          MPIDI_NM_mpi_bcast(buffer, count, datatype, root,
-                             comm, errflag, bcast_container);
-      if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    }
-#endif/*MPIDI_BUILD_CH4_SHM*/
 
 fn_exit:
     return mpi_errno;
@@ -358,24 +331,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_composition_beta(const void *sendbu
    int mpi_errno = MPI_SUCCESS;
    void * allred_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
-#ifndef MPIDI_BUILD_CH4_SHM
     mpi_errno =
          MPIDI_NM_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag,
                                 allred_container);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-#else
-    if(comm->is_single_node) {
-        mpi_errno =
-             MPIDI_SHM_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag,
-                                     allred_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    } else {
-        mpi_errno =
-             MPIDI_NM_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag,
-                                    allred_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    }
-#endif/*MPIDI_BUILD_CH4_SHM*/
 
 fn_exit:
     return mpi_errno;
@@ -555,24 +514,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_composition_beta(const void *sendbuf, 
     int mpi_errno = MPI_SUCCESS;
     void * reduce_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
-#ifndef MPIDI_BUILD_CH4_SHM
     mpi_errno =
         MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root,
                             comm, errflag, reduce_container);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-#else
-    if(comm->is_single_node) {
-        mpi_errno =
-            MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root,
-                                 comm, errflag, reduce_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    } else {
-        mpi_errno =
-            MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root,
-                                comm, errflag, reduce_container);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-    }
-#endif/*MPIDI_BUILD_CH4_SHM*/
 
 fn_exit:
     return mpi_errno;


### PR DESCRIPTION
The PR #2935 has implementations of the additional compositions for the case when communicator resides inside one node. In this case, we can invoke one of SHM collectives on the whole communicator. That allowed to get rid of "is_single_node" attribute from MPIR_Comm structure that had been introduced to handle such cases.