### PR TITLE
ch4/ofi: Simplify persistent send/recv

### DIFF
--- a/src/mpid/ch4/generic/mpidig_startall.h
+++ b/src/mpid/ch4/generic/mpidig_startall.h
@@ -32,16 +32,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
         switch (MPIDI_CH4U_REQUEST(preq, p_type)) {
 
             case MPIDI_PTYPE_RECV:
-#ifdef MPIDI_BUILD_CH4_SHM
-                mpi_errno = MPIDI_NM_mpi_irecv(MPIDI_CH4U_REQUEST(preq, buffer),
-                                               MPIDI_CH4U_REQUEST(preq, count),
-                                               MPIDI_CH4U_REQUEST(preq, datatype),
-                                               MPIDI_CH4U_REQUEST(preq, rank),
-                                               MPIDI_CH4U_request_get_tag(preq),
-                                               preq->comm,
-                                               MPIDI_CH4U_request_get_context_offset(preq),
-                                               NULL, &preq->u.persist.real_request);
-#else
                 mpi_errno = MPID_Irecv(MPIDI_CH4U_REQUEST(preq, buffer),
                                        MPIDI_CH4U_REQUEST(preq, count),
                                        MPIDI_CH4U_REQUEST(preq, datatype),
@@ -50,20 +40,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                        preq->comm,
                                        MPIDI_CH4U_request_get_context_offset(preq),
                                        &preq->u.persist.real_request);
-#endif
                 break;
 
             case MPIDI_PTYPE_SEND:
-#ifdef MPIDI_BUILD_CH4_SHM
-                mpi_errno = MPIDI_NM_mpi_isend(MPIDI_CH4U_REQUEST(preq, buffer),
-                                               MPIDI_CH4U_REQUEST(preq, count),
-                                               MPIDI_CH4U_REQUEST(preq, datatype),
-                                               MPIDI_CH4U_REQUEST(preq, rank),
-                                               MPIDI_CH4U_request_get_tag(preq),
-                                               preq->comm,
-                                               MPIDI_CH4U_request_get_context_offset(preq),
-                                               NULL, &preq->u.persist.real_request);
-#else
                 mpi_errno = MPID_Isend(MPIDI_CH4U_REQUEST(preq, buffer),
                                        MPIDI_CH4U_REQUEST(preq, count),
                                        MPIDI_CH4U_REQUEST(preq, datatype),
@@ -72,20 +51,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                        preq->comm,
                                        MPIDI_CH4U_request_get_context_offset(preq),
                                        &preq->u.persist.real_request);
-#endif
                 break;
 
             case MPIDI_PTYPE_SSEND:
-#ifdef MPIDI_BUILD_CH4_SHM
-                mpi_errno = MPIDI_NM_mpi_issend(MPIDI_CH4U_REQUEST(preq, buffer),
-                                                MPIDI_CH4U_REQUEST(preq, count),
-                                                MPIDI_CH4U_REQUEST(preq, datatype),
-                                                MPIDI_CH4U_REQUEST(preq, rank),
-                                                MPIDI_CH4U_request_get_tag(preq),
-                                                preq->comm,
-                                                MPIDI_CH4U_request_get_context_offset(preq),
-                                                NULL, &preq->u.persist.real_request);
-#else
                 mpi_errno = MPID_Issend(MPIDI_CH4U_REQUEST(preq, buffer),
                                         MPIDI_CH4U_REQUEST(preq, count),
                                         MPIDI_CH4U_REQUEST(preq, datatype),
@@ -94,7 +62,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_startall(int count, MPIR_Request * reque
                                         preq->comm,
                                         MPIDI_CH4U_request_get_context_offset(preq),
                                         &preq->u.persist.real_request);
-#endif
                 break;
 
             case MPIDI_PTYPE_BSEND:{

--- a/src/mpid/ch4/netmod/ofi/ofi_startall.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_startall.h
@@ -20,125 +20,12 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_startall(int count, MPIR_Request * requests[])
 {
-    int mpi_errno = MPI_SUCCESS, i;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_STARTALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_STARTALL);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_startall(count, requests);
-        goto fn_exit;
-    }
+    mpi_errno = MPIDIG_mpi_startall(count, requests);
 
-    for (i = 0; i < count; i++) {
-        MPIR_Request *const preq = requests[i];
-
-        switch (MPIDI_OFI_REQUEST(preq, util.persist.type)) {
-            case MPIDI_PTYPE_RECV:
-#ifdef MPIDI_BUILD_CH4_SHM
-                mpi_errno = MPIDI_NM_mpi_irecv(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                               MPIDI_OFI_REQUEST(preq, datatype),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                               preq->comm,
-                                               MPIDI_OFI_REQUEST(preq,
-                                                                 util_id) -
-                                               preq->comm->recvcontext_id,
-                                               MPIDIU_comm_rank_to_av(preq->comm,
-                                                                      MPIDI_OFI_REQUEST(preq,
-                                                                                        util.persist.rank)),
-                                               &preq->u.persist.real_request);
-                break;
-#else
-                mpi_errno = MPID_Irecv(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                       MPIDI_OFI_REQUEST(preq, datatype),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                       preq->comm,
-                                       MPIDI_OFI_REQUEST(preq,
-                                                         util_id) - preq->comm->recvcontext_id,
-                                       &preq->u.persist.real_request);
-                break;
-#endif
-
-            case MPIDI_PTYPE_SEND:
-#ifdef MPIDI_BUILD_CH4_SHM
-                mpi_errno = MPIDI_NM_mpi_isend(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                               MPIDI_OFI_REQUEST(preq, datatype),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                               MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                               preq->comm,
-                                               MPIDI_OFI_REQUEST(preq,
-                                                                 util_id) - preq->comm->context_id,
-                                               MPIDIU_comm_rank_to_av(preq->comm,
-                                                                      MPIDI_OFI_REQUEST(preq,
-                                                                                        util.persist.rank)),
-                                               &preq->u.persist.real_request);
-                break;
-#else
-                mpi_errno = MPID_Isend(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                       MPIDI_OFI_REQUEST(preq, datatype),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                       MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                       preq->comm,
-                                       MPIDI_OFI_REQUEST(preq, util_id) - preq->comm->context_id,
-                                       &preq->u.persist.real_request);
-                break;
-#endif
-
-            case MPIDI_PTYPE_SSEND:
-                mpi_errno = MPID_Issend(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                        MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                        MPIDI_OFI_REQUEST(preq, datatype),
-                                        MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                        MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                        preq->comm,
-                                        MPIDI_OFI_REQUEST(preq, util_id) - preq->comm->context_id,
-                                        &preq->u.persist.real_request);
-                break;
-
-            case MPIDI_PTYPE_BSEND:{
-                    MPI_Request sreq_handle;
-                    mpi_errno = MPIR_Ibsend_impl(MPIDI_OFI_REQUEST(preq, util.persist.buf),
-                                                 MPIDI_OFI_REQUEST(preq, util.persist.count),
-                                                 MPIDI_OFI_REQUEST(preq, datatype),
-                                                 MPIDI_OFI_REQUEST(preq, util.persist.rank),
-                                                 MPIDI_OFI_REQUEST(preq, util.persist.tag),
-                                                 preq->comm, &sreq_handle);
-
-                    if (mpi_errno == MPI_SUCCESS)
-                        MPIR_Request_get_ptr(sreq_handle, preq->u.persist.real_request);
-
-                    break;
-                }
-
-            default:
-                mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL, __FUNCTION__,
-                                                 __LINE__, MPI_ERR_INTERN, "**ch3|badreqtype",
-                                                 "**ch3|badreqtype %d", MPIDI_OFI_REQUEST(preq,
-                                                                                          util.persist.type));
-        }
-
-        if (mpi_errno == MPI_SUCCESS) {
-            preq->status.MPI_ERROR = MPI_SUCCESS;
-
-            if (MPIDI_OFI_REQUEST(preq, util.persist.type) == MPIDI_PTYPE_BSEND) {
-                preq->cc_ptr = &preq->cc;
-                MPIR_cc_set(&preq->cc, 0);
-            } else
-                preq->cc_ptr = &preq->u.persist.real_request->cc;
-        } else {
-            preq->u.persist.real_request = NULL;
-            preq->status.MPI_ERROR = mpi_errno;
-            preq->cc_ptr = &preq->cc;
-            MPIR_cc_set(&preq->cc, 0);
-        }
-    }
-
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_STARTALL);
     return mpi_errno;
 }


### PR DESCRIPTION
We can always call MPID_Isend/Irecv from OFI startall, because
MPID_Isend/Irecv takes care of the different shared memory build
mode.

In case it ends up with netmod send/recv, it feels a little bit
redundant to go up to MPID level, but given these function calls
are inlined, runtime overhead would be negligible. So we simply
choose code simplicity here.