### PR TITLE
ch4/ofi: Reset hints based on caps of a provider

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -566,6 +566,9 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
              * hints included this time. */
             hints->caps = prov_use->caps;
             if (!MPIR_CVAR_OFI_USE_PROVIDER) {
+                /* as soon as we updates globals for the provider, let's update
+                 * hints that corresponds to the current globals */
+                MPIDI_OFI_init_hints(hints);
                 /* set provider name to hints to make more accurate selection */
                 provname = MPL_strdup(prov_use->fabric_attr->prov_name);
                 hints->fabric_attr->prov_name = provname;


### PR DESCRIPTION
This PR addresses the following issue:
There are some OFI providers (BGQ, verbs, RxM) that have `MPIDI_OFI_ENABLE_AV_TABLE_` set to `MPIDI_OFI_OFF` in the capability sets. In its turn, `MPIDI_OFI_ENABLE_AV_TABLE_MINIMAL` is set to `MPIDI_OFI_ON`

Let's imagine the following situation:
The OFI provider name isn't specified by means of `MPIR_CVAR_OFI_USE_PROVIDER` env variable and `MPIR_CVAR_OFI_ENABLE_TAGGED` env variable isn't set to any value (i.e. it has default one - `-1`). So, the `hints::domain_attr::av_type` is set to `FI_AV_TABLE` and  `global::enable_av_table` to `MPIDI_OFI_ON`, because these are initialized by "unknown" provider, (i.e. from MINIMAL capability set). Then, after first calling of `fi_getinfo()`, this call returns a list of infos with matched providers set. (some explanations from OFI point of view -- if a provider supports both `FI_AV_TABLE` and `FI_AV_MAP`, the checks are OK and a generated fi_info is altered AV type filed to the requested AV type set or default one if this is unset). Each entry of fi_info list will contain AV type set to `FI_AV_TABLE` in our case. Let's now assume that RxM has been chosen. Then the global settings are updated by current provider (RxM) [here](https://github.com/pmodels/mpich/blob/a750d6f6aae22f7ab0408c437b2ea58fe6d13716/src/mpid/ch4/netmod/ofi/ofi_init.h#L500). This provider will be chosen and fi_getinfo will be called the second time with hints that are generated for "unknown" provider (i.e. AV type is set to `FI_AV_TABLE`, but global setting has been modified to the RxM defaults). After that, fi_av_open will be failed. because `fi_info::domain_attr::av_type` = `FI_AV_TABLE`, but `MPIDI_OFI_ENABLE_AV_TABLE` = 0 (based on RxM defaults).

The fix is to reset hints based on updated global setting for the found provider.
