### PR TITLE
warning squash

### DIFF
--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -775,7 +775,7 @@ PMPI_LOCAL int MPIR_Dims_create_impl(int nnodes, int ndims, int dims[])
      * have already trimmed off some large factors */
     /* First, find all of the divisors given by the remaining factors */
     ndivs = ndivisors_from_factor(nf, (const Factors *) f);
-    MPIR_CHKLMEM_MALLOC(divs, int *, (ndivs) * sizeof(int), mpi_errno, "divs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(divs, int *, ((unsigned int) ndivs) * sizeof(int), mpi_errno, "divs", MPL_MEM_COMM);
     ndivs = factor_to_divisors(nf, f, ndivs, divs);
     if (MPIR_CVAR_DIMS_VERBOSE) {
         for (i = 0; i < ndivs; i++) {

--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.h
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.h
@@ -15,7 +15,7 @@
 #include <assert.h>
 
 struct HYDT_topo_hwloc_info {
-    int num_bitmaps;
+    unsigned int num_bitmaps;
     hwloc_bitmap_t *bitmap;
     hwloc_membind_policy_t membind;
     int user_binding;


### PR DESCRIPTION
Some compilers complain when the range of the possible values passed
to malloc can be negative.