### PR TITLE
romio: Fixup ad_pvfs2 Makefile

### DIFF
--- a/src/mpi/romio/adio/ad_pvfs2/Makefile.mk
+++ b/src/mpi/romio/adio/ad_pvfs2/Makefile.mk
@@ -7,9 +7,9 @@
 
 if BUILD_AD_PVFS2
 
-noinst_HEADERS +=
-    adio/ad_pvfs2/ad_pvfs2.h 		\
-    adio/ad_pvfs2/ad_pvfs2_io.h 	\
+noinst_HEADERS +=                       \
+    adio/ad_pvfs2/ad_pvfs2.h            \
+    adio/ad_pvfs2/ad_pvfs2_io.h         \
     adio/ad_pvfs2/ad_pvfs2_common.h
 
 romio_other_sources +=                          \


### PR DESCRIPTION
[c43f61f5da4f] was supposed to just convert tabs to spaces. However,
in this file it added an unescaped newline, and left existing tabs in
place. This fixes both issues.