### PR TITLE
Help message update in Hydra

### DIFF
--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -204,7 +204,7 @@ static HYD_status handle_bitmap_binding(const char *binding, const char *mapping
 
     if (!valid_binding) {
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR,
-                            "unrecognized binding string \"%s\"\n", mapping);
+                            "unrecognized binding string \"%s\"\n", binding);
     }
 
     /* get the mapping */

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -948,6 +948,12 @@ static void bind_to_help_fn(void)
     printf("            l3dcache         -- map to L3 data cache domain\n");
     printf("            l3icache         -- map to L3 instruction cache domain\n");
     printf("            l3ucache         -- map to L3 unified cache domain\n");
+    printf("            l4cache          -- map to L4 cache domain\n");
+    printf("            l4dcache         -- map to L4 data cache domain\n");
+    printf("            l4ucache         -- map to L4 unified cache domain\n");
+    printf("            l5cache          -- map to L5 cache domain\n");
+    printf("            l5dcache         -- map to L5 data cache domain\n");
+    printf("            l5ucache         -- map to L5 unified cache domain\n");
 
 
     printf("\n\n");


### PR DESCRIPTION

1. Hydra map-by help message missed out in #2959
2.Wrong string argument to an error message print statement.