### PR TITLE
Fixed various spawn bugs

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.h
@@ -762,7 +762,6 @@ static inline int MPIDI_NM_mpi_comm_accept(const char *port_name,
                                (root, MPIDI_OFI_DYNPROC_SENDER,
                                 port_id, &conn, conname, comm_ptr, &child_root,
                                 &remote_size, &remote_upid_size, &remote_upids, &remote_node_ids));
-        MPIDI_OFI_CALL(fi_av_remove(MPIDI_Global.av, &conn, 1, 0ULL), avmap);
         MPIR_CHKLMEM_MALLOC(remote_lupids, int *, remote_size * sizeof(int),
                             mpi_errno, "remote_lupids", MPL_MEM_ADDRESS);
         MPIDIU_upids_to_lupids(remote_size, remote_upid_size, remote_upids, &remote_lupids,

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -496,10 +496,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm,
         } else {
             if (local_upid_size[0] == remote_upid_size[0]) {
                 *is_low_group = memcmp(local_upids, remote_upids, local_upid_size[0]);
+                MPIR_Assert(*is_low_group != 0);
+                if (*is_low_group < 0)
+                    *is_low_group = 0;
+                else
+                    *is_low_group = 1;
             } else {
                 *is_low_group = local_upid_size[0] < remote_upid_size[0];
             }
-            (*is_low_group) |= MPIDI_DYNPROC_MASK;
         }
 
         /* At this point, we're done with the local lpids; they'll

--- a/src/mpid/ch4/src/ch4i_comm.h
+++ b/src/mpid/ch4/src/ch4i_comm.h
@@ -666,7 +666,7 @@ static inline int MPIDI_check_convert_mlut_to_lut(MPIDI_rank_map_t * src)
     int mpi_errno = MPI_SUCCESS, i;
     int flag = 1;
     int avtid;
-    MPIDI_rank_map_mlut_t *mlut = NULL;
+    MPIDI_rank_map_lut_t *lut = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CHECK_CONVERT_MLUT_TO_LUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CHECK_CONVERT_MLUT_TO_LUT);
@@ -693,15 +693,15 @@ static inline int MPIDI_check_convert_mlut_to_lut(MPIDI_rank_map_t * src)
     } else {
         src->mode = MPIDI_RANK_MAP_LUT;
     }
-    mlut = src->irreg.mlut.t;
-    mpi_errno = MPIDIU_alloc_lut(&src->irreg.lut.t, src->size);
+    mpi_errno = MPIDIU_alloc_lut(&lut, src->size);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    src->irreg.lut.lpid = src->irreg.lut.t->lpid;
     for (i = 0; i < src->size; i++) {
-        src->irreg.lut.lpid[i] = mlut->gpid[i].lpid;
+        lut->lpid[i] = src->irreg.mlut.gpid[i].lpid;
     }
-    MPIDIU_release_mlut(mlut);
+    MPIDIU_release_mlut(src->irreg.mlut.t);
+    src->irreg.lut.t = lut;
+    src->irreg.lut.lpid = src->irreg.lut.t->lpid;
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_MAP, VERBOSE, (MPL_DBG_FDEST, " avtid %d", src->avtid));
 
   fn_exit:


### PR DESCRIPTION
Fixed a few bugs in AV table and the spawning implementation in CH4, and submitted a separate PR to libfabric to fix socket provider (which has been merged).
All bugs including spaiccreate, spaiccreate2, disconnect_reconnect, disconnect_reconnect2, and disconnect_reconnect3, etc are fixed in this patch (for socket provider).