### PR TITLE
Finalize CH3 channels after destructing COMM_WORLD/SELF

### DIFF
--- a/src/mpid/ch3/src/mpid_finalize.c
+++ b/src/mpid/ch3/src/mpid_finalize.c
@@ -111,11 +111,6 @@ int MPID_Finalize(void)
     if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 #endif
 
-    /* Note that the CH3I_Progress_finalize call has been removed; the
-       CH3_Finalize routine should call it */
-    mpi_errno = MPIDI_CH3_Finalize();
-    if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
-
 #ifdef MPID_NEEDS_ICOMM_WORLD
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.icomm_world);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
@@ -126,6 +121,11 @@ int MPID_Finalize(void)
 
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_world);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+
+    /* Note that the CH3I_Progress_finalize call has been removed; the
+       CH3_Finalize routine should call it */
+    mpi_errno = MPIDI_CH3_Finalize();
+    if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 
     /* Tell the process group code that we're done with the process groups.
        This will notify PMI (with PMI_Finalize) if necessary.  It


### PR DESCRIPTION
This patch moves the invocation of MPIDI_CH3_Finalize after the
destruction of MPI_COMM_WORLD/SELF.
Some CH3 channel (e.g. Nemesis) register comm destructor which
refers to the channel-specific data structures. Finalizing channels
before destructing all the communicators causes a semantic conflict.
Channel initialization happens before creation of COMM_WORLD/SELF,
so finalizing channels after comm destruction makes more sense than
the opposite way.

This was a part of #2477, but since Nemesis shared memory barrier is gone, only this patch remained relevant.

Signed-off-by: Charles J Archer <charles.j.archer@intel.com>