### PR TITLE
ch4: Return default value from coll selection

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
@@ -40,6 +40,8 @@ MPL_STATIC_INLINE_PREFIX
             return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Bcast_intra_scatter_ring_allgather_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -64,6 +66,8 @@ MPL_STATIC_INLINE_PREFIX
         return (MPIDI_OFI_coll_algo_container_t *) &
             MPIDI_OFI_Allreduce_intra_reduce_scatter_allgather_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -88,6 +92,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Reduce_intra_binomial_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -184,6 +190,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Alltoall_intra_pairwise_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -206,6 +214,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Alltoallv_intra_scattered_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -228,6 +238,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Alltoallw_intra_scattered_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -255,6 +267,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Allgather_intra_ring_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -292,6 +306,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_OFI_coll_algo_container_t *) & MPIDI_OFI_Allgatherv_intra_ring_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -363,6 +379,8 @@ MPL_STATIC_INLINE_PREFIX
                 MPIDI_OFI_Reduce_scatter_intra_recursive_doubling_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -424,6 +442,8 @@ MPL_STATIC_INLINE_PREFIX
                 MPIDI_OFI_Reduce_scatter_block_intra_recursive_doubling_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX

--- a/src/mpid/ch4/shm/posix/posix_coll_select.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_select.h
@@ -42,6 +42,8 @@ MPL_STATIC_INLINE_PREFIX
                 MPIDI_POSIX_Bcast_intra_scatter_ring_allgather_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -67,6 +69,8 @@ MPL_STATIC_INLINE_PREFIX
         return (MPIDI_POSIX_coll_algo_container_t *) &
             MPIDI_POSIX_Allreduce_intra_reduce_scatter_allgather_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -90,6 +94,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Reduce_intra_binomial_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -186,6 +192,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Alltoall_intra_pairwise_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -208,6 +216,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Alltoallv_intra_scattered_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -230,6 +240,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Alltoallw_intra_scattered_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -258,6 +270,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Allgather_intra_ring_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -296,6 +310,8 @@ MPL_STATIC_INLINE_PREFIX
     } else {
         return (MPIDI_POSIX_coll_algo_container_t *) & MPIDI_POSIX_Allgatherv_intra_ring_cnt;
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -369,6 +385,8 @@ MPL_STATIC_INLINE_PREFIX
                 MPIDI_POSIX_Reduce_scatter_intra_recursive_doubling_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX
@@ -431,6 +449,8 @@ MPL_STATIC_INLINE_PREFIX
                 MPIDI_POSIX_Reduce_scatter_block_intra_recursive_doubling_cnt;
         }
     }
+
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX


### PR DESCRIPTION
Intel compilers generate warnings about not returning anything from a
function with a return type. Even though this case will never be hit,
add a default return.