### PR TITLE
ch4/ucx: Fix some type warnings

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -75,8 +75,8 @@ static inline ucs_status_t MPIDI_UCX_Unpack(void *state, size_t offset, const vo
                                             size_t count)
 {
     struct MPIDI_UCX_pack_state *pack_state = (struct MPIDI_UCX_pack_state *) state;
-    size_t last = MPL_MIN(pack_state->packsize, offset + count);
-    size_t last_pack = last;
+    MPI_Aint last = MPL_MIN(pack_state->packsize, offset + count);
+    MPI_Aint last_pack = last;
 
     MPIR_Segment_unpack(pack_state->segment_ptr, offset, &last, (void *) src);
     if (unlikely(last != last_pack)) {

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -37,13 +37,6 @@ static inline uint64_t MPIDI_UCX_init_tag(MPIR_Context_id_t contextid, int sourc
     return ucp_tag;
 }
 
-#ifndef MPIR_TAG_ERROR_BIT
-#define MPIR_TAG_ERROR_BIT (1 << 30)
-#endif
-#ifndef  MPIR_TAG_PROC_FAILURE_BIT
-#define MPIR_TAG_PROC_FAILURE_BIT (1 << 29)
-#endif
-
 static inline uint64_t MPIDI_UCX_tag_mask(int mpi_tag, int src)
 {
     uint64_t tag_mask;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -48,11 +48,10 @@ static inline int MPIDI_UCX_noncontig_put(const void *origin_addr,
                                           MPIR_Win * win, MPIDI_av_entry_t * addr)
 {
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
-    size_t offset, last;
-    uint64_t base;
+    MPI_Aint segment_first, last;
+    size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     ucs_status_t status;
-    size_t segment_first;
     struct MPIR_Segment *segment_ptr;
     char *buffer = NULL;
     MPIR_Comm *comm = win->comm_ptr;
@@ -92,8 +91,7 @@ static inline int MPIDI_UCX_contig_get(void *origin_addr,
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
-    size_t offset;
-    uint64_t base;
+    size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     ucs_status_t status;
     MPIR_Comm *comm = win->comm_ptr;


### PR DESCRIPTION
Segment routines use MPI_Aint and ucp routines use size_t.