### PR TITLE
romio: prevent MPI from interfering with rand/random series

### DIFF
--- a/src/mpi/romio/adio/common/shfp_fname.c
+++ b/src/mpi/romio/adio/common/shfp_fname.c
@@ -7,16 +7,6 @@
 
 #include "adio.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
-#ifdef HAVE_TIME_H
-#include <time.h>
-#endif
 /* The following function selects the name of the file to be used to
    store the shared file pointer. The shared-file-pointer file is a
    hidden file in the same directory as the real file being accessed.
@@ -33,17 +23,13 @@ void ADIOI_Shfp_fname(ADIO_File fd, int rank, int *error_code)
 {
     int i;
     int len;
-    char *slash, *ptr, tmp[128];
+    char *slash, *ptr, tmp[PATH_MAX];
     int pid = 0;
 
     fd->shared_fp_fname = (char *) ADIOI_Malloc(PATH_MAX);
 
     if (!rank) {
-        /* srand takes int but time returns long; keep the lower and most
-         * significant  32 bits */
-        srand(time(NULL) & 0xffffffff);
-        i = rand();
-        pid = (int) getpid();
+        MPL_create_pathname(tmp, NULL, ".shfp", 0);
 
         if (ADIOI_Strncpy(fd->shared_fp_fname, fd->filename, PATH_MAX)) {
             *error_code = ADIOI_Err_create_code("ADIOI_Shfp_fname", fd->filename, ENAMETOOLONG);
@@ -82,7 +68,6 @@ void ADIOI_Shfp_fname(ADIO_File fd, int rank, int *error_code)
             }
         }
 
-        MPL_snprintf(tmp, 128, ".shfp.%d.%d", pid, i);
         /* MPL_strnapp will return non-zero if truncated.  That's ok */
         MPL_strnapp(fd->shared_fp_fname, tmp, PATH_MAX);
 

--- a/src/mpi/romio/mpi-io/mpir_cst_filesys.c
+++ b/src/mpi/romio/mpi-io/mpir_cst_filesys.c
@@ -6,16 +6,10 @@
 
 #include "mpioimpl.h"
 
-#ifdef HAVE_UNISTD_H
-#include <unistd.h>
-#endif
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
 
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
 #ifdef HAVE_DIRENT_H
 #include <dirent.h>
 #endif
@@ -51,14 +45,9 @@ static int comm_split_filesystem_exhaustive(MPI_Comm comm, int key,
     filename = MPL_malloc(PATH_MAX, MPL_MEM_IO);
     ranks = MPL_malloc(nprocs * sizeof(int), MPL_MEM_IO);
 
-    if (rank == 0) {
-        /* same algorithim as shared file pointer name */
-        srand(time(NULL) & 0xffffffff);
-        pid = (int) getpid();
+    if (rank == 0)
+        MPL_create_pathname(testdirname, dirname, ".commonfstest.0", 1);
 
-        MPL_snprintf(testdirname, PATH_MAX, "%s/.commonfstest.%d.%d.%d/",
-                     dirname == NULL ? "." : dirname, rank, rand(), pid);
-    }
     MPI_Bcast(testdirname, PATH_MAX, MPI_BYTE, 0, comm);
     /* ignore EEXIST: quite likely another process will have made this
      * directory, but since the whole point is to figure out who we share this
@@ -184,17 +173,8 @@ static int comm_split_filesystem_heuristic(MPI_Comm comm, int key,
 
     filename = MPL_calloc(PATH_MAX, sizeof(char), MPL_MEM_IO);
 
-    if (rank == 0) {
-        int r, pid;
-
-        /* same algorithim as shared file pointer name */
-        srand(time(NULL) & 0xffffffff);
-        r = rand();
-        pid = (int) getpid();
-
-        MPL_snprintf(filename, PATH_MAX, "%s/.commonfstest.%d.%d.%d",
-                     dirname == NULL ? "." : dirname, rank, r, pid);
-    }
+    if (rank == 0)
+        MPL_create_pathname(filename, dirname, ".commonfstest.0", 0);
 
     MPI_Bcast(filename, PATH_MAX, MPI_BYTE, 0, comm);
 

--- a/src/mpl/include/mpl_str.h
+++ b/src/mpl/include/mpl_str.h
@@ -48,6 +48,8 @@ char *MPL_strerror(int errnum);
 #endif /* MPL_HAVE_STRERROR */
 
 int MPL_strnapp(char *dest, const char *src, size_t n);
+void MPL_create_pathname(char *dest_filename, const char *dirname,
+                         const char *prefix, const int is_dir);
 
 /* *INDENT-ON* */
 #if defined(__cplusplus)


### PR DESCRIPTION
On rank 0 romio changes the seed by calling srand() and rand().
It is affecting the values in the user application. This is for
instance the case if srand() is called before MPI_init().

This patch makes romio use a local seed which is not shared with
user application. It also refactors the way the path name is
generated to reduce duplicate code.

It solves the issue [ #2806 MPI_File_open changes the seed of the random](https://github.com/pmodels/mpich/issues/2806)