### PR TITLE
CH4/OFI: Call generic send/recv_init

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -127,14 +127,6 @@ typedef struct {
         struct iovec *nopack;
     } noncontig;
     union {
-        /* persistent send fields */
-        struct {
-            int type;
-            int rank;
-            int tag;
-            int count;
-            void *buf;
-        } persist;
 #if defined (MPL_HAVE_VAR_ATTRIBUTE_ALIGNED)
         struct iovec iov MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
 #else

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -340,43 +340,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
                                                     int context_offset, MPIDI_av_entry_t * addr,
                                                     MPIR_Request ** request)
 {
-    MPIR_Request *rreq;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RECV_INIT);
 
-    if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno =
-            MPIDIG_mpi_recv_init(buf, count, datatype, rank, tag, comm, context_offset, request);
-        goto fn_exit;
-    }
+    mpi_errno =
+        MPIDIG_mpi_recv_init(buf, count, datatype, rank, tag, comm, context_offset, request);
 
-    MPIDI_OFI_REQUEST_CREATE((rreq), MPIR_REQUEST_KIND__PREQUEST_RECV);
-
-    *request = rreq;
-    rreq->comm = comm;
-    MPIR_Comm_add_ref(comm);
-
-    MPIDI_OFI_REQUEST(rreq, util.persist.buf) = (void *) buf;
-    MPIDI_OFI_REQUEST(rreq, util.persist.count) = count;
-    MPIDI_OFI_REQUEST(rreq, datatype) = datatype;
-    MPIDI_OFI_REQUEST(rreq, util.persist.rank) = rank;
-    MPIDI_OFI_REQUEST(rreq, util.persist.tag) = tag;
-    MPIDI_OFI_REQUEST(rreq, util_comm) = comm;
-    MPIDI_OFI_REQUEST(rreq, util_id) = comm->context_id + context_offset;
-    rreq->u.persist.real_request = NULL;
-
-    MPIDI_CH4U_request_complete(rreq);
-
-    MPIDI_OFI_REQUEST(rreq, util.persist.type) = MPIDI_PTYPE_RECV;
-
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-        MPIR_Datatype *dt_ptr;
-        MPIR_Datatype_get_ptr(datatype, dt_ptr);
-        MPIR_Datatype_ptr_add_ref(dt_ptr);
-    }
-
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV_INIT);
     return mpi_errno;
 }


### PR DESCRIPTION
OFI should use generic implementation of send_init/recv_init functions for consistency with generic startall implementation (https://github.com/pmodels/mpich/commit/523e8f2cc16059c2e8cf56f582373575edbb58e8 )

Signed-off-by: Sannikov, Alexander <alexander.sannikov@intel.com>