### PR TITLE
coll: Fix error checks in igather

### DIFF
--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -315,14 +315,6 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_COMM(comm, mpi_errno);
-            if (sendbuf != MPI_IN_PLACE) {
-                MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            }
-            MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
         }
         MPID_END_ERROR_CHECKS;
     }


### PR DESCRIPTION
Error checks for send and recv buffers are performed further down in
the code. Remove these redundant and/or erroneous checks to match what
we do in blocking MPI_Gather. Fixes #3005.