### PR TITLE
ch4/generic: Remove protocol from match parts

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -129,7 +129,7 @@ static inline int MPIDI_do_irecv(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_IRECV);
 
     root_comm = MPIDI_CH4U_context_id_to_comm(comm->recvcontext_id);
-    unexp_req = MPIDI_CH4U_dequeue_unexp(rank, 0, tag, context_id,
+    unexp_req = MPIDI_CH4U_dequeue_unexp(rank, tag, context_id,
                                          &MPIDI_CH4U_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
@@ -176,7 +176,6 @@ static inline int MPIDI_do_irecv(void *buf,
 
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_CH4U_REQUEST(rreq, rank) = rank;
-    MPIDI_CH4U_REQUEST(rreq, protocol) = 0;
     MPIDI_CH4U_REQUEST(rreq, tag) = tag;
     MPIDI_CH4U_REQUEST(rreq, context_id) = context_id;
     MPIDI_CH4U_REQUEST(rreq, datatype) = datatype;
@@ -259,7 +258,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv_init(void *buf,
     MPIDI_CH4U_REQUEST(rreq, count) = count;
     MPIDI_CH4U_REQUEST(rreq, datatype) = datatype;
     MPIDI_CH4U_REQUEST(rreq, rank) = rank;
-    MPIDI_CH4U_REQUEST(rreq, protocol) = 0;
     MPIDI_CH4U_REQUEST(rreq, tag) = tag;
     MPIDI_CH4U_REQUEST(rreq, context_id) = comm->context_id + context_offset;
     rreq->u.persist.real_request = NULL;

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -47,7 +47,6 @@ static inline int MPIDI_am_isend(const void *buf, MPI_Aint count, MPI_Datatype d
     *request = sreq;
 
     am_hdr.src_rank = comm->rank;
-    am_hdr.protocol = 0;
     am_hdr.tag = tag;
     am_hdr.context_id = comm->context_id + context_offset;
     if (type == MPIDI_CH4U_SSEND_REQ) {
@@ -100,7 +99,6 @@ static inline int MPIDI_psend_init(const void *buf,
     MPIDI_CH4U_REQUEST(sreq, count) = count;
     MPIDI_CH4U_REQUEST(sreq, datatype) = datatype;
     MPIDI_CH4U_REQUEST(sreq, rank) = rank;
-    MPIDI_CH4U_REQUEST(sreq, protocol) = 0;
     MPIDI_CH4U_REQUEST(sreq, tag) = tag;
     MPIDI_CH4U_REQUEST(sreq, context_id) = comm->context_id + context_offset;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -63,7 +63,6 @@ typedef struct MPIDI_CH4U_lreq_t {
     const void *src_buf;
     MPI_Count count;
     MPI_Datatype datatype;
-    short protocol;
     int rank;
     int tag;
     MPIR_Context_id_t context_id;
@@ -158,7 +157,6 @@ typedef struct MPIDI_CH4U_req_t {
     MPIDI_ptype p_type;         /* persistent request type */
     void *buffer;
     uint64_t count;
-    short protocol;
     int rank;
     int tag;
     MPIR_Context_id_t context_id;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -441,7 +441,6 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).count = count;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDI_CH4U_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDI_CH4U_REQUEST(sreq, req->lreq).protocol = lreq_hdr.hdr.protocol;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -89,7 +89,6 @@ static inline int MPIDI_NM_am_isend(int rank,
         MPIDI_CH4U_REQUEST(sreq, req->lreq).count = count;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDI_CH4U_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDI_CH4U_REQUEST(sreq, req->lreq).protocol = lreq_hdr.hdr.protocol;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
         MPIDI_CH4U_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -100,7 +100,6 @@ enum {
 };
 
 typedef struct MPIDI_CH4U_hdr_t {
-    short protocol;
     int src_rank;
     int tag;
     MPIR_Context_id_t context_id;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -115,7 +115,6 @@ static inline int MPIDI_handle_unexp_cmpl(MPIR_Request * rreq)
         if (root_comm)
             match_req =
                 MPIDI_CH4U_dequeue_posted(MPIDI_CH4U_REQUEST(rreq, rank),
-                                          MPIDI_CH4U_REQUEST(rreq, protocol),
                                           MPIDI_CH4U_REQUEST(rreq, tag),
                                           MPIDI_CH4U_REQUEST(rreq, context_id),
                                           &MPIDI_CH4U_COMM(root_comm, posted_list));
@@ -382,7 +381,7 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
     root_comm = MPIDI_CH4U_context_id_to_comm(hdr->context_id);
     if (root_comm) {
         /* MPIDI_CS_ENTER(); */
-        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->protocol, hdr->tag, hdr->context_id,
+        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
                                          &MPIDI_CH4U_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     }
@@ -398,7 +397,6 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
             MPIDI_CH4U_REQUEST(rreq, count) = 0;
         }
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
         MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_BUSY;
@@ -417,7 +415,6 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
         /* Decrement the refcnt when popping a request out from posted_list */
         MPIR_Comm_release(root_comm);
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
         MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
     }
@@ -453,7 +450,7 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
     root_comm = MPIDI_CH4U_context_id_to_comm(hdr->context_id);
     if (root_comm) {
         /* MPIDI_CS_ENTER(); */
-        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->protocol, hdr->tag, hdr->context_id,
+        rreq = MPIDI_CH4U_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
                                          &MPIDI_CH4U_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     }
@@ -467,7 +464,6 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_LONG_RTS;
         MPIDI_CH4U_REQUEST(rreq, req->rreq.peer_req_ptr) = lreq_hdr->sreq_ptr;
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
         MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
 
@@ -487,7 +483,6 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_LONG_RTS;
         MPIDI_CH4U_REQUEST(rreq, req->rreq.peer_req_ptr) = lreq_hdr->sreq_ptr;
         MPIDI_CH4U_REQUEST(rreq, rank) = hdr->src_rank;
-        MPIDI_CH4U_REQUEST(rreq, protocol) = hdr->protocol;
         MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         mpi_errno = MPIDI_NM_am_recv(rreq);

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_iprobe(int source,
     root_comm = MPIDI_CH4U_context_id_to_comm(comm->context_id);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDI_CH4U_find_unexp(source, 0, tag, root_comm->recvcontext_id + context_offset,
+    unexp_req = MPIDI_CH4U_find_unexp(source, tag, root_comm->recvcontext_id + context_offset,
                                       &MPIDI_CH4U_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
@@ -92,7 +92,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_improbe(int source,
     root_comm = MPIDI_CH4U_context_id_to_comm(comm->context_id);
 
     /* MPIDI_CS_ENTER(); */
-    unexp_req = MPIDI_CH4U_dequeue_unexp(source, 0, tag, root_comm->recvcontext_id + context_offset,
+    unexp_req = MPIDI_CH4U_dequeue_unexp(source, tag, root_comm->recvcontext_id + context_offset,
                                          &MPIDI_CH4U_COMM(root_comm, unexp_list));
 
     if (unexp_req) {

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -23,22 +23,20 @@ extern unsigned long long PVAR_COUNTER_unexpected_recvq_match_attempts ATTRIBUTE
 extern MPIR_T_pvar_timer_t PVAR_TIMER_time_failed_matching_postedq ATTRIBUTE((unused));
 extern MPIR_T_pvar_timer_t PVAR_TIMER_time_matching_unexpectedq ATTRIBUTE((unused));
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_match_posted(int rank, short protocol, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_match_posted(int rank, int tag,
                                                  MPIR_Context_id_t context_id, MPIR_Request * req)
 {
     return (rank == MPIDI_CH4U_REQUEST(req, rank) ||
             MPIDI_CH4U_REQUEST(req, rank) == MPI_ANY_SOURCE) &&
-        protocol == MPIDI_CH4U_REQUEST(req, protocol) &&
         (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDI_CH4U_REQUEST(req, tag)) ||
          MPIDI_CH4U_REQUEST(req, tag) == MPI_ANY_TAG) &&
         context_id == MPIDI_CH4U_REQUEST(req, context_id);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_match_unexp(int rank, short protocol, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_match_unexp(int rank, int tag,
                                                 MPIR_Context_id_t context_id, MPIR_Request * req)
 {
     return (rank == MPIDI_CH4U_REQUEST(req, rank) || rank == MPI_ANY_SOURCE) &&
-        protocol == MPIDI_CH4U_REQUEST(req, protocol) &&
         (tag == MPIR_TAG_MASK_ERROR_BITS(MPIDI_CH4U_REQUEST(req, tag)) ||
          tag == MPI_ANY_TAG) && context_id == MPIDI_CH4U_REQUEST(req, context_id);
 }
@@ -129,7 +127,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
-                                                                       short protocol,
                                                                        int tag,
                                                                        MPIR_Context_id_t context_id,
                                                                        MPIDI_CH4U_rreq_t ** list)
@@ -144,7 +141,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
-            MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+            MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -161,7 +158,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
-                                                                short protocol,
                                                                 int tag,
                                                                 MPIR_Context_id_t context_id,
                                                                 MPIDI_CH4U_rreq_t ** list)
@@ -175,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -192,7 +188,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
-                                                             short protocol,
                                                              int tag,
                                                              MPIR_Context_id_t context_id,
                                                              MPIDI_CH4U_rreq_t ** list)
@@ -206,7 +201,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             break;
         }
         req = NULL;
@@ -221,7 +216,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
-                                                                 short protocol,
                                                                  int tag,
                                                                  MPIR_Context_id_t context_id,
                                                                  MPIDI_CH4U_rreq_t ** list)
@@ -235,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_posted(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_posted(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
@@ -329,7 +323,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4U_delete_unexp(MPIR_Request * req, MPIDI_
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
-                                                                       short protocol,
                                                                        int tag,
                                                                        MPIR_Context_id_t context_id,
                                                                        MPIDI_CH4U_rreq_t ** list)
@@ -344,7 +337,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
         if (!(MPIDI_CH4U_REQUEST(req, req->status) & MPIDI_CH4U_REQ_BUSY) &&
-            MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+            MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -361,7 +354,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp_strict(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
-                                                                short protocol,
                                                                 int tag,
                                                                 MPIR_Context_id_t context_id,
                                                                 MPIDI_CH4U_rreq_t ** list)
@@ -375,7 +367,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
     DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(MPIDI_CH4_Global.unexp_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
             break;
@@ -392,7 +384,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_unexp(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
-                                                             short protocol,
                                                              int tag,
                                                              MPIR_Context_id_t context_id,
                                                              MPIDI_CH4U_rreq_t ** list)
@@ -406,7 +397,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
     DL_FOREACH_SAFE(MPIDI_CH4_Global.unexp_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_unexp(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             break;
         }
         req = NULL;
@@ -421,7 +412,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_find_unexp(int rank,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
-                                                                 short protocol,
                                                                  int tag,
                                                                  MPIR_Context_id_t context_id,
                                                                  MPIDI_CH4U_rreq_t ** list)
@@ -435,7 +425,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4U_dequeue_posted(int rank,
     DL_FOREACH_SAFE(MPIDI_CH4_Global.posted_list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
         req = (MPIR_Request *) curr->request;
-        if (MPIDIG_match_posted(rank, protocol, tag, context_id, req)) {
+        if (MPIDIG_match_posted(rank, tag, context_id, req)) {
             DL_DELETE(MPIDI_CH4_Global.posted_list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;


### PR DESCRIPTION
This field was not used in a meaningful way. Protocol information
should be part of the message header and not involved in matching.