### PR TITLE
 ch4/ofi: Set FI_WAIT_UNSPEC for RMA win counters

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -293,7 +293,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
     index =
         MPIDI_OFI_index_allocator_alloc(MPIDI_OFI_COMM(MPIR_Process.comm_world).rma_id_allocator,
                                         MPL_MEM_RMA);
-    MPIR_Assert((int) index < MPIDI_Global.max_huge_rmas);
+    MPIR_Assert(index < MPIDI_Global.max_huge_rmas);
     lmt_info->rma_key = MPIDI_OFI_ENABLE_MR_SCALABLE ? index << MPIDI_Global.huge_rma_shift : 0;
 
     MPIR_cc_incr(sreq->cc_ptr, &c);     /* send completion */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -747,6 +747,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* ------------------------------------------------------------------------ */
     memset(&cntr_attr, 0, sizeof(cntr_attr));
     cntr_attr.events = FI_CNTR_EVENTS_COMP;
+    cntr_attr.wait_obj = FI_WAIT_UNSPEC;
     MPIDI_OFI_CALL(fi_cntr_open(MPIDI_Global.domain,    /* In:  Domain Object        */
                                 &cntr_attr,     /* In:  Configuration object */
                                 &MPIDI_Global.rma_cmpl_cntr,    /* Out: Counter Object       */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -190,6 +190,7 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
 
         memset(&cntr_attr, 0, sizeof(cntr_attr));
         cntr_attr.events = FI_CNTR_EVENTS_COMP;
+        cntr_attr.wait_obj = FI_WAIT_UNSPEC;
         MPIDI_OFI_CALL(fi_cntr_open(MPIDI_Global.domain,        /* In:  Domain Object        */
                                     &cntr_attr, /* In:  Configuration object */
                                     &MPIDI_OFI_WIN(win).cmpl_cntr,      /* Out: Counter Object       */


### PR DESCRIPTION
The PR consists of two patches that are going to address two problems:
- If a caller of fi_cntr_open() specifies `fi_cntr_attr::wait_obj = FI_WAIT_NONE (0)`, the OFI cntr doesn't create wait object. But implementation of Win fence progressing requires the use of CNTR's wait object.
- Remove casting unsigned 64-bit integer value to signed  32-bit integer value