### PR TITLE
Bug fix for the TSP model

### DIFF
--- a/src/mpi/coll/transports/stubtran/tsp_stubtran_types.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran_types.h
@@ -12,6 +12,8 @@
 #define TSP_STUBTRAN_TYPES_H_INCLUDED
 
 typedef struct MPII_Stubutil_sched_t {
+    /* empty structures are invalid on some systems/compilers */
+    int dummy;
 } MPII_Stubutil_sched_t;
 
 #endif /* TSP_STUBTRAN_TYPES_H_INCLUDED */


### PR DESCRIPTION
Solaris complains about the empty structure used in the stub TSP transport.