### PR TITLE
test/mpi: Remove space after substitutions in testlist.in

### DIFF
--- a/test/mpi/threads/comm/testlist.in
+++ b/test/mpi/threads/comm/testlist.in
@@ -4,8 +4,8 @@ comm_dup_deadlock 4
 comm_create_threads 4
 comm_create_group_threads 4 mpiversion=3.0
 comm_create_group_threads2 4 mpiversion=3.0
-@comm_overlap@ idup_deadlock 4 mpiversion=3.0
-@comm_overlap@ comm_idup 4 mpiversion=3.0
-@comm_overlap@ ctxidup 4 mpiversion=3.0
-@comm_overlap@ idup_nb 4 mpiversion=3.0
-@comm_overlap@ idup_comm_gen 4 mpiversion=3.0
+@comm_overlap@idup_deadlock 4 mpiversion=3.0
+@comm_overlap@comm_idup 4 mpiversion=3.0
+@comm_overlap@ctxidup 4 mpiversion=3.0
+@comm_overlap@idup_nb 4 mpiversion=3.0
+@comm_overlap@idup_comm_gen 4 mpiversion=3.0


### PR DESCRIPTION
The leading space here causes an issue with our xfail scripts.

No reviewer.