### PR TITLE
collective tag fixes

### DIFF
--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -35,7 +35,6 @@ typedef struct MPIR_Process_t {
                                          * that is separate from user's
                                          * versions */
     PreDefined_attrs attrs;     /* Predefined attribute values */
-    int tagged_coll_mask;       /* Tag space mask for tagged collectives */
 
 #ifdef HAVE_HWLOC
     hwloc_topology_t topology;  /* HWLOC topology */

--- a/src/include/mpir_tags.h
+++ b/src/include/mpir_tags.h
@@ -66,6 +66,14 @@
 #define MPIR_TAG_PROC_FAILURE_BIT
 #endif
 
+/* This bitmask is used to differentiate between collective operations
+   with user-supplied tags and internally-defined tags. */
+#ifdef HAVE_TAG_ERROR_BITS
+#define MPIR_TAG_COLL_BIT (1 << 28)
+#else
+#define MPIR_TAG_COLL_BIT (1 << 30)
+#endif
+
 /* This macro checks the value of the error bit in the MPI tag and returns 1
  * if the tag is set and 0 if it is not. */
 #ifdef HAVE_TAG_ERROR_BITS

--- a/src/include/mpir_tags.h
+++ b/src/include/mpir_tags.h
@@ -118,4 +118,11 @@
 #define MPIR_TAG_MASK_ERROR_BITS(tag) (tag)
 #endif
 
+/* This macro defines tags bits which are reserved by the MPI layer */
+#ifdef HAVE_TAG_ERROR_BITS
+#define MPIR_TAG_USABLE_BITS (INT_MAX & ~(MPIR_TAG_ERROR_BIT | MPIR_TAG_PROC_FAILURE_BIT | MPIR_TAG_COLL_BIT))
+#else
+#define MPIR_TAG_USABLE_BITS (INT_MAX & ~MPI_TAG_COLL_BIT)
+#endif
+
 #endif /* MPIR_TAGS_H_INCLUDED */

--- a/src/mpi/comm/comm_create_group.c
+++ b/src/mpi/comm/comm_create_group.c
@@ -50,6 +50,9 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
     n = group_ptr->size;
     *newcomm_ptr = NULL;
 
+    /* Shift tag into the tagged coll space */
+    tag |= MPIR_TAG_COLL_BIT;
+
     /* Create a new communicator from the specified group members */
 
     if (group_ptr->rank != MPI_UNDEFINED) {

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -483,7 +483,7 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
          * other processes to enter the global or brief global critical section.
          */
         if (group_ptr != NULL) {
-            int coll_tag = tag | MPIR_Process.tagged_coll_mask; /* Shift tag into the tagged coll space */
+            int coll_tag = tag | MPIR_TAG_COLL_BIT;     /* Shift tag into the tagged coll space */
             mpi_errno = MPII_Allreduce_group(MPI_IN_PLACE, st.local_mask, MPIR_MAX_CONTEXT_MASK + 1,
                                              MPI_INT, MPI_BAND, comm_ptr, group_ptr, coll_tag,
                                              &errflag);
@@ -584,7 +584,7 @@ int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr
                 minfree = nfree;
 
             if (group_ptr != NULL) {
-                int coll_tag = tag | MPIR_Process.tagged_coll_mask;     /* Shift tag into the tagged coll space */
+                int coll_tag = tag | MPIR_TAG_COLL_BIT; /* Shift tag into the tagged coll space */
                 mpi_errno = MPII_Allreduce_group(MPI_IN_PLACE, &minfree, 1, MPI_INT, MPI_MIN,
                                                  comm_ptr, group_ptr, coll_tag, &errflag);
             } else {

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -51,7 +51,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
 
     /* Shift tag into the tagged coll space (tag provided by the user
      * is ignored as of MPI 3.0) */
-    cts_tag = MPIR_COMM_KIND__INTERCOMM_CREATE_TAG | MPIR_Process.tagged_coll_mask;
+    cts_tag = MPIR_COMM_KIND__INTERCOMM_CREATE_TAG | MPIR_TAG_COLL_BIT;
 
     mpi_errno = MPID_Intercomm_exchange_map(local_comm_ptr, local_leader,
                                             peer_comm_ptr, remote_leader,

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -8,8 +8,6 @@
 #include "mpiimpl.h"
 #include "mpicomm.h"
 
-#define MPIR_COMM_KIND__INTERCOMM_CREATE_TAG 0
-
 /* -- Begin Profiling Symbol Block for routine MPI_Intercomm_create */
 #if defined(HAVE_PRAGMA_WEAK)
 #pragma weak MPI_Intercomm_create = PMPI_Intercomm_create
@@ -43,15 +41,13 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     int remote_size = 0, *remote_lpids = NULL;
     int comm_info[3];
     int is_low_group = 0;
-    int cts_tag;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_COMM_KIND__INTERCOMM_CREATE_IMPL);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_KIND__INTERCOMM_CREATE_IMPL);
 
-    /* Shift tag into the tagged coll space (tag provided by the user
-     * is ignored as of MPI 3.0) */
-    cts_tag = MPIR_COMM_KIND__INTERCOMM_CREATE_TAG | MPIR_TAG_COLL_BIT;
+    /* Shift tag into the tagged coll space */
+    tag |= MPIR_TAG_COLL_BIT;
 
     mpi_errno = MPID_Intercomm_exchange_map(local_comm_ptr, local_leader,
                                             peer_comm_ptr, remote_leader,
@@ -83,8 +79,8 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
         MPIR_Context_id_t remote_context_id;
 
         mpi_errno =
-            MPIC_Sendrecv(&recvcontext_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, cts_tag,
-                          &remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, cts_tag,
+            MPIC_Sendrecv(&recvcontext_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, tag,
+                          &remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, tag,
                           peer_comm_ptr, MPI_STATUS_IGNORE, &errflag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/comm/intercomm_merge.c
+++ b/src/mpi/comm/intercomm_merge.c
@@ -128,110 +128,57 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
      * inter-node) to one. This is normally not possible (a communicator
      * is either intra- or inter-node) - which makes this context_id unique.
      *
-     * There are two path to get it.
-     * 1. If the remote and local groups of the intercomm belongs to the same
-     *    comm_world. We can merge them into on group and do a
-     *    MPIR_Get_contextid_sparse_group on MPI_COMM_WORLD.
-     *
-     * 2. If not, we fallback to the old "temorary intracomm contextid hack"
      */
 
     new_size = comm_ptr->local_size + comm_ptr->remote_size;
 
-    if (MPID_INTERCOMM_NO_DYNPROC(comm_ptr)) {
-        MPIR_Group *merge_group_ptr = NULL;
-        MPIR_Group *comm_world_group = NULL;
-        int *lupids;
-        int lupid, i;
+    mpi_errno = MPIR_Comm_create(new_intracomm_ptr);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
-        MPL_DBG_MSG(MPIR_DBG_COMM, VERBOSE, "Intercomm_merge contextid fastpath");
-        lupids = (int *) MPL_malloc(new_size * sizeof(int), MPL_MEM_COMM);
-
-        if (!local_high) {
-            for (i = 0; i < comm_ptr->local_size; i++) {
-                MPID_Comm_get_lpid(comm_ptr, i, &lupid, FALSE);
-                lupids[i] = lupid;
-            }
-            for (i = 0; i < comm_ptr->remote_size; i++) {
-                MPID_Comm_get_lpid(comm_ptr, i, &lupid, TRUE);
-                lupids[i + comm_ptr->local_size] = lupid;
-            }
-        } else {
-            for (i = 0; i < comm_ptr->remote_size; i++) {
-                MPID_Comm_get_lpid(comm_ptr, i, &lupid, TRUE);
-                lupids[i] = lupid;
-            }
-            for (i = 0; i < comm_ptr->local_size; i++) {
-                MPID_Comm_get_lpid(comm_ptr, i, &lupid, FALSE);
-                lupids[i + comm_ptr->remote_size] = lupid;
-            }
-        }
-        MPIR_Comm_group_impl(MPIR_Process.comm_world, &comm_world_group);
-        MPIR_Group_incl_impl(comm_world_group, new_size, lupids, &merge_group_ptr);
-
-        MPL_free(lupids);
-
-        new_context_id = 0;
-        mpi_errno = MPIR_Get_contextid_sparse_group(MPIR_Process.comm_world, merge_group_ptr,
-                                                    MPIR_Process.attrs.tag_ub, &new_context_id,
-                                                    FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-        MPIR_Assert(new_context_id != 0);
-
-        mpi_errno = MPIR_Group_release(comm_world_group);
-        mpi_errno = MPIR_Group_release(merge_group_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+    if (local_high) {
+        (*new_intracomm_ptr)->context_id =
+            MPIR_CONTEXT_SET_FIELD(SUBCOMM, comm_ptr->recvcontext_id, 3);
     } else {
-        mpi_errno = MPIR_Comm_create(new_intracomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-
-        if (local_high) {
-            (*new_intracomm_ptr)->context_id =
-                MPIR_CONTEXT_SET_FIELD(SUBCOMM, comm_ptr->recvcontext_id, 3);
-        } else {
-            (*new_intracomm_ptr)->context_id =
-                MPIR_CONTEXT_SET_FIELD(SUBCOMM, comm_ptr->context_id, 3);
-        }
-        (*new_intracomm_ptr)->recvcontext_id = (*new_intracomm_ptr)->context_id;
-        (*new_intracomm_ptr)->remote_size = (*new_intracomm_ptr)->local_size = new_size;
-        (*new_intracomm_ptr)->pof2 = MPL_pof2(new_size);
-        (*new_intracomm_ptr)->rank = -1;
-        (*new_intracomm_ptr)->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-
-        /* Now we know which group comes first.  Build the new mapping
-         * from the existing comm */
-        mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-
-        /* We've setup a temporary context id, based on the context id
-         * used by the intercomm.  This allows us to perform the allreduce
-         * operations within the context id algorithm, since we already
-         * have a valid (almost - see comm_create_hook) communicator.
-         */
-        mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-
-        /* printf("About to get context id \n"); fflush(stdout); */
-        /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
-         * calling routine already holds the single criticial section */
-        new_context_id = 0;
-        mpi_errno = MPIR_Get_contextid_sparse((*new_intracomm_ptr), &new_context_id, FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-        MPIR_Assert(new_context_id != 0);
-
-        /* We release this communicator that was involved just to
-         * get valid context id and create true one
-         */
-        mpi_errno = MPIR_Comm_release(*new_intracomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        (*new_intracomm_ptr)->context_id =
+            MPIR_CONTEXT_SET_FIELD(SUBCOMM, comm_ptr->context_id, 3);
     }
+    (*new_intracomm_ptr)->recvcontext_id = (*new_intracomm_ptr)->context_id;
+    (*new_intracomm_ptr)->remote_size = (*new_intracomm_ptr)->local_size = new_size;
+    (*new_intracomm_ptr)->pof2 = MPL_pof2(new_size);
+    (*new_intracomm_ptr)->rank = -1;
+    (*new_intracomm_ptr)->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+
+    /* Now we know which group comes first.  Build the new mapping
+     * from the existing comm */
+    mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* We've setup a temporary context id, based on the context id
+     * used by the intercomm.  This allows us to perform the allreduce
+     * operations within the context id algorithm, since we already
+     * have a valid (almost - see comm_create_hook) communicator.
+     */
+    mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* printf("About to get context id \n"); fflush(stdout); */
+    /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
+     * calling routine already holds the single criticial section */
+    new_context_id = 0;
+    mpi_errno = MPIR_Get_contextid_sparse((*new_intracomm_ptr), &new_context_id, FALSE);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+    MPIR_Assert(new_context_id != 0);
+
+    /* We release this communicator that was involved just to
+     * get valid context id and create true one
+     */
+    mpi_errno = MPIR_Comm_release(*new_intracomm_ptr);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     mpi_errno = MPIR_Comm_create(new_intracomm_ptr);
     if (mpi_errno)

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -537,9 +537,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 #else
     MPIR_Process.attrs.tag_ub >>= 1;
 #endif
-    /* The bit for error checking is set in a macro in mpiimpl.h for
-     * performance reasons. */
-    MPIR_Process.tagged_coll_mask = MPIR_Process.attrs.tag_ub + 1;
 
     /* Assert: tag_ub is at least the minimum asked for in the MPI spec */
     MPIR_Assert(MPIR_Process.attrs.tag_ub >= 32767);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -403,7 +403,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_Process.attrs.host = MPI_PROC_NULL;
     MPIR_Process.attrs.io = MPI_PROC_NULL;
     MPIR_Process.attrs.lastusedcode = MPI_ERR_LASTCODE;
-    MPIR_Process.attrs.tag_ub = 0;
+    MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;
     MPIR_Process.attrs.universe = MPIR_UNIVERSE_SIZE_NOT_SET;
     MPIR_Process.attrs.wtime_is_global = 0;
 
@@ -530,13 +530,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* Assert: tag_ub should be a power of 2 minus 1 */
     MPIR_Assert(((unsigned) MPIR_Process.
                  attrs.tag_ub & ((unsigned) MPIR_Process.attrs.tag_ub + 1)) == 0);
-
-    /* Set aside tag space for tagged collectives and failure notification */
-#ifdef HAVE_TAG_ERROR_BITS
-    MPIR_Process.attrs.tag_ub >>= 3;
-#else
-    MPIR_Process.attrs.tag_ub >>= 1;
-#endif
 
     /* Assert: tag_ub is at least the minimum asked for in the MPI spec */
     MPIR_Assert(MPIR_Process.attrs.tag_ub >= 32767);

--- a/src/mpid/ch3/src/mpid_iprobe.c
+++ b/src/mpid/ch3/src/mpid_iprobe.c
@@ -34,8 +34,8 @@ int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -33,8 +33,8 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"Comm has been revoked. Returning from MPID_IRECV.");
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -40,8 +40,8 @@ int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
     

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -52,8 +52,8 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"Communicator revoked. MPID_ISEND returning");
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -39,8 +39,8 @@ int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
     

--- a/src/mpid/ch3/src/mpid_probe.c
+++ b/src/mpid/ch3/src/mpid_probe.c
@@ -28,8 +28,8 @@ int MPID_Probe(int source, int tag, MPIR_Comm * comm, int context_offset,
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -41,8 +41,8 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 

--- a/src/mpid/ch3/src/mpid_rsend.c
+++ b/src/mpid/ch3/src/mpid_rsend.c
@@ -42,8 +42,8 @@ int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
     

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -40,8 +40,8 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 

--- a/src/mpid/ch3/src/mpid_ssend.c
+++ b/src/mpid/ch3/src/mpid_ssend.c
@@ -39,8 +39,8 @@ int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
-            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask) &&
-            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_Process.tagged_coll_mask)) {
+            MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&
+            MPIR_SHRINK_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT)) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -528,7 +528,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
-    cts_tag = 0 | MPIR_Process.tagged_coll_mask;
+    cts_tag = 0 | MPIR_TAG_COLL_BIT;
 
     if (local_comm_ptr->rank == local_leader) {
 

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -37,13 +37,6 @@ static inline uint64_t MPIDI_UCX_init_tag(MPIR_Context_id_t contextid, int sourc
     return ucp_tag;
 }
 
-#ifndef MPIR_TAG_ERROR_BIT
-#define MPIR_TAG_ERROR_BIT (1 << 30)
-#endif
-#ifndef  MPIR_TAG_PROC_FAILURE_BIT
-#define MPIR_TAG_PROC_FAILURE_BIT (1 << 29)
-#endif
-
 static inline uint64_t MPIDI_UCX_tag_mask(int mpi_tag, int src)
 {
     uint64_t tag_mask = 0xffffffffffffffff;

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -46,10 +46,10 @@ static inline uint64_t MPIDI_UCX_init_tag(MPIR_Context_id_t contextid, int sourc
 
 static inline uint64_t MPIDI_UCX_tag_mask(int mpi_tag, int src)
 {
-    uint64_t tag_mask;
-    tag_mask = ~(MPIR_TAG_PROC_FAILURE_BIT | MPIR_TAG_ERROR_BIT);
+    uint64_t tag_mask = 0xffffffffffffffff;
+    MPIR_TAG_CLEAR_ERROR_BITS(tag_mask);
     if (mpi_tag == MPI_ANY_TAG)
-        tag_mask &= ~MPIDI_UCX_TAG_MASK;
+        tag_mask &= ~MPIDI_UCX_TAG_USABLE_BITS;
 
     if (src == MPI_ANY_SOURCE)
         tag_mask &= ~(MPIDI_UCX_SOURCE_MASK);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -219,6 +219,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_cc_set(&MPIDI_UCX_global.lw_send_req->cc, 0);
 #endif
 
+    /* we reserve one bit to differentiate AMs from native messages */
+    *tag_ub = MPIDI_UCX_TAG_USABLE_BITS;
+
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_EXIT);

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -23,7 +23,8 @@
 /* Active Message Stuff */
 #define MPIDI_UCX_NUM_AM_BUFFERS       (64)
 #define MPIDI_UCX_MAX_AM_EAGER_SZ      (16*1024)
-#define MPIDI_UCX_AM_TAG               (1 << 28)
+#define MPIDI_UCX_TAG_USABLE_BITS      (MPIR_TAG_USABLE_BITS >> 1)
+#define MPIDI_UCX_AM_TAG               (MPIDI_UCX_TAG_USABLE_BITS + 1)
 
 typedef struct {
     int avtid;

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -348,7 +348,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(5);
 
-    cts_tag = 0 | MPIR_Process.tagged_coll_mask;
+    cts_tag = 0 | MPIR_TAG_COLL_BIT;
     local_size = local_comm->local_size;
 
     /*

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -246,9 +246,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     }
 #endif
 
-    MPIR_Process.attrs.tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
-    /* discuss */
-
     /* Call any and all MPID_Init type functions */
     MPIR_Err_init();
     MPIR_Datatype_init();


### PR DESCRIPTION
A bunch of fixes for tag usage in `src/mpi/comm`. There is still an issue here (https://github.com/pmodels/mpich/blob/master/src/mpi/comm/contextid.c#L800) that I am working, but this set should be ready to test.