### PR TITLE
Allow device to override progress thread

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -89,4 +89,8 @@ int MPIR_Close_port_impl(const char *port_name);
 int MPIR_Open_port_impl(MPIR_Info * info_ptr, char *port_name);
 int MPIR_Cancel_impl(MPIR_Request * request_ptr);
 
+/* Default routines for asynchronous progress thread */
+int MPIR_Init_async_thread(void);
+int MPIR_Finalize_async_thread(void);
+
 #endif /* MPIR_MISC_H_INCLUDED */

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -175,7 +175,7 @@ int MPI_Finalize(void)
     /* If the user requested for asynchronous progress, we need to
      * shutdown the progress thread */
     if (MPIR_async_thread_initialized) {
-        mpi_errno = MPIR_Finalize_async_thread();
+        mpi_errno = MPID_Finalize_async_thread();
         if (mpi_errno)
             goto fn_fail;
     }

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -187,7 +187,7 @@ int MPI_Init(int *argc, char ***argv)
         goto fn_fail;
 #else
         if (provided == MPI_THREAD_MULTIPLE) {
-            mpi_errno = MPIR_Init_async_thread();
+            mpi_errno = MPID_Init_async_thread();
             if (mpi_errno)
                 goto fn_fail;
 

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -738,7 +738,7 @@ int MPI_Init_thread(int *argc, char ***argv, int required, int *provided)
         goto fn_fail;
 #else
         if (*provided == MPI_THREAD_MULTIPLE) {
-            mpi_errno = MPIR_Init_async_thread();
+            mpi_errno = MPID_Init_async_thread();
             if (mpi_errno)
                 goto fn_fail;
 

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -9,8 +9,6 @@
 
 /* Definitions local to src/mpi/init only */
 int MPIR_Init_thread(int *, char ***, int, int *);
-int MPIR_Init_async_thread(void);
-int MPIR_Finalize_async_thread(void);
 int MPIR_Thread_CS_Finalize(void);
 
 extern int MPIR_async_thread_initialized;

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -208,4 +208,17 @@ int MPIDI_CH3I_Progress_deactivate_hook(int id);
 #define MPID_Progress_activate_hook(id_) MPIDI_CH3I_Progress_activate_hook(id_)
 #define MPID_Progress_deactivate_hook(id_) MPIDI_CH3I_Progress_deactivate_hook(id_)
 
+/*
+  Device override hooks for asynchronous progress threads
+*/
+MPL_STATIC_INLINE_PREFIX int MPID_Init_async_thread(void)
+{
+    return MPIR_Init_async_thread();
+}
+
+MPL_STATIC_INLINE_PREFIX int MPID_Finalize_async_thread(void)
+{
+    return MPIR_Finalize_async_thread();
+}
+
 #endif /* MPIDPOST_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -49,4 +49,17 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_destroy_hook(MPIR_Request * req)
     return;
 }
 
+/*
+  Device override hooks for asynchronous progress threads
+*/
+MPL_STATIC_INLINE_PREFIX int MPID_Init_async_thread(void)
+{
+    return MPIR_Init_async_thread();
+}
+
+MPL_STATIC_INLINE_PREFIX int MPID_Finalize_async_thread(void)
+{
+    return MPIR_Finalize_async_thread();
+}
+
 #endif /* MPIDPOST_H_INCLUDED */


### PR DESCRIPTION
This patch defines new interfaces in a device to start/shutdown
asynchronous progress threads, so each device can provide its
own progress thread.
In this patch, these functions are implemented as a fallback to
the existing MPIR functions.