### PR TITLE
ROMIO: combined two separated send/recv for offsets and lengths into one

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -429,7 +429,6 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -453,7 +452,6 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, int count,
         for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -444,7 +444,6 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -464,7 +463,6 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
@@ -209,8 +209,8 @@ void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
     for (i = 0; i < nprocs; i++) {
         if (count_my_req_per_proc[i]) {
             my_req[i].offsets = (ADIO_Offset *)
-                ADIOI_Malloc(count_my_req_per_proc[i] * sizeof(ADIO_Offset));
-            my_req[i].lens = ADIOI_Malloc(count_my_req_per_proc[i] * sizeof(ADIO_Offset));
+                ADIOI_Malloc(count_my_req_per_proc[i] * 2 * sizeof(ADIO_Offset));
+            my_req[i].lens = my_req[i].offsets + count_my_req_per_proc[i];
             count_my_req_procs++;
         }
         my_req[i].count = 0;    /* will be incremented where needed later */

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -335,7 +335,6 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }
@@ -344,7 +343,6 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);

--- a/src/mpi/romio/adio/common/ad_aggregate.c
+++ b/src/mpi/romio/adio/common/ad_aggregate.c
@@ -466,7 +466,7 @@ void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
 /* now send the calculated offsets and lengths to respective processes */
 
     requests = (MPI_Request *)
-        ADIOI_Malloc(1 + 2 * (count_my_req_procs + count_others_req_procs) * sizeof(MPI_Request));
+        ADIOI_Malloc(1 + (count_my_req_procs + count_others_req_procs) * sizeof(MPI_Request));
 /* +1 to avoid a 0-size malloc */
 
     j = 0;
@@ -485,6 +485,7 @@ void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
     }
 
     if (j) {
+        /* TODO: consider using MPI_STATUSES_IGNORE to avoid malloc */
         statuses = (MPI_Status *) ADIOI_Malloc(j * sizeof(MPI_Status));
         MPI_Waitall(j, requests, statuses);
         ADIOI_Free(statuses);

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -467,7 +467,6 @@ static void ADIOI_GEN_IreadStridedColl_read(ADIOI_NBC_Request * nbc_req, int *er
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -509,7 +508,6 @@ static void ADIOI_GEN_IreadStridedColl_free(ADIOI_NBC_Request * nbc_req, int *er
     for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -460,7 +460,6 @@ static void ADIOI_GEN_IwriteStridedColl_exch(ADIOI_NBC_Request * nbc_req, int *e
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -550,7 +549,6 @@ static void ADIOI_GEN_IwriteStridedColl_free(ADIOI_NBC_Request * nbc_req, int *e
     for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -216,7 +216,6 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -235,7 +234,6 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -186,7 +186,6 @@ void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (my_req[i].count) {
             ADIOI_Free(my_req[i].offsets);
-            ADIOI_Free(my_req[i].lens);
         }
     }
     ADIOI_Free(my_req);
@@ -240,7 +239,6 @@ void ADIOI_GEN_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     for (i = 0; i < nprocs; i++) {
         if (others_req[i].count) {
             ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].lens);
             ADIOI_Free(others_req[i].mem_ptrs);
         }
     }


### PR DESCRIPTION
This PR combines the separated malloc for `my_req[i].offsets` and `my_req[i].lens` into one malloc (same for `others_req[i].offsets` and `others_req[i].lens)` , so the separated Isend for offsets and lens can be combined into one Isend (same for Irecv). Hopefully, this can improve ROMIO performance when run in large scale.