### PR TITLE
Refactoring internal test/wait

### DIFF
--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,6 +10,7 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
+
 int MPIR_Test_impl(MPIR_Request * request_ptr, int *flag, MPI_Status * status);
 int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[], int *indx,
                       int *flag, MPI_Status * status);
@@ -17,7 +18,11 @@ int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount
                        int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Testall_impl(int count, MPIR_Request * array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
+
 int MPIR_Wait_impl(MPIR_Request * request_ptr, MPI_Status * status);
+int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_Status * status);
+int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount,
+                       int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[]);
 
 int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,8 +10,8 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
-int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
-int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
+int MPIR_Test_impl(MPIR_Request * request_ptr, int *flag, MPI_Status * status);
+int MPIR_Testall_impl(int count, MPIR_Request * array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status);
 int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -18,6 +18,9 @@ int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount
 int MPIR_Testall_impl(int count, MPIR_Request * array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status);
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);
+int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[]);
+
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[]);
 
 #endif /* MPIR_PT2PT_H_INCLUDED */

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -17,7 +17,7 @@ int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount
                        int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Testall_impl(int count, MPIR_Request * array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
-int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status);
+int MPIR_Wait_impl(MPIR_Request * request_ptr, MPI_Status * status);
 int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[]);
 
 int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,7 +10,7 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
-int MPIR_Test_impl(MPI_Request * request, int *flag, MPI_Status * status);
+int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status);
 int MPIR_Testall_impl(int count, MPI_Request array_of_requests[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status);

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -11,6 +11,10 @@
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
 int MPIR_Test_impl(MPIR_Request * request_ptr, int *flag, MPI_Status * status);
+int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[], int *indx,
+                      int *flag, MPI_Status * status);
+int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount,
+                       int array_of_indices[], MPI_Status array_of_statuses[]);
 int MPIR_Testall_impl(int count, MPIR_Request * array_of_request_ptrs[], int *flag,
                       MPI_Status array_of_statuses[]);
 int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status);

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -160,6 +160,20 @@ extern MPIR_Object_alloc_t MPIR_Request_mem;
 /* Preallocated request objects */
 extern MPIR_Request MPIR_Request_direct[];
 
+
+/* Return whether a request is active.
+ * A persistent request and the handle to it are "inactive"
+ * if the request is not associated with any ongoing communication.
+ * A handle is "active" if it is neither null nor "inactive". */
+static inline int MPIR_Request_is_active(MPIR_Request * req_ptr)
+{
+    if (req_ptr == NULL)
+        return 0;
+    return (((req_ptr)->kind != MPIR_REQUEST_KIND__PREQUEST_SEND &&
+             (req_ptr)->kind != MPIR_REQUEST_KIND__PREQUEST_RECV) ||
+            (req_ptr)->u.persist.real_request != NULL);
+}
+
 static inline int MPIR_Request_is_persistent(MPIR_Request * req_ptr)
 {
     return (req_ptr->kind == MPIR_REQUEST_KIND__PREQUEST_SEND ||

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -296,6 +296,21 @@ int MPIR_Request_completion_processing(MPIR_Request *, MPI_Status *, int *);
 int MPIR_Request_get_error(MPIR_Request *);
 int MPIR_Progress_wait_request(MPIR_Request * req);
 
+static inline int MPIR_Request_wait_and_complete(MPIR_Request * req_ptr)
+{
+    if (req_ptr == NULL)
+        return MPI_SUCCESS;
+
+    int active_flag;
+    int mpi_errno = MPIR_Wait_impl(req_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno != MPI_SUCCESS)
+        return mpi_errno;
+    mpi_errno = MPIR_Request_completion_processing(req_ptr, MPI_STATUS_IGNORE,
+                                                   &active_flag);
+    MPIR_Request_free(req_ptr);
+    return mpi_errno;
+}
+
 /* The following routines perform the callouts to the user routines registered
    as part of a generalized request.  They handle any language binding issues
    that are necessary. They are used when completing, freeing, cancelling or

--- a/src/mpi/coll/allgather/allgather_nb.c
+++ b/src/mpi/coll/allgather/allgather_nb.c
@@ -15,7 +15,6 @@ int MPIR_Allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                       MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/allgatherv/allgatherv_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_nb.c
@@ -15,7 +15,6 @@ int MPIR_Allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                          comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/allreduce/allreduce_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_nb.c
@@ -14,17 +14,13 @@ int MPIR_Allreduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatyp
                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/alltoall/alltoall_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_nb.c
@@ -15,7 +15,6 @@ int MPIR_Alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, 
                      MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, 
                        &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/alltoallv/alltoallv_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_nb.c
@@ -16,7 +16,6 @@ int MPIR_Alltoallv_nb(const void *sendbuf, const int *sendcounts, const int *sdi
                       MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -25,10 +24,7 @@ int MPIR_Alltoallv_nb(const void *sendbuf, const int *sendcounts, const int *sdi
                         recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/alltoallw/alltoallw_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_nb.c
@@ -16,7 +16,6 @@ int MPIR_Alltoallw_nb(const void *sendbuf, const int sendcounts[], const int sdi
                       MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -25,10 +24,7 @@ int MPIR_Alltoallw_nb(const void *sendbuf, const int sendcounts[], const int sdi
                         recvtypes, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/barrier/barrier_nb.c
+++ b/src/mpi/coll/barrier/barrier_nb.c
@@ -13,17 +13,13 @@
 int MPIR_Barrier_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/bcast/bcast_nb.c
+++ b/src/mpi/coll/bcast/bcast_nb.c
@@ -14,17 +14,13 @@ int MPIR_Bcast_nb(void *buffer, int count, MPI_Datatype datatype, int root, MPIR
                   MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/exscan/exscan_nb.c
+++ b/src/mpi/coll/exscan/exscan_nb.c
@@ -14,17 +14,13 @@ int MPIR_Exscan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/gather/gather_nb.c
+++ b/src/mpi/coll/gather/gather_nb.c
@@ -15,7 +15,6 @@ int MPIR_Gather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, vo
                    MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Gather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, vo
                      &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/gatherv/gatherv_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_nb.c
@@ -15,7 +15,6 @@ int MPIR_Gatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Gatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                       comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -603,12 +603,10 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPI_Request request_ptr_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
-    MPI_Request *request_ptrs = request_ptr_array;
     MPI_Status status_static_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
     MPI_Status *status_array = statuses;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_WAITALL);
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIC_WAITALL);
 
@@ -619,8 +617,6 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
     }
 
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno,
-                            "request pointers", MPL_MEM_BUFFER);
         MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno,
                             "status objects", MPL_MEM_BUFFER);
     }
@@ -631,12 +627,14 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
          * tag fields here. */
         status_array[i].MPI_TAG = 0;
         status_array[i].MPI_SOURCE = MPI_PROC_NULL;
-
-        /* Convert the MPIR_Request objects to MPI_Request objects */
-        request_ptrs[i] = requests[i]->handle;
     }
 
-    mpi_errno = MPIR_Waitall_impl(numreq, request_ptrs, status_array);
+    mpi_errno = MPIR_Waitall_impl(numreq, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
+    mpi_errno = MPIR_Waitall_post(numreq, NULL, requests, status_array);
+    if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+        goto fn_fail;
 
     /* The errflag value here is for all requests, not just a single one.  If
      * in the future, this function is used for multiple collectives at a

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_nb.c
@@ -15,7 +15,6 @@ int MPIR_Neighbor_allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype 
                                MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Neighbor_allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype 
                                  comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_nb.c
@@ -15,8 +15,6 @@ int MPIR_Neighbor_allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype
                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -25,10 +23,7 @@ int MPIR_Neighbor_allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype
                                           comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_nb.c
@@ -15,7 +15,6 @@ int MPIR_Neighbor_alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype s
                               MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -23,10 +22,7 @@ int MPIR_Neighbor_alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype s
                                         recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_nb.c
@@ -15,7 +15,6 @@ int MPIR_Neighbor_alltoallv_nb(const void *sendbuf, const int sendcounts[], cons
                                const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Neighbor_alltoallv_nb(const void *sendbuf, const int sendcounts[], cons
                                  rdispls, recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_nb.c
@@ -16,7 +16,6 @@ int MPIR_Neighbor_alltoallw_nb(const void *sendbuf, const int sendcounts[],
                                const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -25,10 +24,7 @@ int MPIR_Neighbor_alltoallw_nb(const void *sendbuf, const int sendcounts[],
                                  rdispls, recvtypes, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/reduce/reduce_nb.c
+++ b/src/mpi/coll/reduce/reduce_nb.c
@@ -14,17 +14,13 @@ int MPIR_Reduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
                    int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_nb.c
@@ -15,7 +15,6 @@ int MPIR_Reduce_scatter_nb(const void *sendbuf, void *recvbuf, const int recvcou
                            MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -23,10 +22,7 @@ int MPIR_Reduce_scatter_nb(const void *sendbuf, void *recvbuf, const int recvcou
         MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_nb.c
@@ -15,7 +15,6 @@ int MPIR_Reduce_scatter_block_nb(const void *sendbuf, void *recvbuf, int recvcou
                                  MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -23,10 +22,7 @@ int MPIR_Reduce_scatter_block_nb(const void *sendbuf, void *recvbuf, int recvcou
         MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/scan/scan_nb.c
+++ b/src/mpi/coll/scan/scan_nb.c
@@ -14,17 +14,13 @@ int MPIR_Scan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/scatter/scatter_nb.c
+++ b/src/mpi/coll/scatter/scatter_nb.c
@@ -15,7 +15,6 @@ int MPIR_Scatter_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                     MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Scatter_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                       &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/scatterv/scatterv_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_nb.c
@@ -15,7 +15,6 @@ int MPIR_Scatterv_nb(const void *sendbuf, const int *sendcounts, const int *disp
                      int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
@@ -24,10 +23,7 @@ int MPIR_Scatterv_nb(const void *sendbuf, const int *sendcounts, const int *disp
                        comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    if (req_ptr)
-        req = req_ptr->handle;
-
-    mpi_errno = MPIR_Wait_impl(&req, MPI_STATUS_IGNORE);
+    mpi_errno = MPIR_Request_wait_and_complete(req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/init/async.c
+++ b/src/mpi/init/async.c
@@ -28,8 +28,6 @@ static void progress_fn(void *data)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *request_ptr = NULL;
-    MPI_Request request;
-    MPI_Status status;
 
     /* Explicitly add CS_ENTER/EXIT since this thread is created from
      * within an internal function and will call NMPI functions
@@ -48,8 +46,7 @@ static void progress_fn(void *data)
     mpi_errno = MPID_Irecv(NULL, 0, MPI_CHAR, 0, WAKE_TAG, progress_comm_ptr,
                            MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     MPIR_Assert(!mpi_errno);
-    request = request_ptr->handle;
-    mpi_errno = MPIR_Wait_impl(&request, &status);
+    mpi_errno = MPIR_Request_wait_and_complete(request_ptr);
     MPIR_Assert(!mpi_errno);
 
     /* Send a signal to the main thread saying we are done */
@@ -124,8 +121,6 @@ int MPIR_Finalize_async_thread(void)
     int mpi_errno = MPI_SUCCESS;
 #if MPICH_THREAD_LEVEL == MPI_THREAD_MULTIPLE
     MPIR_Request *request_ptr = NULL;
-    MPI_Request request;
-    MPI_Status status;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);
@@ -133,8 +128,7 @@ int MPIR_Finalize_async_thread(void)
     mpi_errno = MPID_Isend(NULL, 0, MPI_CHAR, 0, WAKE_TAG, progress_comm_ptr,
                            MPIR_CONTEXT_INTRA_PT2PT, &request_ptr);
     MPIR_Assert(!mpi_errno);
-    request = request_ptr->handle;
-    mpi_errno = MPIR_Wait_impl(&request, &status);
+    mpi_errno = MPIR_Request_wait_and_complete(request_ptr);
     MPIR_Assert(!mpi_errno);
 
     /* XXX DJG why is this unlock/lock necessary?  Should we just YIELD here or later?  */

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -508,7 +508,9 @@ static int MPIR_Bsend_check_active(void)
                 MPIR_ERR_POP(mpi_errno);
         }
         if (flag) {
-            mpi_errno = MPIR_Request_completion_processing(&r, active->request, MPI_STATUS_IGNORE, &active_flag);
+            mpi_errno =
+                MPIR_Request_completion_processing(&r, active->request, MPI_STATUS_IGNORE,
+                                                   &active_flag);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* We're done.  Remove this segment */

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -489,7 +489,7 @@ static int MPIR_Bsend_check_active(void)
             flag = 0;
             /* XXX DJG FIXME-MT should we be checking this? */
             if (MPIR_Object_get_ref(active->request) == 1) {
-                mpi_errno = MPIR_Test_impl(active->request, &flag, MPI_STATUS_IGNORE);
+                mpi_errno = MPID_Test(active->request, &flag, MPI_STATUS_IGNORE);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             } else {
@@ -503,7 +503,7 @@ static int MPIR_Bsend_check_active(void)
                     MPIR_ERR_POP(mpi_errno);
             }
         } else {
-            mpi_errno = MPIR_Test_impl(active->request, &flag, MPI_STATUS_IGNORE);
+            mpi_errno = MPID_Test(active->request, &flag, MPI_STATUS_IGNORE);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -62,7 +62,7 @@ PMPI_LOCAL int MPIR_Ibsend_cancel(void *extra, int complete)
     ibsend_req_info *ibsend_info = (ibsend_req_info *) extra;
     MPI_Status status;
     MPIR_Request *req = ibsend_info->req;
-    MPI_Request req_hdl = req->handle;
+    int active_flag;
 
     /* FIXME: There should be no unreferenced args! */
     /* Note that this value should always be 1 because
@@ -75,9 +75,13 @@ PMPI_LOCAL int MPIR_Ibsend_cancel(void *extra, int complete)
     mpi_errno = MPIR_Cancel_impl(req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Wait_impl(&req_hdl, &status);
+    mpi_errno = MPIR_Wait_impl(req, &status);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
+    mpi_errno = MPIR_Request_completion_processing(req, &status, &active_flag);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
     ibsend_info->cancelled = MPIR_STATUS_GET_CANCEL_BIT(status);
 
     /* If the cancelation is successful, free the memory in the

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -30,22 +30,10 @@ int MPI_Test(MPI_Request * request, int *flag, MPI_Status * status)
 #define FUNCNAME MPIR_Test_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Test_impl(MPI_Request * request, int *flag, MPI_Status * status)
+int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int active_flag;
-    MPIR_Request *request_ptr = NULL;
-
-    /* If this is a null request handle, then return an empty status */
-    if (*request == MPI_REQUEST_NULL) {
-        MPIR_Status_set_empty(status);
-        *flag = TRUE;
-        goto fn_exit;
-    }
-
     *flag = FALSE;
-
-    MPIR_Request_get_ptr(*request, request_ptr);
 
     /* If the request is already completed AND we want to avoid calling
      * the progress engine, we could make the call to MPID_Progress_test
@@ -64,23 +52,9 @@ int MPIR_Test_impl(MPI_Request * request, int *flag, MPI_Status * status)
     }
 
     if (MPIR_Request_is_complete(request_ptr)) {
-        mpi_errno = MPIR_Request_completion_processing(request_ptr, status, &active_flag);
-        if (!MPIR_Request_is_persistent(request_ptr)) {
-            MPIR_Request_free(request_ptr);
-            *request = MPI_REQUEST_NULL;
-        }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
         *flag = TRUE;
-        /* Fall through to the exit */
-    } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                        MPID_Request_is_anysource(request_ptr) &&
-                        !MPID_Comm_AS_enabled(request_ptr->comm))) {
-        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-        if (status != MPI_STATUS_IGNORE)
-            status->MPI_ERROR = mpi_errno;
-        goto fn_fail;
     }
+
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -119,6 +93,7 @@ Output Parameters:
 int MPI_Test(MPI_Request * request, int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
+    int active_flag;
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TEST);
 
@@ -161,12 +136,36 @@ int MPI_Test(MPI_Request * request, int *flag, MPI_Status * status)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* If this is a null request handle, then return an empty status */
+    if (*request == MPI_REQUEST_NULL) {
+        MPIR_Status_set_empty(status);
+        *flag = TRUE;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Test_impl(request, flag, status);
-    if (mpi_errno)
-        goto fn_fail;
+    mpi_errno = MPIR_Test_impl(request_ptr, flag, status);
+    if (mpi_errno) goto fn_fail;
 
+    if (*flag != FALSE) {
+        mpi_errno = MPIR_Request_completion_processing(request_ptr, status,
+                                                       &active_flag);
+        if (!MPIR_Request_is_persistent(request_ptr)) {
+            MPIR_Request_free(request_ptr);
+            *request = MPI_REQUEST_NULL;
+        }
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+        /* Fall through to the exit */
+    } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                        MPID_Request_is_anysource(request_ptr) &&
+                        !MPID_Comm_AS_enabled(request_ptr->comm))) {
+        MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+        if (status != MPI_STATUS_IGNORE)
+            status->MPI_ERROR = mpi_errno;
+        goto fn_fail;
+    }
     /* ... end of body of routine ... */
 
   fn_exit:

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -30,7 +30,7 @@ int MPI_Test(MPI_Request * request, int *flag, MPI_Status * status)
 #define FUNCNAME MPIR_Test_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Test_impl(MPIR_Request *request_ptr, int *flag, MPI_Status *status)
+int MPIR_Test_impl(MPIR_Request * request_ptr, int *flag, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     *flag = FALSE;
@@ -146,7 +146,8 @@ int MPI_Test(MPI_Request * request, int *flag, MPI_Status * status)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Test_impl(request_ptr, flag, status);
-    if (mpi_errno) goto fn_fail;
+    if (mpi_errno)
+        goto fn_fail;
 
     if (*flag != FALSE) {
         mpi_errno = MPIR_Request_completion_processing(request_ptr, status,

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -30,10 +30,52 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx, int *flag
 #undef MPI_Testany
 #define MPI_Testany PMPI_Testany
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Testany_impl
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[], int *indx,
+                      int *flag, MPI_Status * status)
+{
+    int i;
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPID_Progress_test();
+    /* --BEGIN ERROR HANDLING-- */
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] != NULL &&
+            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
+            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
+            mpi_errno =
+                (request_ptrs[i]->u.ureq.greq_fns->poll_fn) (request_ptrs[i]->u.ureq.
+                                                             greq_fns->grequest_extra_state,
+                                                             status);
+            if (mpi_errno != MPI_SUCCESS)
+                goto fn_fail;
+        }
+        if (MPIR_Request_is_active(request_ptrs[i]) && MPIR_Request_is_complete(request_ptrs[i])) {
+            *flag = TRUE;
+            *indx = i;
+            goto fn_exit;
+        }
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 #endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Testany
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 
 /*@
     MPI_Testany - Tests for completion of any previdously initiated
@@ -67,7 +109,6 @@ program to unexecpectedly terminate or produce incorrect results.
 int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
                 int *flag, MPI_Status * status)
 {
-    static const char FCNAME[] = "MPI_Testany";
     MPIR_Request *request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request **request_ptrs = request_ptr_array;
     int i;
@@ -119,6 +160,14 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
         if (array_of_requests[i] != MPI_REQUEST_NULL) {
             MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
             /* Validate object pointers if error checking is enabled */
+            if (!MPIR_Request_is_active(request_ptrs[i]))
+                n_inactive += 1;
+            if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                         MPID_Request_is_anysource(request_ptrs[i]) &&
+                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm) &&
+                         !MPIR_Request_is_complete(request_ptrs[i]))) {
+                last_disabled_anysource = i;
+            }
 #ifdef HAVE_ERROR_CHECKING
             {
                 MPID_BEGIN_ERROR_CHECKS;
@@ -147,47 +196,24 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     *flag = FALSE;
     *indx = MPI_UNDEFINED;
 
-    mpi_errno = MPID_Progress_test();
+    mpi_errno = MPIR_Testany_impl(count, request_ptrs, indx, flag, status);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS) {
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */
 
-    for (i = 0; i < count; i++) {
-        if (request_ptrs[i] != NULL &&
-            request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-            request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
-            mpi_errno =
-                (request_ptrs[i]->u.ureq.greq_fns->poll_fn) (request_ptrs[i]->u.ureq.
-                                                             greq_fns->grequest_extra_state,
-                                                             status);
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+    if (*flag != FALSE) {
+        mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx], status,
+                                                       &active_flag);
+        if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
+            MPIR_Request_free(request_ptrs[*indx]);
+            array_of_requests[*indx] = MPI_REQUEST_NULL;
         }
-        if (request_ptrs[i] != NULL) {
-            if (MPIR_Request_is_complete(request_ptrs[i])) {
-                mpi_errno = MPIR_Request_completion_processing(request_ptrs[i], status,
-                                                               &active_flag);
-                if (!MPIR_Request_is_persistent(request_ptrs[i])) {
-                    MPIR_Request_free(request_ptrs[i]);
-                    array_of_requests[i] = MPI_REQUEST_NULL;
-                }
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
-                if (active_flag) {
-                    *flag = TRUE;
-                    *indx = i;
-                    goto fn_exit;
-                } else {
-                    n_inactive += 1;
-                }
-            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                MPID_Request_is_anysource(request_ptrs[i]) &&
-                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                last_disabled_anysource = i;
-            }
-        }
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        goto fn_exit;
     }
 
     /* If none of the requests completed, mark the last anysource request as
@@ -198,12 +224,6 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
             status->MPI_ERROR = mpi_errno;
         *flag = TRUE;
         goto fn_fail;
-    }
-
-    if (n_inactive == count) {
-        *flag = TRUE;
-        *indx = MPI_UNDEFINED;
-        /* status set to empty by MPIR_Request_completion_processing() */
     }
 
     /* ... end of body of routine ... */

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -196,7 +196,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
     *flag = FALSE;
     *indx = MPI_UNDEFINED;
 
-    mpi_errno = MPIR_Testany_impl(count, request_ptrs, indx, flag, status);
+    mpi_errno = MPID_Testany(count, request_ptrs, indx, flag, status);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS) {
         goto fn_fail;

--- a/src/mpi/request/testsome.c
+++ b/src/mpi/request/testsome.c
@@ -203,8 +203,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
         goto fn_exit;
     }
 
-    mpi_errno =
-        MPIR_Testsome_impl(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
+    mpi_errno = MPID_Testsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -171,7 +171,7 @@ int MPI_Wait(MPI_Request * request, MPI_Status * status)
     /* save copy of comm because request will be freed */
     if (request_ptr)
         comm_ptr = request_ptr->comm;
-    mpi_errno = MPIR_Wait_impl(request_ptr, status);
+    mpi_errno = MPID_Wait(request_ptr, status);
     if (mpi_errno)
         goto fn_fail;
     mpi_errno = MPIR_Request_completion_processing(request_ptr, status, &active_flag);

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -51,7 +51,7 @@ int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status)
         if (unlikely(MPIR_CVAR_ENABLE_FT &&
                      MPID_Request_is_anysource(request_ptr) &&
                      !MPID_Comm_AS_enabled(request_ptr->comm))) {
-            mpi_errno = MPIR_Test_impl(request, &active_flag, status);
+            mpi_errno = MPIR_Test_impl(request_ptr, &active_flag, status);
             goto fn_exit;
         }
 

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -28,19 +28,10 @@ int MPI_Wait(MPI_Request * request, MPI_Status * status) __attribute__ ((weak, a
 #define FUNCNAME MPIR_Wait_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status)
+int MPIR_Wait_impl(MPIR_Request * request_ptr, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     int active_flag;
-    MPIR_Request *request_ptr = NULL;
-
-    /* If this is a null request handle, then return an empty status */
-    if (*request == MPI_REQUEST_NULL) {
-        MPIR_Status_set_empty(status);
-        goto fn_exit;
-    }
-
-    MPIR_Request_get_ptr(*request, request_ptr);
 
     if (!MPIR_Request_is_complete(request_ptr)) {
         MPID_Progress_state progress_state;
@@ -92,14 +83,6 @@ int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status)
         MPID_Progress_end(&progress_state);
     }
 
-    mpi_errno = MPIR_Request_completion_processing(request_ptr, status, &active_flag);
-    if (!MPIR_Request_is_persistent(request_ptr)) {
-        MPIR_Request_free(request_ptr);
-        *request = MPI_REQUEST_NULL;
-    }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -139,6 +122,7 @@ int MPI_Wait(MPI_Request * request, MPI_Status * status)
     MPIR_Request *request_ptr = NULL;
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *comm_ptr = NULL;
+    int active_flag;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAIT);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -187,9 +171,16 @@ int MPI_Wait(MPI_Request * request, MPI_Status * status)
     /* save copy of comm because request will be freed */
     if (request_ptr)
         comm_ptr = request_ptr->comm;
-    mpi_errno = MPIR_Wait_impl(request, status);
+    mpi_errno = MPIR_Wait_impl(request_ptr, status);
     if (mpi_errno)
         goto fn_fail;
+    mpi_errno = MPIR_Request_completion_processing(request_ptr, status, &active_flag);
+    if (!MPIR_Request_is_persistent(request_ptr)) {
+        MPIR_Request_free(request_ptr);
+        *request = MPI_REQUEST_NULL;
+    }
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -51,7 +51,7 @@ int MPIR_Wait_impl(MPI_Request * request, MPI_Status * status)
         if (unlikely(MPIR_CVAR_ENABLE_FT &&
                      MPID_Request_is_anysource(request_ptr) &&
                      !MPID_Comm_AS_enabled(request_ptr->comm))) {
-            mpi_errno = MPIR_Test_impl(request_ptr, &active_flag, status);
+            mpi_errno = MPID_Test(request_ptr, &active_flag, status);
             goto fn_exit;
         }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -146,8 +146,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status arr
     }
 
     if (unlikely(disabled_anysource)) {
-        mpi_errno =
-            MPIR_Testall_impl(count, array_of_requests, &disabled_anysource, array_of_statuses);
+        mpi_errno = MPIR_Testall_impl(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -69,124 +69,31 @@ static inline int request_complete_fastpath(MPI_Request * request, MPIR_Request 
 #define FUNCNAME MPIR_Waitall_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[])
+int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
-    MPIR_Request **request_ptrs = request_ptr_array;
-    MPI_Status *status_ptr = NULL;
+    MPI_Status *status_ptr;
     MPID_Progress_state progress_state;
-    int i, j;
+    int i;
     int n_completed;
-    int active_flag;
     int rc = MPI_SUCCESS;
     int n_greqs;
-    int proc_failure = FALSE;
-    int disabled_anysource = FALSE;
     const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
-    int optimize = ignoring_statuses;   /* see NOTE-O1 */
-    MPIR_CHKLMEM_DECL(1);
-
-    /* Convert MPI request handles to a request object pointers */
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *),
-                            mpi_errno, "request pointers", MPL_MEM_OBJECT);
-    }
 
     n_greqs = 0;
     n_completed = 0;
     for (i = 0; i < count; i++) {
-        if (array_of_requests[i] != MPI_REQUEST_NULL) {
-            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-            /* Validate object pointers if error checking is enabled */
-#ifdef HAVE_ERROR_CHECKING
-            {
-                MPID_BEGIN_ERROR_CHECKS;
-                {
-                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
-                    MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
-                                         mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d",
-                                         i);
-                }
-                MPID_END_ERROR_CHECKS;
-            }
-#endif
-            if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
-                request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND) {
-                optimize = FALSE;
-            }
-
+        if (request_ptrs[i] != NULL) {
             if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST)
                 ++n_greqs;
-
-            /* If one of the requests is an anysource on a communicator that's
-             * disabled such communication, convert this operation to a testall
-             * instead to prevent getting stuck in the progress engine. */
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                         !MPIR_Request_is_complete(request_ptrs[i]) &&
-                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                disabled_anysource = TRUE;
-            }
         } else {
-            status_ptr =
-                (array_of_statuses !=
-                 MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
-            MPIR_Status_set_empty(status_ptr);
-            request_ptrs[i] = NULL;
             n_completed += 1;
-            optimize = FALSE;
         }
     }
 
     if (n_completed == count) {
         goto fn_exit;
     }
-
-    if (unlikely(disabled_anysource)) {
-        mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
-        goto fn_exit;
-    }
-
-    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
-     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
-     * out as many unnecessary jumps and error handling as possible.
-     *
-     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
-     * additional branch inside the for-loop below. */
-    if (optimize) {
-        MPID_Progress_start(&progress_state);
-        for (i = 0; i < count; ++i) {
-            while (!MPIR_Request_is_complete(request_ptrs[i])) {
-                mpi_errno = MPID_Progress_wait(&progress_state);
-                /* must check and handle the error, can't guard with HAVE_ERROR_CHECKING, but it's
-                 * OK for the error case to be slower */
-                if (unlikely(mpi_errno)) {
-                    /* --BEGIN ERROR HANDLING-- */
-                    if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                 MPID_Request_is_anysource(request_ptrs[i]) &&
-                                 !MPIR_Request_is_complete(request_ptrs[i]) &&
-                                 !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                        MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
-                    }
-                    MPID_Progress_end(&progress_state);
-                    MPIR_ERR_POP(mpi_errno);
-                    /* --END ERROR HANDLING-- */
-                }
-            }
-            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
-        }
-
-        MPID_Progress_end(&progress_state);
-
-        goto fn_exit;
-    }
-
-    /* ------ "slow" code path below ------ */
 
     /* Grequest_waitall may run the progress engine - thus, we don't
      * invoke progress_start until after running Grequest_waitall */
@@ -227,12 +134,48 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status arr
                 status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
                 if (status_ptr != MPI_STATUS_IGNORE)
                     status_ptr->MPI_ERROR = mpi_errno;
-                proc_failure = TRUE;
-                break;
+                mpi_errno = rc;
+                goto fn_fail;
             }
+        }
+    }
+    MPID_Progress_end(&progress_state);
+
+  fn_exit:
+
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/*
+  Post-processing of MPI_Waitall
+  Setting statuses, freeing requests objects, etc.
+*/
+#undef FUNCNAME
+#define FUNCNAME do_waitall_post
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+static inline int do_waitall_post(int count, MPI_Request array_of_requests[],
+                                  MPIR_Request * request_ptrs[],
+                                  MPI_Status array_of_statuses[])
+{
+    int i, j;
+    int mpi_errno = MPI_SUCCESS;
+    int rc = MPI_SUCCESS;
+    const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
+    MPI_Status *status_ptr;
+    MPI_Request *req_hndl_ptr;
+
+    for (i = 0; i < count; i++) {
+        if (request_ptrs[i] == NULL) {
+            if (!ignoring_statuses)
+                array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            continue;
         }
 
         if (MPIR_Request_is_complete(request_ptrs[i])) {
+            int active_flag;
             /* complete the request and check the status */
             status_ptr = (ignoring_statuses) ? MPI_STATUS_IGNORE : &array_of_statuses[i];
             rc = MPIR_Request_completion_processing(request_ptrs[i], status_ptr, &active_flag);
@@ -247,13 +190,13 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status arr
             if (!ignoring_statuses)
                 status_ptr->MPI_ERROR = MPI_SUCCESS;
         } else {
+            int proc_failure = FALSE;
+
             /* req completed with an error */
             MPIR_ERR_SET(mpi_errno, MPI_ERR_IN_STATUS, "**instatus");
 
-            if (!proc_failure) {
-                if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
-                    proc_failure = TRUE;
-            }
+            if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(rc))
+                proc_failure = TRUE;
 
             if (!ignoring_statuses) {
                 /* set the error code for this request */
@@ -277,19 +220,22 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status arr
             break;
         }
     }
-    MPID_Progress_end(&progress_state);
-
-  fn_exit:
-    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
-        MPIR_CHKLMEM_FREEALL();
-    }
 
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 #endif
+
+/* External entry point of do_waitall_post for users outside of this compile unit */
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitall_post
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitall_post(int count, MPI_Request array_of_requests[],
+                      MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[])
+{
+    return do_waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
+}
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitall
@@ -334,6 +280,13 @@ program to unexecpectedly terminate or produce incorrect results.
 int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[])
 {
     int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
+    MPIR_Request **request_ptrs = NULL;
+    MPI_Status *status_ptr;
+    int disabled_anysource = FALSE;
+    int optimize = (array_of_statuses == MPI_STATUSES_IGNORE);  /* see NOTE-O1 */
+    int i;
+    MPIR_CHKLMEM_DECL(1);
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITALL);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -341,12 +294,19 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_PT2PT_ENTER(MPID_STATE_MPI_WAITALL);
 
+    /* Convert MPI request handles to a request object pointers */
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE) {
+        MPIR_CHKLMEM_MALLOC(request_ptrs, MPIR_Request **, count * sizeof(MPIR_Request *),
+                            mpi_errno, "request pointers", MPL_MEM_OBJECT);
+    } else {
+        request_ptrs = request_ptr_array;
+    }
+
     /* Check the arguments */
 #ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            int i;
             MPIR_ERRTEST_COUNT(count, mpi_errno);
 
             if (count != 0) {
@@ -366,13 +326,97 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_
 
     /* ... body of routine ...  */
 
-    mpi_errno = MPIR_Waitall_impl(count, array_of_requests, array_of_statuses);
+    /* Translate array-of-request-handles to array-of-request-pointers */
+    for (i = 0; i < count; i++) {
+        if (array_of_requests[i] == MPI_REQUEST_NULL) {
+            request_ptrs[i] = NULL;
+            status_ptr =
+                (array_of_statuses !=
+                 MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
+            MPIR_Status_set_empty(status_ptr);
+            optimize = FALSE;
+            continue;
+        }
+        MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+        /* Validate object pointers if error checking is enabled */
+#ifdef HAVE_ERROR_CHECKING
+        {
+            MPID_BEGIN_ERROR_CHECKS;
+            {
+                MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
+                if (mpi_errno)
+                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
+                                     mpi_errno, MPI_ERR_ARG, "**msgnotreq", "**msgnotreq %d", i);
+            }
+            MPID_END_ERROR_CHECKS;
+        }
+#endif
+        /* If one of the requests is an anysource on a communicator that's
+         * disabled such communication, convert this operation to a testall
+         * instead to prevent getting stuck in the progress engine. */
+        if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                     MPID_Request_is_anysource(request_ptrs[i]) &&
+                     !MPIR_Request_is_complete(request_ptrs[i]) &&
+                     !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+            disabled_anysource = TRUE;
+        }
+
+        /* Message rate optimization applies only to send/recv requests */
+        if (request_ptrs[i]->kind != MPIR_REQUEST_KIND__RECV &&
+            request_ptrs[i]->kind != MPIR_REQUEST_KIND__SEND)
+            optimize = FALSE;
+    }
+
+    if (unlikely(disabled_anysource)) {
+        mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+        goto fn_exit;
+    }
+
+    /* Make progress and wait for completion */
+    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    switch (mpi_errno) {
+        case MPI_SUCCESS:
+            break;
+
+        case MPIX_ERR_PROC_FAILED_PENDING:
+            optimize = FALSE;
+            break;
+
+        default:
+            goto fn_fail;
+    }
+
+    /* Free completed request objects */
+
+    /* NOTE-O1: high-message-rate optimization.  For simple send and recv
+     * operations and MPI_STATUSES_IGNORE we use a fastpath approach that strips
+     * out as many unnecessary jumps and error handling as possible.
+     *
+     * Possible variation: permit request_ptrs[i]==NULL at the cost of an
+     * additional branch inside the for-loop below. */
+    if (optimize) {
+        for (i = 0; i < count; i++) {
+            mpi_errno = request_complete_fastpath(&array_of_requests[i], request_ptrs[i]);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+        goto fn_exit;
+    }
+
+    /* ------ "slow" code path below ------ */
+    mpi_errno = do_waitall_post(count, array_of_requests, request_ptrs, array_of_statuses);
     if (mpi_errno)
         goto fn_fail;
 
     /* ... end of body of routine ... */
 
   fn_exit:
+    if (count > MPIR_REQUEST_PTR_ARRAY_SIZE)
+        MPIR_CHKLMEM_FREEALL();
+
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITALL);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -146,7 +146,7 @@ int MPIR_Waitall_impl(int count, MPI_Request array_of_requests[], MPI_Status arr
     }
 
     if (unlikely(disabled_anysource)) {
-        mpi_errno = MPIR_Testall_impl(count, request_ptrs, &disabled_anysource, array_of_statuses);
+        mpi_errno = MPID_Testall(count, request_ptrs, &disabled_anysource, array_of_statuses);
         goto fn_exit;
     }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -165,7 +165,6 @@ static inline int do_waitall_post(int count, MPI_Request array_of_requests[],
     int rc = MPI_SUCCESS;
     const int ignoring_statuses = (array_of_statuses == MPI_STATUSES_IGNORE);
     MPI_Status *status_ptr;
-    MPI_Request *req_hndl_ptr;
 
     for (i = 0; i < count; i++) {
         if (request_ptrs[i] == NULL) {
@@ -181,7 +180,7 @@ static inline int do_waitall_post(int count, MPI_Request array_of_requests[],
             rc = MPIR_Request_completion_processing(request_ptrs[i], status_ptr, &active_flag);
             if (!MPIR_Request_is_persistent(request_ptrs[i])) {
                 MPIR_Request_free(request_ptrs[i]);
-                array_of_requests[i] = MPI_REQUEST_NULL;
+                if (array_of_requests) array_of_requests[i] = MPI_REQUEST_NULL;
             }
         }
 

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -375,7 +375,7 @@ int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_
     }
 
     /* Make progress and wait for completion */
-    mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses);
+    mpi_errno = MPID_Waitall(count, request_ptrs, array_of_statuses);
     switch (mpi_errno) {
         case MPI_SUCCESS:
             break;

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -213,7 +213,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
         goto fn_exit;
     }
 
-    mpi_errno = MPIR_Waitany_impl(count, request_ptrs, indx, status);
+    mpi_errno = MPID_Waitany(count, request_ptrs, indx, status);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
     mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx],

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -11,6 +11,71 @@
 #define MPIR_REQUEST_PTR_ARRAY_SIZE 16
 #endif
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitany
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_Status * status)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPID_Progress_state progress_state;
+    int last_disabled_anysource = -1;
+    int i;
+
+    MPID_Progress_start(&progress_state);
+    for (;;) {
+        for (i = 0; i < count; i++) {
+            if (request_ptrs[i] == NULL)
+                continue;
+
+            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
+                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
+                /* this is a generalized request; make progress on it */
+                mpi_errno =
+                    (request_ptrs[i]->u.ureq.greq_fns->poll_fn) (request_ptrs[i]->u.ureq.
+                                                                 greq_fns->grequest_extra_state,
+                                                                 status);
+                if (mpi_errno != MPI_SUCCESS)
+                    goto fn_progress_end_fail;
+            }
+            if (MPIR_Request_is_active(request_ptrs[i]) &&
+                MPIR_Request_is_complete(request_ptrs[i])) {
+                *indx = i;
+                goto break_l1;
+            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
+                                MPID_Request_is_anysource(request_ptrs[i]) &&
+                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+                last_disabled_anysource = i;
+            }
+        }
+
+        /* If none of the requests completed, mark the last anysource request
+         * as pending failure and break out. */
+        if (unlikely(last_disabled_anysource != -1)) {
+            MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
+            if (status != MPI_STATUS_IGNORE)
+                status->MPI_ERROR = mpi_errno;
+            goto fn_progress_end_fail;
+        }
+
+        mpi_errno = MPID_Progress_test();
+        if (mpi_errno != MPI_SUCCESS)
+            goto fn_progress_end_fail;
+        /* Avoid blocking other threads since I am inside an infinite loop */
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    }
+  break_l1:
+    MPID_Progress_end(&progress_state);
+
+  fn_exit:
+    return mpi_errno;
+
+  fn_progress_end_fail:
+    MPID_Progress_end(&progress_state);
+
+    goto fn_exit;
+}
+
 /* -- Begin Profiling Symbol Block for routine MPI_Waitany */
 #if defined(HAVE_PRAGMA_WEAK)
 #pragma weak MPI_Waitany = PMPI_Waitany
@@ -34,7 +99,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitany
-
+#undef FCNAME
 /*@
     MPI_Waitany - Waits for any specified MPI Request to complete
 
@@ -71,13 +136,9 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
     static const char FCNAME[] = "MPI_Waitany";
     MPIR_Request *request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request **request_ptrs = request_ptr_array;
-    MPID_Progress_state progress_state;
     int i;
-    int n_inactive;
     int active_flag;
-    int init_req_array;
-    int found_nonnull_req;
-    int last_disabled_anysource = -1;
+    int found_nonnull_req = FALSE;
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL(1);
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_WAITANY);
@@ -113,110 +174,56 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
                                    mpi_errno, "request pointers", MPL_MEM_OBJECT);
     }
 
-    n_inactive = 0;
-    init_req_array = TRUE;
-    found_nonnull_req = FALSE;
-
-    MPID_Progress_start(&progress_state);
-    for (;;) {
-        for (i = 0; i < count; i++) {
-            if (init_req_array) {
+    for (i = 0; i < count; i++) {
 #ifdef HAVE_ERROR_CHECKING
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+        }
+        MPID_END_ERROR_CHECKS;
+#endif /* HAVE_ERROR_CHECKING */
+        if (array_of_requests[i] != MPI_REQUEST_NULL) {
+            MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            if (!MPIR_Request_is_active(request_ptrs[i]))
+                continue;
+
+            /* Validate object pointers if error checking is enabled */
+#ifdef HAVE_ERROR_CHECKING
+            {
                 MPID_BEGIN_ERROR_CHECKS;
                 {
-                    MPIR_ERRTEST_ARRAYREQUEST_OR_NULL(array_of_requests[i], i, mpi_errno);
+                    MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
+                    if (mpi_errno != MPI_SUCCESS)
+                        goto fn_fail;
                 }
                 MPID_END_ERROR_CHECKS;
-#endif /* HAVE_ERROR_CHECKING */
-                if (array_of_requests[i] != MPI_REQUEST_NULL) {
-                    MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
-                    /* Validate object pointers if error checking is enabled */
-#ifdef HAVE_ERROR_CHECKING
-                    {
-                        MPID_BEGIN_ERROR_CHECKS;
-                        {
-                            MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
-                            if (mpi_errno != MPI_SUCCESS)
-                                goto fn_progress_end_fail;
-                        }
-                        MPID_END_ERROR_CHECKS;
-                    }
+            }
 #endif
-                } else {
-                    request_ptrs[i] = NULL;
-                    ++n_inactive;
-                }
-            }
-            if (request_ptrs[i] == NULL)
-                continue;
-            /* we found at least one non-null request */
             found_nonnull_req = TRUE;
-
-            if (request_ptrs[i]->kind == MPIR_REQUEST_KIND__GREQUEST &&
-                request_ptrs[i]->u.ureq.greq_fns->poll_fn != NULL) {
-                /* this is a generalized request; make progress on it */
-                mpi_errno =
-                    (request_ptrs[i]->u.ureq.greq_fns->poll_fn) (request_ptrs[i]->u.ureq.
-                                                                 greq_fns->grequest_extra_state,
-                                                                 status);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_progress_end_fail;
-            }
-            if (MPIR_Request_is_complete(request_ptrs[i])) {
-                mpi_errno = MPIR_Request_completion_processing(request_ptrs[i], status,
-                                                               &active_flag);
-                if (!MPIR_Request_is_persistent(request_ptrs[i])) {
-                    MPIR_Request_free(request_ptrs[i]);
-                    array_of_requests[i] = MPI_REQUEST_NULL;
-                }
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
-                if (active_flag) {
-                    *indx = i;
-                    goto break_l1;
-                } else {
-                    ++n_inactive;
-                    request_ptrs[i] = NULL;
-
-                    if (n_inactive == count) {
-                        *indx = MPI_UNDEFINED;
-                        /* status is set to empty by MPIR_Request_completion_processing */
-                        goto break_l1;
-                    }
-                }
-            } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                MPID_Request_is_anysource(request_ptrs[i]) &&
-                                !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                last_disabled_anysource = i;
-            }
+        } else {
+            request_ptrs[i] = NULL;
         }
-        init_req_array = FALSE;
-
-        if (!found_nonnull_req) {
-            /* all requests were NULL */
-            *indx = MPI_UNDEFINED;
-            if (status != NULL) /* could be null if count=0 */
-                MPIR_Status_set_empty(status);
-            goto break_l1;
-        }
-
-        /* If none of the requests completed, mark the last anysource request
-         * as pending failure and break out. */
-        if (unlikely(last_disabled_anysource != -1)) {
-            MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-            if (status != MPI_STATUS_IGNORE)
-                status->MPI_ERROR = mpi_errno;
-            goto fn_progress_end_fail;
-        }
-
-        mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_progress_end_fail;
-        /* Avoid blocking other threads since I am inside an infinite loop */
-        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
-  break_l1:
-    MPID_Progress_end(&progress_state);
+
+    if (!found_nonnull_req) {
+        /* all requests were NULL */
+        *indx = MPI_UNDEFINED;
+        if (status != NULL)     /* could be null if count=0 */
+            MPIR_Status_set_empty(status);
+        goto fn_exit;
+    }
+
+    mpi_errno = MPIR_Waitany_impl(count, request_ptrs, indx, status);
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
+    mpi_errno = MPIR_Request_completion_processing(request_ptrs[*indx],
+                                                   status, &active_flag);
+    if (!MPIR_Request_is_persistent(request_ptrs[*indx])) {
+        MPIR_Request_free(request_ptrs[*indx]);
+        array_of_requests[*indx] = MPI_REQUEST_NULL;
+    }
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     /* ... end of body of routine ... */
 
@@ -228,9 +235,6 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
     MPIR_FUNC_TERSE_PT2PT_EXIT(MPID_STATE_MPI_WAITANY);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
-
-  fn_progress_end_fail:
-    MPID_Progress_end(&progress_state);
 
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -238,8 +238,7 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
         goto fn_exit;
     }
 
-    mpi_errno =
-        MPIR_Waitsome_impl(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
+    mpi_errno = MPID_Waitsome(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS) {
         /* --BEGIN ERROR HANDLING-- */
         goto fn_fail;

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -31,11 +31,68 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount,
 #undef MPI_Waitsome
 #define MPI_Waitsome PMPI_Waitsome
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Waitsome_impl
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[], int *outcount,
+                       int array_of_indices[], MPI_Status array_of_statuses[])
+{
+    MPID_Progress_state progress_state;
+    int i;
+    int mpi_errno = MPI_SUCCESS;
+
+    /* Bill Gropp says MPI_Waitsome() is expected to try to make
+     * progress even if some requests have already completed;
+     * therefore, we kick the pipes once and then fall into a loop
+     * checking for completion and waiting for progress. */
+    mpi_errno = MPID_Progress_test();
+    if (mpi_errno != MPI_SUCCESS) {
+        /* --BEGIN ERROR HANDLING-- */
+        goto fn_fail;
+        /* --END ERROR HANDLING-- */
+    }
+
+    MPID_Progress_start(&progress_state);
+    for (;;) {
+        mpi_errno = MPIR_Grequest_progress_poke(incount, request_ptrs, array_of_statuses);
+        if (mpi_errno != MPI_SUCCESS)
+            goto fn_fail;
+        for (i = 0; i < incount; i++) {
+            if (MPIR_Request_is_active(request_ptrs[i]) &&
+                MPIR_Request_is_complete(request_ptrs[i])) {
+                array_of_indices[*outcount] = i;
+                *outcount += 1;
+            }
+        }
+
+        if (*outcount > 0)
+            break;
+
+        mpi_errno = MPID_Progress_test();
+        if (mpi_errno != MPI_SUCCESS) {
+            /* --BEGIN ERROR HANDLING-- */
+            MPID_Progress_end(&progress_state);
+            goto fn_fail;
+            /* --END ERROR HANDLING-- */
+        }
+        /* Avoid blocking other threads since I am inside an infinite loop */
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    }
+    MPID_Progress_end(&progress_state);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 #endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Waitsome
-
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 /*@
     MPI_Waitsome - Waits for some given MPI Requests to complete
 
@@ -86,13 +143,10 @@ completion of the message.
 int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
                  int *outcount, int array_of_indices[], MPI_Status array_of_statuses[])
 {
-    static const char FCNAME[] = "MPI_Waitsome";
     MPIR_Request *request_ptr_array[MPIR_REQUEST_PTR_ARRAY_SIZE];
     MPIR_Request **request_ptrs = request_ptr_array;
     MPI_Status *status_ptr;
-    MPID_Progress_state progress_state;
     int i;
-    int n_active;
     int n_inactive;
     int active_flag;
     int rc = MPI_SUCCESS;
@@ -143,16 +197,16 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
     for (i = 0; i < incount; i++) {
         if (array_of_requests[i] != MPI_REQUEST_NULL) {
             MPIR_Request_get_ptr(array_of_requests[i], request_ptrs[i]);
+            if (!MPIR_Request_is_active(request_ptrs[i]))
+                n_inactive += 1;
             /* Validate object pointers if error checking is enabled */
 #ifdef HAVE_ERROR_CHECKING
             {
                 MPID_BEGIN_ERROR_CHECKS;
                 {
                     MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS) {
+                    if (mpi_errno != MPI_SUCCESS)
                         goto fn_fail;
-                    }
-
                 }
                 MPID_END_ERROR_CHECKS;
             }
@@ -184,95 +238,40 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
         goto fn_exit;
     }
 
-    /* Bill Gropp says MPI_Waitsome() is expected to try to make
-     * progress even if some requests have already completed;
-     * therefore, we kick the pipes once and then fall into a loop
-     * checking for completion and waiting for progress. */
-    mpi_errno = MPID_Progress_test();
+    mpi_errno =
+        MPIR_Waitsome_impl(incount, request_ptrs, outcount, array_of_indices, array_of_statuses);
     if (mpi_errno != MPI_SUCCESS) {
         /* --BEGIN ERROR HANDLING-- */
         goto fn_fail;
         /* --END ERROR HANDLING-- */
     }
 
-    n_active = 0;
-    MPID_Progress_start(&progress_state);
-    for (;;) {
-        mpi_errno = MPIR_Grequest_progress_poke(incount, request_ptrs, array_of_statuses);
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-        for (i = 0; i < incount; i++) {
-            if (request_ptrs[i] != NULL) {
-                if (MPIR_Request_is_complete(request_ptrs[i])) {
-                    status_ptr =
-                        (array_of_statuses !=
-                         MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
-                    rc = MPIR_Request_completion_processing(request_ptrs[i],
-                                                            status_ptr, &active_flag);
-                    if (!MPIR_Request_is_persistent(request_ptrs[i])) {
-                        MPIR_Request_free(request_ptrs[i]);
-                        array_of_requests[i] = MPI_REQUEST_NULL;
-                    }
-                    if (active_flag) {
-                        array_of_indices[n_active] = i;
-                        n_active += 1;
-
-                        if (rc == MPI_SUCCESS) {
-                            request_ptrs[i] = NULL;
-                        } else {
-                            mpi_errno = MPI_ERR_IN_STATUS;
-                            if (status_ptr != MPI_STATUS_IGNORE) {
-                                status_ptr->MPI_ERROR = rc;
-                            }
-                        }
-                    } else {
-                        request_ptrs[i] = NULL;
-                        n_inactive += 1;
-                    }
-                } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                    MPID_Request_is_anysource(request_ptrs[i]) &&
-                                    !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
-                    mpi_errno = MPI_ERR_IN_STATUS;
-                    MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
-                    status_ptr =
-                        (array_of_statuses !=
-                         MPI_STATUSES_IGNORE) ? &array_of_statuses[n_active] : MPI_STATUS_IGNORE;
-                    if (status_ptr != MPI_STATUS_IGNORE)
-                        status_ptr->MPI_ERROR = rc;
-                }
-            }
+    for (i = 0; i < *outcount; i++) {
+        int indx = array_of_indices[i];
+        status_ptr =
+            (array_of_statuses != MPI_STATUSES_IGNORE) ? &array_of_statuses[i] : MPI_STATUS_IGNORE;
+        rc = MPIR_Request_completion_processing(request_ptrs[indx],
+                                                status_ptr, &active_flag);
+        if (!MPIR_Request_is_persistent(request_ptrs[indx])) {
+            MPIR_Request_free(request_ptrs[indx]);
+            array_of_requests[indx] = MPI_REQUEST_NULL;
         }
-
-        if (mpi_errno == MPI_ERR_IN_STATUS) {
-            if (array_of_statuses != MPI_STATUSES_IGNORE) {
-                for (i = 0; i < n_active; i++) {
-                    if (request_ptrs[array_of_indices[i]] == NULL) {
-                        array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
-                    }
-                }
-            }
-            *outcount = n_active;
-            break;
-        } else if (n_active > 0) {
-            *outcount = n_active;
-            break;
-        } else if (n_inactive == incount) {
-            *outcount = MPI_UNDEFINED;
-            break;
+        if (rc == MPI_SUCCESS)
+            request_ptrs[indx] = NULL;
+        else {
+            mpi_errno = MPI_ERR_IN_STATUS;
+            if (status_ptr != MPI_STATUS_IGNORE)
+                status_ptr->MPI_ERROR = rc;
         }
-
-        mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS) {
-            /* --BEGIN ERROR HANDLING-- */
-            MPID_Progress_end(&progress_state);
-            goto fn_fail;
-            /* --END ERROR HANDLING-- */
-        }
-        /* Avoid blocking other threads since I am inside an infinite loop */
-        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
-    MPID_Progress_end(&progress_state);
 
+    if (mpi_errno == MPI_ERR_IN_STATUS && array_of_statuses != MPI_STATUSES_IGNORE) {
+        for (i = 0; i < *outcount; i++) {
+            if (request_ptrs[array_of_indices[i]] == NULL) {
+                array_of_statuses[i].MPI_ERROR = MPI_SUCCESS;
+            }
+        }
+    }
     /* ... end of body of routine ... */
 
   fn_exit:

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -177,6 +177,14 @@ static inline int MPID_Progress_test(void)
 }
 #define MPID_Progress_poke()		     MPIDI_CH3_Progress_poke()
 
+/*
+ * Device level MPI wait/test functions
+ */
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
+
 /* Dynamic process support */
 int MPIDI_GPID_GetAllInComm( MPIR_Comm *comm_ptr, int local_size,
                              MPIDI_Gpid local_gpids[], int *singlePG );

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -180,6 +180,10 @@ static inline int MPID_Progress_test(void)
 /*
  * Device level MPI wait/test functions
  */
+#define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_impl
+#define MPID_Waitany MPIR_Waitany_impl
+#define MPID_Waitsome MPIR_Waitsome_impl
 #define MPID_Test MPIR_Test_impl
 #define MPID_Testall MPIR_Testall_impl
 #define MPID_Testany MPIR_Testany_impl

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -727,7 +727,7 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
     win_ptr->at_completion_counter += post_grp_ptr->size;
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
-        MPI_Request *req;
+        MPIR_Request **req_ptrs;
         MPI_Status *status;
         int i, post_grp_size, dst, rank;
         MPIR_Comm *win_comm_ptr;
@@ -745,8 +745,8 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
-        MPIR_CHKLMEM_MALLOC(req, MPI_Request *, post_grp_size * sizeof(MPI_Request),
-                            mpi_errno, "req", MPL_MEM_RMA);
+        MPIR_CHKLMEM_MALLOC(req_ptrs, MPIR_Request **, post_grp_size * sizeof(MPIR_Request *),
+                            mpi_errno, "req_ptrs", MPL_MEM_RMA);
         MPIR_CHKLMEM_MALLOC(status, MPI_Status *, post_grp_size * sizeof(MPI_Status),
                             mpi_errno, "status", MPL_MEM_RMA);
 
@@ -755,19 +755,20 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
             dst = post_ranks_in_win_grp[i];
 
             if (dst != rank) {
-                MPIR_Request *req_ptr;
                 mpi_errno = MPID_Isend(&i, 0, MPI_INT, dst, SYNC_POST_TAG, win_comm_ptr,
-                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptr);
+                                       MPIR_CONTEXT_INTRA_PT2PT, &req_ptrs[i]);
                 if (mpi_errno != MPI_SUCCESS)
                     MPIR_ERR_POP(mpi_errno);
-                req[i] = req_ptr->handle;
             }
             else {
-                req[i] = MPI_REQUEST_NULL;
+                req_ptrs[i] = NULL;
             }
         }
 
-        mpi_errno = MPIR_Waitall_impl(post_grp_size, req, status);
+        mpi_errno = MPIR_Waitall_impl(post_grp_size, req_ptrs, status);
+        if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPIR_Waitall_post(post_grp_size, NULL, req_ptrs, status);
         if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
             MPIR_ERR_POP(mpi_errno);
 
@@ -862,7 +863,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 
     if ((assert & MPI_MODE_NOCHECK) == 0) {
         int i, intra_cnt;
-        MPI_Request *intra_start_req = NULL;
+        MPIR_Request **intra_start_req = NULL;
         MPI_Status *intra_start_status = NULL;
         MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
         int rank = comm_ptr->rank;
@@ -872,8 +873,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
         /* post IRECVs */
         if (win_ptr->shm_allocated == TRUE) {
             int node_comm_size = comm_ptr->node_comm->local_size;
-            MPIR_CHKLMEM_MALLOC(intra_start_req, MPI_Request *,
-                                node_comm_size * sizeof(MPI_Request), mpi_errno, "intra_start_req", MPL_MEM_RMA);
+            MPIR_CHKLMEM_MALLOC(intra_start_req, MPIR_Request **,
+                                node_comm_size * sizeof(MPIR_Request *), mpi_errno, "intra_start_req", MPL_MEM_RMA);
             MPIR_CHKLMEM_MALLOC(intra_start_status, MPI_Status *,
                                 node_comm_size * sizeof(MPI_Status),
                                 mpi_errno, "intra_start_status", MPL_MEM_RMA);
@@ -895,7 +896,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
                     MPIR_ERR_POP(mpi_errno);
 
                 if (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id) {
-                    intra_start_req[intra_cnt++] = req_ptr->handle;
+                    intra_start_req[intra_cnt++] = req_ptr;
                 }
                 else {
                     if (!MPIR_Request_is_complete(req_ptr)) {
@@ -914,6 +915,10 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
             mpi_errno = MPIR_Waitall_impl(intra_cnt, intra_start_req, intra_start_status);
             if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
                 MPIR_ERR_POP(mpi_errno);
+            mpi_errno = MPIR_Waitall_post(intra_cnt, NULL, intra_start_req, intra_start_status);
+            if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
+                MPIR_ERR_POP(mpi_errno);
+
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno == MPI_ERR_IN_STATUS) {
                 for (i = 0; i < intra_cnt; i++) {

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -234,4 +234,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
     return mpi_errno;
 }
 
+/* Device level wait/test implementations */
+#define MPID_Test MPIR_Test_impl
+#define MPID_Testall MPIR_Testall_impl
+#define MPID_Testany MPIR_Testany_impl
+#define MPID_Testsome MPIR_Testsome_impl
+
 #endif /* CH4_PROGRESS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -239,5 +239,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deactivate(int id)
 #define MPID_Testall MPIR_Testall_impl
 #define MPID_Testany MPIR_Testany_impl
 #define MPID_Testsome MPIR_Testsome_impl
+#define MPID_Wait MPIR_Wait_impl
+#define MPID_Waitall MPIR_Waitall_impl
+#define MPID_Waitany MPIR_Waitany_impl
+#define MPID_Waitsome MPIR_Waitsome_impl
 
 #endif /* CH4_PROGRESS_H_INCLUDED */


### PR DESCRIPTION
This is the third attempt to make this a clean PR (#2742, #2951):

* Make series of `MPIR_Wait/Test*` taking `MPIR_Request` as default implementation of MPID_Wait/Test*
* Assume the device will set `flag` (Test), `outcount` and `index/array_of_indices` (`*any/some`), MPI runtime only handle status and error checking.
* Make a new `MPIR_Request_is_active` since Test/Wait any/some only records "active" request, and there is no way to know without `MPIR_Request_complete` it.
* Make a new `MPIR_Request_wait_and_complete` to reduce duplicated code in collective when the non-blocking version is used as the implementation of blocking one.
* Make each commit self-contained.
* Co-authored-by @hajimefu (please help review some of the code in any/some cases which I tried to make the device do the work instead of duplicating work)