### PR TITLE
Separate AM Match Fields

### DIFF
--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -25,7 +25,6 @@ static inline int MPIDI_am_isend(const void *buf, MPI_Aint count, MPI_Datatype d
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
-    uint64_t match_bits;
     MPIDI_CH4U_hdr_t am_hdr;
     MPIDI_CH4U_ssend_req_msg_t ssend_req;
 
@@ -46,10 +45,11 @@ static inline int MPIDI_am_isend(const void *buf, MPI_Aint count, MPI_Datatype d
     MPIR_Assert(sreq);
 
     *request = sreq;
-    match_bits = MPIDI_CH4U_init_send_tag(comm->context_id + context_offset, comm->rank, tag);
 
-    am_hdr.msg_tag = match_bits;
     am_hdr.src_rank = comm->rank;
+    am_hdr.protocol = 0;
+    am_hdr.tag = tag;
+    am_hdr.context_id = comm->context_id + context_offset;
     if (type == MPIDI_CH4U_SSEND_REQ) {
         ssend_req.hdr = am_hdr;
         ssend_req.sreq_ptr = (uint64_t) sreq;
@@ -86,7 +86,6 @@ static inline int MPIDI_psend_init(const void *buf,
                                    MPIR_Request ** request)
 {
     MPIR_Request *sreq;
-    uint64_t match_bits;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PSEND_INIT);
@@ -96,13 +95,14 @@ static inline int MPIDI_psend_init(const void *buf,
 
     MPIR_Comm_add_ref(comm);
     sreq->comm = comm;
-    match_bits = MPIDI_CH4U_init_send_tag(comm->context_id + context_offset, rank, tag);
 
     MPIDI_CH4U_REQUEST(sreq, buffer) = (void *) buf;
     MPIDI_CH4U_REQUEST(sreq, count) = count;
     MPIDI_CH4U_REQUEST(sreq, datatype) = datatype;
-    MPIDI_CH4U_REQUEST(sreq, match_bits) = match_bits;
     MPIDI_CH4U_REQUEST(sreq, rank) = rank;
+    MPIDI_CH4U_REQUEST(sreq, protocol) = 0;
+    MPIDI_CH4U_REQUEST(sreq, tag) = tag;
+    MPIDI_CH4U_REQUEST(sreq, context_id) = comm->context_id + context_offset;
 
     sreq->u.persist.real_request = NULL;
     MPID_Request_complete(sreq);

--- a/src/mpid/ch4/generic/mpidig_startall.h
+++ b/src/mpid/ch4/generic/mpidig_startall.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                                MPIDI_CH4U_REQUEST(preq, count),
                                                MPIDI_CH4U_REQUEST(preq, datatype),
                                                MPIDI_CH4U_REQUEST(preq, rank),
-                                               MPIDI_CH4U_request_get_tag(preq),
+                                               MPIDI_CH4U_REQUEST(preq, tag),
                                                preq->comm,
                                                MPIDI_CH4U_request_get_context_offset(preq),
                                                NULL, &preq->u.persist.real_request);
@@ -46,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                        MPIDI_CH4U_REQUEST(preq, count),
                                        MPIDI_CH4U_REQUEST(preq, datatype),
                                        MPIDI_CH4U_REQUEST(preq, rank),
-                                       MPIDI_CH4U_request_get_tag(preq),
+                                       MPIDI_CH4U_REQUEST(preq, tag),
                                        preq->comm,
                                        MPIDI_CH4U_request_get_context_offset(preq),
                                        &preq->u.persist.real_request);
@@ -59,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                                MPIDI_CH4U_REQUEST(preq, count),
                                                MPIDI_CH4U_REQUEST(preq, datatype),
                                                MPIDI_CH4U_REQUEST(preq, rank),
-                                               MPIDI_CH4U_request_get_tag(preq),
+                                               MPIDI_CH4U_REQUEST(preq, tag),
                                                preq->comm,
                                                MPIDI_CH4U_request_get_context_offset(preq),
                                                NULL, &preq->u.persist.real_request);
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                        MPIDI_CH4U_REQUEST(preq, count),
                                        MPIDI_CH4U_REQUEST(preq, datatype),
                                        MPIDI_CH4U_REQUEST(preq, rank),
-                                       MPIDI_CH4U_request_get_tag(preq),
+                                       MPIDI_CH4U_REQUEST(preq, tag),
                                        preq->comm,
                                        MPIDI_CH4U_request_get_context_offset(preq),
                                        &preq->u.persist.real_request);
@@ -81,7 +81,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                                 MPIDI_CH4U_REQUEST(preq, count),
                                                 MPIDI_CH4U_REQUEST(preq, datatype),
                                                 MPIDI_CH4U_REQUEST(preq, rank),
-                                                MPIDI_CH4U_request_get_tag(preq),
+                                                MPIDI_CH4U_REQUEST(preq, tag),
                                                 preq->comm,
                                                 MPIDI_CH4U_request_get_context_offset(preq),
                                                 NULL, &preq->u.persist.real_request);
@@ -90,7 +90,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                         MPIDI_CH4U_REQUEST(preq, count),
                                         MPIDI_CH4U_REQUEST(preq, datatype),
                                         MPIDI_CH4U_REQUEST(preq, rank),
-                                        MPIDI_CH4U_request_get_tag(preq),
+                                        MPIDI_CH4U_REQUEST(preq, tag),
                                         preq->comm,
                                         MPIDI_CH4U_request_get_context_offset(preq),
                                         &preq->u.persist.real_request);
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                                  MPIDI_CH4U_REQUEST(preq, count),
                                                  MPIDI_CH4U_REQUEST(preq, datatype),
                                                  MPIDI_CH4U_REQUEST(preq, rank),
-                                                 MPIDI_CH4U_request_get_tag(preq),
+                                                 MPIDI_CH4U_REQUEST(preq, tag),
                                                  preq->comm, &sreq_handle);
                     if (mpi_errno == MPI_SUCCESS)
                         MPIR_Request_get_ptr(sreq_handle, preq->u.persist.real_request);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -63,7 +63,10 @@ typedef struct MPIDI_CH4U_lreq_t {
     const void *src_buf;
     MPI_Count count;
     MPI_Datatype datatype;
-    uint64_t match_bits;
+    int rank;
+    short protocol;
+    int tag;
+    MPIR_Context_id_t context_id;
 } MPIDI_CH4U_lreq_t;
 
 typedef struct MPIDI_CH4U_rreq_t {
@@ -155,8 +158,10 @@ typedef struct MPIDI_CH4U_req_t {
     MPIDI_ptype p_type;         /* persistent request type */
     void *buffer;
     uint64_t count;
-    uint64_t match_bits;
     int rank;
+    short protocol;
+    int tag;
+    MPIR_Context_id_t context_id;
     MPI_Datatype datatype;
 } MPIDI_CH4U_req_t;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -63,8 +63,8 @@ typedef struct MPIDI_CH4U_lreq_t {
     const void *src_buf;
     MPI_Count count;
     MPI_Datatype datatype;
-    int rank;
     short protocol;
+    int rank;
     int tag;
     MPIR_Context_id_t context_id;
 } MPIDI_CH4U_lreq_t;
@@ -158,8 +158,8 @@ typedef struct MPIDI_CH4U_req_t {
     MPIDI_ptype p_type;         /* persistent request type */
     void *buffer;
     uint64_t count;
-    int rank;
     short protocol;
+    int rank;
     int tag;
     MPIR_Context_id_t context_id;
     MPI_Datatype datatype;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -196,7 +196,7 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
     msg.rreq_ptr = (uint64_t) req;
     MPIR_Assert((void *) msg.sreq_ptr != NULL);
     mpi_errno =
-        MPIDI_NM_am_send_hdr_reply(MPIDI_CH4U_get_context(MPIDI_CH4U_REQUEST(req, match_bits)),
+        MPIDI_NM_am_send_hdr_reply(MPIDI_CH4U_REQUEST(req, context_id),
                                    MPIDI_CH4U_REQUEST(req, rank), MPIDI_CH4U_SEND_LONG_ACK, &msg,
                                    sizeof(msg));
     if (mpi_errno)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -437,7 +437,10 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).count = count;
         dtype_add_ref_if_not_builtin(datatype);
         MPIDI_CH4U_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDI_CH4U_REQUEST(sreq, req->lreq).match_bits = lreq_hdr.hdr.msg_tag;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).protocol = lreq_hdr.hdr.protocol;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;
         MPIDI_CH4U_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDI_CH4U_SEND_LONG_REQ,
                                          &lreq_hdr, sizeof(lreq_hdr));

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -611,7 +611,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     if (MPIDI_OFI_ENABLE_TAGGED)
         *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
     else
-        *tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
+        *tag_ub = INT_MAX - 1;
 
     if (MPIDI_OFI_ENABLE_RUNTIME_CHECKS) {
         /* ------------------------------------------------------------------------ */

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -89,7 +89,10 @@ static inline int MPIDI_NM_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).count = count;
         dtype_add_ref_if_not_builtin(datatype);
         MPIDI_CH4U_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDI_CH4U_REQUEST(sreq, req->lreq).match_bits = lreq_hdr.hdr.msg_tag;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).protocol = lreq_hdr.hdr.protocol;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
+        MPIDI_CH4U_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;
         MPIDI_CH4U_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDI_CH4U_SEND_LONG_REQ,
                                          &lreq_hdr, sizeof(lreq_hdr));
@@ -448,7 +451,7 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
     msg.rreq_ptr = (uint64_t) req;
     MPIR_Assert((void *) msg.sreq_ptr != NULL);
     mpi_errno =
-        MPIDI_NM_am_send_hdr_reply(MPIDI_CH4U_get_context(MPIDI_CH4U_REQUEST(req, match_bits)),
+        MPIDI_NM_am_send_hdr_reply(MPIDI_CH4U_REQUEST(req, context_id),
                                    MPIDI_CH4U_REQUEST(req, rank), MPIDI_CH4U_SEND_LONG_ACK, &msg,
                                    sizeof(msg));
     if (mpi_errno)

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -219,6 +219,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_cc_set(&MPIDI_UCX_global.lw_send_req->cc, 0);
 #endif
 
+    *tag_ub = MPIDI_UCX_AM_TAG - 1;
+
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_EXIT);

--- a/src/mpid/ch4/shm/glue/shm_init.h
+++ b/src/mpid/ch4/shm/glue/shm_init.h
@@ -11,14 +11,15 @@
 #include <shm.h>
 #include "../posix/shm_direct.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided,
+                                                     int *tag_ub)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
 
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vnis_provided);
+    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vnis_provided, tag_ub);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_INIT_HOOK);
     return ret;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -15,7 +15,8 @@
 #include <mpidimpl.h>
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
-                                                     int *n_vnis_provided) MPL_STATIC_INLINE_SUFFIX;
+                                                     int *n_vnis_provided,
+                                                     int *tag_ub) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -23,7 +23,7 @@ extern char *MPIDI_POSIX_asym_base_addr;
 
 #undef FCNAME
 #define FCNAME DECL_FUNC(MPIDI_POSIX_mpi_init_hook)
-static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_provided)
+static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_provided, int *tag_ub)
 {
     int mpi_errno = MPI_SUCCESS;
     int num_local = 0;
@@ -222,6 +222,9 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
     }
 
 #undef MPIDI_POSIX_MAILBOX_INDEX
+
+    /* There is no restriction on the tag_ub from the posix shmod side */
+    *tag_ub = INT_MAX;
 
     MPIR_CHKPMEM_COMMIT();
   fn_exit:

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -80,13 +80,11 @@ static inline int MPIDI_CH4U_request_get_tag(MPIR_Request * req)
 static inline int MPIDI_CH4U_request_get_context_offset(MPIR_Request * req)
 {
     int context_offset;
-    uint64_t match_bits;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_REQUEST_GET_CONTEXT_OFFSET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_REQUEST_GET_CONTEXT_OFFSET);
 
-    match_bits = MPIDI_CH4U_REQUEST(req, match_bits);
-    context_offset = MPIDI_CH4U_get_context(match_bits) - req->comm->context_id;
+    context_offset = MPIDI_CH4U_REQUEST(req, context_id) - req->comm->context_id;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_REQUEST_GET_CONTEXT_OFFSET);
 

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -290,19 +290,25 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     }
 #endif
 
+    {
+        int shm_tag_ub = MPIR_Process.attrs.tag_ub, nm_tag_ub = MPIR_Process.attrs.tag_ub;
 #ifdef MPIDI_BUILD_CH4_SHM
-    mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vnis_provided);
+        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vnis_provided, &shm_tag_ub);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POPFATAL(mpi_errno);
-    }
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POPFATAL(mpi_errno);
+        }
 #endif
 
-    mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &MPIR_Process.attrs.tag_ub,
-                                       MPIR_Process.comm_world,
-                                       MPIR_Process.comm_self, has_parent, &n_nm_vnis_provided);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POPFATAL(mpi_errno);
+        mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_ub,
+                                           MPIR_Process.comm_world,
+                                           MPIR_Process.comm_self, has_parent, &n_nm_vnis_provided);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POPFATAL(mpi_errno);
+        }
+
+        /* Use the minimum tag_ub from the netmod and shmod */
+        MPIR_Process.attrs.tag_ub = MPL_MIN(shm_tag_ub, nm_tag_ub);
     }
 
     MPIR_Process.attrs.appnum = appnum;

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -247,7 +247,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     }
 #endif
 
-    MPIR_Process.attrs.tag_ub = (1ULL << MPIDI_CH4U_TAG_SHIFT) - 1;
     /* discuss */
 
     /* Call any and all MPID_Init type functions */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -17,24 +17,6 @@
 #include "pmi.h"
 
 /* Macros and inlines */
-/* match/ignore bit manipulation
- *
- * 0123 4567 01234567 0123 4567 01234567 0123 4567 01234567 01234567 01234567
- *     |                  |                  |
- * ^   |    context id    |       source     |       message tag
- * |   |                  |                  |
- * +---- protocol
- */
-#define MPIDI_CH4U_PROTOCOL_MASK (0x9000000000000000ULL)
-#define MPIDI_CH4U_CONTEXT_MASK  (0x0FFFF00000000000ULL)
-#define MPIDI_CH4U_SOURCE_MASK   (0x00000FFFF0000000ULL)
-#define MPIDI_CH4U_TAG_MASK      (0x000000000FFFFFFFULL)
-#define MPIDI_CH4U_DYNPROC_SEND  (0x4000000000000000ULL)
-#define MPIDI_CH4U_TAG_SHIFT     (28)
-#define MPIDI_CH4U_SOURCE_SHIFT  (16)
-#define MPIDI_CH4U_SOURCE_SHIFT_UNPACK (sizeof(int)*8 - MPIDI_CH4U_SOURCE_SHIFT)
-#define MPIDI_CH4U_TAG_SHIFT_UNPACK (sizeof(int)*8 - MPIDI_CH4U_TAG_SHIFT)
-
 #define MPIDI_CH4U_MAP_NOT_FOUND      ((void*)(-1UL))
 
 #define MAX_PROGRESS_HOOKS 4
@@ -118,8 +100,10 @@ enum {
 };
 
 typedef struct MPIDI_CH4U_hdr_t {
-    uint64_t msg_tag;
     int src_rank;
+    short protocol;
+    int tag;
+    MPIR_Context_id_t context_id;
 } MPIDI_CH4U_hdr_t;
 
 typedef struct MPIDI_CH4U_send_long_req_msg_t {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -100,8 +100,8 @@ enum {
 };
 
 typedef struct MPIDI_CH4U_hdr_t {
-    int src_rank;
     short protocol;
+    int src_rank;
     int tag;
     MPIR_Context_id_t context_id;
 } MPIDI_CH4U_hdr_t;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -85,7 +85,6 @@ static inline int MPIDI_handle_unexp_cmpl(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS, in_use;
     MPIR_Comm *root_comm;
     MPIR_Request *match_req = NULL;
-    uint64_t match_bits;
     size_t count;
     MPI_Aint last;
     int dt_contig;
@@ -107,8 +106,7 @@ static inline int MPIDI_handle_unexp_cmpl(MPIR_Request * rreq)
     }
     /* MPIDI_CS_EXIT(); */
 
-    match_bits = MPIDI_CH4U_REQUEST(rreq, match_bits);
-    root_comm = MPIDI_CH4U_context_id_to_comm(MPIDI_CH4U_get_context(match_bits));
+    root_comm = MPIDI_CH4U_context_id_to_comm(MPIDI_CH4U_REQUEST(rreq, context_id));
 
     if (MPIDI_CH4U_REQUEST(rreq, req->status) & MPIDI_CH4U_REQ_MATCHED) {
         match_req = (MPIR_Request *) MPIDI_CH4U_REQUEST(rreq, req->rreq.match_req);
@@ -116,7 +114,11 @@ static inline int MPIDI_handle_unexp_cmpl(MPIR_Request * rreq)
         /* MPIDI_CS_ENTER(); */
         if (root_comm)
             match_req =
-                MPIDI_CH4U_dequeue_posted(match_bits, &MPIDI_CH4U_COMM(root_comm, posted_list));
+                MPIDI_CH4U_dequeue_posted(MPIDI_CH4U_REQUEST(rreq, rank),
+                                          MPIDI_CH4U_REQUEST(rreq, protocol),
+                                          MPIDI_CH4U_REQUEST(rreq, tag),
+                                          MPIDI_CH4U_REQUEST(rreq, context_id),
+                                          &MPIDI_CH4U_COMM(root_comm, posted_list));
 
         if (match_req) {
             MPIDI_CH4U_delete_unexp(rreq, &MPIDI_CH4U_COMM(root_comm, unexp_list));
@@ -133,7 +135,7 @@ static inline int MPIDI_handle_unexp_cmpl(MPIR_Request * rreq)
     }
 
     match_req->status.MPI_SOURCE = MPIDI_CH4U_REQUEST(rreq, rank);
-    match_req->status.MPI_TAG = MPIDI_CH4U_get_tag(match_bits);
+    match_req->status.MPI_TAG = MPIDI_CH4U_REQUEST(rreq, tag);
 
     MPIDI_Datatype_get_info(MPIDI_CH4U_REQUEST(match_req, count),
                             MPIDI_CH4U_REQUEST(match_req, datatype),
@@ -287,7 +289,7 @@ static inline int MPIDI_recv_target_cmpl_cb(MPIR_Request * rreq)
     }
 
     rreq->status.MPI_SOURCE = MPIDI_CH4U_REQUEST(rreq, rank);
-    rreq->status.MPI_TAG = MPIDI_CH4U_request_get_tag(rreq);
+    rreq->status.MPI_TAG = MPIDI_CH4U_REQUEST(rreq, tag);
 
     if (MPIDI_CH4U_REQUEST(rreq, req->status) & MPIDI_CH4U_REQ_PEER_SSEND) {
         mpi_errno = MPIDI_reply_ssend(rreq);
@@ -375,14 +377,13 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
     MPIR_Request *rreq = NULL;
     MPIR_Comm *root_comm;
     MPIDI_CH4U_hdr_t *hdr = (MPIDI_CH4U_hdr_t *) am_hdr;
-    MPIR_Context_id_t context_id;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_TARGET_MSG_CB);
-    context_id = MPIDI_CH4U_get_context(hdr->msg_tag);
-    root_comm = MPIDI_CH4U_context_id_to_comm(context_id);
+    root_comm = MPIDI_CH4U_context_id_to_comm(hdr->context_id);
     if (root_comm) {
         /* MPIDI_CS_ENTER(); */
-        rreq = MPIDI_CH4U_dequeue_posted(hdr->msg_tag, &MPIDI_CH4U_COMM(root_comm, posted_list));
+        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->protocol, hdr->tag, hdr->context_id,
+                                         &MPIDI_CH4U_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     }
 
@@ -396,8 +397,10 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
             MPIDI_CH4U_REQUEST(rreq, buffer) = NULL;
             MPIDI_CH4U_REQUEST(rreq, count) = 0;
         }
-        MPIDI_CH4U_REQUEST(rreq, match_bits) = hdr->msg_tag;
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
+        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
+        MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
+        MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_BUSY;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_UNEXPECTED;
         /* MPIDI_CS_ENTER(); */
@@ -405,7 +408,7 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
             MPIR_Comm_add_ref(root_comm);
             MPIDI_CH4U_enqueue_unexp(rreq, &MPIDI_CH4U_COMM(root_comm, unexp_list));
         } else {
-            MPIDI_CH4U_enqueue_unexp(rreq, MPIDI_CH4U_context_id_to_uelist(context_id));
+            MPIDI_CH4U_enqueue_unexp(rreq, MPIDI_CH4U_context_id_to_uelist(hdr->context_id));
         }
         /* MPIDI_CS_EXIT(); */
     } else {
@@ -414,7 +417,9 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
         /* Decrement the refcnt when popping a request out from posted_list */
         MPIR_Comm_release(root_comm);
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDI_CH4U_REQUEST(rreq, match_bits) = hdr->msg_tag;
+        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
+        MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
+        MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
     }
 
     *req = rreq;
@@ -441,16 +446,15 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
     MPIR_Comm *root_comm;
     MPIDI_CH4U_hdr_t *hdr = (MPIDI_CH4U_hdr_t *) am_hdr;
     MPIDI_CH4U_send_long_req_msg_t *lreq_hdr = (MPIDI_CH4U_send_long_req_msg_t *) am_hdr;
-    MPIR_Context_id_t context_id;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_LONG_REQ_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_LONG_REQ_TARGET_MSG_CB);
 
-    context_id = MPIDI_CH4U_get_context(hdr->msg_tag);
-    root_comm = MPIDI_CH4U_context_id_to_comm(context_id);
+    root_comm = MPIDI_CH4U_context_id_to_comm(hdr->context_id);
     if (root_comm) {
         /* MPIDI_CS_ENTER(); */
-        rreq = MPIDI_CH4U_dequeue_posted(hdr->msg_tag, &MPIDI_CH4U_COMM(root_comm, posted_list));
+        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->protocol, hdr->tag, hdr->context_id,
+                                         &MPIDI_CH4U_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     }
 
@@ -462,15 +466,17 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
         MPIDI_CH4U_REQUEST(rreq, count) = lreq_hdr->data_sz;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_LONG_RTS;
         MPIDI_CH4U_REQUEST(rreq, req->rreq.peer_req_ptr) = lreq_hdr->sreq_ptr;
-        MPIDI_CH4U_REQUEST(rreq, match_bits) = hdr->msg_tag;
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
+        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
+        MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
+        MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
 
         /* MPIDI_CS_ENTER(); */
         if (root_comm) {
             MPIR_Comm_add_ref(root_comm);
             MPIDI_CH4U_enqueue_unexp(rreq, &MPIDI_CH4U_COMM(root_comm, unexp_list));
         } else {
-            MPIDI_CH4U_enqueue_unexp(rreq, MPIDI_CH4U_context_id_to_uelist(context_id));
+            MPIDI_CH4U_enqueue_unexp(rreq, MPIDI_CH4U_context_id_to_uelist(MPIDI_CH4U_REQUEST(rreq, context_id)));
         }
         /* MPIDI_CS_EXIT(); */
     } else {
@@ -478,8 +484,10 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
         MPIR_Comm_release(root_comm);   /* -1 for posted_list */
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_LONG_RTS;
         MPIDI_CH4U_REQUEST(rreq, req->rreq.peer_req_ptr) = lreq_hdr->sreq_ptr;
-        MPIDI_CH4U_REQUEST(rreq, match_bits) = hdr->msg_tag;
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
+        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
+        MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
+        MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         mpi_errno = MPIDI_NM_am_recv(rreq);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -604,8 +612,7 @@ static inline int MPIDI_send_long_ack_target_msg_cb(int handler_id, void *am_hdr
     /* Start the main data transfer */
     send_hdr.rreq_ptr = msg_hdr->rreq_ptr;
     mpi_errno =
-        MPIDI_NM_am_isend_reply(MPIDI_CH4U_get_context
-                                (MPIDI_CH4U_REQUEST(sreq, req->lreq).match_bits),
+        MPIDI_NM_am_isend_reply(MPIDI_CH4U_REQUEST(sreq, req->lreq).context_id,
                                 MPIDI_CH4U_REQUEST(sreq, rank), MPIDI_CH4U_SEND_LONG_LMT, &send_hdr,
                                 sizeof(send_hdr), MPIDI_CH4U_REQUEST(sreq, req->lreq).src_buf,
                                 MPIDI_CH4U_REQUEST(sreq, req->lreq).count, MPIDI_CH4U_REQUEST(sreq,

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -26,7 +26,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *root_comm;
     MPIR_Request *unexp_req;
-    uint64_t match_bits, mask_bits;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_IPROBE);
 
@@ -37,18 +36,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
     }
 
     root_comm = MPIDI_CH4U_context_id_to_comm(comm->context_id);
-    match_bits = MPIDI_CH4U_init_recvtag(&mask_bits, root_comm->recvcontext_id +
-                                         context_offset, source, tag);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDI_CH4U_find_unexp(match_bits, mask_bits,
+    unexp_req = MPIDI_CH4U_find_unexp(source, 0, tag, root_comm->recvcontext_id + context_offset,
                                       &MPIDI_CH4U_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
         *flag = 1;
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
         unexp_req->status.MPI_SOURCE = MPIDI_CH4U_REQUEST(unexp_req, rank);
-        unexp_req->status.MPI_TAG = MPIDI_CH4U_request_get_tag(unexp_req);
+        unexp_req->status.MPI_TAG = MPIDI_CH4U_REQUEST(unexp_req, tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDI_CH4U_REQUEST(unexp_req, count));
 
         status->MPI_TAG = unexp_req->status.MPI_TAG;
@@ -82,7 +79,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *root_comm;
     MPIR_Request *unexp_req;
-    uint64_t match_bits, mask_bits;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_IMPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_IMPROBE);
@@ -94,11 +90,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
     }
 
     root_comm = MPIDI_CH4U_context_id_to_comm(comm->context_id);
-    match_bits = MPIDI_CH4U_init_recvtag(&mask_bits, root_comm->recvcontext_id +
-                                         context_offset, source, tag);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDI_CH4U_dequeue_unexp(match_bits, mask_bits,
+    unexp_req = MPIDI_CH4U_dequeue_unexp(source, 0, tag, root_comm->recvcontext_id + context_offset,
                                          &MPIDI_CH4U_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
@@ -113,7 +107,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
 
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
         unexp_req->status.MPI_SOURCE = MPIDI_CH4U_REQUEST(unexp_req, rank);
-        unexp_req->status.MPI_TAG = MPIDI_CH4U_request_get_tag(unexp_req);
+        unexp_req->status.MPI_TAG = MPIDI_CH4U_REQUEST(unexp_req, tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDI_CH4U_REQUEST(unexp_req, count));
         MPIDI_CH4U_REQUEST(unexp_req, req->status) |= MPIDI_CH4U_REQ_UNEXP_DQUED;
 

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -28,7 +28,7 @@ static inline int MPIDI_reply_ssend(MPIR_Request * rreq)
     ack_msg.sreq_ptr = MPIDI_CH4U_REQUEST(rreq, req->rreq.peer_req_ptr);
 
     mpi_errno =
-        MPIDI_NM_am_isend_reply(MPIDI_CH4U_get_context(MPIDI_CH4U_REQUEST(rreq, match_bits)),
+        MPIDI_NM_am_isend_reply(MPIDI_CH4U_REQUEST(rreq, context_id),
                                 MPIDI_CH4U_REQUEST(rreq, rank), MPIDI_CH4U_SSEND_ACK, &ack_msg,
                                 sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq);
     if (mpi_errno)
@@ -63,7 +63,7 @@ static inline int MPIDI_handle_unexp_mrecv(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_HANDLE_UNEXP_MRECV);
 
     rreq->status.MPI_SOURCE = MPIDI_CH4U_REQUEST(rreq, rank);
-    rreq->status.MPI_TAG = MPIDI_CH4U_request_get_tag(rreq);
+    rreq->status.MPI_TAG = MPIDI_CH4U_REQUEST(rreq, tag);
 
     buf = MPIDI_CH4U_REQUEST(rreq, req->rreq.mrcv_buffer);
     count = MPIDI_CH4U_REQUEST(rreq, req->rreq.mrcv_count);

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -108,8 +108,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp_strict
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
-                                                                       uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
+                                                                       short protocol,
+                                                                       int tag,
+                                                                       MPIR_Context_id_t context_id,
                                                                        MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -122,7 +124,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
-            ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore))) {
+            (rank == MPIDI_CH4U_REQUEST(req, rank)) &&
+            (protocol == MPIDI_CH4U_REQUEST(req, protocol)) &&
+            (tag == MPIDI_CH4U_REQUEST(req, tag)) &&
+            (context_id == MPIDI_CH4U_REQUEST(req, context_id))) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -138,7 +143,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
+                                                                short protocol,
+                                                                int tag,
+                                                                MPIR_Context_id_t context_id,
                                                                 MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -150,7 +158,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore)) {
+        if (rank == MPIDI_CH4U_REQUEST(req, rank) &&
+            protocol == MPIDI_CH4U_REQUEST(req, protocol) &&
+            tag == MPIDI_CH4U_REQUEST(req, tag) &&
+            context_id == MPIDI_CH4U_REQUEST(req, context_id)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -166,7 +177,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
 #define FUNCNAME MPIDI_CH4U_find_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
+                                                             short protocol,
+                                                             int tag,
+                                                             MPIR_Context_id_t context_id,
                                                              MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -178,7 +192,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore)) {
+        if (rank == MPIDI_CH4U_REQUEST(req, rank) &&
+            protocol == MPIDI_CH4U_REQUEST(req, protocol) &&
+            tag == MPIDI_CH4U_REQUEST(req, tag) &&
+            context_id == MPIDI_CH4U_REQUEST(req, context_id)) {
             break;
         }
         req = NULL;
@@ -192,7 +209,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
 #define FUNCNAME MPIDI_CH4U_dequeue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
+                                                                 short protocol,
+                                                                 int tag,
+                                                                 MPIR_Context_id_t context_id,
                                                                  MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
@@ -204,8 +224,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~(MPIDI_CH4U_REQUEST(req, req->rreq.ignore))) ==
-            (MPIDI_CH4U_REQUEST(req, match_bits) & ~(MPIDI_CH4U_REQUEST(req, req->rreq.ignore)))) {
+        if (rank == MPIDI_CH4U_REQUEST(req, rank) &&
+            protocol == MPIDI_CH4U_REQUEST(req, protocol) &&
+            tag == MPIDI_CH4U_REQUEST(req, tag) &&
+            context_id == MPIDI_CH4U_REQUEST(req, context_id)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
@@ -298,8 +320,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp_strict
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t tag,
-                                                                       uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
+                                                                       short protocol,
+                                                                       int tag,
+                                                                       MPIR_Context_id_t context_id,
                                                                        MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -312,7 +336,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
-            ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore))) {
+            (rank == MPIDI_CH4U_REQUEST(req, rank)) &&
+            (protocol == MPIDI_CH4U_REQUEST(req, protocol)) &&
+            (tag == MPIDI_CH4U_REQUEST(req, tag)) &&
+            (context_id == MPIDI_CH4U_REQUEST(req, context_id))) {
             DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -328,7 +355,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(uint64_t 
 #define FUNCNAME MPIDI_CH4U_dequeue_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
+                                                                short protocol,
+                                                                int tag,
+                                                                MPIR_Context_id_t context_id,
                                                                 MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -340,7 +370,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
     DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore)) {
+        if ((rank == MPIDI_CH4U_REQUEST(req, rank)) &&
+            (protocol == MPIDI_CH4U_REQUEST(req, protocol)) &&
+            (tag == MPIDI_CH4U_REQUEST(req, tag)) &&
+            (context_id == MPIDI_CH4U_REQUEST(req, context_id))) {
             DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -356,7 +389,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(uint64_t tag, ui
 #define FUNCNAME MPIDI_CH4U_find_unexp
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint64_t ignore,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
+                                                             short protocol,
+                                                             int tag,
+                                                             MPIR_Context_id_t context_id,
                                                              MPIDI_CH4U_rreq_t ** list)
 {
     MPIDI_CH4U_rreq_t *curr, *tmp;
@@ -368,7 +404,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
     DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~ignore) == (MPIDI_CH4U_REQUEST(req, match_bits) & ~ignore)) {
+        if ((rank == MPIDI_CH4U_REQUEST(req, rank)) &&
+            (protocol == MPIDI_CH4U_REQUEST(req, protocol)) &&
+            (tag == MPIDI_CH4U_REQUEST(req, tag)) &&
+            (context_id == MPIDI_CH4U_REQUEST(req, context_id))) {
             break;
         }
         req = NULL;
@@ -382,7 +421,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(uint64_t tag, uint6
 #define FUNCNAME MPIDI_CH4U_dequeue_posted
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
+                                                                 short protocol,
+                                                                 int tag,
+                                                                 MPIR_Context_id_t context_id,
                                                                  MPIDI_CH4U_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
@@ -394,8 +436,10 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(uint64_t tag,
     DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if ((tag & ~MPIDI_CH4U_REQUEST(req, req->rreq.ignore)) ==
-            (MPIDI_CH4U_REQUEST(req, match_bits) & ~MPIDI_CH4U_REQUEST(req, req->rreq.ignore))) {
+        if ((rank == MPIDI_CH4U_REQUEST(req, rank)) &&
+            (protocol == MPIDI_CH4U_REQUEST(req, protocol)) &&
+            (tag == MPIDI_CH4U_REQUEST(req, tag)) &&
+            (context_id == MPIDI_CH4U_REQUEST(req, context_id))) {
             DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;


### PR DESCRIPTION
There is no reason the AM match fields need to be shoved into a 64 bit field and doing so arbitrarily limits `tag_ub` and makes determining this value across shared memory and tagged/untagged netmod modules complex.

Remove the `uint64_t` field and use 4 `int`s to replace it instead.