### PR TITLE
ROMIO: Bug fixes when read/write are larger than INT_MAX

### DIFF
--- a/src/mpi/romio/adio/common/ad_read_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_read_str_naive.c
@@ -286,6 +286,9 @@ void ADIOI_GEN_ReadStrided_naive(ADIO_File fd, void *buf, int count,
                 ADIO_Offset new_brd_size = brd_size, new_frd_size = frd_size;
 
                 size = MPL_MIN(frd_size, brd_size);
+                /* keep max of a single read amount <= INT_MAX */
+                size = MPL_MIN(size, INT_MAX);
+
                 if (size) {
                     req_off = off;
                     req_len = size;

--- a/src/mpi/romio/adio/common/ad_write_str_naive.c
+++ b/src/mpi/romio/adio/common/ad_write_str_naive.c
@@ -284,6 +284,9 @@ void ADIOI_GEN_WriteStrided_naive(ADIO_File fd, const void *buf, int count,
                 ADIO_Offset new_bwr_size = bwr_size, new_fwr_size = fwr_size;
 
                 size = MPL_MIN(fwr_size, bwr_size);
+                /* keep max of a single read amount <= INT_MAX */
+                size = MPL_MIN(size, INT_MAX);
+
                 if (size) {
                     req_off = off;
                     req_len = size;


### PR DESCRIPTION
This PR supersedes #2886 and #2887 which were originally created by @wkliao.