### PR TITLE
ch4/ofi: Rename progress during retry

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -76,12 +76,6 @@
         if (mpi_errno!=MPI_SUCCESS) MPIR_ERR_POP(mpi_errno);      \
     } while (0)
 
-#define MPIDI_OFI_PROGRESS_NONINLINE()                            \
-    do {                                                          \
-        mpi_errno = MPIDI_OFI_progress_test_no_inline();          \
-        if (mpi_errno!=MPI_SUCCESS) MPIR_ERR_POP(mpi_errno);      \
-    } while (0)
-
 #define MPIDI_OFI_PROGRESS_WHILE(cond)                 \
     while (cond) MPIDI_OFI_PROGRESS()
 
@@ -139,7 +133,9 @@
                               fi_strerror(-_ret));          \
         if (LOCK == MPIDI_OFI_CALL_NO_LOCK)                 \
             MPID_THREAD_CS_EXIT(POBJ,MPIDI_OFI_THREAD_FI_MUTEX);     \
-        MPIDI_OFI_PROGRESS_NONINLINE();                              \
+        mpi_errno = MPIDI_OFI_retry_progress();                      \
+        if (mpi_errno != MPI_SUCCESS)                                \
+            MPIR_ERR_POP(mpi_errno);                                 \
         if (LOCK == MPIDI_OFI_CALL_NO_LOCK)                 \
             MPID_THREAD_CS_ENTER(POBJ,MPIDI_OFI_THREAD_FI_MUTEX);    \
     } while (_ret == -FI_EAGAIN);                           \
@@ -163,7 +159,9 @@
                               __LINE__,                     \
                               FCNAME,                       \
                               fi_strerror(-_ret));          \
-        MPIDI_OFI_PROGRESS_NONINLINE();                         \
+        mpi_errno = MPIDI_OFI_retry_progress();                      \
+        if (mpi_errno != MPI_SUCCESS)                                \
+            MPIR_ERR_POP(mpi_errno);                                 \
         MPID_THREAD_CS_ENTER(POBJ,MPIDI_OFI_THREAD_FI_MUTEX);   \
     } while (_ret == -FI_EAGAIN);                           \
     } while (0)
@@ -267,7 +265,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
 
 /* Externs:  see util.c for definition */
 int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
-int MPIDI_OFI_progress_test_no_inline(void);
+int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
                               void **data, size_t * data_sz, int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -29,7 +29,7 @@ int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
     return mpi_errno;
 }
 
-int MPIDI_OFI_progress_test_no_inline()
+int MPIDI_OFI_retry_progress()
 {
     /* We do not call progress on hooks form netmod level
      * because it is not reentrant safe.


### PR DESCRIPTION
`MPIDI_OFI_progress_test_no_inline()` was called only when a retry
happened. This patch renames it to `MPIDI_OFI_progress_retry()`
to make it easier to understand.
Also removes `MPIDI_OFI_PROGRESS_NONINLINE` macro for more
code readability.