### PR TITLE
Fix missing mem class

### DIFF
--- a/src/mpi/coll/igather/igather_intra_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_binomial.c
@@ -300,7 +300,7 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
         else
             MPIR_Pack_size_impl(sendcount * (comm_size / 2), sendtype, &tmp_buf_size);
 
-        MPIR_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+        MPIR_CHKPMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         position = 0;
         if (sendbuf != MPI_IN_PLACE) {

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -233,7 +233,8 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype
         if (rank == root) {
             MPIR_Pack_size_impl(sendcount * comm_size, sendtype, &tmp_buf_size);
 
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf",
+                                MPL_MEM_BUFFER);
 
             /* calculate the value of nbytes, the number of bytes in packed
              * representation that each process receives. We can't
@@ -290,7 +291,8 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype
             }
         } else {
             MPIR_Pack_size_impl(recvcount * (comm_size / 2), recvtype, &tmp_buf_size);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf");
+            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf",
+                                MPL_MEM_BUFFER);
 
             /* calculate nbytes */
             position = 0;

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -207,7 +207,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
         char *addr;
 
         MPIR_CHKPMEM_MALLOC(addr, char *, segment_len + MPIDU_SHM_CACHE_LINE_LEN, mpi_errno,
-                            "segment");
+                            "segment", class);
 
         memory->base_addr = addr;
         current_addr =


### PR DESCRIPTION
We are missing the memory class argument in some invocation of `MPIR_CHKPMEM_MALLOC` and ` MPIR_CHKLMEM_MALLOC`. This patch fix it.

This bug is responsible for breaking the build with Cray PMI on Theta.