### PR TITLE
ROMIO: fix invalid file descriptor for reading hint file

### DIFF
--- a/src/mpi/romio/adio/common/system_hints.c
+++ b/src/mpi/romio/adio/common/system_hints.c
@@ -98,7 +98,7 @@ static int file_to_info_all(int fd, MPI_Info info, int rank, MPI_Comm comm)
     buffer = (char *) ADIOI_Calloc(HINTFILE_MAX_SIZE, sizeof(char));
 
     if (rank == 0) {
-        ret = read(fd, buffer, HINTFILE_MAX_SIZE);
+        ret = (fd >= 0) ? read(fd, buffer, HINTFILE_MAX_SIZE) : -1;
         /* any error: bad/nonexistent fd, no perms, anything: set up a null
          * buffer and the subsequent string parsing will quit immediately */
         if (ret == -1)


### PR DESCRIPTION
This fixes the issue pmodels/mpich#2894 which reported a valgrind warning caused by ROMIO passing an invalid file descriptor to `read()`. The issue happens because in `adio/common/system_hints.c` `find_file()` fails to open the `/etc/romio-hints` file. The resulting `-1` fd is then passed to `file_to_info_all()` which uses it to read the file without first checking its validity.