### PR TITLE
mtest: Add huge message sends over dup'd comm

### DIFF
--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -58,6 +58,7 @@ noinst_PROGRAMS =  \
     manylmt        \
     huge_underflow \
     huge_anysrc    \
+    huge_dupcomm   \
     dtype_send		 \
     recv_any		\
     irecv_any

--- a/test/mpi/pt2pt/huge_dupcomm.c
+++ b/test/mpi/pt2pt/huge_dupcomm.c
@@ -1,0 +1,63 @@
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ *
+ *  This program checks if MPICH can correctly handle huge message sends
+ *  over multiple different communicators simultaneously
+ *
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "mpitest.h"
+
+#define COUNT (4*1024*1024)
+#define NCOMMS 4
+
+int main(int argc, char *argv[])
+{
+    int *buff;
+    int size, rank;
+    int i;
+    MPI_Comm comms[NCOMMS];
+    MPI_Request reqs[NCOMMS];
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size != 2) {
+        fprintf(stderr, "Launch with two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    buff = malloc(COUNT * NCOMMS * sizeof(int));
+
+    for (i = 0; i < NCOMMS; i++)
+        MPI_Comm_dup(MPI_COMM_WORLD, &comms[i]);
+
+    for (i = 0; i < NCOMMS; i++) {
+        if (rank == 0)
+            MPI_Isend(buff + COUNT*i, COUNT, MPI_INT, 1 /* dest */, 0 /* tag */, comms[i], &reqs[i]);
+        else
+            MPI_Irecv(buff + COUNT*i, COUNT, MPI_INT, 0 /* src */, 0 /* tag */, comms[i], &reqs[i]);
+    }
+    MPI_Waitall(NCOMMS, reqs, MPI_STATUSES_IGNORE);
+
+    for (i = 0; i < NCOMMS; i++)
+        MPI_Comm_free(&comms[i]);
+
+    free(buff);
+
+    MTest_Finalize(0);
+
+    return 0;
+}

--- a/test/mpi/pt2pt/testlist
+++ b/test/mpi/pt2pt/testlist
@@ -46,6 +46,7 @@ many_isend 3
 manylmt 2
 huge_underflow 2
 huge_anysrc 2
+huge_dupcomm 2
 dtype_send 2
 recv_any 2
 irecv_any 2


### PR DESCRIPTION
This commit adds a test case for sending huge messages over multiple different communicators.

Note this is a test case for a bug which we recently found in the CH4 OFI netmod but haven't implemented a fix yet. @yfguo please xfail this for ch4/ofi once it gets merged.