### PR TITLE
.gitmodules: Remove unnecessary branch configs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,8 +7,6 @@
 [submodule "src/hwloc"]
 	path = src/hwloc
 	url = https://github.com/pmodels/hwloc
-	branch = 1.11.8-mpich
 [submodule "src/mpid/ch4/netmod/ucx/ucx"]
 	path = src/mpid/ch4/netmod/ucx/ucx
 	url = https://github.com/pmodels/ucx
-	branch = 1.2.1-mpich


### PR DESCRIPTION
These values were out of date and are not used when initializing or
updating submodules.