### PR TITLE
Use "allcomm" for communicator-type independent algorithms

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -75,9 +75,9 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int send
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag);
+int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Allgatherv ********************************/
@@ -119,9 +119,10 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, int sen
                                                     MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                       MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, const int *recvcounts, const int *displs,
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * errflag);
 
 
 /******************************** Allreduce ********************************/
@@ -150,8 +151,8 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Allreduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Alltoall ********************************/
@@ -189,9 +190,9 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, int sendcount, MP
                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                     int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                     MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Alltoallv ********************************/
@@ -230,9 +231,10 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendc
                                            MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoallv_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                      MPI_Datatype sendtype, void *recvbuf, const int *recvcnts, const int *rdispls,
-                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
+                              MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
+                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag);
 
 
 /******************************** Alltoallw ********************************/
@@ -274,10 +276,10 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const int *sendc
                                            MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Alltoallw_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                      const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                      const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
+                              const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
+                              const int *rdispls, const MPI_Datatype * recvtypes,
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Barrier ********************************/
@@ -294,7 +296,7 @@ int MPIR_Barrier_inter_auto(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Barrier_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Bcast ********************************/
@@ -326,8 +328,8 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer, int count, MPI_Dataty
                                              MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Bcast_nb(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                  MPIR_Errflag_t * errflag);
+int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int root,
+                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Exscan ********************************/
@@ -344,8 +346,8 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int
                                          MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Exscan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Gather ********************************/
@@ -376,9 +378,9 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcnt,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Gather_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag);
+int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
+                           int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag);
 
 
 /******************************** Gatherv ********************************/
@@ -400,12 +402,13 @@ int MPIR_Gatherv_inter_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendt
                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Gatherv_linear(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                        const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                    const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_allcomm_linear(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
+                                void *recvbuf, const int *recvcnts, const int *displs,
+                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
+                            const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
+                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Iallgather ********************************/
@@ -858,10 +861,10 @@ int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
                                    MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Igatherv_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
-                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                       void *recvbuf, const int *recvcounts, const int *displs,
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_allgather ********************************/
@@ -894,9 +897,10 @@ int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount
                                               MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_allgather_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_allgatherv ********************************/
@@ -933,11 +937,11 @@ int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcoun
                                                MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_allgatherv_sched_linear(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
-                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                           MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
+                                                   MPI_Datatype sendtype, void *recvbuf,
+                                                   const int recvcounts[], const int displs[],
+                                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                                   MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_alltoall ********************************/
@@ -970,9 +974,10 @@ int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
                                              MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoall_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_alltoallv ********************************/
@@ -1012,11 +1017,11 @@ int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sen
                                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallv_sched_linear(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                  const int sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const int recvcounts[],
+                                                  const int rdispls[], MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ineighbor_alltoallw ********************************/
@@ -1060,11 +1065,12 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
                                               MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallw_sched_linear(const void *sendbuf, const int sendcounts[],
-                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                  const MPI_Aint sdispls[],
+                                                  const MPI_Datatype sendtypes[], void *recvbuf,
+                                                  const int recvcounts[], const MPI_Aint rdispls[],
+                                                  const MPI_Datatype recvtypes[],
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Ireduce ********************************/
@@ -1296,10 +1302,10 @@ int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int *sendcounts, 
                                     MPIR_Sched_t s);
 
 /* sched-based anycomm functions */
-int MPIR_Iscatterv_sched_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int *sendcounts,
+                                        const int *displs, MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 
 
 /******************************** Neighbor_allgather ********************************/
@@ -1321,9 +1327,9 @@ int MPIR_Neighbor_allgather_inter_auto(const void *sendbuf, int sendcount, MPI_D
                                        MPIR_Comm * comm_ptr);
 
 /* anycomm functions */
-int MPIR_Neighbor_allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                       MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_allgatherv ********************************/
@@ -1345,9 +1351,9 @@ int MPIR_Neighbor_allgatherv_inter_auto(const void *sendbuf, int sendcount, MPI_
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* anycomm functions */
-int MPIR_Neighbor_allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int recvcounts[], const int displs[],
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                        void *recvbuf, const int recvcounts[], const int displs[],
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoall ********************************/
@@ -1368,9 +1374,9 @@ int MPIR_Neighbor_alltoall_inter_auto(const void *sendbuf, int sendcount, MPI_Da
                                       MPIR_Comm * comm_ptr);
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoallv ********************************/
@@ -1394,9 +1400,10 @@ int MPIR_Neighbor_alltoallv_inter_auto(const void *sendbuf, const int sendcounts
                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoallv_nb(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                               MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                               const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts[],
+                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
+                                       const int recvcounts[], const int rdispls[],
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
 
 
 /******************************** Neighbor_alltoallw ********************************/
@@ -1424,10 +1431,11 @@ int MPIR_Neighbor_alltoallw_inter_auto(const void *sendbuf, const int sendcounts
                                        MPIR_Comm * comm_ptr);
 
 /* anycomm functions */
-int MPIR_Neighbor_alltoallw_nb(const void *sendbuf, const int sendcounts[],
-                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                               void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr);
+int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[],
+                                       const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                       void *recvbuf, const int recvcounts[],
+                                       const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                       MPIR_Comm * comm_ptr);
 
 
 /******************************** Reduce ********************************/
@@ -1455,8 +1463,8 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf, void *recvbu
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Reduce_local ********************************/
@@ -1502,9 +1510,9 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
                                                           MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_scatter_nb(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int *recvcnts,
+                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                                   MPIR_Errflag_t * errflag);
 
 
 /******************************** Reduce_scatter_block ********************************/
@@ -1545,9 +1553,9 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
                                                                 MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Reduce_scatter_block_nb(const void *sendbuf, void *recvbuf, int recvcount,
-                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int recvcount,
+                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                                         MPIR_Errflag_t * errflag);
 
 
 /******************************** Scan ********************************/
@@ -1566,8 +1574,8 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datat
                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Scan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 
 /******************************** Scatter ********************************/
@@ -1599,9 +1607,9 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendcn
                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Scatter_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                    int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * errflag);
+int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
+                            int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                            MPIR_Errflag_t * errflag);
 
 
 /******************************** Scatterv ********************************/
@@ -1625,11 +1633,13 @@ int MPIR_Scatterv_inter_auto(const void *sendbuf, const int *sendcnts, const int
                              MPIR_Errflag_t * errflag);
 
 /* anycomm functions */
-int MPIR_Scatterv_linear(const void *sendbuf, const int *sendcnts, const int *displs,
-                         MPI_Datatype sendtype, void *recvbuf, int recvcnt, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_nb(const void *sendbuf, const int *sendcnts, const int *displs,
-                     MPI_Datatype sendtype, void *recvbuf, int recvcnt, MPI_Datatype recvtype,
-                     int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcnts, const int *displs,
+                                 MPI_Datatype sendtype, void *recvbuf, int recvcnt,
+                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                 MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *displs,
+                             MPI_Datatype sendtype, void *recvbuf, int recvcnt,
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag);
 
 #endif /* MPIR_COLL_H_INCLUDED */

--- a/src/mpi/coll/allgather/Makefile.mk
+++ b/src/mpi/coll/allgather/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/allgather/allgather.c
 
 mpi_core_sources +=											\
-	src/mpi/coll/allgather/allgather_nb.c	\
+	src/mpi/coll/allgather/allgather_allcomm_nb.c	\
 	src/mpi/coll/allgather/allgather_intra_recursive_doubling.c	\
 	src/mpi/coll/allgather/allgather_intra_brucks.c				\
 	src/mpi/coll/allgather/allgather_intra_ring.c					\

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -201,8 +201,8 @@ int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
                 break;
             case MPIR_ALLGATHER_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                      comm_ptr, errflag);
+                    MPIR_Allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                              recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -223,8 +223,8 @@ int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
                 break;
             case MPIR_ALLGATHER_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                      comm_ptr, errflag);
+                    MPIR_Allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                              recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHER_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -7,12 +7,12 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Neighbor_alltoallv_nb
+#define FUNCNAME MPIR_Allgather_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Neighbor_alltoallv_nb(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                               MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                               const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +20,8 @@ int MPIR_Neighbor_alltoallv_nb(const void *sendbuf, const int sendcounts[], cons
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
-                                 rdispls, recvtype, comm_ptr, &req_ptr);
+        MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
+                        &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/allgatherv/Makefile.mk
+++ b/src/mpi/coll/allgatherv/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/allgatherv/allgatherv.c
 
 mpi_core_sources +=											\
-	src/mpi/coll/allgatherv/allgatherv_nb.c	\
+	src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c	\
 	src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c	\
 	src/mpi/coll/allgatherv/allgatherv_intra_brucks.c				\
 	src/mpi/coll/allgatherv/allgatherv_intra_ring.c				\

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -214,9 +214,9 @@ int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendty
                                                        comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHERV_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Allgatherv_nb(sendbuf, sendcount, sendtype,
-                                               recvbuf, recvcounts, displs, recvtype,
-                                               comm_ptr, errflag);
+                mpi_errno = MPIR_Allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                       recvbuf, recvcounts, displs, recvtype,
+                                                       comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -236,9 +236,9 @@ int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendty
                                                                     recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHERV_INTER_ALGO_NB:
-                mpi_errno = MPIR_Allgatherv_nb(sendbuf, sendcount, sendtype,
-                                               recvbuf, recvcounts, displs, recvtype,
-                                               comm_ptr, errflag);
+                mpi_errno = MPIR_Allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                       recvbuf, recvcounts, displs, recvtype,
+                                                       comm_ptr, errflag);
                 break;
             case MPIR_ALLGATHERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -7,12 +7,13 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Scatterv_nb
+#define FUNCNAME MPIR_Allgatherv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Scatterv_nb(const void *sendbuf, const int *sendcounts, const int *displs,
-                     MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                     int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                               void *recvbuf, const int *recvcounts, const int *displs,
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +21,8 @@ int MPIR_Scatterv_nb(const void *sendbuf, const int *sendcounts, const int *disp
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
-                       comm_ptr, &req_ptr);
+        MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
+                         comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/allreduce/Makefile.mk
+++ b/src/mpi/coll/allreduce/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/allreduce/allreduce.c
 
 mpi_core_sources +=											\
-	src/mpi/coll/allreduce/allreduce_nb.c	\
+	src/mpi/coll/allreduce/allreduce_allcomm_nb.c	\
 	src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c	\
 	src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c	\
 	src/mpi/coll/allreduce/allreduce_intra_smp.c	\

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -289,8 +289,8 @@ int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datat
                                                                           errflag);
                 break;
             case MPIR_ALLREDUCE_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Allreduce_nb(sendbuf, recvbuf, count,
-                                              datatype, op, comm_ptr, errflag);
+                mpi_errno = MPIR_Allreduce_allcomm_nb(sendbuf, recvbuf, count,
+                                                      datatype, op, comm_ptr, errflag);
                 break;
             case MPIR_ALLREDUCE_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -308,8 +308,8 @@ int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datat
                                                                op, comm_ptr, errflag);
                 break;
             case MPIR_ALLREDUCE_INTER_ALGO_NB:
-                mpi_errno = MPIR_Allreduce_nb(sendbuf, recvbuf, count,
-                                              datatype, op, comm_ptr, errflag);
+                mpi_errno = MPIR_Allreduce_allcomm_nb(sendbuf, recvbuf, count,
+                                                      datatype, op, comm_ptr, errflag);
                 break;
             case MPIR_ALLREDUCE_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -7,20 +7,18 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Neighbor_alltoall_nb
+#define FUNCNAME MPIR_Allreduce_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Neighbor_alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr)
+int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype,
-                                        recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/alltoall/Makefile.mk
+++ b/src/mpi/coll/alltoall/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/alltoall/alltoall.c
 
 mpi_core_sources +=												\
-	src/mpi/coll/alltoall/alltoall_nb.c	\
+	src/mpi/coll/alltoall/alltoall_allcomm_nb.c	\
 	src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c	\
 	src/mpi/coll/alltoall/alltoall_intra_brucks.c						\
 	src/mpi/coll/alltoall/alltoall_intra_scattered.c					\

--- a/src/mpi/coll/alltoall/alltoall.c
+++ b/src/mpi/coll/alltoall/alltoall.c
@@ -226,8 +226,9 @@ int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                                                           comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALL_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Alltoall_nb(sendbuf, sendcount, sendtype,
-                                             recvbuf, recvcount, recvtype, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                     recvbuf, recvcount, recvtype, comm_ptr,
+                                                     errflag);
                 break;
             case MPIR_ALLTOALL_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -246,8 +247,9 @@ int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                                                                   comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALL_INTER_ALGO_NB:
-                mpi_errno = MPIR_Alltoall_nb(sendbuf, sendcount, sendtype,
-                                             recvbuf, recvcount, recvtype, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                     recvbuf, recvcount, recvtype, comm_ptr,
+                                                     errflag);
                 break;
             case MPIR_ALLTOALL_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -7,12 +7,12 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Allgatherv_nb
+#define FUNCNAME MPIR_Alltoall_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                       MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +20,8 @@ int MPIR_Allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
-                         comm_ptr, &req_ptr);
+        MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
+                       &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/alltoallv/Makefile.mk
+++ b/src/mpi/coll/alltoallv/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/alltoallv/alltoallv.c
 
 mpi_core_sources +=												\
-	src/mpi/coll/alltoallv/alltoallv_nb.c	\
+	src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c	\
 	src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c	\
 	src/mpi/coll/alltoallv/alltoallv_intra_scattered.c					\
 	src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c

--- a/src/mpi/coll/alltoallv/alltoallv.c
+++ b/src/mpi/coll/alltoallv/alltoallv.c
@@ -160,9 +160,9 @@ int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *s
                                                            rdispls, recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLV_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Alltoallv_nb(sendbuf, sendcounts, sdispls,
-                                              sendtype, recvbuf, recvcounts,
-                                              rdispls, recvtype, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls,
+                                                      sendtype, recvbuf, recvcounts,
+                                                      rdispls, recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -182,9 +182,9 @@ int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *s
                                                                    errflag);
                 break;
             case MPIR_ALLTOALLV_INTER_ALGO_NB:
-                mpi_errno = MPIR_Alltoallv_nb(sendbuf, sendcounts, sdispls,
-                                              sendtype, recvbuf, recvcounts,
-                                              rdispls, recvtype, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls,
+                                                      sendtype, recvbuf, recvcounts,
+                                                      rdispls, recvtype, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -7,22 +7,22 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Neighbor_allgatherv_nb
+#define FUNCNAME MPIR_Alltoallv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Neighbor_allgatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int recvcounts[], const int displs[],
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
+int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *sdispls,
+                              MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
+                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,
-                                          recvbuf, recvcounts, displs, recvtype,
-                                          comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
+                        recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/alltoallw/Makefile.mk
+++ b/src/mpi/coll/alltoallw/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/alltoallw/alltoallw.c
 
 mpi_core_sources +=												\
-	src/mpi/coll/alltoallw/alltoallw_nb.c	\
+	src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c	\
 	src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c	\
 	src/mpi/coll/alltoallw/alltoallw_intra_scattered.c					\
 	src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c

--- a/src/mpi/coll/alltoallw/alltoallw.c
+++ b/src/mpi/coll/alltoallw/alltoallw.c
@@ -157,9 +157,9 @@ int MPIR_Alltoallw_impl(const void *sendbuf, const int sendcounts[], const int s
                                                            rdispls, recvtypes, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLW_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Alltoallw_nb(sendbuf, sendcounts,
-                                              sdispls, sendtypes, recvbuf, recvcounts,
-                                              rdispls, recvtypes, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoallw_allcomm_nb(sendbuf, sendcounts,
+                                                      sdispls, sendtypes, recvbuf, recvcounts,
+                                                      rdispls, recvtypes, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLW_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -179,9 +179,9 @@ int MPIR_Alltoallw_impl(const void *sendbuf, const int sendcounts[], const int s
                                                                    errflag);
                 break;
             case MPIR_ALLTOALLW_INTER_ALGO_NB:
-                mpi_errno = MPIR_Alltoallw_nb(sendbuf, sendcounts,
-                                              sdispls, sendtypes, recvbuf, recvcounts,
-                                              rdispls, recvtypes, comm_ptr, errflag);
+                mpi_errno = MPIR_Alltoallw_allcomm_nb(sendbuf, sendcounts,
+                                                      sdispls, sendtypes, recvbuf, recvcounts,
+                                                      rdispls, recvtypes, comm_ptr, errflag);
                 break;
             case MPIR_ALLTOALLW_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -7,13 +7,13 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Alltoallv_nb
+#define FUNCNAME MPIR_Alltoallw_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Alltoallv_nb(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                      const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag)
+int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[], const int sdispls[],
+                              const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
+                              const int rdispls[], const MPI_Datatype recvtypes[],
+                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -21,8 +21,8 @@ int MPIR_Alltoallv_nb(const void *sendbuf, const int *sendcounts, const int *sdi
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
-                        recvtype, comm_ptr, &req_ptr);
+        MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
+                        recvtypes, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/barrier/Makefile.mk
+++ b/src/mpi/coll/barrier/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/barrier/barrier.c
 
 mpi_core_sources +=										\
-	src/mpi/coll/barrier/barrier_nb.c	\
+	src/mpi/coll/barrier/barrier_allcomm_nb.c	\
 	src/mpi/coll/barrier/barrier_intra_recursive_doubling.c	\
 	src/mpi/coll/barrier/barrier_intra_smp.c				\
 	src/mpi/coll/barrier/barrier_inter_bcast.c

--- a/src/mpi/coll/barrier/barrier.c
+++ b/src/mpi/coll/barrier/barrier.c
@@ -145,7 +145,7 @@ int MPIR_Barrier_impl(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
                 mpi_errno = MPIR_Barrier_intra_recursive_doubling(comm_ptr, errflag);
                 break;
             case MPIR_BARRIER_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Barrier_nb(comm_ptr, errflag);
+                mpi_errno = MPIR_Barrier_allcomm_nb(comm_ptr, errflag);
                 break;
             case MPIR_BARRIER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -160,7 +160,7 @@ int MPIR_Barrier_impl(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
                 mpi_errno = MPIR_Barrier_inter_bcast(comm_ptr, errflag);
                 break;
             case MPIR_BARRIER_INTER_ALGO_NB:
-                mpi_errno = MPIR_Barrier_nb(comm_ptr, errflag);
+                mpi_errno = MPIR_Barrier_allcomm_nb(comm_ptr, errflag);
                 break;
             case MPIR_BARRIER_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -7,21 +7,17 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Allgather_nb
+#define FUNCNAME MPIR_Barrier_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag)
+int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno =
-        MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
-                        &req_ptr);
+    mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/bcast/Makefile.mk
+++ b/src/mpi/coll/bcast/Makefile.mk
@@ -17,7 +17,7 @@ mpi_sources +=                     		\
 
 mpi_core_sources +=											\
 	src/mpi/coll/bcast/bcast_utils.c						\
-	src/mpi/coll/bcast/bcast_nb.c						\
+	src/mpi/coll/bcast/bcast_allcomm_nb.c						\
 	src/mpi/coll/bcast/bcast_intra_binomial.c						\
 	src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c	\
 	src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c		\

--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -295,7 +295,7 @@ int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MP
                                                             errflag);
                 break;
             case MPIR_BCAST_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Bcast_nb(buffer, count, datatype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Bcast_allcomm_nb(buffer, count, datatype, root, comm_ptr, errflag);
                 break;
             case MPIR_BCAST_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -312,7 +312,7 @@ int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MP
                                                              comm_ptr, errflag);
                 break;
             case MPIR_BCAST_INTER_ALGO_NB:
-                mpi_errno = MPIR_Bcast_nb(buffer, count, datatype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Bcast_allcomm_nb(buffer, count, datatype, root, comm_ptr, errflag);
                 break;
             case MPIR_BCAST_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -7,18 +7,18 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Reduce_nb
+#define FUNCNAME MPIR_Bcast_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Reduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int root,
+                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/exscan/Makefile.mk
+++ b/src/mpi/coll/exscan/Makefile.mk
@@ -16,5 +16,5 @@ mpi_sources +=                     		\
 	src/mpi/coll/exscan/exscan.c
 
 mpi_core_sources +=									\
-	src/mpi/coll/exscan/exscan_nb.c \
+	src/mpi/coll/exscan/exscan_allcomm_nb.c \
 	src/mpi/coll/exscan/exscan_intra_recursive_doubling.c

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -102,7 +102,8 @@ int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count,
                                                      comm_ptr, errflag);
             break;
         case MPIR_EXSCAN_INTRA_ALGO_NB:
-            mpi_errno = MPIR_Exscan_nb(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+            mpi_errno =
+                MPIR_Exscan_allcomm_nb(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
             break;
         case MPIR_EXSCAN_INTRA_ALGO_AUTO:
             MPL_FALLTHROUGH;

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -7,18 +7,18 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Scan_nb
+#define FUNCNAME MPIR_Exscan_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Scan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/gather/Makefile.mk
+++ b/src/mpi/coll/gather/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/gather/gather.c
 
 mpi_core_sources +=									\
-	src/mpi/coll/gather/gather_nb.c			\
+	src/mpi/coll/gather/gather_allcomm_nb.c			\
 	src/mpi/coll/gather/gather_intra_binomial.c			\
 	src/mpi/coll/gather/gather_inter_linear.c \
 	src/mpi/coll/gather/gather_inter_local_gather_remote_send.c

--- a/src/mpi/coll/gather/gather.c
+++ b/src/mpi/coll/gather/gather.c
@@ -171,8 +171,9 @@ int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                                        comm_ptr, errflag);
                 break;
             case MPIR_GATHER_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Gather_nb(sendbuf, sendcount, sendtype,
-                                           recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Gather_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                   recvbuf, recvcount, recvtype, root, comm_ptr,
+                                                   errflag);
                 break;
             case MPIR_GATHER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -196,8 +197,9 @@ int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                                                        root, comm_ptr, errflag);
                 break;
             case MPIR_GATHER_INTER_ALGO_NB:
-                mpi_errno = MPIR_Gather_nb(sendbuf, sendcount, sendtype,
-                                           recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Gather_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                   recvbuf, recvcount, recvtype, root, comm_ptr,
+                                                   errflag);
                 break;
             case MPIR_GATHER_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -7,18 +7,21 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Allreduce_nb
+#define FUNCNAME MPIR_Gather_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Allreduce_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
+                           int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                           MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
+                     &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/gatherv/Makefile.mk
+++ b/src/mpi/coll/gatherv/Makefile.mk
@@ -16,5 +16,5 @@ mpi_sources +=                     		\
 	src/mpi/coll/gatherv/gatherv.c
 
 mpi_core_sources +=									\
-	src/mpi/coll/gatherv/gatherv_nb.c \
-	src/mpi/coll/gatherv/gatherv_linear.c
+	src/mpi/coll/gatherv/gatherv_allcomm_nb.c \
+	src/mpi/coll/gatherv/gatherv_allcomm_linear.c

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -87,8 +87,8 @@ int MPIR_Gatherv_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Gatherv_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
-                            root, comm_ptr, errflag);
+        MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
+                                    recvtype, root, comm_ptr, errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -113,8 +113,8 @@ int MPIR_Gatherv_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Gatherv_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
-                            root, comm_ptr, errflag);
+        MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
+                                    recvtype, root, comm_ptr, errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -143,13 +143,13 @@ int MPIR_Gatherv_impl(const void *sendbuf, int sendcount,
         switch (MPIR_Gatherv_intra_algo_choice) {
             case MPIR_GATHERV_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Gatherv_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                        recvtype, root, comm_ptr, errflag);
+                    MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                                displs, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_GATHERV_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Gatherv_nb(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                    recvtype, root, comm_ptr, errflag);
+                    MPIR_Gatherv_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                            displs, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_GATHERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -163,13 +163,13 @@ int MPIR_Gatherv_impl(const void *sendbuf, int sendcount,
         switch (MPIR_Gatherv_inter_algo_choice) {
             case MPIR_GATHERV_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Gatherv_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                        recvtype, root, comm_ptr, errflag);
+                    MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                                displs, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_GATHERV_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Gatherv_nb(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                    recvtype, root, comm_ptr, errflag);
+                    MPIR_Gatherv_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                            displs, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_GATHERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -38,17 +38,17 @@ cvars:
  * Cost = (p-1).alpha + n.((p-1)/p).beta
 */
 #undef FUNCNAME
-#define FUNCNAME MPIR_Gatherv_linear
+#define FUNCNAME MPIR_Gatherv_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Gatherv_linear(const void *sendbuf,
-                        int sendcount,
-                        MPI_Datatype sendtype,
-                        void *recvbuf,
-                        const int *recvcounts,
-                        const int *displs,
-                        MPI_Datatype recvtype,
-                        int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
+                                int sendcount,
+                                MPI_Datatype sendtype,
+                                void *recvbuf,
+                                const int *recvcounts,
+                                const int *displs,
+                                MPI_Datatype recvtype,
+                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -7,12 +7,13 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Alltoall_nb
+#define FUNCNAME MPIR_Gatherv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                     int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                     MPIR_Errflag_t * errflag)
+int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, const int *recvcounts, const int *displs,
+                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                            MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +21,8 @@ int MPIR_Alltoall_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, 
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
-                       &req_ptr);
+        MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
+                      comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/igatherv/Makefile.mk
+++ b/src/mpi/coll/igatherv/Makefile.mk
@@ -16,5 +16,5 @@ mpi_sources +=                                  \
     src/mpi/coll/igatherv/igatherv.c
 
 mpi_core_sources +=                          \
-    src/mpi/coll/igatherv/igatherv_linear.c
+    src/mpi/coll/igatherv/igatherv_allcomm_linear.c
 

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -84,8 +84,8 @@ int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Igatherv_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                   recvtype, root, comm_ptr, s);
+        MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                           displs, recvtype, root, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -108,8 +108,8 @@ int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Igatherv_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                   recvtype, root, comm_ptr, s);
+        MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
+                                           displs, recvtype, root, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -134,8 +134,9 @@ int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
         switch (MPIR_Igatherv_intra_algo_choice) {
             case MPIR_IGATHERV_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Igatherv_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                               displs, recvtype, root, comm_ptr, s);
+                    MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf,
+                                                       recvcounts, displs, recvtype, root, comm_ptr,
+                                                       s);
                 break;
             case MPIR_IGATHERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -149,8 +150,9 @@ int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
         switch (MPIR_Igatherv_inter_algo_choice) {
             case MPIR_IGATHERV_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Igatherv_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                               displs, recvtype, root, comm_ptr, s);
+                    MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf,
+                                                       recvcounts, displs, recvtype, root, comm_ptr,
+                                                       s);
                 break;
             case MPIR_IGATHERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
@@ -13,13 +13,13 @@
  */
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Igatherv_sched_linear
+#define FUNCNAME MPIR_Igatherv_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Igatherv_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int recvcounts[], const int displs[],
-                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                       void *recvbuf, const int recvcounts[], const int displs[],
+                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpi/coll/ineighbor_allgather/Makefile.mk
+++ b/src/mpi/coll/ineighbor_allgather/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_allgather/ineighbor_allgather_linear.c
+    src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -83,8 +83,9 @@ int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_allgather_sched_linear(sendbuf, sendcount, sendtype,
-                                                      recvbuf, recvcount, recvtype, comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -106,8 +107,9 @@ int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_allgather_sched_linear(sendbuf, sendcount, sendtype,
-                                                      recvbuf, recvcount, recvtype, comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -131,7 +133,8 @@ int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_Ineighbor_allgather_intra_algo_choice) {
             case MPIR_INEIGHBOR_ALLGATHER_INTRA_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_allgather_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                   recvbuf, recvcount, recvtype,
                                                                   comm_ptr, s);
                 break;
@@ -146,7 +149,8 @@ int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_
     } else {
         switch (MPIR_Ineighbor_allgather_inter_algo_choice) {
             case MPIR_INEIGHBOR_ALLGATHER_INTER_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_allgather_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                   recvbuf, recvcount, recvtype,
                                                                   comm_ptr, s);
                 break;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
@@ -14,31 +14,26 @@
  */
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Ineighbor_allgatherv_sched_linear
+#define FUNCNAME MPIR_Ineighbor_allgather_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ineighbor_allgatherv_sched_linear(const void *sendbuf, int sendcount,
-                                           MPI_Datatype sendtype, void *recvbuf,
-                                           const int recvcounts[], const int displs[],
-                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                           MPIR_Sched_t s)
+int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
+                                                  MPI_Datatype sendtype, void *recvbuf,
+                                                  int recvcount, MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
-    int comm_size;
     MPI_Aint recvtype_extent;
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (displs[i] * recvtype_extent));
-    }
+    /* This is the largest offset we add to recvbuf */
+    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
+                                     (comm_ptr->local_size * recvcount * recvtype_extent));
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
@@ -58,8 +53,8 @@ int MPIR_Ineighbor_allgatherv_sched_linear(const void *sendbuf, int sendcount,
     }
 
     for (l = 0; l < indegree; ++l) {
-        char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
+        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_allgatherv/Makefile.mk
+++ b/src/mpi/coll/ineighbor_allgatherv/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_linear.c
+    src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -84,9 +84,9 @@ int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcoun
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_allgatherv_sched_linear(sendbuf, sendcount, sendtype,
-                                                       recvbuf, recvcounts, displs, recvtype,
-                                                       comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                               recvbuf, recvcounts, displs,
+                                                               recvtype, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -109,9 +109,9 @@ int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcoun
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_allgatherv_sched_linear(sendbuf, sendcount, sendtype,
-                                                       recvbuf, recvcounts, displs, recvtype,
-                                                       comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                               recvbuf, recvcounts, displs,
+                                                               recvtype, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -137,7 +137,8 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_Ineighbor_allgatherv_intra_algo_choice) {
             case MPIR_INEIGHBOR_ALLGATHERV_INTRA_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_allgatherv_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcounts, displs,
                                                                    recvtype, comm_ptr, s);
                 break;
@@ -152,7 +153,8 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
     } else {
         switch (MPIR_Ineighbor_allgatherv_inter_algo_choice) {
             case MPIR_INEIGHBOR_ALLGATHERV_INTER_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_allgatherv_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcounts, displs,
                                                                    recvtype, comm_ptr, s);
                 break;

--- a/src/mpi/coll/ineighbor_alltoall/Makefile.mk
+++ b/src/mpi/coll/ineighbor_alltoall/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_linear.c
+    src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -83,8 +83,9 @@ int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoall_sched_linear(sendbuf, sendcount, sendtype,
-                                                     recvbuf, recvcount, recvtype, comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                             recvbuf, recvcount, recvtype, comm_ptr,
+                                                             s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -106,8 +107,9 @@ int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoall_sched_linear(sendbuf, sendcount, sendtype,
-                                                     recvbuf, recvcount, recvtype, comm_ptr, s);
+    mpi_errno = MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
+                                                             recvbuf, recvcount, recvtype, comm_ptr,
+                                                             s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -132,7 +134,8 @@ int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_Ineighbor_alltoall_intra_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALL_INTRA_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_alltoall_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                  recvbuf, recvcount, recvtype,
                                                                  comm_ptr, s);
                 break;
@@ -147,7 +150,8 @@ int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
     } else {
         switch (MPIR_Ineighbor_alltoall_inter_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALL_INTER_ALGO_LINEAR:
-                mpi_errno = MPIR_Ineighbor_alltoall_sched_linear(sendbuf, sendcount, sendtype,
+                mpi_errno =
+                    MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                  recvbuf, recvcount, recvtype,
                                                                  comm_ptr, s);
                 break;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
@@ -14,34 +14,30 @@
  */
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Ineighbor_alltoallv_sched_linear
+#define FUNCNAME MPIR_Ineighbor_alltoall_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ineighbor_alltoallv_sched_linear(const void *sendbuf, const int sendcounts[],
-                                          const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                          const int recvcounts[], const int rdispls[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s)
+int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
+                                                 MPI_Datatype sendtype, void *recvbuf,
+                                                 int recvcount, MPI_Datatype recvtype,
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
-    int comm_size;
     MPI_Aint sendtype_extent, recvtype_extent;
     MPIR_CHKLMEM_DECL(2);
-
-    comm_size = comm_ptr->local_size;
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                         (sdispls[i] * sendtype_extent));
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (rdispls[i] * recvtype_extent));
-    }
+    /* This is the largest offset we add to sendbuf */
+    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
+                                     (comm_ptr->local_size * sendcount * sendtype_extent));
+    /* This is the largest offset we add to recvbuf */
+    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
+                                     (comm_ptr->local_size * recvcount * recvtype_extent));
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
@@ -55,15 +51,15 @@ int MPIR_Ineighbor_alltoallv_sched_linear(const void *sendbuf, const int sendcou
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
+        char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
+        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
-        char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
+        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallv/Makefile.mk
+++ b/src/mpi/coll/ineighbor_alltoallv/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_linear.c
+    src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -85,7 +85,8 @@ int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sen
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoallv_sched_linear(sendbuf, sendcounts, sdispls, sendtype,
+    mpi_errno =
+        MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtype,
                                                       recvbuf, recvcounts, rdispls, recvtype,
                                                       comm_ptr, s);
     if (mpi_errno)
@@ -110,7 +111,8 @@ int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sen
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoallv_sched_linear(sendbuf, sendcounts, sdispls, sendtype,
+    mpi_errno =
+        MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtype,
                                                       recvbuf, recvcounts, rdispls, recvtype,
                                                       comm_ptr, s);
     if (mpi_errno)
@@ -139,9 +141,9 @@ int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcount
         switch (MPIR_Ineighbor_alltoallv_intra_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALLV_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Ineighbor_alltoallv_sched_linear(sendbuf, sendcounts, sdispls, sendtype,
-                                                          recvbuf, recvcounts, rdispls, recvtype,
-                                                          comm_ptr, s);
+                    MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls,
+                                                                  sendtype, recvbuf, recvcounts,
+                                                                  rdispls, recvtype, comm_ptr, s);
                 break;
             case MPIR_INEIGHBOR_ALLTOALLV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -156,9 +158,9 @@ int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcount
         switch (MPIR_Ineighbor_alltoallv_inter_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALLV_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Ineighbor_alltoallv_sched_linear(sendbuf, sendcounts, sdispls, sendtype,
-                                                          recvbuf, recvcounts, rdispls, recvtype,
-                                                          comm_ptr, s);
+                    MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls,
+                                                                  sendtype, recvbuf, recvcounts,
+                                                                  rdispls, recvtype, comm_ptr, s);
                 break;
             case MPIR_INEIGHBOR_ALLTOALLV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
@@ -14,29 +14,34 @@
  */
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Ineighbor_alltoall_sched_linear
+#define FUNCNAME MPIR_Ineighbor_alltoallv_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ineighbor_alltoall_sched_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                  const int sdispls[], MPI_Datatype sendtype,
+                                                  void *recvbuf, const int recvcounts[],
+                                                  const int rdispls[], MPI_Datatype recvtype,
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int k, l;
+    int i, k, l;
     int *srcs, *dsts;
+    int comm_size;
     MPI_Aint sendtype_extent, recvtype_extent;
     MPIR_CHKLMEM_DECL(2);
+
+    comm_size = comm_ptr->local_size;
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to sendbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                     (comm_ptr->local_size * sendcount * sendtype_extent));
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_ptr->local_size * recvcount * recvtype_extent));
+    for (i = 0; i < comm_size; ++i) {
+        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
+                                         (sdispls[i] * sendtype_extent));
+        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
+                                         (rdispls[i] * recvtype_extent));
+    }
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
@@ -50,15 +55,15 @@ int MPIR_Ineighbor_alltoall_sched_linear(const void *sendbuf, int sendcount, MPI
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
+        char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
+        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
-        char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
+        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallw/Makefile.mk
+++ b/src/mpi/coll/ineighbor_alltoallw/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_linear.c
+    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -86,7 +86,8 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoallw_sched_linear(sendbuf, sendcounts, sdispls, sendtypes,
+    mpi_errno =
+        MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
                                                       recvbuf, recvcounts, rdispls, recvtypes,
                                                       comm_ptr, s);
     if (mpi_errno)
@@ -112,7 +113,8 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ineighbor_alltoallw_sched_linear(sendbuf, sendcounts, sdispls, sendtypes,
+    mpi_errno =
+        MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
                                                       recvbuf, recvcounts, rdispls, recvtypes,
                                                       comm_ptr, s);
     if (mpi_errno)
@@ -141,9 +143,9 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
         switch (MPIR_Ineighbor_alltoallw_intra_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Ineighbor_alltoallw_sched_linear(sendbuf, sendcounts, sdispls, sendtypes,
-                                                          recvbuf, recvcounts, rdispls, recvtypes,
-                                                          comm_ptr, s);
+                    MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls,
+                                                                  sendtypes, recvbuf, recvcounts,
+                                                                  rdispls, recvtypes, comm_ptr, s);
                 break;
             case MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -158,9 +160,9 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
         switch (MPIR_Ineighbor_alltoallw_inter_algo_choice) {
             case MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Ineighbor_alltoallw_sched_linear(sendbuf, sendcounts, sdispls, sendtypes,
-                                                          recvbuf, recvcounts, rdispls, recvtypes,
-                                                          comm_ptr, s);
+                    MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls,
+                                                                  sendtypes, recvbuf, recvcounts,
+                                                                  rdispls, recvtypes, comm_ptr, s);
                 break;
             case MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
@@ -14,14 +14,15 @@
  */
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Ineighbor_alltoallw_sched_linear
+#define FUNCNAME MPIR_Ineighbor_alltoallw_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ineighbor_alltoallw_sched_linear(const void *sendbuf, const int sendcounts[],
-                                          const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                          void *recvbuf, const int recvcounts[],
-                                          const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                  const MPI_Aint sdispls[],
+                                                  const MPI_Datatype sendtypes[], void *recvbuf,
+                                                  const int recvcounts[], const MPI_Aint rdispls[],
+                                                  const MPI_Datatype recvtypes[],
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;

--- a/src/mpi/coll/iscatterv/Makefile.mk
+++ b/src/mpi/coll/iscatterv/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources +=                                  \
     src/mpi/coll/iscatterv/iscatterv.c
 
 mpi_core_sources +=                             \
-    src/mpi/coll/iscatterv/iscatterv_linear.c
+    src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -86,8 +86,8 @@ int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Iscatterv_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                    recvtype, root, comm_ptr, s);
+        MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                            recvcount, recvtype, root, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -110,8 +110,8 @@ int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Iscatterv_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                    recvtype, root, comm_ptr, s);
+        MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                            recvcount, recvtype, root, comm_ptr, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -136,8 +136,9 @@ int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const
         switch (MPIR_Iscatterv_intra_algo_choice) {
             case MPIR_ISCATTERV_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Iscatterv_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                                recvcount, recvtype, root, comm_ptr, s);
+                    MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype,
+                                                        recvbuf, recvcount, recvtype, root,
+                                                        comm_ptr, s);
                 break;
             case MPIR_ISCATTERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -151,8 +152,9 @@ int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const
         switch (MPIR_Iscatterv_inter_algo_choice) {
             case MPIR_ISCATTERV_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Iscatterv_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                                recvcount, recvtype, root, comm_ptr, s);
+                    MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype,
+                                                        recvbuf, recvcount, recvtype, root,
+                                                        comm_ptr, s);
                 break;
             case MPIR_ISCATTERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
@@ -17,13 +17,13 @@
  * Cost = (p-1).alpha + n.((p-1)/p).beta
 */
 #undef FUNCNAME
-#define FUNCNAME MPIR_Iscatterv_sched_linear
+#define FUNCNAME MPIR_Iscatterv_sched_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Iscatterv_sched_linear(const void *sendbuf, const int sendcounts[], const int displs[],
-                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s)
+int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                        const int displs[], MPI_Datatype sendtype, void *recvbuf,
+                                        int recvcount, MPI_Datatype recvtype, int root,
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;

--- a/src/mpi/coll/neighbor_allgather/Makefile.mk
+++ b/src/mpi/coll/neighbor_allgather/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/neighbor_allgather/neighbor_allgather.c
 
 mpi_core_sources += \
-    src/mpi/coll/neighbor_allgather/neighbor_allgather_nb.c
+    src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
@@ -84,8 +84,8 @@ int MPIR_Neighbor_allgather_intra_auto(const void *sendbuf, int sendcount, MPI_D
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                   comm_ptr);
+        MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                           recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -106,8 +106,8 @@ int MPIR_Neighbor_allgather_inter_auto(const void *sendbuf, int sendcount, MPI_D
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                   comm_ptr);
+        MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                           recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -131,8 +131,8 @@ int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount,
         switch (MPIR_Neighbor_allgather_intra_algo_choice) {
             case MPIR_NEIGHBOR_ALLGATHER_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                               recvtype, comm_ptr);
+                    MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf,
+                                                       recvcount, recvtype, comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLGATHER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -146,8 +146,8 @@ int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount,
         switch (MPIR_Neighbor_allgather_inter_algo_choice) {
             case MPIR_NEIGHBOR_ALLGATHER_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_allgather_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                               recvtype, comm_ptr);
+                    MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf,
+                                                       recvcount, recvtype, comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLGATHER_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -7,17 +7,21 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Barrier_nb
+#define FUNCNAME MPIR_Neighbor_allgather_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Barrier_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                       MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                 comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/neighbor_allgatherv/Makefile.mk
+++ b/src/mpi/coll/neighbor_allgatherv/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
 
 mpi_core_sources += \
-    src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_nb.c
+    src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -84,8 +84,9 @@ int MPIR_Neighbor_allgatherv_intra_auto(const void *sendbuf, int sendcount, MPI_
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Neighbor_allgatherv_nb(sendbuf, sendcount, sendtype,
-                                            recvbuf, recvcounts, displs, recvtype, comm_ptr);
+    mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                    recvbuf, recvcounts, displs, recvtype,
+                                                    comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -106,8 +107,9 @@ int MPIR_Neighbor_allgatherv_inter_auto(const void *sendbuf, int sendcount, MPI_
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Neighbor_allgatherv_nb(sendbuf, sendcount, sendtype,
-                                            recvbuf, recvcounts, displs, recvtype, comm_ptr);
+    mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                    recvbuf, recvcounts, displs, recvtype,
+                                                    comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -132,9 +134,9 @@ int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_Neighbor_allgatherv_intra_algo_choice) {
             case MPIR_NEIGHBOR_ALLGATHERV_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Neighbor_allgatherv_nb(sendbuf, sendcount, sendtype,
-                                                        recvbuf, recvcounts, displs, recvtype,
-                                                        comm_ptr);
+                mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                                recvbuf, recvcounts, displs,
+                                                                recvtype, comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLGATHERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -147,9 +149,9 @@ int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     } else {
         switch (MPIR_Neighbor_allgatherv_inter_algo_choice) {
             case MPIR_NEIGHBOR_ALLGATHERV_INTER_ALGO_NB:
-                mpi_errno = MPIR_Neighbor_allgatherv_nb(sendbuf, sendcount, sendtype,
-                                                        recvbuf, recvcounts, displs, recvtype,
-                                                        comm_ptr);
+                mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                                recvbuf, recvcounts, displs,
+                                                                recvtype, comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLGATHERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -7,22 +7,22 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Alltoallw_nb
+#define FUNCNAME MPIR_Neighbor_allgatherv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Alltoallw_nb(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                      const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                      const int rdispls[], const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag)
+int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                        void *recvbuf, const int recvcounts[], const int displs[],
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
+
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno =
-        MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
-                        recvtypes, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,
+                                          recvbuf, recvcounts, displs, recvtype,
+                                          comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/neighbor_alltoall/Makefile.mk
+++ b/src/mpi/coll/neighbor_alltoall/Makefile.mk
@@ -16,5 +16,5 @@ mpi_sources += \
     src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
 
 mpi_core_sources += \
-    src/mpi/coll/neighbor_alltoall/neighbor_alltoall_nb.c
+    src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
 

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
@@ -83,8 +83,8 @@ int MPIR_Neighbor_alltoall_intra_auto(const void *sendbuf, int sendcount, MPI_Da
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Neighbor_alltoall_nb(sendbuf, sendcount, sendtype,
-                                          recvbuf, recvcount, recvtype, comm_ptr);
+    mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                  recvbuf, recvcount, recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -105,8 +105,8 @@ int MPIR_Neighbor_alltoall_inter_auto(const void *sendbuf, int sendcount, MPI_Da
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Neighbor_alltoall_nb(sendbuf, sendcount, sendtype,
-                                          recvbuf, recvcount, recvtype, comm_ptr);
+    mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                  recvbuf, recvcount, recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -130,8 +130,9 @@ int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount,
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         switch (MPIR_Neighbor_alltoall_intra_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALL_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Neighbor_alltoall_nb(sendbuf, sendcount, sendtype,
-                                                      recvbuf, recvcount, recvtype, comm_ptr);
+                mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALL_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -144,8 +145,9 @@ int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount,
     } else {
         switch (MPIR_Neighbor_alltoall_inter_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALL_INTER_ALGO_NB:
-                mpi_errno = MPIR_Neighbor_alltoall_nb(sendbuf, sendcount, sendtype,
-                                                      recvbuf, recvcount, recvtype, comm_ptr);
+                mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALL_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -7,21 +7,20 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Gather_nb
+#define FUNCNAME MPIR_Neighbor_alltoall_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Gather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag)
+int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                      MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno =
-        MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
-                     &req_ptr);
+    mpi_errno = MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype,
+                                        recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/neighbor_alltoallv/Makefile.mk
+++ b/src/mpi/coll/neighbor_alltoallv/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
 
 mpi_core_sources += \
-    src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_nb.c
+    src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
@@ -86,8 +86,8 @@ int MPIR_Neighbor_alltoallv_intra_auto(const void *sendbuf, const int sendcounts
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_alltoallv_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
-                                   rdispls, recvtype, comm_ptr);
+        MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                           recvcounts, rdispls, recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -110,8 +110,8 @@ int MPIR_Neighbor_alltoallv_inter_auto(const void *sendbuf, const int sendcounts
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_alltoallv_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
-                                   rdispls, recvtype, comm_ptr);
+        MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                           recvcounts, rdispls, recvtype, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -137,8 +137,9 @@ int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
         switch (MPIR_Neighbor_alltoallv_intra_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALLV_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_alltoallv_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                               recvcounts, rdispls, recvtype, comm_ptr);
+                    MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype,
+                                                       recvbuf, recvcounts, rdispls, recvtype,
+                                                       comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALLV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -153,8 +154,9 @@ int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
         switch (MPIR_Neighbor_alltoallv_inter_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALLV_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_alltoallv_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                               recvcounts, rdispls, recvtype, comm_ptr);
+                    MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype,
+                                                       recvbuf, recvcounts, rdispls, recvtype,
+                                                       comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALLV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -7,12 +7,13 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Gatherv_nb
+#define FUNCNAME MPIR_Neighbor_alltoallv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Gatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts[],
+                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
+                                       const int recvcounts[], const int rdispls[],
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +21,8 @@ int MPIR_Gatherv_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
-                      comm_ptr, &req_ptr);
+        MPIR_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
+                                 rdispls, recvtype, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/neighbor_alltoallw/Makefile.mk
+++ b/src/mpi/coll/neighbor_alltoallw/Makefile.mk
@@ -16,4 +16,4 @@ mpi_sources += \
     src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
 
 mpi_core_sources += \
-    src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_nb.c
+    src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
@@ -87,8 +87,8 @@ int MPIR_Neighbor_alltoallw_intra_auto(const void *sendbuf, const int sendcounts
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_alltoallw_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
-                                   rdispls, recvtypes, comm_ptr);
+        MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
+                                           recvcounts, rdispls, recvtypes, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -112,8 +112,8 @@ int MPIR_Neighbor_alltoallw_inter_auto(const void *sendbuf, const int sendcounts
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Neighbor_alltoallw_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
-                                   rdispls, recvtypes, comm_ptr);
+        MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
+                                           recvcounts, rdispls, recvtypes, comm_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -141,8 +141,9 @@ int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
         switch (MPIR_Neighbor_alltoallw_intra_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALLW_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_alltoallw_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
-                                               recvcounts, rdispls, recvtypes, comm_ptr);
+                    MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes,
+                                                       recvbuf, recvcounts, rdispls, recvtypes,
+                                                       comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALLW_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -157,8 +158,9 @@ int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
         switch (MPIR_Neighbor_alltoallw_inter_algo_choice) {
             case MPIR_NEIGHBOR_ALLTOALLW_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Neighbor_alltoallw_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
-                                               recvcounts, rdispls, recvtypes, comm_ptr);
+                    MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes,
+                                                       recvbuf, recvcounts, rdispls, recvtypes,
+                                                       comm_ptr);
                 break;
             case MPIR_NEIGHBOR_ALLTOALLW_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -7,12 +7,14 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Scatter_nb
+#define FUNCNAME MPIR_Neighbor_alltoallw_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Scatter_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * errflag)
+int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[],
+                                       const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
+                                       void *recvbuf, const int recvcounts[],
+                                       const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
+                                       MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,8 +22,8 @@ int MPIR_Scatter_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
-                      &req_ptr);
+        MPIR_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
+                                 rdispls, recvtypes, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/reduce/Makefile.mk
+++ b/src/mpi/coll/reduce/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/reduce/reduce.c
 
 mpi_core_sources +=										\
-	src/mpi/coll/reduce/reduce_nb.c				\
+	src/mpi/coll/reduce/reduce_allcomm_nb.c				\
 	src/mpi/coll/reduce/reduce_intra_binomial.c				\
 	src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c			\
 	src/mpi/coll/reduce/reduce_intra_smp.c			\

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -278,8 +278,8 @@ int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count,
                                                                     comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Reduce_nb(sendbuf, recvbuf,
-                                           count, datatype, op, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Reduce_allcomm_nb(sendbuf, recvbuf,
+                                                   count, datatype, op, root, comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -297,8 +297,8 @@ int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count,
                                                                op, root, comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_INTER_ALGO_NB:
-                mpi_errno = MPIR_Reduce_nb(sendbuf, recvbuf,
-                                           count, datatype, op, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Reduce_allcomm_nb(sendbuf, recvbuf,
+                                                   count, datatype, op, root, comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -7,21 +7,18 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Neighbor_allgather_nb
+#define FUNCNAME MPIR_Reduce_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Neighbor_allgather_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr)
+int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno =
-        MPIR_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                 comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/reduce_scatter/Makefile.mk
+++ b/src/mpi/coll/reduce_scatter/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/reduce_scatter/reduce_scatter.c
 
 mpi_core_sources +=											\
-	src/mpi/coll/reduce_scatter/reduce_scatter_nb.c		\
+	src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c		\
 	src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c		\
 	src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c				\
 	src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c		\

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -277,8 +277,9 @@ int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf,
                                                                          comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_SCATTER_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Reduce_scatter_nb(sendbuf, recvbuf,
-                                                   recvcounts, datatype, op, comm_ptr, errflag);
+                mpi_errno = MPIR_Reduce_scatter_allcomm_nb(sendbuf, recvbuf,
+                                                           recvcounts, datatype, op, comm_ptr,
+                                                           errflag);
                 break;
             case MPIR_REDUCE_SCATTER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -298,8 +299,9 @@ int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf,
                                                                           comm_ptr, errflag);
                 break;
             case MPIR_REDUCE_SCATTER_INTER_ALGO_NB:
-                mpi_errno = MPIR_Reduce_scatter_nb(sendbuf, recvbuf,
-                                                   recvcounts, datatype, op, comm_ptr, errflag);
+                mpi_errno = MPIR_Reduce_scatter_allcomm_nb(sendbuf, recvbuf,
+                                                           recvcounts, datatype, op, comm_ptr,
+                                                           errflag);
                 break;
             case MPIR_REDUCE_SCATTER_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -7,18 +7,20 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Exscan_nb
+#define FUNCNAME MPIR_Reduce_scatter_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Exscan_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int recvcounts[],
+                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                                   MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/reduce_scatter_block/Makefile.mk
+++ b/src/mpi/coll/reduce_scatter_block/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
 
 mpi_core_sources +=														\
-	src/mpi/coll/reduce_scatter_block/reduce_scatter_block_nb.c		\
+	src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c		\
 	src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c		\
 	src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c				\
 	src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c		\

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -242,9 +242,9 @@ int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                                                                                errflag);
                 break;
             case MPIR_REDUCE_SCATTER_BLOCK_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Reduce_scatter_block_nb(sendbuf, recvbuf,
-                                                         recvcount, datatype, op, comm_ptr,
-                                                         errflag);
+                mpi_errno = MPIR_Reduce_scatter_block_allcomm_nb(sendbuf, recvbuf,
+                                                                 recvcount, datatype, op, comm_ptr,
+                                                                 errflag);
                 break;
             case MPIR_REDUCE_SCATTER_BLOCK_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -265,9 +265,9 @@ int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                                                                                 errflag);
                 break;
             case MPIR_REDUCE_SCATTER_BLOCK_INTER_ALGO_NB:
-                mpi_errno = MPIR_Reduce_scatter_block_nb(sendbuf, recvbuf,
-                                                         recvcount, datatype, op, comm_ptr,
-                                                         errflag);
+                mpi_errno = MPIR_Reduce_scatter_block_allcomm_nb(sendbuf, recvbuf,
+                                                                 recvcount, datatype, op, comm_ptr,
+                                                                 errflag);
                 break;
             case MPIR_REDUCE_SCATTER_BLOCK_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -7,12 +7,12 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Reduce_scatter_nb
+#define FUNCNAME MPIR_Reduce_scatter_block_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Reduce_scatter_nb(const void *sendbuf, void *recvbuf, const int recvcounts[],
-                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag)
+int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int recvcount,
+                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
+                                         MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,7 +20,7 @@ int MPIR_Reduce_scatter_nb(const void *sendbuf, void *recvbuf, const int recvcou
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
+        MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/scan/Makefile.mk
+++ b/src/mpi/coll/scan/Makefile.mk
@@ -16,6 +16,6 @@ mpi_sources +=                     		\
 	src/mpi/coll/scan/scan.c
 
 mpi_core_sources +=									\
-	src/mpi/coll/scan/scan_nb.c \
+	src/mpi/coll/scan/scan_allcomm_nb.c \
 	src/mpi/coll/scan/scan_intra_recursive_doubling.c \
 	src/mpi/coll/scan/scan_intra_smp.c

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -112,7 +112,8 @@ int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count,
                                                    errflag);
             break;
         case MPIR_SCAN_INTRA_ALGO_NB:
-            mpi_errno = MPIR_Scan_nb(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+            mpi_errno =
+                MPIR_Scan_allcomm_nb(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
             break;
         case MPIR_SCAN_INTRA_ALGO_AUTO:
             MPL_FALLTHROUGH;

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -7,18 +7,18 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Bcast_nb
+#define FUNCNAME MPIR_Scan_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Bcast_nb(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                  MPIR_Errflag_t * errflag)
+int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/scatter/Makefile.mk
+++ b/src/mpi/coll/scatter/Makefile.mk
@@ -16,7 +16,7 @@ mpi_sources +=                     		\
 	src/mpi/coll/scatter/scatter.c
 
 mpi_core_sources +=									\
-	src/mpi/coll/scatter/scatter_nb.c			\
+	src/mpi/coll/scatter/scatter_allcomm_nb.c			\
 	src/mpi/coll/scatter/scatter_intra_binomial.c			\
 	src/mpi/coll/scatter/scatter_inter_linear.c \
 	src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c

--- a/src/mpi/coll/scatter/scatter.c
+++ b/src/mpi/coll/scatter/scatter.c
@@ -172,8 +172,9 @@ int MPIR_Scatter_impl(const void *sendbuf, int sendcount,
                                                         comm_ptr, errflag);
                 break;
             case MPIR_SCATTER_INTRA_ALGO_NB:
-                mpi_errno = MPIR_Scatter_nb(sendbuf, sendcount, sendtype,
-                                            recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Scatter_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                    recvbuf, recvcount, recvtype, root, comm_ptr,
+                                                    errflag);
                 break;
             case MPIR_SCATTER_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -192,8 +193,9 @@ int MPIR_Scatter_impl(const void *sendbuf, int sendcount,
                                                       comm_ptr, errflag);
                 break;
             case MPIR_SCATTER_INTER_ALGO_NB:
-                mpi_errno = MPIR_Scatter_nb(sendbuf, sendcount, sendtype,
-                                            recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                mpi_errno = MPIR_Scatter_allcomm_nb(sendbuf, sendcount, sendtype,
+                                                    recvbuf, recvcount, recvtype, root, comm_ptr,
+                                                    errflag);
                 break;
             case MPIR_SCATTER_INTER_ALGO_REMOTE_SEND_LOCAL_SCATTER:
                 mpi_errno =

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -7,13 +7,12 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Neighbor_alltoallw_nb
+#define FUNCNAME MPIR_Scatter_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Neighbor_alltoallw_nb(const void *sendbuf, const int sendcounts[],
-                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                               void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr)
+int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
+                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -21,8 +20,8 @@ int MPIR_Neighbor_alltoallw_nb(const void *sendbuf, const int sendcounts[],
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
-                                 rdispls, recvtypes, comm_ptr, &req_ptr);
+        MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
+                      &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)

--- a/src/mpi/coll/scatterv/Makefile.mk
+++ b/src/mpi/coll/scatterv/Makefile.mk
@@ -16,5 +16,5 @@ mpi_sources +=                     		\
 	src/mpi/coll/scatterv/scatterv.c
 
 mpi_core_sources +=							\
-	src/mpi/coll/scatterv/scatterv_nb.c \
-	src/mpi/coll/scatterv/scatterv_linear.c
+	src/mpi/coll/scatterv/scatterv_allcomm_nb.c \
+	src/mpi/coll/scatterv/scatterv_allcomm_linear.c

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -87,8 +87,8 @@ int MPIR_Scatterv_intra_auto(const void *sendbuf, const int *sendcounts, const i
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Scatterv_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype,
-                             root, comm_ptr, errflag);
+        MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
+                                     recvtype, root, comm_ptr, errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -113,8 +113,8 @@ int MPIR_Scatterv_inter_auto(const void *sendbuf, const int *sendcounts, const i
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPIR_Scatterv_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype,
-                             root, comm_ptr, errflag);
+        MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
+                                     recvtype, root, comm_ptr, errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -142,13 +142,13 @@ int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
         switch (MPIR_Scatterv_intra_algo_choice) {
             case MPIR_SCATTERV_INTRA_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Scatterv_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                         recvtype, root, comm_ptr, errflag);
+                    MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                                 recvcount, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_SCATTERV_INTRA_ALGO_NB:
                 mpi_errno =
-                    MPIR_Scatterv_nb(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                     recvtype, root, comm_ptr, errflag);
+                    MPIR_Scatterv_allcomm_nb(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                             recvcount, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_SCATTERV_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
@@ -162,13 +162,13 @@ int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
         switch (MPIR_Scatterv_inter_algo_choice) {
             case MPIR_SCATTERV_INTER_ALGO_LINEAR:
                 mpi_errno =
-                    MPIR_Scatterv_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                         recvtype, root, comm_ptr, errflag);
+                    MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                                 recvcount, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_SCATTERV_INTER_ALGO_NB:
                 mpi_errno =
-                    MPIR_Scatterv_nb(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
-                                     recvtype, root, comm_ptr, errflag);
+                    MPIR_Scatterv_allcomm_nb(sendbuf, sendcounts, displs, sendtype, recvbuf,
+                                             recvcount, recvtype, root, comm_ptr, errflag);
                 break;
             case MPIR_SCATTERV_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -20,12 +20,13 @@
    Cost = (p-1).alpha + n.((p-1)/p).beta
 */
 #undef FUNCNAME
-#define FUNCNAME MPIR_Scatterv_linear
+#define FUNCNAME MPIR_Scatterv_allcomm_linear
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Scatterv_linear(const void *sendbuf, const int *sendcounts, const int *displs,
-                         MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
+int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, const int *displs,
+                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                                 MPIR_Errflag_t * errflag)
 {
     int rank, comm_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -7,12 +7,13 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Reduce_scatter_block_nb
+#define FUNCNAME MPIR_Scatterv_allcomm_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Reduce_scatter_block_nb(const void *sendbuf, void *recvbuf, int recvcount,
-                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag)
+int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const int *displs,
+                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Request req = MPI_REQUEST_NULL;
@@ -20,7 +21,8 @@ int MPIR_Reduce_scatter_block_nb(const void *sendbuf, void *recvbuf, int recvcou
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
+        MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
+                       comm_ptr, &req_ptr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (req_ptr)


### PR DESCRIPTION
Introducing `allcomm` keyword into names for communicator-type independent algorithms