### PR TITLE
ch4/ofi: Call fi_av_remove when destorying the connection manager

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -370,6 +370,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                             (MPL_DBG_FDEST, "conn_id=%d closed", i));
         }
+        MPIDI_OFI_CALL(fi_av_remove(MPIDI_Global.av, conn, j, 0ULL), avmap);
 
         MPL_free(req);
         MPL_free(conn);

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.h
@@ -762,7 +762,6 @@ static inline int MPIDI_NM_mpi_comm_accept(const char *port_name,
                                (root, MPIDI_OFI_DYNPROC_SENDER,
                                 port_id, &conn, conname, comm_ptr, &child_root,
                                 &remote_size, &remote_upid_size, &remote_upids, &remote_node_ids));
-        MPIDI_OFI_CALL(fi_av_remove(MPIDI_Global.av, &conn, 1, 0ULL), avmap);
         MPIR_CHKLMEM_MALLOC(remote_lupids, int *, remote_size * sizeof(int),
                             mpi_errno, "remote_lupids", MPL_MEM_ADDRESS);
         MPIDIU_upids_to_lupids(remote_size, remote_upid_size, remote_upids, &remote_lupids,


### PR DESCRIPTION
`MPIDI_NM_mpi_comm_accept` removes address from OFI AV right after `fi_av_insert()` and then uses this address. It leads that add-matching with this addresses doesn't work.
The hanging in `MPI_Finalize()` is the consequences of this incorrect behavior. The hanging appears in the `MPIDI_OFI_conn_manager_destroy()` when the processes are waiting for receiving disconnection messages.

Btw, `MPIDI_NM_mpi_comm_conn` doesn't remove address from OFI AV.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>