### PR TITLE
ch4/ofi: Refactor RMA window setup and enable scalable EP for RMA window

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -810,29 +810,6 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     }
 
     /* ------------------------------------------------------------------------ */
-    /* Construct:  Shared TX Context for RMA                                    */
-    /* ------------------------------------------------------------------------ */
-    if (MPIR_CVAR_CH4_OFI_ENABLE_PER_WIN_SYNC && MPIDI_OFI_ENABLE_SHARED_CONTEXTS) {
-        int ret;
-        struct fi_tx_attr tx_attr;
-        memset(&tx_attr, 0, sizeof(tx_attr));
-        /* A shared transmit context’s attributes must be a union of all associated
-         * endpoints' transmit capabilities. */
-        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
-        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
-        tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
-        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
-                                             &tx_attr,
-                                             &MPIDI_Global.rma_stx_ctx, NULL /* context */), ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to create shared TX context for RMA, "
-                        "falling back to global EP/counter scheme");
-            MPIDI_Global.rma_stx_ctx = NULL;
-        }
-    }
-
-    /* ------------------------------------------------------------------------ */
     /* Create a transport level communication endpoint.  To use the endpoint,   */
     /* it must be bound to completion counters or event queues and enabled,     */
     /* and the resources consumed by it, such as address vectors, counters,     */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -816,6 +816,10 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         int ret;
         struct fi_tx_attr tx_attr;
         memset(&tx_attr, 0, sizeof(tx_attr));
+        /* A shared transmit context’s attributes must be a union of all associated
+         * endpoints' transmit capabilities. */
+        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
+        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
         tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
         MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
                                              &tx_attr,

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -823,12 +823,12 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
         MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
                                              &tx_attr,
-                                             &MPIDI_Global.stx_ctx, NULL /* context */), ret);
+                                             &MPIDI_Global.rma_stx_ctx, NULL /* context */), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         "Failed to create shared TX context for RMA, "
                         "falling back to global EP/counter scheme");
-            MPIDI_Global.stx_ctx = NULL;
+            MPIDI_Global.rma_stx_ctx = NULL;
         }
     }
 
@@ -1109,8 +1109,8 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
         }
     }
 
-    if (MPIDI_OFI_ENABLE_SHARED_CONTEXTS && MPIDI_Global.stx_ctx != NULL)
-        MPIDI_OFI_CALL(fi_close(&MPIDI_Global.stx_ctx->fid), stx_ctx_close);
+    if (MPIDI_OFI_ENABLE_SHARED_CONTEXTS && MPIDI_Global.rma_stx_ctx != NULL)
+        MPIDI_OFI_CALL(fi_close(&MPIDI_Global.rma_stx_ctx->fid), stx_ctx_close);
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.ep->fid), epclose);
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.av->fid), avclose);
     MPIDI_OFI_CALL(fi_close(&MPIDI_Global.p2p_cq->fid), cqclose);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -169,6 +169,8 @@ typedef struct {
     struct fid_mr *mr;
     uint64_t mr_key;
     struct fid_ep *ep;          /* EP with counter & completion */
+    int sep_tx_idx;             /* transmit context index for scalable EP,
+                                 * -1 means using non scalable EP. */
     uint64_t *issued_cntr;
     uint64_t issued_cntr_v;     /* main body of an issued counter,
                                  * if we are to use per-window counter */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -345,6 +345,7 @@ typedef struct {
     struct fid_cq *p2p_cq;
     struct fid_cntr *rma_cmpl_cntr;
     struct fid_stx *rma_stx_ctx;        /* shared TX context for RMA */
+    struct fid_ep *rma_sep;     /* dedicated scalable EP for RMA */
 
     /* Queryable limits */
     uint64_t max_buffered_send;
@@ -362,6 +363,7 @@ typedef struct {
     size_t rx_iov_limit;
     size_t rma_iov_limit;
     int max_ch4_vnis;
+    int max_rma_sep_tx_cnt;     /* Max number of transmit context on one RMA scalable EP */
     size_t max_order_raw;
     size_t max_order_war;
     size_t max_order_waw;
@@ -378,6 +380,7 @@ typedef struct {
     void *win_map;
     uint64_t rma_issued_cntr;
     MPIDI_OFI_atomic_valid_t win_op_table[MPIDI_OFI_DT_SIZES][MPIDI_OFI_OP_SIZES];
+    UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     /* Active Message Globals */
     struct iovec am_iov[MPIDI_OFI_NUM_AM_BUFFERS] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -344,7 +344,7 @@ typedef struct {
     struct fid_ep *ep;
     struct fid_cq *p2p_cq;
     struct fid_cntr *rma_cmpl_cntr;
-    struct fid_stx *stx_ctx;    /* shared TX context for RMA */
+    struct fid_stx *rma_stx_ctx;        /* shared TX context for RMA */
 
     /* Queryable limits */
     uint64_t max_buffered_send;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -191,6 +191,27 @@ static inline int MPIDI_OFI_win_init_stx(MPIR_Win * win)
     finfo = fi_dupinfo(MPIDI_Global.prov_use);
     MPIR_Assert(finfo);
 
+    /* Create shared context only in first call. */
+    if (MPIDI_Global.rma_stx_ctx == NULL) {
+        memset(finfo->tx_attr, 0, sizeof(struct fi_tx_attr));
+        /* A shared transmit context’s attributes must be a union of all associated
+         * endpoints' transmit capabilities. */
+        finfo->tx_attr->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
+        finfo->tx_attr->msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+        finfo->tx_attr->op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
+        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
+                                             finfo->tx_attr,
+                                             &MPIDI_Global.rma_stx_ctx, NULL /* context */), ret);
+        if (ret < 0) {
+            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        "Failed to create shared TX context for RMA, "
+                        "falling back to global EP/counter scheme");
+            MPIDI_Global.rma_stx_ctx = NULL;
+            mpi_errno = MPIDI_OFI_ENAVAIL;
+            goto fn_fail;
+        }
+    }
+
     /* Set per window transmit attributes. */
     MPIDI_OFI_set_rma_fi_info(win, finfo);
     /* Still need to take out rx capabilities for shared context. */
@@ -314,7 +335,7 @@ static inline int MPIDI_OFI_win_init(MPI_Aint length,
     MPIDI_OFI_WIN(win).win_id = ((uint64_t) comm_ptr->context_id) | (window_instance << 32);
     MPIDI_CH4U_map_set(MPIDI_Global.win_map, MPIDI_OFI_WIN(win).win_id, win, MPL_MEM_RMA);
 
-    if (MPIR_CVAR_CH4_OFI_ENABLE_PER_WIN_SYNC && MPIDI_Global.rma_stx_ctx != NULL) {
+    if (MPIR_CVAR_CH4_OFI_ENABLE_PER_WIN_SYNC) {
         /* Create tx using shared transmit context. */
         if (MPIDI_OFI_win_init_stx(win) == MPI_SUCCESS) {
             goto fn_exit;


### PR DESCRIPTION
This PR contains two major changes:
- Refactor RMA window setup: 
OFI_win_init function is split it into a few parts including per window sync, init shared context, init global context and set fi info for RMA capabilities.
- Enable scalable endpoint for RMA window: 
Scalable endpoint is enabled for RMA window to support multiple transmit contexts. When all transmit contexts are used up on scalable EP, it will fall back to use shared transmit context or global endpoint.