### PR TITLE
Revert "maint: Use const char * for CVAR strings"

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -210,7 +210,7 @@ foreach my $p (@cvars) {
     }
 
     if ($p->{type} eq 'string') {
-        printf OUTPUT_C "%s ${uc_ns}_%s = (%s) %s;\n", Type2Ctype($p->{type}), $p->{name}, Type2Ctype($p->{type}), $default;
+        printf OUTPUT_C "%s ${uc_ns}_%s = (char*)%s;\n", Type2Ctype($p->{type}), $p->{name}, $default;
     } else {
         printf OUTPUT_C "%s ${uc_ns}_%s = %s;\n", Type2Ctype($p->{type}), $p->{name}, $default;
     }
@@ -263,7 +263,7 @@ foreach my $p (@cvars) {
         $mpi_dtype = "MPI_CHAR";
         $count = "${uc_ns}_MAX_STRLEN";
         $dftval = FmtDefault($p->{name}, $p->{default}, $p->{type});
-        printf OUTPUT_C qq(    defaultval.str = (const char *)%s;\n), $dftval;
+        printf OUTPUT_C qq(    defaultval.str = (char *)%s;\n), $dftval;
     }
     elsif ($p->{type} eq 'int' or $p->{type} eq 'boolean') {
         $mpi_dtype = "MPI_INT";
@@ -461,7 +461,7 @@ sub Type2Ctype {
     my %typemap = (
         'int'     => 'int',
         'double'  => 'double',
-        'string'  => 'const char *',
+        'string'  => 'char *',
         'boolean' => 'int',
         'range'   => "MPIR_T_cvar_range_value_t",
     );

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -75,7 +75,7 @@ typedef union MPIR_T_cvar_value_s {
     unsigned ul;
     unsigned ull;
     MPI_Count c;
-    const char *str;
+    char *str;
     double f;
     MPIR_T_cvar_range_value_t range;
 } MPIR_T_cvar_value_t;


### PR DESCRIPTION
This reverts commit 2f4a52a62414264864e05cf182efc6de27e8ca47.