### PR TITLE
CH4/OFI: Fix initialization of tag_ub for AM

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -603,7 +603,15 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIDI_OFI_CALL(fi_getinfo(fi_version, NULL, NULL, 0ULL, hints, &prov), addrinfo);
     MPIDI_OFI_CHOOSE_PROVIDER(prov, &prov_use, "No suitable provider provider found");
 
-    *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
+    /* Tag_ub is initialized as maximum suppported
+     * tag value in AM if that code path is chosen instead of
+     * maximum supported value in the provider because some
+     * providers support bigger tag than the maximum supported
+     * tag value in AM */
+    if (MPIDI_OFI_ENABLE_TAGGED)
+       *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
+    else
+       *tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
 
     if (MPIDI_OFI_ENABLE_RUNTIME_CHECKS) {
         /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
Tag_ub is initialized as maximum suppported
tag value in AM if that code path is enabled instead of
maximum supported value in the provider because some
providers support bigger tag than the maximum supported
tag value in AM.

Fixes a bunch of collectives, comm and rma tests that were failing due to incorrect tag. 