### PR TITLE
ch4/ofi: Allocate MR key only in case of Scalable MR mode

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -362,15 +362,18 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
     MPIR_Request *sreq;
     MPIDI_OFI_ack_msg_payload_t *ack_msg;
     int handler_id;
-    uint64_t index;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_HANDLE_LMT_ACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_LMT_ACK);
 
     ack_msg = (MPIDI_OFI_ack_msg_payload_t *) msg_hdr->payload;
     sreq = (MPIR_Request *) ack_msg->sreq_ptr;
 
-    index = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)) >> MPIDI_Global.huge_rma_shift;
-    MPIDI_OFI_index_allocator_free(MPIDI_OFI_COMM(MPIR_Process.comm_world).rma_id_allocator, index);
+    if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
+        uint64_t index =
+            fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)) >> MPIDI_Global.huge_rma_shift;
+        MPIDI_OFI_index_allocator_free(MPIDI_OFI_COMM(MPIR_Process.comm_world).rma_id_allocator,
+                                       index);
+    }
     MPIDI_OFI_CALL_NOLOCK(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
     OPA_decr_int(&MPIDI_Global.am_inflight_rma_send_mrs);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -339,12 +339,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 
         MPID_THREAD_CS_ENTER(POBJ, MPIDI_OFI_THREAD_FI_MUTEX);
 
-        /* Set up a memory region for the lmt data transfer */
-        ctrl.rma_key =
-            MPIDI_OFI_index_allocator_alloc(MPIDI_OFI_COMM(comm).rma_id_allocator, MPL_MEM_RMA);
-        MPIR_Assert(ctrl.rma_key < MPIDI_Global.max_huge_rmas);
-        if (MPIDI_OFI_ENABLE_MR_SCALABLE)
+        if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
+            /* Set up a memory region for the lmt data transfer */
+            ctrl.rma_key =
+                MPIDI_OFI_index_allocator_alloc(MPIDI_OFI_COMM(comm).rma_id_allocator, MPL_MEM_RMA);
+            MPIR_Assert(ctrl.rma_key < MPIDI_Global.max_huge_rmas);
             rma_key = ctrl.rma_key << MPIDI_Global.huge_rma_shift;
+        }
         MPIDI_OFI_CALL_NOLOCK(fi_mr_reg(MPIDI_Global.domain,    /* In:  Domain Object       */
                                         send_buf,       /* In:  Lower memory address */
                                         data_sz,        /* In:  Length              */


### PR DESCRIPTION
The MR key should be generated only for the Scalable MR mode.

This PR fixes the following problem in case of Basic MR mode:
When LMT req is initiated, the index is allocated and used for the MR key (the generated MR key is ignored in case of Basic MR mode). After that fi_mr_key is called to retrieve generated Remote Key.
So, when the acknowledgment of LMT is received, the allocated index is calculating by means of `fi_mr_key() << MPIDI_Global.huge_rma_shift`. This is wrong for the Basic MR mode and this produces leakage of indices.

The fix is to not allocate indices in case of `!MPIDI_OFI_ENABLE_MR_SCALABLE`
