### PR TITLE
mtest: Fix spawn tests after return value patch

### DIFF
--- a/test/commands/rtestx.cxx
+++ b/test/commands/rtestx.cxx
@@ -1,10 +1,10 @@
 /* -*- Mode: C++; c-basic-offset:4 ; -*- */
-/*  
+/*
  *  (C) 2006 by Argonne National Laboratory.
  *      See COPYRIGHT in top-level directory.
  */
 #include <iostream.h>
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     cout << testname;
     return 0;

--- a/test/mpi/cxx/attr/attricx.cxx
+++ b/test/mpi/cxx/attr/attricx.cxx
@@ -31,9 +31,9 @@ using namespace std;
 
 /* #define DEBUG */
 static int verbose = 0;
-int test_communicators ( void );
-int copy_fn ( const MPI::Comm &, int, void *, void *, void *, bool & );
-int delete_fn ( MPI::Comm &, int, void *, void * );
+int test_communicators(void);
+int copy_fn(const MPI::Comm &, int, void *, void *, void *, bool &);
+int delete_fn(MPI::Comm &, int, void *, void *);
 
 #ifdef DEBUG
 #define FFLUSH fflush(stdout);
@@ -41,145 +41,142 @@ int delete_fn ( MPI::Comm &, int, void *, void * );
 #define FFLUSH
 #endif
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     int errs = 0;
     MTest_Init();
-    
+
     errs = test_communicators();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }
 
-int copy_fn( const MPI::Comm &oldcomm, int keyval, void *extra_state,
-	     void *attribute_val_in, void *attribute_val_out, bool &flag)
+int copy_fn(const MPI::Comm & oldcomm, int keyval, void *extra_state,
+            void *attribute_val_in, void *attribute_val_out, bool & flag)
 {
     /* Note that if (sizeof(int) < sizeof(void *), just setting the int
-       part of attribute_val_out may leave some dirty bits
-    */
-    *(MPI::Aint *)attribute_val_out = (MPI::Aint)attribute_val_in;
+     * part of attribute_val_out may leave some dirty bits
+     */
+    *(MPI::Aint *) attribute_val_out = (MPI::Aint) attribute_val_in;
     flag = 1;
     return MPI_SUCCESS;
 }
 
-int delete_fn( MPI::Comm &comm, int keyval, void *attribute_val, 
-	       void *extra_state)
+int delete_fn(MPI::Comm & comm, int keyval, void *attribute_val, void *extra_state)
 {
     int world_rank;
     world_rank = MPI::COMM_WORLD.Get_rank();
-    if ((MPI::Aint)attribute_val != (MPI::Aint)world_rank) {
-	cout << "incorrect attribute value %d\n" << *(int*)attribute_val << "\n";
-	MPI::COMM_WORLD.Abort( 1005 );
+    if ((MPI::Aint) attribute_val != (MPI::Aint) world_rank) {
+        cout << "incorrect attribute value %d\n" << *(int *) attribute_val << "\n";
+        MPI::COMM_WORLD.Abort(1005);
     }
     return MPI_SUCCESS;
 }
 
-int test_communicators( void )
+int test_communicators(void)
 {
     MPI::Intercomm dup_comm, comm;
     void *vvalue;
     int flag, world_rank, world_size, key_1, key_3;
     int errs = 0;
     MPI::Aint value;
-    int      isLeft;
+    int isLeft;
 
     world_rank = MPI::COMM_WORLD.Get_rank();
     world_size = MPI::COMM_WORLD.Get_size();
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "*** Communicators ***\n";
+        cout << "*** Communicators ***\n";
     }
 #endif
 
-    while (MTestGetIntercomm( comm, isLeft, 2 )) {
-	if (verbose) {
-	    cout << "start while loop, isLeft=" << isLeft << "\n";
-	}
+    while (MTestGetIntercomm(comm, isLeft, 2)) {
+        if (verbose) {
+            cout << "start while loop, isLeft=" << isLeft << "\n";
+        }
 
-	if (comm == MPI::COMM_NULL) {
-	    if (verbose) {
-		cout << "got COMM_NULL, skipping\n";
-	    }
+        if (comm == MPI::COMM_NULL) {
+            if (verbose) {
+                cout << "got COMM_NULL, skipping\n";
+            }
             continue;
         }
 
-	/*
-	  Check Comm_dup by adding attributes to comm & duplicating
-	*/
-    
-	value = 9;
-	key_1 = MPI::Comm::Create_keyval(copy_fn,     delete_fn,   &value );
-	if (verbose) {
-	    cout << "Keyval_create key=" << key_1 << " value=" << value << "\n";
-	}
-	value = 7;
-	key_3 = MPI::Comm::Create_keyval(MPI::Comm::NULL_COPY_FN, 
-					 MPI::Comm::NULL_DELETE_FN,
-					 &value ); 
-	if (verbose) {
-	    cout << "Keyval_create key=" << key_3 << " value=" << value << "\n";
-	}
+        /*
+         * Check Comm_dup by adding attributes to comm & duplicating
+         */
 
-	/* This may generate a compilation warning; it is, however, an
-	   easy way to cache a value instead of a pointer */
-	/* printf( "key1 = %x key3 = %x\n", key_1, key_3 ); */
-	comm.Set_attr( key_1, (void *) (MPI::Aint) world_rank );
-	comm.Set_attr( key_3, (void *)0 );
-	
-	if (verbose) {
-	    cout << "Comm_dup\n";
-	}
-	dup_comm = comm.Dup();
+        value = 9;
+        key_1 = MPI::Comm::Create_keyval(copy_fn, delete_fn, &value);
+        if (verbose) {
+            cout << "Keyval_create key=" << key_1 << " value=" << value << "\n";
+        }
+        value = 7;
+        key_3 = MPI::Comm::Create_keyval(MPI::Comm::NULL_COPY_FN,
+                                         MPI::Comm::NULL_DELETE_FN, &value);
+        if (verbose) {
+            cout << "Keyval_create key=" << key_3 << " value=" << value << "\n";
+        }
 
-	/* Note that if sizeof(int) < sizeof(void *), we can't use
-	   (void **)&value to get the value we passed into Attr_put.  To avoid 
-	   problems (e.g., alignment errors), we recover the value into 
-	   a (void *) and cast to int. Note that this may generate warning
-	   messages from the compiler.  */
-	flag = dup_comm.Get_attr( key_1, (void **)&vvalue );
-	value = (MPI::Aint)vvalue;
-	
-	if (! flag) {
-	    errs++;
-	    cout << "dup_comm key_1 not found on " << world_rank << "\n";
-	    MPI::COMM_WORLD.Abort( 3004 );
-	}
-	
-	if (value != world_rank) {
-	    errs++;
-	    cout << "dup_comm key_1 value incorrect: " << (long)value << "\n";
-	    MPI::COMM_WORLD.Abort( 3005 );
-	}
+        /* This may generate a compilation warning; it is, however, an
+         * easy way to cache a value instead of a pointer */
+        /* printf("key1 = %x key3 = %x\n", key_1, key_3); */
+        comm.Set_attr(key_1, (void *) (MPI::Aint) world_rank);
+        comm.Set_attr(key_3, (void *) 0);
 
-	flag = dup_comm.Get_attr( key_3, (void **)&vvalue );
-	value = (MPI::Aint)vvalue;
-	if (flag) {
-	    errs++;
-	    cout << "dup_comm key_3 found!\n";
-	    MPI::COMM_WORLD.Abort( 3008 );
-	}
-	if (verbose) { 
-	    cout << "Keyval_free key=" << key_1 << "\n";
-	}
-	MPI::Comm::Free_keyval( key_1 );
-	if (verbose) {
-	    cout << "Keyval_free key=" << key_3 << "\n";
-	}
-	MPI::Comm::Free_keyval( key_3 );
-	/*
-	  Free all communicators created
-	*/
-	if (verbose) {
-	    cout << "Comm_free comm\n";
-	}
-	comm.Free();
-	if (verbose) {
-	    cout << "Comm_free dup_comm\n";
-	}
-	dup_comm.Free();
+        if (verbose) {
+            cout << "Comm_dup\n";
+        }
+        dup_comm = comm.Dup();
+
+        /* Note that if sizeof(int) < sizeof(void *), we can't use
+         * (void **)&value to get the value we passed into Attr_put.  To avoid
+         * problems (e.g., alignment errors), we recover the value into
+         * a (void *) and cast to int. Note that this may generate warning
+         * messages from the compiler.  */
+        flag = dup_comm.Get_attr(key_1, (void **) &vvalue);
+        value = (MPI::Aint) vvalue;
+
+        if (!flag) {
+            errs++;
+            cout << "dup_comm key_1 not found on " << world_rank << "\n";
+            MPI::COMM_WORLD.Abort(3004);
+        }
+
+        if (value != world_rank) {
+            errs++;
+            cout << "dup_comm key_1 value incorrect: " << (long) value << "\n";
+            MPI::COMM_WORLD.Abort(3005);
+        }
+
+        flag = dup_comm.Get_attr(key_3, (void **) &vvalue);
+        value = (MPI::Aint) vvalue;
+        if (flag) {
+            errs++;
+            cout << "dup_comm key_3 found!\n";
+            MPI::COMM_WORLD.Abort(3008);
+        }
+        if (verbose) {
+            cout << "Keyval_free key=" << key_1 << "\n";
+        }
+        MPI::Comm::Free_keyval(key_1);
+        if (verbose) {
+            cout << "Keyval_free key=" << key_3 << "\n";
+        }
+        MPI::Comm::Free_keyval(key_3);
+        /*
+         * Free all communicators created
+         */
+        if (verbose) {
+            cout << "Comm_free comm\n";
+        }
+        comm.Free();
+        if (verbose) {
+            cout << "Comm_free dup_comm\n";
+        }
+        dup_comm.Free();
     }
 
     return errs;
 }
-

--- a/test/mpi/cxx/attr/attrtx.cxx
+++ b/test/mpi/cxx/attr/attrtx.cxx
@@ -32,48 +32,46 @@ using namespace std;
 
 /* #define DEBUG */
 
-int test_communicators ( void );
-int copy_fn ( const MPI::Comm &, int, void *, void *, void *, bool & );
-int delete_fn ( MPI::Comm &, int, void *, void * );
+int test_communicators(void);
+int copy_fn(const MPI::Comm &, int, void *, void *, void *, bool &);
+int delete_fn(MPI::Comm &, int, void *, void *);
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     int errs = 0;
 
     MTest_Init();
-    
+
     errs = test_communicators();
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }
 
-int copy_fn( const MPI::Comm &oldcomm, int keyval, void *extra_state,
-	     void *attribute_val_in, void *attribute_val_out, bool &flag)
+int copy_fn(const MPI::Comm & oldcomm, int keyval, void *extra_state,
+            void *attribute_val_in, void *attribute_val_out, bool & flag)
 {
     /* Note that if (sizeof(int) < sizeof(void *), just setting the int
-       part of attribute_val_out may leave some dirty bits
-    */
-    *(MPI::Aint *)attribute_val_out = (MPI::Aint)attribute_val_in;
+     * part of attribute_val_out may leave some dirty bits
+     */
+    *(MPI::Aint *) attribute_val_out = (MPI::Aint) attribute_val_in;
     flag = 1;
     return MPI::SUCCESS;
 }
 
-int delete_fn( MPI::Comm &comm, int keyval, void *attribute_val, 
-	       void *extra_state)
+int delete_fn(MPI::Comm & comm, int keyval, void *attribute_val, void *extra_state)
 {
     int world_rank;
     world_rank = MPI::COMM_WORLD.Get_rank();
-    if ((MPI::Aint)attribute_val != (MPI::Aint)world_rank) {
-	cout << "incorrect attribute value " << *(int*)attribute_val << "\n";
-	MPI::COMM_WORLD.Abort( 1005 );
+    if ((MPI::Aint) attribute_val != (MPI::Aint) world_rank) {
+        cout << "incorrect attribute value " << *(int *) attribute_val << "\n";
+        MPI::COMM_WORLD.Abort(1005);
     }
     return MPI::SUCCESS;
 }
 
-int test_communicators( void )
+int test_communicators(void)
 {
-    MPI::Intracomm dup_comm_world, lo_comm, rev_comm, dup_comm, 
-	split_comm, world_comm;
+    MPI::Intracomm dup_comm_world, lo_comm, rev_comm, dup_comm, split_comm, world_comm;
     MPI::Group world_group, lo_group, rev_group;
     void *vvalue;
     int ranges[1][3];
@@ -86,30 +84,30 @@ int test_communicators( void )
     world_size = MPI::COMM_WORLD.Get_size();
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "*** Communicators ***\n";
+        cout << "*** Communicators ***\n";
     }
 #endif
 
     dup_comm_world = MPI::COMM_WORLD.Dup();
 
     /*
-      Exercise Comm_create by creating an equivalent to dup_comm_world
-      (sans attributes) and a half-world communicator.
-    */
+     * Exercise Comm_create by creating an equivalent to dup_comm_world
+     * (sans attributes) and a half-world communicator.
+     */
 
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "    Comm_create\n";
+        cout << "    Comm_create\n";
     }
 #endif
 
     world_group = dup_comm_world.Get_group();
-    world_comm  = dup_comm_world.Create( world_group );
+    world_comm = dup_comm_world.Create(world_group);
     rank = world_comm.Get_rank();
     if (rank != world_rank) {
-	errs++;
-	cout << "incorrect rank in world comm: " << rank << "\n";
-	MPI::COMM_WORLD.Abort( 3001 );
+        errs++;
+        cout << "incorrect rank in world comm: " << rank << "\n";
+        MPI::COMM_WORLD.Abort(3001);
     }
 
     n = world_size / 2;
@@ -121,178 +119,176 @@ int test_communicators( void )
 #ifdef DEBUG
     cout << "world rank = " << world_rank << " before range incl\n";
 #endif
-    lo_group = world_group.Range_incl( 1, ranges );
+    lo_group = world_group.Range_incl(1, ranges);
 #ifdef DEBUG
     cout << "world rank = " << world_rank << " after range incl\n";
 #endif
-    lo_comm = world_comm.Create( lo_group );
+    lo_comm = world_comm.Create(lo_group);
 #ifdef DEBUG
     cout << "world rank = " << world_rank << " before group free\n";
 #endif
     lo_group.Free();
-    
+
 #ifdef DEBUG
     cout << "world rank = " << world_rank << " after group free\n";
 #endif
 
     if (world_rank < (world_size - n)) {
-	rank = lo_comm.Get_rank();
-	if (rank == MPI::UNDEFINED) {
-	    errs++;
-	    cout << "incorrect lo group rank: " << rank << "\n";
-	    MPI::COMM_WORLD.Abort( 3002 );
-	}
-	else {
-	    lo_comm.Barrier();
-	}
+        rank = lo_comm.Get_rank();
+        if (rank == MPI::UNDEFINED) {
+            errs++;
+            cout << "incorrect lo group rank: " << rank << "\n";
+            MPI::COMM_WORLD.Abort(3002);
+        } else {
+            lo_comm.Barrier();
+        }
+    } else {
+        if (lo_comm != MPI::COMM_NULL) {
+            errs++;
+            cout << "incorrect lo comm:\n";
+            MPI::COMM_WORLD.Abort(3003);
+        }
     }
-    else {
-	if (lo_comm != MPI::COMM_NULL) {
-	    errs++;
-	    cout << "incorrect lo comm:\n";
-	    MPI::COMM_WORLD.Abort( 3003 );
-	}
-    }
-    
+
 #ifdef DEBUG
     cout << "worldrank = " << world_rank << "\n";
 #endif
     world_comm.Barrier();
-    
+
 #ifdef DEBUG
     cout << "bar!\n";
 #endif
     /*
-      Check Comm_dup by adding attributes to lo_comm & duplicating
-    */
+     * Check Comm_dup by adding attributes to lo_comm & duplicating
+     */
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "    Comm_dup\n";
+        cout << "    Comm_dup\n";
     }
 #endif
-    
+
     if (lo_comm != MPI::COMM_NULL) {
-	value = 9;
-	key_1 = MPI::Comm::Create_keyval(copy_fn, delete_fn, &value );
-	value = 8;
-	value = 7;
-	key_3 = MPI::Comm::Create_keyval(MPI::Comm::NULL_COPY_FN, 
-					 MPI::Comm::NULL_DELETE_FN, &value ); 
-	
-	/* This may generate a compilation warning; it is, however, an
-	   easy way to cache a value instead of a pointer */
-	lo_comm.Set_attr( key_1, (void *) (MPI_Aint) world_rank );
-	lo_comm.Set_attr( key_3, (void *)0 );
-	
-	dup_comm = lo_comm.Dup();
+        value = 9;
+        key_1 = MPI::Comm::Create_keyval(copy_fn, delete_fn, &value);
+        value = 8;
+        value = 7;
+        key_3 = MPI::Comm::Create_keyval(MPI::Comm::NULL_COPY_FN,
+                                         MPI::Comm::NULL_DELETE_FN, &value);
 
-	/* Note that if sizeof(int) < sizeof(void *), we can't use
-	   (void **)&value to get the value we passed into Attr_put.  To avoid 
-	   problems (e.g., alignment errors), we recover the value into 
-	   a (void *) and cast to int. Note that this may generate warning
-	   messages from the compiler.  */
-	flag = dup_comm.Get_attr( key_1, (void **)&vvalue );
-	value = (MPI::Aint)vvalue;
-	
-	if (! flag) {
-	    errs++;
-	    cout << "dup_comm key_1 not found on " << world_rank << "\n";
-	    MPI::COMM_WORLD.Abort( 3004 );
-	}
-	
-	if (value != world_rank) {
-	    errs++;
-	    cout << "dup_comm key_1 value incorrect: " << (long)value << "\n";
-	    MPI::COMM_WORLD.Abort( 3005 );
-	}
+        /* This may generate a compilation warning; it is, however, an
+         * easy way to cache a value instead of a pointer */
+        lo_comm.Set_attr(key_1, (void *) (MPI_Aint) world_rank);
+        lo_comm.Set_attr(key_3, (void *) 0);
 
-	flag = dup_comm.Get_attr( key_3, (void **)&vvalue );
-	if (flag) {
-	    errs++;
-	    cout << "dup_comm key_3 found!\n";
-	    MPI::COMM_WORLD.Abort( 3008 );
-	}
-	// Some C++ compilers (e.g., Solaris) refuse to 
-	// accept a straight cast to an int.
-	// value = (MPI::Aint)vvalue;
-	MPI::Comm::Free_keyval( key_1 );
-	MPI::Comm::Free_keyval( key_3 );
+        dup_comm = lo_comm.Dup();
+
+        /* Note that if sizeof(int) < sizeof(void *), we can't use
+         * (void **)&value to get the value we passed into Attr_put.  To avoid
+         * problems (e.g., alignment errors), we recover the value into
+         * a (void *) and cast to int. Note that this may generate warning
+         * messages from the compiler.  */
+        flag = dup_comm.Get_attr(key_1, (void **) &vvalue);
+        value = (MPI::Aint) vvalue;
+
+        if (!flag) {
+            errs++;
+            cout << "dup_comm key_1 not found on " << world_rank << "\n";
+            MPI::COMM_WORLD.Abort(3004);
+        }
+
+        if (value != world_rank) {
+            errs++;
+            cout << "dup_comm key_1 value incorrect: " << (long) value << "\n";
+            MPI::COMM_WORLD.Abort(3005);
+        }
+
+        flag = dup_comm.Get_attr(key_3, (void **) &vvalue);
+        if (flag) {
+            errs++;
+            cout << "dup_comm key_3 found!\n";
+            MPI::COMM_WORLD.Abort(3008);
+        }
+        // Some C++ compilers (e.g., Solaris) refuse to
+        // accept a straight cast to an int.
+        // value = (MPI::Aint)vvalue;
+        MPI::Comm::Free_keyval(key_1);
+        MPI::Comm::Free_keyval(key_3);
     }
-    /* 
-       Split the world into even & odd communicators with reversed ranks.
-    */
+    /*
+     * Split the world into even & odd communicators with reversed ranks.
+     */
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "    Comm_split\n";
+        cout << "    Comm_split\n";
     }
 #endif
-    
+
     color = world_rank % 2;
-    key   = world_size - world_rank;
-    
-    split_comm = dup_comm_world.Split( color, key );
+    key = world_size - world_rank;
+
+    split_comm = dup_comm_world.Split(color, key);
     size = split_comm.Get_size();
     rank = split_comm.Get_rank();
-    if (rank != ((size - world_rank/2) - 1)) {
-	errs++;
-	cout << "incorrect split rank: " << rank << "\n";
-	MPI::COMM_WORLD.Abort( 3009 );
+    if (rank != ((size - world_rank / 2) - 1)) {
+        errs++;
+        cout << "incorrect split rank: " << rank << "\n";
+        MPI::COMM_WORLD.Abort(3009);
     }
-    
+
     split_comm.Barrier();
     /*
-      Test each possible Comm_compare result
-    */
+     * Test each possible Comm_compare result
+     */
 #ifdef DEBUG
     if (world_rank == 0) {
-	cout << "    Comm_compare\n";
+        cout << "    Comm_compare\n";
     }
 #endif
-    
-    result = MPI::Comm::Compare(world_comm, world_comm );
+
+    result = MPI::Comm::Compare(world_comm, world_comm);
     if (result != MPI::IDENT) {
-	errs++;
-	cout << "incorrect ident result: " << result << "\n";
-	MPI::COMM_WORLD.Abort( 3010 );
+        errs++;
+        cout << "incorrect ident result: " << result << "\n";
+        MPI::COMM_WORLD.Abort(3010);
     }
-    
+
     if (lo_comm != MPI::COMM_NULL) {
-	result = MPI::Comm::Compare(lo_comm, dup_comm );
-	if (result != MPI::CONGRUENT) {
-	    errs++;
+        result = MPI::Comm::Compare(lo_comm, dup_comm);
+        if (result != MPI::CONGRUENT) {
+            errs++;
             cout << "incorrect congruent result: " << result << "\n";
-            MPI::COMM_WORLD.Abort( 3011 );
-	}
+            MPI::COMM_WORLD.Abort(3011);
+        }
     }
-    
+
     ranges[0][0] = world_size - 1;
     ranges[0][1] = 0;
     ranges[0][2] = -1;
 
-    rev_group = world_group.Range_incl( 1, ranges );
-    rev_comm  = world_comm.Create( rev_group );
+    rev_group = world_group.Range_incl(1, ranges);
+    rev_comm = world_comm.Create(rev_group);
 
-    result = MPI::Comm::Compare(world_comm, rev_comm );
+    result = MPI::Comm::Compare(world_comm, rev_comm);
     if (result != MPI::SIMILAR && world_size != 1) {
-	errs++;
-	cout << "incorrect similar result: " << result << "\n";
-	MPI::COMM_WORLD.Abort( 3012 );
+        errs++;
+        cout << "incorrect similar result: " << result << "\n";
+        MPI::COMM_WORLD.Abort(3012);
     }
-    
+
     if (lo_comm != MPI::COMM_NULL) {
-	result = MPI::Comm::Compare(world_comm, lo_comm );
-	if (result != MPI::UNEQUAL && world_size != 1) {
-	    errs++;
-	    cout << "incorrect unequal result: " << result << "\n";
-	    MPI::COMM_WORLD.Abort( 3013 );
-	}
+        result = MPI::Comm::Compare(world_comm, lo_comm);
+        if (result != MPI::UNEQUAL && world_size != 1) {
+            errs++;
+            cout << "incorrect unequal result: " << result << "\n";
+            MPI::COMM_WORLD.Abort(3013);
+        }
     }
     /*
-      Free all communicators created
-    */
+     * Free all communicators created
+     */
 #ifdef DEBUG
-    if (world_rank == 0) 
-	cout << "    Comm_free\n";
+    if (world_rank == 0)
+        cout << "    Comm_free\n";
 #endif
 
     world_comm.Free();
@@ -303,12 +299,11 @@ int test_communicators( void )
 
     world_group.Free();
     rev_group.Free();
-    
+
     if (lo_comm != MPI::COMM_NULL) {
-	lo_comm.Free();
-	dup_comm.Free();
+        lo_comm.Free();
+        dup_comm.Free();
     }
-    
+
     return errs;
 }
-

--- a/test/mpi/cxx/attr/baseattrcommx.cxx
+++ b/test/mpi/cxx/attr/baseattrcommx.cxx
@@ -25,108 +25,99 @@ using namespace std;
 #include <string.h>
 #endif
 
-int main( int argc, char **argv)
+int main(int argc, char **argv)
 {
-    int    errs = 0;
+    int errs = 0;
     void *v;
     bool flag;
-    int  vval;
-    int  rank, size;
+    int vval;
+    int rank, size;
 
     MTest_Init();
     size = MPI::COMM_WORLD.Get_size();
     rank = MPI::COMM_WORLD.Get_rank();
 
-    flag = MPI::COMM_WORLD.Get_attr( MPI::TAG_UB, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::TAG_UB, &v);
     if (!flag) {
-	errs++;
-	cout << "Could not get TAG_UB\n";
-    }
-    else {
-	vval = *(int*)v;
-	if (vval < 32767) {
-	    errs++;
-	    cout << "Got too-small value (" << vval << 
-		") for TAG_UB\n";
-	}
+        errs++;
+        cout << "Could not get TAG_UB\n";
+    } else {
+        vval = *(int *) v;
+        if (vval < 32767) {
+            errs++;
+            cout << "Got too-small value (" << vval << ") for TAG_UB\n";
+        }
     }
 
-    flag = MPI::COMM_WORLD.Get_attr( MPI::HOST, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::HOST, &v);
     if (!flag) {
-	errs++;
-	cout << "Could not get HOST\n";
+        errs++;
+        cout << "Could not get HOST\n";
+    } else {
+        vval = *(int *) v;
+        if ((vval < 0 || vval >= size) && vval != MPI::PROC_NULL) {
+            errs++;
+            cout << "Got invalid value " << vval << " for HOST\n";
+        }
     }
-    else {
-	vval = *(int*)v;
-	if ((vval < 0 || vval >= size) && vval != MPI::PROC_NULL) {
-	    errs++;
-	    cout << "Got invalid value " << vval << " for HOST\n";
-	}
-    }
-    flag = MPI::COMM_WORLD.Get_attr( MPI::IO, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::IO, &v);
     if (!flag) {
-	errs++;
-	cout << "Could not get IO\n";
-    }
-    else {
-	vval = *(int*)v;
-	if ((vval < 0 || vval >= size) && vval != MPI::ANY_SOURCE &&
-		  vval != MPI::PROC_NULL) {
-	    errs++;
-	    cout << "Got invalid value " << vval << " for IO\n";
-	}
+        errs++;
+        cout << "Could not get IO\n";
+    } else {
+        vval = *(int *) v;
+        if ((vval < 0 || vval >= size) && vval != MPI::ANY_SOURCE && vval != MPI::PROC_NULL) {
+            errs++;
+            cout << "Got invalid value " << vval << " for IO\n";
+        }
     }
 
-    flag = MPI::COMM_WORLD.Get_attr( MPI::WTIME_IS_GLOBAL, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::WTIME_IS_GLOBAL, &v);
     if (flag) {
-	/* Wtime need not be set */
-	vval = *(int*)v;
-	if (vval < 0 || vval > 1) {
-	    errs++;
-	    cout << "Invalid value for WTIME_IS_GLOBAL (got " << vval << ")\n";
-	}
+        /* Wtime need not be set */
+        vval = *(int *) v;
+        if (vval < 0 || vval > 1) {
+            errs++;
+            cout << "Invalid value for WTIME_IS_GLOBAL (got " << vval << ")\n";
+        }
     }
 
-    flag = MPI::COMM_WORLD.Get_attr( MPI::APPNUM, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::APPNUM, &v);
     /* appnum need not be set */
     if (flag) {
-	vval = *(int *)v;
-	if (vval < 0) {
-	    errs++;
-	    cout << "MPI_APPNUM is defined as " << vval << 
-		" but must be nonnegative\n";
-	}
+        vval = *(int *) v;
+        if (vval < 0) {
+            errs++;
+            cout << "MPI_APPNUM is defined as " << vval << " but must be nonnegative\n";
+        }
     }
 
-    flag = MPI::COMM_WORLD.Get_attr( MPI::UNIVERSE_SIZE, &v );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::UNIVERSE_SIZE, &v);
     /* MPI_UNIVERSE_SIZE need not be set */
     if (flag) {
-	/* But if it is set, it must be at least the size of comm_world */
-	vval = *(int *)v;
-	if (vval < size) {
-	    errs++;
-	    cout << "MPI_UNIVERSE_SIZE = " << vval << 
-		", less than comm world (" << size << ")\n";
-	}
-    }
-    
-    flag = MPI::COMM_WORLD.Get_attr( MPI::LASTUSEDCODE, &v );
-    /* Last used code must be defined and >= MPI_ERR_LASTCODE */
-    if (flag) {
-	vval = *(int*)v;
-	if (vval < MPI_ERR_LASTCODE) {
-	    errs++;
-	    cout << "MPI_LASTUSEDCODE points to an integer (" << vval << 
-		") smaller than MPI_ERR_LASTCODE (" << 
-		MPI_ERR_LASTCODE << ")\n";
-	}
-    }
-    else {
-	errs++;
-	cout << "MPI_LASTUSECODE is not defined\n";
+        /* But if it is set, it must be at least the size of comm_world */
+        vval = *(int *) v;
+        if (vval < size) {
+            errs++;
+            cout << "MPI_UNIVERSE_SIZE = " << vval << ", less than comm world (" << size << ")\n";
+        }
     }
 
-    MTest_Finalize( errs );
+    flag = MPI::COMM_WORLD.Get_attr(MPI::LASTUSEDCODE, &v);
+    /* Last used code must be defined and >= MPI_ERR_LASTCODE */
+    if (flag) {
+        vval = *(int *) v;
+        if (vval < MPI_ERR_LASTCODE) {
+            errs++;
+            cout << "MPI_LASTUSEDCODE points to an integer (" << vval <<
+                ") smaller than MPI_ERR_LASTCODE (" << MPI_ERR_LASTCODE << ")\n";
+        }
+    } else {
+        errs++;
+        cout << "MPI_LASTUSECODE is not defined\n";
+    }
+
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/cxx/attr/fkeyvalcommx.cxx
+++ b/test/mpi/cxx/attr/fkeyvalcommx.cxx
@@ -29,29 +29,27 @@ a communicator, then make sure that the keyval delete and copy code are still \
 executed";
 
 /* Copy increments the attribute value */
-int copy_fn( const MPI::Comm &oldcomm, int keyval, void *extra_state,
-	     void *attribute_val_in, void *attribute_val_out, 
-	     bool &flag)
+int copy_fn(const MPI::Comm & oldcomm, int keyval, void *extra_state,
+            void *attribute_val_in, void *attribute_val_out, bool & flag)
 {
     /* Copy the address of the attribute */
-    *(void **)attribute_val_out = attribute_val_in;
+    *(void **) attribute_val_out = attribute_val_in;
     /* Change the value */
-    *(int *)attribute_val_in = *(int *)attribute_val_in + 1;
+    *(int *) attribute_val_in = *(int *) attribute_val_in + 1;
     /* set flag to 1 to tell comm dup to insert this attribute
-       into the new communicator */
+     * into the new communicator */
     flag = 1;
     return MPI::SUCCESS;
 }
 
 /* Delete decrements the attribute value */
-int delete_fn( MPI::Comm &comm, int keyval, void *attribute_val, 
-	       void *extra_state)
+int delete_fn(MPI::Comm & comm, int keyval, void *attribute_val, void *extra_state)
 {
-    *(int *)attribute_val = *(int *)attribute_val - 1;
+    *(int *) attribute_val = *(int *) attribute_val - 1;
     return MPI::SUCCESS;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int attrval;
@@ -60,65 +58,61 @@ int main( int argc, char *argv[] )
 
     MTest_Init();
 
-    while (MTestGetIntracomm( comm, 1 )) {
-	if (comm == MPI::COMM_NULL) continue;
+    while (MTestGetIntracomm(comm, 1)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
 
-	keyval = MPI::Comm::Create_keyval( copy_fn, delete_fn, (void *)0 );
-	saveKeyval = keyval;   /* in case we need to free explicitly */
-	attrval = 1;
-	comm.Set_attr( keyval, &attrval );
-	/* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
-	   is in use in an attribute */
-	MPI::Comm::Free_keyval( keyval );
-	
-	/* We create some dummy keyvals here in case the same keyval
-	   is reused */
-	for (i=0; i<32; i++) {
-	    key[i] = MPI::Comm::Create_keyval( MPI::Comm::NULL_COPY_FN, 
-					       MPI::Comm::NULL_DELETE_FN,
-					       (void *)0 );
-	}
+        keyval = MPI::Comm::Create_keyval(copy_fn, delete_fn, (void *) 0);
+        saveKeyval = keyval;    /* in case we need to free explicitly */
+        attrval = 1;
+        comm.Set_attr(keyval, &attrval);
+        /* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
+         * is in use in an attribute */
+        MPI::Comm::Free_keyval(keyval);
 
-	dupcomm = comm.Dup();
-	/* Check that the attribute was copied */
-	if (attrval != 2) {
-	    errs++;
-	    cout << "Attribute not incremented when comm dup'ed, attrval = " <<
-		attrval << " should be 2 in communicator " << 
-		MTestGetIntracommName() << "\n";
-	}
-	dupcomm.Free();
-	if (attrval != 1) {
-	    errs++;
-	    cout << "Attribute not decremented when comm dup'ed, attrval = " <<
-		attrval << " should be 1 in communicator " << 
-		MTestGetIntracommName() << "\n";
-	}
-	/* Check that the attribute was freed in the dupcomm */
+        /* We create some dummy keyvals here in case the same keyval
+         * is reused */
+        for (i = 0; i < 32; i++) {
+            key[i] = MPI::Comm::Create_keyval(MPI::Comm::NULL_COPY_FN,
+                                              MPI::Comm::NULL_DELETE_FN, (void *) 0);
+        }
 
-	if (comm != MPI::COMM_WORLD && comm != MPI::COMM_SELF) {
-	    comm.Free();
-	    /* Check that the original attribute was freed */
-	    if (attrval != 0) {
-		errs++;
-		printf( "Attribute not decremented when comm %s freed\n",
-			MTestGetIntracommName() );
-	    }
-	}
-	else {
-	    /* Explicitly delete the attributes from world and self */
-	    comm.Delete_attr( saveKeyval );
-	}
-	/* Free those other keyvals */
-	for (i=0; i<32; i++) {
-	    MPI::Comm::Free_keyval( key[i] );
-	}
+        dupcomm = comm.Dup();
+        /* Check that the attribute was copied */
+        if (attrval != 2) {
+            errs++;
+            cout << "Attribute not incremented when comm dup'ed, attrval = " <<
+                attrval << " should be 2 in communicator " << MTestGetIntracommName() << "\n";
+        }
+        dupcomm.Free();
+        if (attrval != 1) {
+            errs++;
+            cout << "Attribute not decremented when comm dup'ed, attrval = " <<
+                attrval << " should be 1 in communicator " << MTestGetIntracommName() << "\n";
+        }
+        /* Check that the attribute was freed in the dupcomm */
+
+        if (comm != MPI::COMM_WORLD && comm != MPI::COMM_SELF) {
+            comm.Free();
+            /* Check that the original attribute was freed */
+            if (attrval != 0) {
+                errs++;
+                printf("Attribute not decremented when comm %s freed\n", MTestGetIntracommName());
+            }
+        } else {
+            /* Explicitly delete the attributes from world and self */
+            comm.Delete_attr(saveKeyval);
+        }
+        /* Free those other keyvals */
+        for (i = 0; i < 32; i++) {
+            MPI::Comm::Free_keyval(key[i]);
+        }
     }
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
-    /* The attributes on comm self and world were deleted by finalize 
-       (see separate test) */
-    
+    /* The attributes on comm self and world were deleted by finalize
+     * (see separate test) */
+
     return 0;
-  
+
 }

--- a/test/mpi/cxx/attr/fkeyvaltypex.cxx
+++ b/test/mpi/cxx/attr/fkeyvaltypex.cxx
@@ -28,33 +28,31 @@ a datatype, then make sure that the keyval delete and copy code are still \
 executed";
 
 /* Copy increments the attribute value */
-int copy_fn( const MPI::Datatype &oldtype, int keyval, void *extra_state,
-	     void *attribute_val_in, void *attribute_val_out, 
-	     bool &flag)
+int copy_fn(const MPI::Datatype & oldtype, int keyval, void *extra_state,
+            void *attribute_val_in, void *attribute_val_out, bool & flag)
 {
     /* Copy the address of the attribute */
-    *(void **)attribute_val_out = attribute_val_in;
+    *(void **) attribute_val_out = attribute_val_in;
     /* Change the value */
-    *(int *)attribute_val_in = *(int *)attribute_val_in + 1;
+    *(int *) attribute_val_in = *(int *) attribute_val_in + 1;
     /* set flag to 1 to tell comm dup to insert this attribute
-       into the new communicator */
+     * into the new communicator */
     flag = 1;
     return MPI::SUCCESS;
 }
 
 /* Delete decrements the attribute value */
-int delete_fn( MPI::Datatype &type, int keyval, void *attribute_val, 
-	       void *extra_state)
+int delete_fn(MPI::Datatype & type, int keyval, void *attribute_val, void *extra_state)
 {
-    *(int *)attribute_val = *(int *)attribute_val - 1;
+    *(int *) attribute_val = *(int *) attribute_val - 1;
     return MPI::SUCCESS;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
-    int           errs = 0;
-    int           attrval;
-    int           i, key[32], keyval, saveKeyval;
+    int errs = 0;
+    int attrval;
+    int i, key[32], keyval, saveKeyval;
     MPI::Datatype type, duptype;
     MTestDatatype mstype, mrtype;
     char dtypename[MPI_MAX_OBJECT_NAME];
@@ -62,72 +60,69 @@ int main( int argc, char *argv[] )
 
     MTest_Init();
 
-    while (MTestGetDatatypes( &mstype, &mrtype, 1 )) {
-	type = mstype.datatype;
-	keyval = MPI::Datatype::Create_keyval( copy_fn, delete_fn, (void *)0 );
-	saveKeyval = keyval;   /* in case we need to free explicitly */
-	attrval = 1;
-	type.Set_attr( keyval, &attrval );
-	/* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
-	   is in use in an attribute */
-	MPI::Datatype::Free_keyval( keyval );
-	
-	/* We create some dummy keyvals here in case the same keyval
-	   is reused */
-	for (i=0; i<32; i++) {
-	    key[i] = MPI::Datatype::Create_keyval( 
-		MPI::Datatype::NULL_COPY_FN, MPI::Datatype::NULL_DELETE_FN,
-		(void *)0 );
-	}
+    while (MTestGetDatatypes(&mstype, &mrtype, 1)) {
+        type = mstype.datatype;
+        keyval = MPI::Datatype::Create_keyval(copy_fn, delete_fn, (void *) 0);
+        saveKeyval = keyval;    /* in case we need to free explicitly */
+        attrval = 1;
+        type.Set_attr(keyval, &attrval);
+        /* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
+         * is in use in an attribute */
+        MPI::Datatype::Free_keyval(keyval);
 
-	if (attrval != 1) {
-	    errs++;
-	    type.Get_name( dtypename, tnlen );
-	    cout << "attrval is " << attrval << ", should be 1, before dup in type " << dtypename << "\n";
-	}
-	duptype = type.Dup();
-	/* Check that the attribute was copied */
-	if (attrval != 2) {
-	    errs++;
-	    type.Get_name( dtypename, tnlen );
-	    cout << "Attribute not incremented when type dup'ed ( " <<
-		dtypename << ")\n";
-	}
-	duptype.Free();
-	if (attrval != 1) {
-	    errs++;
-	    type.Get_name( dtypename, tnlen );
-	    cout << "Attribute not decremented when duptype " << dtypename <<
-		" freed\n";
-	}
-	/* Check that the attribute was freed in the duptype */
+        /* We create some dummy keyvals here in case the same keyval
+         * is reused */
+        for (i = 0; i < 32; i++) {
+            key[i] =
+                MPI::Datatype::Create_keyval(MPI::Datatype::NULL_COPY_FN,
+                                             MPI::Datatype::NULL_DELETE_FN, (void *) 0);
+        }
 
-	if (!mstype.isBasic) {
-	    type.Get_name( dtypename, tnlen );
+        if (attrval != 1) {
+            errs++;
+            type.Get_name(dtypename, tnlen);
+            cout << "attrval is " << attrval << ", should be 1, before dup in type " << dtypename <<
+                "\n";
+        }
+        duptype = type.Dup();
+        /* Check that the attribute was copied */
+        if (attrval != 2) {
+            errs++;
+            type.Get_name(dtypename, tnlen);
+            cout << "Attribute not incremented when type dup'ed (" << dtypename << ")\n";
+        }
+        duptype.Free();
+        if (attrval != 1) {
+            errs++;
+            type.Get_name(dtypename, tnlen);
+            cout << "Attribute not decremented when duptype " << dtypename << " freed\n";
+        }
+        /* Check that the attribute was freed in the duptype */
+
+        if (!mstype.isBasic) {
+            type.Get_name(dtypename, tnlen);
             MTestFreeDatatype(&mstype);
-	    /* Check that the original attribute was freed */
-	    if (attrval != 0) {
-		errs++;
-		cout << "Attribute not decremented when type " << dtypename <<
-		    " freed\n";
-	    }
-	}
-	else {
-	    /* Explicitly delete the attributes from world and self */
-	    type.Delete_attr( saveKeyval );
+            /* Check that the original attribute was freed */
+            if (attrval != 0) {
+                errs++;
+                cout << "Attribute not decremented when type " << dtypename << " freed\n";
+            }
+        } else {
+            /* Explicitly delete the attributes from world and self */
+            type.Delete_attr(saveKeyval);
             if (mstype.buf) {
                 free(mstype.buf);
                 mstype.buf = 0;
             }
-	}
-	/* Free those other keyvals */
-	for (i=0; i<32; i++) {
-	    MPI::Datatype::Free_keyval( key[i] );
-	}
+        }
+        /* Free those other keyvals */
+        for (i = 0; i < 32; i++) {
+            MPI::Datatype::Free_keyval(key[i]);
+        }
         MTestFreeDatatype(&mrtype);
     }
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
-  
+
 }

--- a/test/mpi/cxx/coll/alltoallw2x.cxx
+++ b/test/mpi/cxx/coll/alltoallw2x.cxx
@@ -25,89 +25,89 @@ using namespace std;
 
   Because there are separate send and receive types to alltoallw,
   there need to be tests to rearrange data on the fly.  Not done yet.
-  
+
   The first test sends i items to processor i from all processors.
 
   Currently, the test uses only MPI_INT; this is adequate for testing systems
   that use point-to-point operations
  */
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Intracomm comm;
-    int      *sbuf, *rbuf;
-    int      rank, size;
-    int      *sendcounts, *recvcounts, *rdispls, *sdispls;
-    int      i, j, *p, err;
-    MPI::Datatype *sendtypes, *recvtypes;
-    
-    MTest_Init( );
+    int *sbuf, *rbuf;
+    int rank, size;
+    int *sendcounts, *recvcounts, *rdispls, *sdispls;
+    int i, j, *p, err;
+    MPI::Datatype * sendtypes, *recvtypes;
+
+    MTest_Init();
     err = 0;
-    
-    while (MTestGetIntracommGeneral( comm, 2, true )) {
-      if (comm == MPI::COMM_NULL) continue;
 
-      /* Create the buffer */
-      size = comm.Get_size();
-      rank = comm.Get_rank();
-      sbuf = new int [ size * size ];
-      rbuf = new int [ size * size ];
-      if (!sbuf || !rbuf) {
-	cout << "Could not allocate buffers!\n";
-	comm.Abort( 1 );
-      }
-      
-      /* Load up the buffers */
-      for (i=0; i<size*size; i++) {
-	sbuf[i] = i + 100*rank;
-	rbuf[i] = -i;
-      }
-      
-      /* Create and load the arguments to alltoallv */
-      sendcounts = new int [ size ];
-      recvcounts = new int [ size ];
-      rdispls    = new int [ size ];
-      sdispls    = new int [ size ];
-      sendtypes    = new MPI::Datatype [size];
-      recvtypes    = new MPI::Datatype [size];
-      if (!sendcounts || !recvcounts || !rdispls || !sdispls || !sendtypes || !recvtypes) {
-	  cout << "Could not allocate arg items!\n";
-	  comm.Abort( 1 );
-      }
-      /* Note that process 0 sends no data (sendcounts[0] = 0) */
-      for (i=0; i<size; i++) {
-	sendcounts[i] = i;
-	recvcounts[i] = rank;
-	rdispls[i]    = i * rank * sizeof(int);
-	sdispls[i]    = (((i+1) * (i))/2) * sizeof(int);
-        sendtypes[i] = recvtypes[i] = MPI::INT;
-      }
-      comm.Alltoallw( sbuf, sendcounts, sdispls, sendtypes,
-		      rbuf, recvcounts, rdispls, recvtypes );
-      
-      /* Check rbuf */
-      for (i=0; i<size; i++) {
-	p = rbuf + rdispls[i]/sizeof(int);
-	for (j=0; j<rank; j++) {
-	  if (p[j] != i * 100 + (rank*(rank+1))/2 + j) {
-	      cout << "[" << rank << "] got " << p[j] << " expected " <<
-		  (i*(i+1))/2 + j << " for " << j << "th\n";
-	      err++;
-	  }
-	}
-      }
+    while (MTestGetIntracommGeneral(comm, 2, true)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
 
-      delete [] sendtypes;
-      delete [] recvtypes;
-      delete [] sdispls;
-      delete [] rdispls;
-      delete [] recvcounts;
-      delete [] sendcounts;
-      delete [] rbuf;
-      delete [] sbuf;
-      MTestFreeComm(comm);
+        /* Create the buffer */
+        size = comm.Get_size();
+        rank = comm.Get_rank();
+        sbuf = new int[size * size];
+        rbuf = new int[size * size];
+        if (!sbuf || !rbuf) {
+            cout << "Could not allocate buffers!\n";
+            comm.Abort(1);
+        }
+
+        /* Load up the buffers */
+        for (i = 0; i < size * size; i++) {
+            sbuf[i] = i + 100 * rank;
+            rbuf[i] = -i;
+        }
+
+        /* Create and load the arguments to alltoallv */
+        sendcounts = new int[size];
+        recvcounts = new int[size];
+        rdispls = new int[size];
+        sdispls = new int[size];
+        sendtypes = new MPI::Datatype[size];
+        recvtypes = new MPI::Datatype[size];
+        if (!sendcounts || !recvcounts || !rdispls || !sdispls || !sendtypes || !recvtypes) {
+            cout << "Could not allocate arg items!\n";
+            comm.Abort(1);
+        }
+        /* Note that process 0 sends no data (sendcounts[0] = 0) */
+        for (i = 0; i < size; i++) {
+            sendcounts[i] = i;
+            recvcounts[i] = rank;
+            rdispls[i] = i * rank * sizeof(int);
+            sdispls[i] = (((i + 1) * (i)) / 2) * sizeof(int);
+            sendtypes[i] = recvtypes[i] = MPI::INT;
+        }
+        comm.Alltoallw(sbuf, sendcounts, sdispls, sendtypes, rbuf, recvcounts, rdispls, recvtypes);
+
+        /* Check rbuf */
+        for (i = 0; i < size; i++) {
+            p = rbuf + rdispls[i] / sizeof(int);
+            for (j = 0; j < rank; j++) {
+                if (p[j] != i * 100 + (rank * (rank + 1)) / 2 + j) {
+                    cout << "[" << rank << "] got " << p[j] << " expected " <<
+                        (i * (i + 1)) / 2 + j << " for " << j << "th\n";
+                    err++;
+                }
+            }
+        }
+
+        delete[]sendtypes;
+        delete[]recvtypes;
+        delete[]sdispls;
+        delete[]rdispls;
+        delete[]recvcounts;
+        delete[]sendcounts;
+        delete[]rbuf;
+        delete[]sbuf;
+        MTestFreeComm(comm);
     }
 
-    MTest_Finalize( err );
+    MTest_Finalize(err);
     return 0;
 }

--- a/test/mpi/cxx/coll/arcomplex.cxx
+++ b/test/mpi/cxx/coll/arcomplex.cxx
@@ -21,73 +21,73 @@ using namespace std;
 #include <complex>
 #include "mpitestcxx.h"
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int size, rank;
     long sum;
-    complex<float> c[2], c_out[2];
-    complex<double> cd[2], cd_out[2];
+    complex < float >c[2], c_out[2];
+    complex < double >cd[2], cd_out[2];
 #ifdef HAVE_LONG_DOUBLE
-    complex<long double> cld[2], cld_out[2];
-    MTEST_VG_MEM_INIT(cld, 2 * sizeof(complex<long double>));
+    complex < long double >cld[2], cld_out[2];
+    MTEST_VG_MEM_INIT(cld, 2 * sizeof(complex < long double >));
 #endif
 
-    MTest_Init( );
+    MTest_Init();
 
     size = comm.Get_size();
     rank = comm.Get_rank();
-    
-    c[0]   = ((float)rank)*complex<float>(1,2);
-    c[1]   = ((float)rank)*complex<float>(-1,4);
-    cd[0]  = ((double)rank)*complex<double>(1,2);
-    cd[1]  = ((double)rank)*complex<double>(-1,4);
+
+    c[0] = ((float) rank) * complex < float >(1, 2);
+    c[1] = ((float) rank) * complex < float >(-1, 4);
+    cd[0] = ((double) rank) * complex < double >(1, 2);
+    cd[1] = ((double) rank) * complex < double >(-1, 4);
 #ifdef HAVE_LONG_DOUBLE
-    cld[0] = ((long double)rank)*complex<long double>(1,2);
-    cld[1] = ((long double)rank)*complex<long double>(-1,4);
+    cld[0] = ((long double) rank) * complex < long double >(1, 2);
+    cld[1] = ((long double) rank) * complex < long double >(-1, 4);
 #endif
-    
+
     // Sums are easy - real and imaginary parts separate
     // result should be sum(0:size-1) *{ complex(1,2), complex(-1,4) }
     // The sum is (size*(size-1))/2
-    comm.Allreduce( c, c_out, 2, MPI::COMPLEX, MPI::SUM );
-    sum = (size * (size-1) ) / 2;
-    if (c_out[0] != ((float)sum) * complex<float>(1,2)) {
-	errs++;
-	cout << "c_out[0] was " << c_out[0] << " expected " << 
-	    ((float)sum) * complex<float>(1,2);
+    comm.Allreduce(c, c_out, 2, MPI::COMPLEX, MPI::SUM);
+    sum = (size * (size - 1)) / 2;
+    if (c_out[0] != ((float) sum) * complex < float >(1, 2)) {
+        errs++;
+        cout << "c_out[0] was " << c_out[0] << " expected " <<
+            ((float) sum) * complex < float >(1, 2);
     }
-    if (c_out[1] != ((float)sum) * complex<float>(-1,4)) {
-	errs++;
-	cout << "c_out[1] was " << c_out[1] << " expected " << 
-	    ((float)sum) * complex<float>(-1,4);
+    if (c_out[1] != ((float) sum) * complex < float >(-1, 4)) {
+        errs++;
+        cout << "c_out[1] was " << c_out[1] << " expected " <<
+            ((float) sum) * complex < float >(-1, 4);
     }
-    comm.Allreduce( cd, cd_out, 2, MPI::DOUBLE_COMPLEX, MPI::SUM );
-    if (cd_out[0] != ((double)sum) * complex<double>(1,2)) {
-	errs++;
-	cout << "cd_out[0] was " << cd_out[0] << " expected " << 
-	    ((double)sum) * complex<double>(1,2);
+    comm.Allreduce(cd, cd_out, 2, MPI::DOUBLE_COMPLEX, MPI::SUM);
+    if (cd_out[0] != ((double) sum) * complex < double >(1, 2)) {
+        errs++;
+        cout << "cd_out[0] was " << cd_out[0] << " expected " <<
+            ((double) sum) * complex < double >(1, 2);
     }
-    if (cd_out[1] != ((double)sum) * complex<double>(-1,4)) {
-	errs++;
-	cout << "cd_out[1] was " << cd_out[1] << " expected " << 
-	    ((double)sum) * complex<double>(-1,4);
+    if (cd_out[1] != ((double) sum) * complex < double >(-1, 4)) {
+        errs++;
+        cout << "cd_out[1] was " << cd_out[1] << " expected " <<
+            ((double) sum) * complex < double >(-1, 4);
     }
 #ifdef HAVE_LONG_DOUBLE
-    comm.Allreduce( cld, cld_out, 2, MPI::LONG_DOUBLE_COMPLEX, MPI::SUM );
-    if (cld_out[0] != ((long double)sum) * complex<long double>(1,2)) {
-	errs++;
-	cout << "cld_out[0] was " << cld_out[0] << " expected " << 
-	    ((long double)sum) * complex<long double>(1,2);
+    comm.Allreduce(cld, cld_out, 2, MPI::LONG_DOUBLE_COMPLEX, MPI::SUM);
+    if (cld_out[0] != ((long double) sum) * complex < long double >(1, 2)) {
+        errs++;
+        cout << "cld_out[0] was " << cld_out[0] << " expected " <<
+            ((long double) sum) * complex < long double >(1, 2);
     }
-    if (cld_out[1] != ((long double)sum) * complex<long double>(-1,4)) {
-	errs++;
-	cout << "cld_out[1] was " << cld_out[1] << " expected " << 
-	    ((long double)sum) * complex<long double>(-1,4);
+    if (cld_out[1] != ((long double) sum) * complex < long double >(-1, 4)) {
+        errs++;
+        cout << "cld_out[1] was " << cld_out[1] << " expected " <<
+            ((long double) sum) * complex < long double >(-1, 4);
     }
 #endif
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icallgathervx.cxx
+++ b/test/mpi/cxx/coll/icallgathervx.cxx
@@ -11,7 +11,7 @@
 
 static char MTEST_Descrip[] = "Simple intercomm allgatherv test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *rbuf = 0, *sbuf = 0;
@@ -20,105 +20,98 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    /* The left group will send rank to the right group;
-	       The right group will send -rank to the left group */
-	    rank = comm.Get_rank();
-	    rsize = comm.Get_remote_size();
-	    rbuf = new int [ count * rsize ];
-	    sbuf = new int [ count ];
-	    recvcounts = new int [ rsize ];
-	    recvdispls = new int [ rsize ];
-	    for (i=0; i<count*rsize; i++) rbuf[i] = -1;
-	    for (i=0; i<rsize; i++) {
-		recvcounts[i] = count;
-		recvdispls[i] = i * count;
-	    }
-	    if (leftGroup) {
-		for (i=0; i<count; i++)       sbuf[i] = i + rank*count;
-	    }
-	    else {
-		for (i=0; i<count; i++)       sbuf[i] = -(i + rank*count);
-	    }
-	    try
-	    {
-		comm.Allgatherv( sbuf, count, datatype,
-		    rbuf, recvcounts, recvdispls, datatype );
-	    }
-	    catch (MPI::Exception e)
-	    { 
-		errs++;
-		MTestPrintError( e.Get_error_code() );
-	    }
-	    if (leftGroup) {
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -i) {
-			errs++;
-		    }
-		}
-	    }
-	    else {
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != i) {
-			errs++;
-		    }
-		}
-	    }
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            /* The left group will send rank to the right group;
+             * The right group will send -rank to the left group */
+            rank = comm.Get_rank();
+            rsize = comm.Get_remote_size();
+            rbuf = new int[count * rsize];
+            sbuf = new int[count];
+            recvcounts = new int[rsize];
+            recvdispls = new int[rsize];
+            for (i = 0; i < count * rsize; i++)
+                rbuf[i] = -1;
+            for (i = 0; i < rsize; i++) {
+                recvcounts[i] = count;
+                recvdispls[i] = i * count;
+            }
+            if (leftGroup) {
+                for (i = 0; i < count; i++)
+                    sbuf[i] = i + rank * count;
+            } else {
+                for (i = 0; i < count; i++)
+                    sbuf[i] = -(i + rank * count);
+            }
+            try {
+                comm.Allgatherv(sbuf, count, datatype, rbuf, recvcounts, recvdispls, datatype);
+            }
+            catch(MPI::Exception e) {
+                errs++;
+                MTestPrintError(e.Get_error_code());
+            }
+            if (leftGroup) {
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -i) {
+                        errs++;
+                    }
+                }
+            } else {
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != i) {
+                        errs++;
+                    }
+                }
+            }
 
-	    /* Use Allgather in a unidirectional way */
-	    for (i=0; i<count*rsize; i++) rbuf[i] = -1;
-	    if (leftGroup) {
-		try
-		{
-		    comm.Allgatherv( sbuf, 0, datatype,
-			rbuf, recvcounts, recvdispls, datatype );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -i) {
-			errs++;
-		    }
-		}
-	    }
-	    else {
-                for (i=0; i<rsize; i++) {
+            /* Use Allgather in a unidirectional way */
+            for (i = 0; i < count * rsize; i++)
+                rbuf[i] = -1;
+            if (leftGroup) {
+                try {
+                    comm.Allgatherv(sbuf, 0, datatype, rbuf, recvcounts, recvdispls, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -i) {
+                        errs++;
+                    }
+                }
+            } else {
+                for (i = 0; i < rsize; i++) {
                     recvcounts[i] = 0;
                     recvdispls[i] = 0;
                 }
-		try
-		{
-		    comm.Allgatherv( sbuf, count, datatype,
-			rbuf, recvcounts, recvdispls, datatype );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -1) {
-			errs++;
-		    }
-		}
-	    }
-	    delete [] rbuf;
-	    delete [] sbuf;
-	    delete [] recvcounts;
-	    delete [] recvdispls;
+                try {
+                    comm.Allgatherv(sbuf, count, datatype, rbuf, recvcounts, recvdispls, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -1) {
+                        errs++;
+                    }
+                }
+            }
+            delete[]rbuf;
+            delete[]sbuf;
+            delete[]recvcounts;
+            delete[]recvdispls;
         }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icallgatherx.cxx
+++ b/test/mpi/cxx/coll/icallgatherx.cxx
@@ -10,7 +10,7 @@
 
 static char MTEST_Descrip[] = "Simple intercomm allgather test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *rbuf = 0, *sbuf = 0;
@@ -18,90 +18,86 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI_INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    /* The left group will send rank to the right group;
-	       The right group will send -rank to the left group */
-	    rank = comm.Get_rank();
-	    rsize = comm.Get_remote_size();
-	    rbuf = new int [ count * rsize ];
-	    sbuf = new int [ count ];
-	    for (i=0; i<count*rsize; i++) rbuf[i] = -1;
-	    if (leftGroup) {
-		for (i=0; i<count; i++)       sbuf[i] = i + rank*count;
-	    }
-	    else {
-		for (i=0; i<count; i++)       sbuf[i] = -(i + rank*count);
-	    }
-	    try
-	    {
-		comm.Allgather( sbuf, count, datatype, rbuf, count, datatype );
-	    }
-	    catch (MPI::Exception e)
-	    {
-		errs++;
- 		MTestPrintError( e.Get_error_code() );
-	    }
-	    if (leftGroup) {
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -i) {
-			errs++;
-		    }
-		}
-	    }
-	    else {
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != i) {
-			errs++;
-		    }
-		}
-	    }
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            /* The left group will send rank to the right group;
+             * The right group will send -rank to the left group */
+            rank = comm.Get_rank();
+            rsize = comm.Get_remote_size();
+            rbuf = new int[count * rsize];
+            sbuf = new int[count];
+            for (i = 0; i < count * rsize; i++)
+                rbuf[i] = -1;
+            if (leftGroup) {
+                for (i = 0; i < count; i++)
+                    sbuf[i] = i + rank * count;
+            } else {
+                for (i = 0; i < count; i++)
+                    sbuf[i] = -(i + rank * count);
+            }
+            try {
+                comm.Allgather(sbuf, count, datatype, rbuf, count, datatype);
+            }
+            catch(MPI::Exception e) {
+                errs++;
+                MTestPrintError(e.Get_error_code());
+            }
+            if (leftGroup) {
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -i) {
+                        errs++;
+                    }
+                }
+            } else {
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != i) {
+                        errs++;
+                    }
+                }
+            }
 
-	    /* Use Allgather in a unidirectional way */
-	    for (i=0; i<count*rsize; i++) rbuf[i] = -1;
-	    if (leftGroup) {
-		try
-		{
-		    comm.Allgather( sbuf, 0, datatype, rbuf, count, datatype );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -i) {
-			errs++;
-		    }
-		}
-	    }
-	    else {
-		try
-		{
-		    comm.Allgather( sbuf, count, datatype, rbuf, 0, datatype );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		for (i=0; i<count*rsize; i++) {
-		    if (rbuf[i] != -1) {
-			errs++;
-		    }
-		}
-	    }
-	    delete [] rbuf;
-	    delete [] sbuf;
-	}
+            /* Use Allgather in a unidirectional way */
+            for (i = 0; i < count * rsize; i++)
+                rbuf[i] = -1;
+            if (leftGroup) {
+                try {
+                    comm.Allgather(sbuf, 0, datatype, rbuf, count, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -i) {
+                        errs++;
+                    }
+                }
+            } else {
+                try {
+                    comm.Allgather(sbuf, count, datatype, rbuf, 0, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                for (i = 0; i < count * rsize; i++) {
+                    if (rbuf[i] != -1) {
+                        errs++;
+                    }
+                }
+            }
+            delete[]rbuf;
+            delete[]sbuf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icallreducex.cxx
+++ b/test/mpi/cxx/coll/icallreducex.cxx
@@ -21,7 +21,7 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Simple intercomm allreduce test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *sendbuf = 0, *recvbuf = 0;
@@ -32,60 +32,58 @@ int main( int argc, char *argv[] )
     MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	rank = comm.Get_rank();
-	for (count = 1; count < 65000; count = 2 * count) {
-	    sendbuf = new int [ count ];
-	    recvbuf = new int [ count ];
-	    /* Get an intercommunicator */
-	    if (leftGroup) {
-		for (i=0; i<count; i++) sendbuf[i] = i;
-	    }
-	    else {
-		for (i=0; i<count; i++) sendbuf[i] = -i;
-	    }
-	    for (i=0; i<count; i++) recvbuf[i] = 0;
-	    try
-	    {
-		comm.Allreduce( sendbuf, recvbuf, count, datatype, MPI::SUM );
-	    }
-	    catch (MPI::Exception e)
-	    {
-		errs++;
-		MTestPrintError( e.Get_error_code() );
-	    }
-	    /* In each process should be the sum of the values from the
-	       other process */
-	    rsize = comm.Get_remote_size();
-	    if (leftGroup) {
-		for (i=0; i<count; i++) {
-		    if (recvbuf[i] != -i * rsize) {
-			errs++;
-			if (errs < 10) {
-			    cout << "recvbuf[" << i << "] = " <<
-				recvbuf[i] << "\n";
-			}
-		    }
-		}
-	    }
-	    else {
-		for (i=0; i<count; i++) {
-		    if (recvbuf[i] != i * rsize) {
-			errs++;
-			if (errs < 10) {
-			    cout << "recvbuf[" << i << "] = " << 
-				recvbuf[i] << "\n";
-			}
-		    }
-		}
-	    }
-	    delete [] sendbuf;
-	    delete [] recvbuf;
-	}
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        rank = comm.Get_rank();
+        for (count = 1; count < 65000; count = 2 * count) {
+            sendbuf = new int[count];
+            recvbuf = new int[count];
+            /* Get an intercommunicator */
+            if (leftGroup) {
+                for (i = 0; i < count; i++)
+                    sendbuf[i] = i;
+            } else {
+                for (i = 0; i < count; i++)
+                    sendbuf[i] = -i;
+            }
+            for (i = 0; i < count; i++)
+                recvbuf[i] = 0;
+            try {
+                comm.Allreduce(sendbuf, recvbuf, count, datatype, MPI::SUM);
+            }
+            catch(MPI::Exception e) {
+                errs++;
+                MTestPrintError(e.Get_error_code());
+            }
+            /* In each process should be the sum of the values from the
+             * other process */
+            rsize = comm.Get_remote_size();
+            if (leftGroup) {
+                for (i = 0; i < count; i++) {
+                    if (recvbuf[i] != -i * rsize) {
+                        errs++;
+                        if (errs < 10) {
+                            cout << "recvbuf[" << i << "] = " << recvbuf[i] << "\n";
+                        }
+                    }
+                }
+            } else {
+                for (i = 0; i < count; i++) {
+                    if (recvbuf[i] != i * rsize) {
+                        errs++;
+                        if (errs < 10) {
+                            cout << "recvbuf[" << i << "] = " << recvbuf[i] << "\n";
+                        }
+                    }
+                }
+            }
+            delete[]sendbuf;
+            delete[]recvbuf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icalltoallx.cxx
+++ b/test/mpi/cxx/coll/icalltoallx.cxx
@@ -21,7 +21,7 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Simple intercomm alltoall test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *sendbuf = 0, *recvbuf = 0;
@@ -29,70 +29,67 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 66000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    rsize = comm.Get_remote_size();
-	    rank  = comm.Get_rank();
-	    sendbuf = new int [ rsize * count ];
-	    recvbuf = new int [ rsize * count ];
-	    for (i=0; i<rsize*count; i++) recvbuf[i] = -1;
-	    if (leftGroup) {
-		idx = 0;
-		for (j=0; j<rsize; j++) {
-		    for (i=0; i<count; i++) {
-			sendbuf[idx++] = i + rank;
-		    }
-		}
-		try
-		{
-		    comm.Alltoall( sendbuf, count, datatype, NULL, 0, datatype );
-		}
-		catch (MPI::Exception e)
-		{ 
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-	    }
-	    else {
-		int rank, size;
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 66000; count = 2 * count) {
+            /* Get an intercommunicator */
+            rsize = comm.Get_remote_size();
+            rank = comm.Get_rank();
+            sendbuf = new int[rsize * count];
+            recvbuf = new int[rsize * count];
+            for (i = 0; i < rsize * count; i++)
+                recvbuf[i] = -1;
+            if (leftGroup) {
+                idx = 0;
+                for (j = 0; j < rsize; j++) {
+                    for (i = 0; i < count; i++) {
+                        sendbuf[idx++] = i + rank;
+                    }
+                }
+                try {
+                    comm.Alltoall(sendbuf, count, datatype, NULL, 0, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+            } else {
+                int rank, size;
 
-		rank = comm.Get_rank();
-		size = comm.Get_size();
+                rank = comm.Get_rank();
+                size = comm.Get_size();
 
-		/* In the right group */
-		try
-		{
-		    comm.Alltoall( NULL, 0, datatype, recvbuf, count, datatype );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Check that we have received the correct data */
-		idx = 0;
-		for (j=0; j<rsize; j++) {
-		    for (i=0; i<count; i++) {
-			if (recvbuf[idx++] != i + j) {
-			    errs++;
-			    if (errs < 10) 
-				cout << "buf[" << i << "] = " <<
-				    recvbuf[i] << " on " << rank << "\n";
-			}
-		    }
-		}
-	    }
-	    delete [] recvbuf;
-	    delete [] sendbuf;
-	}
+                /* In the right group */
+                try {
+                    comm.Alltoall(NULL, 0, datatype, recvbuf, count, datatype);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Check that we have received the correct data */
+                idx = 0;
+                for (j = 0; j < rsize; j++) {
+                    for (i = 0; i < count; i++) {
+                        if (recvbuf[idx++] != i + j) {
+                            errs++;
+                            if (errs < 10)
+                                cout << "buf[" << i << "] = " <<
+                                    recvbuf[i] << " on " << rank << "\n";
+                        }
+                    }
+                }
+            }
+            delete[]recvbuf;
+            delete[]sendbuf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icbarrierx.cxx
+++ b/test/mpi/cxx/coll/icbarrierx.cxx
@@ -12,47 +12,43 @@ static char MTEST_Descrip[] = "Simple intercomm barrier test";
 
 /* This only checks that the Barrier operation accepts intercommunicators.
    It does not check for the semantics of a intercomm barrier (all processes
-   in the local group can exit when (but not before) all processes in the 
+   in the local group can exit when (but not before) all processes in the
    remote group enter the barrier */
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int leftGroup;
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-        if (comm == MPI::COMM_NULL) continue;
-	/* Get an intercommunicator */
-	if (leftGroup) {
-	    try
-	    {
-		comm.Barrier( );
-	    }
-	    catch (MPI::Exception e)
-	    {
-		errs++;
-		MTestPrintError( e.Get_error_code() );
-	    }
-	}
-	else {
-	    /* In the right group */
-	    try
-	    {
-		comm.Barrier();
-	    }
-	    catch (MPI::Exception e)
-	    {
-		errs++;
-		MTestPrintError( e.Get_error_code() );
-	    }
-	}
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        /* Get an intercommunicator */
+        if (leftGroup) {
+            try {
+                comm.Barrier();
+            }
+            catch(MPI::Exception e) {
+                errs++;
+                MTestPrintError(e.Get_error_code());
+            }
+        } else {
+            /* In the right group */
+            try {
+                comm.Barrier();
+            }
+            catch(MPI::Exception e) {
+                errs++;
+                MTestPrintError(e.Get_error_code());
+            }
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icbcastx.cxx
+++ b/test/mpi/cxx/coll/icbcastx.cxx
@@ -11,7 +11,7 @@
 
 static char MTEST_Descrip[] = "Simple intercomm broadcast test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *buf = 0;
@@ -22,62 +22,60 @@ int main( int argc, char *argv[] )
     MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-        if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    buf = new int [count];
-	    /* Get an intercommunicator */
-	    if (leftGroup) {
-		rank = comm.Get_rank();
-		if (rank == 0) {
-		    for (i=0; i<count; i++) buf[i] = i;
-		}
-		else {
-		    for (i=0; i<count; i++) buf[i] = -1;
-		}
-		try {
-		    comm.Bcast( buf, count, datatype, 
-			        (rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   broadcast */
-		if (rank != 0) {
-		    for (i=0; i<count; i++) {
-			if (buf[i] != -1) {
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		/* In the right group */
-		for (i=0; i<count; i++) buf[i] = -1;
-		try
-		{
-		    comm.Bcast( buf, count, datatype, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Check that we have received the correct data */
-		for (i=0; i<count; i++) {
-		    if (buf[i] != i) {
-			errs++;
-		    }
-		}
-	    }
-	    delete [] buf;
-	}
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            buf = new int[count];
+            /* Get an intercommunicator */
+            if (leftGroup) {
+                rank = comm.Get_rank();
+                if (rank == 0) {
+                    for (i = 0; i < count; i++)
+                        buf[i] = i;
+                } else {
+                    for (i = 0; i < count; i++)
+                        buf[i] = -1;
+                }
+                try {
+                    comm.Bcast(buf, count, datatype, (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * broadcast */
+                if (rank != 0) {
+                    for (i = 0; i < count; i++) {
+                        if (buf[i] != -1) {
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                /* In the right group */
+                for (i = 0; i < count; i++)
+                    buf[i] = -1;
+                try {
+                    comm.Bcast(buf, count, datatype, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Check that we have received the correct data */
+                for (i = 0; i < count; i++) {
+                    if (buf[i] != i) {
+                        errs++;
+                    }
+                }
+            }
+            delete[]buf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icgathervx.cxx
+++ b/test/mpi/cxx/coll/icgathervx.cxx
@@ -11,7 +11,7 @@
 
 static char MTEST_Descrip[] = "Simple intercomm gatherv test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *buf = 0;
@@ -21,80 +21,77 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    rsize = comm.Get_remote_size();
-	    recvcounts = new int [ rsize ];
-	    recvdispls = new int [ rsize ];
-	    /* This simple test duplicates the Gather test, 
-	       using the same lengths for all messages */
-	    for (i=0; i<rsize; i++) {
-		recvcounts[i] = count;
-		recvdispls[i] = count * i;
-	    }
-	    if (leftGroup) {
-		rank = comm.Get_rank();
-		buf = new int [count * rsize];
-		for (i=0; i<count*rsize; i++) buf[i] = -1;
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            rsize = comm.Get_remote_size();
+            recvcounts = new int[rsize];
+            recvdispls = new int[rsize];
+            /* This simple test duplicates the Gather test,
+             * using the same lengths for all messages */
+            for (i = 0; i < rsize; i++) {
+                recvcounts[i] = count;
+                recvdispls[i] = count * i;
+            }
+            if (leftGroup) {
+                rank = comm.Get_rank();
+                buf = new int[count * rsize];
+                for (i = 0; i < count * rsize; i++)
+                    buf[i] = -1;
 
-		try
-		{
-    		    comm.Gatherv( NULL, 0, datatype,
-    				  buf, recvcounts, recvdispls, datatype, 
-				 (rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
-		}
-		catch (MPI::Exception e)
-		{ 
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   broadcast */
-		if (rank != 0) {
-		    for (i=0; i<count; i++) {
-			if (buf[i] != -1) {
-			    errs++;
-			}
-		    }
-		}
-		else {
-		    /* Check for the correct data */
-		    for (i=0; i<count*rsize; i++) {
-			if (buf[i] != i) {
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		int size;
-		/* In the right group */
-		rank = comm.Get_rank();
-		size = comm.Get_size();
-		buf = new int [count];
-		for (i=0; i<count; i++) buf[i] = rank * count + i;
-		try
-		{
-		    comm.Gatherv( buf, count, datatype, NULL, 0, 0, datatype, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-	    }
-	    delete [] buf;
-	    delete [] recvcounts;
-	    delete [] recvdispls;
-	}
+                try {
+                    comm.Gatherv(NULL, 0, datatype,
+                                 buf, recvcounts, recvdispls, datatype,
+                                 (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * broadcast */
+                if (rank != 0) {
+                    for (i = 0; i < count; i++) {
+                        if (buf[i] != -1) {
+                            errs++;
+                        }
+                    }
+                } else {
+                    /* Check for the correct data */
+                    for (i = 0; i < count * rsize; i++) {
+                        if (buf[i] != i) {
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                int size;
+                /* In the right group */
+                rank = comm.Get_rank();
+                size = comm.Get_size();
+                buf = new int[count];
+                for (i = 0; i < count; i++)
+                    buf[i] = rank * count + i;
+                try {
+                    comm.Gatherv(buf, count, datatype, NULL, 0, 0, datatype, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+            }
+            delete[]buf;
+            delete[]recvcounts;
+            delete[]recvdispls;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icgatherx.cxx
+++ b/test/mpi/cxx/coll/icgatherx.cxx
@@ -11,7 +11,7 @@
 
 static char MTEST_Descrip[] = "Simple intercomm gather test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *buf = 0;
@@ -19,71 +19,67 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    if (leftGroup) {
-		int rsize;
-		rank  = comm.Get_rank();
-		rsize = comm.Get_remote_size();
-		buf   = new int [ count * rsize ];
-		for (i=0; i<count*rsize; i++) buf[i] = -1;
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            if (leftGroup) {
+                int rsize;
+                rank = comm.Get_rank();
+                rsize = comm.Get_remote_size();
+                buf = new int[count * rsize];
+                for (i = 0; i < count * rsize; i++)
+                    buf[i] = -1;
 
-		try
-		{
-		    comm.Gather( NULL, 0, datatype,
-			buf, count, datatype, 
-			(rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   broadcast */
-		if (rank != 0) {
-		    for (i=0; i<count; i++) {
-			if (buf[i] != -1) {
-			    errs++;
-			}
-		    }
-		}
-		else {
-		    /* Check for the correct data */
-		    for (i=0; i<count*rsize; i++) {
-			if (buf[i] != i) {
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		int size;
-		/* In the right group */
-		rank = comm.Get_rank();
-		size = comm.Get_size();
-		buf = new int [ count ];
-		for (i=0; i<count; i++) buf[i] = rank * count + i;
-		try
-		{
-		    comm.Gather( buf, count, datatype, NULL, 0, datatype, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-	    }
-	    delete [] buf;
-	}
+                try {
+                    comm.Gather(NULL, 0, datatype,
+                                buf, count, datatype, (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * broadcast */
+                if (rank != 0) {
+                    for (i = 0; i < count; i++) {
+                        if (buf[i] != -1) {
+                            errs++;
+                        }
+                    }
+                } else {
+                    /* Check for the correct data */
+                    for (i = 0; i < count * rsize; i++) {
+                        if (buf[i] != i) {
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                int size;
+                /* In the right group */
+                rank = comm.Get_rank();
+                size = comm.Get_size();
+                buf = new int[count];
+                for (i = 0; i < count; i++)
+                    buf[i] = rank * count + i;
+                try {
+                    comm.Gather(buf, count, datatype, NULL, 0, datatype, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+            }
+            delete[]buf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icreducex.cxx
+++ b/test/mpi/cxx/coll/icreducex.cxx
@@ -11,10 +11,10 @@
 
 static char MTEST_Descrip[] = "Simple intercomm reduce test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
-    int *sendbuf = 0, *recvbuf=0;
+    int *sendbuf = 0, *recvbuf = 0;
     int leftGroup, i, count, rank;
     MPI::Intercomm comm;
     MPI::Datatype datatype;
@@ -22,72 +22,68 @@ int main( int argc, char *argv[] )
     MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-        if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    sendbuf = new int [count];
-	    recvbuf = new int [count];
-	    /* Get an intercommunicator */
-	    for (i=0; i<count; i++) {
-		sendbuf[i] = -1;
-		recvbuf[i] = -1;
-	    }
-	    if (leftGroup) {
-		rank = comm.Get_rank();
-		try
-		{
-		    comm.Reduce( sendbuf, recvbuf, count, datatype, MPI::SUM,
-			(rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   broadcast, and that we got the right answers */
-		if (rank == 0) {
-		    int rsize;
-		    rsize = comm.Get_remote_size();
-		    for (i=0; i<count; i++) {
-			if (recvbuf[i] != i * rsize) {
-			    errs++;
-			}
-		    }
-		}
-		else {
-		    for (i=0; i<count; i++) {
-			if (recvbuf[i] != -1) {
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		/* In the right group */
-		for (i=0; i<count; i++) sendbuf[i] = i;
-		try
-		{
-		    comm.Reduce( sendbuf, recvbuf, count, datatype, MPI::SUM, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Check that we have received no data */
-		for (i=0; i<count; i++) {
-		    if (recvbuf[i] != -1) {
-			errs++;
-		    }
-		}
-	    }
-	    delete [] sendbuf;
-	    delete [] recvbuf;
-	}
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            sendbuf = new int[count];
+            recvbuf = new int[count];
+            /* Get an intercommunicator */
+            for (i = 0; i < count; i++) {
+                sendbuf[i] = -1;
+                recvbuf[i] = -1;
+            }
+            if (leftGroup) {
+                rank = comm.Get_rank();
+                try {
+                    comm.Reduce(sendbuf, recvbuf, count, datatype, MPI::SUM,
+                                (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * broadcast, and that we got the right answers */
+                if (rank == 0) {
+                    int rsize;
+                    rsize = comm.Get_remote_size();
+                    for (i = 0; i < count; i++) {
+                        if (recvbuf[i] != i * rsize) {
+                            errs++;
+                        }
+                    }
+                } else {
+                    for (i = 0; i < count; i++) {
+                        if (recvbuf[i] != -1) {
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                /* In the right group */
+                for (i = 0; i < count; i++)
+                    sendbuf[i] = i;
+                try {
+                    comm.Reduce(sendbuf, recvbuf, count, datatype, MPI::SUM, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Check that we have received no data */
+                for (i = 0; i < count; i++) {
+                    if (recvbuf[i] != -1) {
+                        errs++;
+                    }
+                }
+            }
+            delete[]sendbuf;
+            delete[]recvbuf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icscattervx.cxx
+++ b/test/mpi/cxx/coll/icscattervx.cxx
@@ -21,7 +21,7 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Simple intercomm scatterv test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *buf = 0;
@@ -31,90 +31,85 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	rsize = comm.Get_remote_size();
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    buf = 0;
-	    sendcounts = new int [ rsize ];
-	    senddispls = new int [ rsize ];
-	    for (i=0; i<rsize; i++) {
-		sendcounts[i] = count;
-		senddispls[i] = count * i;
-	    }
-	    if (leftGroup) {
-		rank = comm.Get_rank();
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        rsize = comm.Get_remote_size();
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            buf = 0;
+            sendcounts = new int[rsize];
+            senddispls = new int[rsize];
+            for (i = 0; i < rsize; i++) {
+                sendcounts[i] = count;
+                senddispls[i] = count * i;
+            }
+            if (leftGroup) {
+                rank = comm.Get_rank();
 
-		buf = new int [count*rsize];
-		if (rank == 0) {
-		    for (i=0; i<count*rsize; i++) buf[i] = i;
-		}
-		else {
-		    for (i=0; i<count*rsize; i++) buf[i] = -1;
-		}
-		try
-		{
-		    comm.Scatterv( buf, sendcounts, senddispls, datatype, 
-			NULL, 0, datatype,
-			(rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
-		}
-		catch (MPI::Exception e)
-		{ 
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   scatter */
-		if (rank != 0) {
-		    for (i=0; i<count*rsize; i++) {
-			if (buf[i] != -1) {
-			    if (errs < 10) {
-				cout << "Received data on root group!\n";
-			    }
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		int rank, size;
-		rank = comm.Get_rank();
-		size = comm.Get_size();
+                buf = new int[count * rsize];
+                if (rank == 0) {
+                    for (i = 0; i < count * rsize; i++)
+                        buf[i] = i;
+                } else {
+                    for (i = 0; i < count * rsize; i++)
+                        buf[i] = -1;
+                }
+                try {
+                    comm.Scatterv(buf, sendcounts, senddispls, datatype,
+                                  NULL, 0, datatype, (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * scatter */
+                if (rank != 0) {
+                    for (i = 0; i < count * rsize; i++) {
+                        if (buf[i] != -1) {
+                            if (errs < 10) {
+                                cout << "Received data on root group!\n";
+                            }
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                int rank, size;
+                rank = comm.Get_rank();
+                size = comm.Get_size();
 
-		buf = new int [ count ];
-		/* In the right group */
-		for (i=0; i<count; i++) buf[i] = -1;
-		try
-		{
-		    comm.Scatterv( NULL, 0, 0, datatype, 
-			buf, count, datatype, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Check that we have received the correct data */
-		for (i=0; i<count; i++) {
-		    if (buf[i] != i + rank * count) {
-			if (errs < 10) 
-			    cout << "buf[" << i << "] = " << buf[i] << 
-				" on " << rank << "\n";
-			errs++;
-		    }
-		}
-	    }
-	    delete [] sendcounts;
-	    delete [] senddispls;
-	    delete [] buf;
-	}
+                buf = new int[count];
+                /* In the right group */
+                for (i = 0; i < count; i++)
+                    buf[i] = -1;
+                try {
+                    comm.Scatterv(NULL, 0, 0, datatype, buf, count, datatype, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Check that we have received the correct data */
+                for (i = 0; i < count; i++) {
+                    if (buf[i] != i + rank * count) {
+                        if (errs < 10)
+                            cout << "buf[" << i << "] = " << buf[i] << " on " << rank << "\n";
+                        errs++;
+                    }
+                }
+            }
+            delete[]sendcounts;
+            delete[]senddispls;
+            delete[]buf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/icscatterx.cxx
+++ b/test/mpi/cxx/coll/icscatterx.cxx
@@ -21,7 +21,7 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Simple intercomm scatter test";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int *buf = 0;
@@ -29,85 +29,81 @@ int main( int argc, char *argv[] )
     MPI::Intercomm comm;
     MPI::Datatype datatype;
 
-    MTest_Init( );
+    MTest_Init();
 
     datatype = MPI::INT;
-    while (MTestGetIntercomm( comm, leftGroup, 4 )) {
-	if (comm == MPI::COMM_NULL) continue;
-	for (count = 1; count < 65000; count = 2 * count) {
-	    /* Get an intercommunicator */
-	    buf = 0;
-	    if (leftGroup) {
-		int rsize;
+    while (MTestGetIntercomm(comm, leftGroup, 4)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
+        for (count = 1; count < 65000; count = 2 * count) {
+            /* Get an intercommunicator */
+            buf = 0;
+            if (leftGroup) {
+                int rsize;
 
-		rsize = comm.Get_remote_size();
-		rank  = comm.Get_rank();
+                rsize = comm.Get_remote_size();
+                rank = comm.Get_rank();
 
-		buf = new int [ count * rsize ];
-		if (rank == 0) {
-		    for (i=0; i<count*rsize; i++) buf[i] = i;
-		}
-		else {
-		    for (i=0; i<count*rsize; i++) buf[i] = -1;
-		}
-		try
-		{
-		    comm.Scatter( buf, count, datatype, 
-			NULL, 0, datatype,
-			(rank == 0) ? MPI::ROOT : MPI::PROC_NULL );
+                buf = new int[count * rsize];
+                if (rank == 0) {
+                    for (i = 0; i < count * rsize; i++)
+                        buf[i] = i;
+                } else {
+                    for (i = 0; i < count * rsize; i++)
+                        buf[i] = -1;
+                }
+                try {
+                    comm.Scatter(buf, count, datatype,
+                                 NULL, 0, datatype, (rank == 0) ? MPI::ROOT : MPI::PROC_NULL);
 
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Test that no other process in this group received the 
-		   scatter */
-		if (rank != 0) {
-		    for (i=0; i<count*rsize; i++) {
-			if (buf[i] != -1) {
-			    if (errs < 10) {
-				cout << "Received data on root group!\n";
-			    }
-			    errs++;
-			}
-		    }
-		}
-	    }
-	    else {
-		int rank, size;
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Test that no other process in this group received the
+                 * scatter */
+                if (rank != 0) {
+                    for (i = 0; i < count * rsize; i++) {
+                        if (buf[i] != -1) {
+                            if (errs < 10) {
+                                cout << "Received data on root group!\n";
+                            }
+                            errs++;
+                        }
+                    }
+                }
+            } else {
+                int rank, size;
 
-		rank = comm.Get_rank();
-		size = comm.Get_size();
+                rank = comm.Get_rank();
+                size = comm.Get_size();
 
-		buf = new int [ count ];
-		/* In the right group */
-		for (i=0; i<count; i++) buf[i] = -1;
-		try
-		{
-		    comm.Scatter( NULL, 0, datatype, buf, count, datatype, 0 );
-		}
-		catch (MPI::Exception e)
-		{
-		    errs++;
-		    MTestPrintError( e.Get_error_code() );
-		}
-		/* Check that we have received the correct data */
-		for (i=0; i<count; i++) {
-		    if (buf[i] != i + rank * count) {
-			if (errs < 10) 
-			    cout << "buf[" << i << "] = " << buf[i] <<
-				" on " << rank << "\n";
-			errs++;
-		    }
-		}
-	    }
-	    delete [] buf;
-	}
+                buf = new int[count];
+                /* In the right group */
+                for (i = 0; i < count; i++)
+                    buf[i] = -1;
+                try {
+                    comm.Scatter(NULL, 0, datatype, buf, count, datatype, 0);
+                }
+                catch(MPI::Exception e) {
+                    errs++;
+                    MTestPrintError(e.Get_error_code());
+                }
+                /* Check that we have received the correct data */
+                for (i = 0; i < count; i++) {
+                    if (buf[i] != i + rank * count) {
+                        if (errs < 10)
+                            cout << "buf[" << i << "] = " << buf[i] << " on " << rank << "\n";
+                        errs++;
+                    }
+                }
+            }
+            delete[]buf;
+        }
         MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/redscatblk.cxx
+++ b/test/mpi/cxx/coll/redscatblk.cxx
@@ -65,8 +65,8 @@ int main(int argc, char **argv)
         }
     }
 
-    delete [] sendbuf;
-    delete [] recvbuf;
+    delete[]sendbuf;
+    delete[]recvbuf;
 
     MTest_Finalize(err);
 

--- a/test/mpi/cxx/coll/reduceboolx.cxx
+++ b/test/mpi/cxx/coll/reduceboolx.cxx
@@ -23,45 +23,44 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int size, i, count, root, rank;
 
-    MTest_Init( );
+    MTest_Init();
 
     size = comm.Get_size();
     rank = comm.Get_rank();
 
     for (count = 1; count < 66000; count = count * 2) {
         bool *vin, *vout;
-        vin  = new bool[count];
+        vin = new bool[count];
         vout = new bool[count];
 
         for (root = 0; root < size; root++) {
-            for (i=0; i<count; i++) {
+            for (i = 0; i < count; i++) {
                 // only rank 0's elements are set to true
-                vin[i]  = (rank ? false : true);
+                vin[i] = (rank ? false : true);
                 vout[i] = false;
             }
             comm.Reduce(vin, vout, count, MPI::BOOL, MPI::LOR, root);
             if (rank == root) {
-                for (i=0; i<count; i++) {
+                for (i = 0; i < count; i++) {
                     if (vout[i] != true) {
                         errs++;
                         if (errs < 10)
                             cerr << rank << ": " << "count=" << count
-                                 << " root=" << root
-                                 << " vout[" << i << "]=" << vout[i] << endl;
+                                << " root=" << root << " vout[" << i << "]=" << vout[i] << endl;
                     }
                 }
             }
         }
-        delete[] vin;
-        delete[] vout;
+        delete[]vin;
+        delete[]vout;
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/uallreduce.cxx
+++ b/test/mpi/cxx/coll/uallreduce.cxx
@@ -19,52 +19,51 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-void uop( const void *invec, void *inoutvec, int count, 
-	  const MPI::Datatype &datatype )
+void uop(const void *invec, void *inoutvec, int count, const MPI::Datatype & datatype)
 {
     int i;
-    int *cin = (int*)invec, *cout = (int*)inoutvec;
+    int *cin = (int *) invec, *cout = (int *) inoutvec;
 
-    for (i=0; i<count; i++) {
-	cout[i] = cin[i] + cout[i];
+    for (i = 0; i < count; i++) {
+        cout[i] = cin[i] + cout[i];
     }
 }
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Op sumop;
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int size, i, count;
 
-    MTest_Init( );
+    MTest_Init();
 
-    sumop.Init( uop, true );
+    sumop.Init(uop, true);
     size = comm.Get_size();
-    
-    for (count = 1; count < 66000; count = count * 2) {
-	int *vin, *vout;
-	vin  = new int[count];
-	vout = new int[count];
 
-	for (i=0; i<count; i++) {
-	    vin[i]  = i;
-	    vout[i] = -1;
-	}
-	comm.Allreduce( vin, vout, count, MPI::INT, sumop );
-	for (i=0; i<count; i++) {
-	    if (vout[i] != i * size) {
-		errs++;
-		if (errs < 10) 
-		    cerr << "vout[" << i << "] = " << vout[i] << endl;
-	    }
-	}
-	
-	delete[] vin;
-	delete[] vout;
+    for (count = 1; count < 66000; count = count * 2) {
+        int *vin, *vout;
+        vin = new int[count];
+        vout = new int[count];
+
+        for (i = 0; i < count; i++) {
+            vin[i] = i;
+            vout[i] = -1;
+        }
+        comm.Allreduce(vin, vout, count, MPI::INT, sumop);
+        for (i = 0; i < count; i++) {
+            if (vout[i] != i * size) {
+                errs++;
+                if (errs < 10)
+                    cerr << "vout[" << i << "] = " << vout[i] << endl;
+            }
+        }
+
+        delete[]vin;
+        delete[]vout;
     }
-    
+
     sumop.Free();
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/uallredx.cxx
+++ b/test/mpi/cxx/coll/uallredx.cxx
@@ -22,7 +22,7 @@ using namespace std;
 static char MTEST_Descrip[] = "Test MPI_Allreduce with non-commutative user-defined operations";
 
 /* We make the error count global so that we can easily control the output
-   of error information (in particular, limiting it after the first 10 
+   of error information (in particular, limiting it after the first 10
    errors */
 int errs = 0;
 
@@ -33,38 +33,38 @@ int errs = 0;
      c(i,j) is cin[j+i*matSize]
  */
 #define MAXCOL 256
-static int matSize = 0;  /* Must be < MAXCOL */
+static int matSize = 0;         /* Must be < MAXCOL */
 static int max_offset = 0;
-void uop( const void *cinPtr, void *coutPtr, int count, const MPI::Datatype &dtype )
+void uop(const void *cinPtr, void *coutPtr, int count, const MPI::Datatype & dtype)
 {
-    const int *cin = (const int *)cinPtr;
-    int *cout = (int *)coutPtr;
+    const int *cin = (const int *) cinPtr;
+    int *cout = (int *) coutPtr;
     int i, j, k, nmat;
     int tempcol[MAXCOL];
     int offset1, offset2;
-    int matsize2 = matSize*matSize;
+    int matsize2 = matSize * matSize;
 
     for (nmat = 0; nmat < count; nmat++) {
-	for (j=0; j<matSize; j++) {
-	    for (i=0; i<matSize; i++) {
-		tempcol[i] = 0;
-		for (k=0; k<matSize; k++) {
-		    /* col[i] += cin(i,k) * cout(k,j) */
-		    offset1    = k+i*matSize;
-		    offset2    = j+k*matSize;
-		    assert(offset1 < max_offset);
-		    assert(offset2 < max_offset);
-		    tempcol[i] += cin[offset1] * cout[offset2];
-		}
-	    }
-	    for (i=0; i<matSize; i++) {
-		offset1       = j+i*matSize;
-		assert(offset1 < max_offset);
-		cout[offset1] = tempcol[i];
-	    }
-	}
-	cin  += matsize2;
-	cout += matsize2;
+        for (j = 0; j < matSize; j++) {
+            for (i = 0; i < matSize; i++) {
+                tempcol[i] = 0;
+                for (k = 0; k < matSize; k++) {
+                    /* col[i] += cin(i,k) * cout(k,j) */
+                    offset1 = k + i * matSize;
+                    offset2 = j + k * matSize;
+                    assert(offset1 < max_offset);
+                    assert(offset2 < max_offset);
+                    tempcol[i] += cin[offset1] * cout[offset2];
+                }
+            }
+            for (i = 0; i < matSize; i++) {
+                offset1 = j + i * matSize;
+                assert(offset1 < max_offset);
+                cout[offset1] = tempcol[i];
+            }
+        }
+        cin += matsize2;
+        cout += matsize2;
     }
 }
 
@@ -73,55 +73,53 @@ void uop( const void *cinPtr, void *coutPtr, int count, const MPI::Datatype &dty
    is the the matrix representing the permutation that shifts left by one.
    As the final matrix (in the size-1 position), we use the matrix that
    shifts RIGHT by one
-*/   
-static void initMat( MPI::Intracomm comm, int mat[] )
+*/
+static void initMat(MPI::Intracomm comm, int mat[])
 {
     int i, j, size, rank;
     int offset;
-    
+
     rank = comm.Get_rank();
     size = comm.Get_size();
 
-    for (i=0; i<size*size; i++) {
-	assert(i < max_offset);
-	mat[i] = 0;
+    for (i = 0; i < size * size; i++) {
+        assert(i < max_offset);
+        mat[i] = 0;
     }
 
-    if (rank < size-1) {
-	/* Create the permutation matrix that exchanges r with r+1 */
-	for (i=0; i<size; i++) {
-	    if (i == rank) {
-		offset = ((i+1)%size) + i * size;
-		assert(offset < max_offset);
-		mat[offset] = 1;
-	    }
-	    else if (i == ((rank + 1)%size)) {
-		offset = ((i+size-1)%size) + i * size;
-		assert(offset < max_offset);
-		mat[offset] = 1;
-	    }
-	    else {
-		offset = i+i*size;
-		assert(offset < max_offset);
-		mat[offset] = 1;
-	    }
-	}
-    }
-    else {
-	/* Create the permutation matrix that shifts right by one */
-	for (i=0; i<size; i++) {
-	    for (j=0; j<size; j++) {
-		offset = j + i * size;  /* location of c(i,j) */
-		mat[offset] = 0;
-		if ( ((j-i+size)%size) == 1 ) mat[offset] = 1;
-	    }
-	}
-	
+    if (rank < size - 1) {
+        /* Create the permutation matrix that exchanges r with r+1 */
+        for (i = 0; i < size; i++) {
+            if (i == rank) {
+                offset = ((i + 1) % size) + i * size;
+                assert(offset < max_offset);
+                mat[offset] = 1;
+            } else if (i == ((rank + 1) % size)) {
+                offset = ((i + size - 1) % size) + i * size;
+                assert(offset < max_offset);
+                mat[offset] = 1;
+            } else {
+                offset = i + i * size;
+                assert(offset < max_offset);
+                mat[offset] = 1;
+            }
+        }
+    } else {
+        /* Create the permutation matrix that shifts right by one */
+        for (i = 0; i < size; i++) {
+            for (j = 0; j < size; j++) {
+                offset = j + i * size;  /* location of c(i,j) */
+                mat[offset] = 0;
+                if (((j - i + size) % size) == 1)
+                    mat[offset] = 1;
+            }
+        }
+
     }
 }
 
 /* Compare a matrix with the identity matrix */
-static int isIdentity( MPI::Intracomm comm, int mat[] )
+static int isIdentity(MPI::Intracomm comm, int mat[])
 {
     int i, j, size, rank, lerrs = 0;
     int offset;
@@ -129,38 +127,39 @@ static int isIdentity( MPI::Intracomm comm, int mat[] )
     rank = comm.Get_rank();
     size = comm.Get_size();
 
-    for (i=0; i<size; i++) {
-	for (j=0; j<size; j++) {
-	    if (i == j) {
-		offset = j+i*size;
-		assert(offset < max_offset);
-		if (mat[offset] != 1) {
-		    lerrs++;
-		    if (errs + lerrs< 10) {
-			cerr << "[" << rank << "] mat[" << i << "," << j << "] = " << mat[offset] << ", expected 1 for comm " << MTestGetIntracommName() << endl;
-		    }
-		}
-	    }
-	    else {
-		offset = j+i*size;
-		assert(offset < max_offset);
-		if (mat[offset] != 0) {
-		    lerrs++;
-		    if (errs + lerrs< 10) {
-			cerr << "[" << rank << "] mat[" << i << "," << j << "] = " << mat[offset] << ", expected 0 for comm " << MTestGetIntracommName() << endl;
-		    }
-		}
-	    }
-	}
+    for (i = 0; i < size; i++) {
+        for (j = 0; j < size; j++) {
+            if (i == j) {
+                offset = j + i * size;
+                assert(offset < max_offset);
+                if (mat[offset] != 1) {
+                    lerrs++;
+                    if (errs + lerrs < 10) {
+                        cerr << "[" << rank << "] mat[" << i << "," << j << "] = " << mat[offset] <<
+                            ", expected 1 for comm " << MTestGetIntracommName() << endl;
+                    }
+                }
+            } else {
+                offset = j + i * size;
+                assert(offset < max_offset);
+                if (mat[offset] != 0) {
+                    lerrs++;
+                    if (errs + lerrs < 10) {
+                        cerr << "[" << rank << "] mat[" << i << "," << j << "] = " << mat[offset] <<
+                            ", expected 0 for comm " << MTestGetIntracommName() << endl;
+                    }
+                }
+            }
+        }
     }
     return lerrs;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int size;
-    int minsize = 2, count; 
-    MPI::Intracomm      comm;
+    int minsize = 2, count;
+    MPI::Intracomm comm;
     int *buf, *bufout;
     MPI::Op op;
     MPI::Datatype mattype;
@@ -169,48 +168,48 @@ int main( int argc, char *argv[] )
 
     op.Init(uop, false);
 
-    while (MTestGetIntracommGeneral( comm, minsize, 1 )) {
-	if ((MPI::Intracomm)comm == (MPI::Intracomm)MPI_COMM_NULL) {
-	    continue;
-	}
-	size = comm.Get_size();
-	matSize = size;
+    while (MTestGetIntracommGeneral(comm, minsize, 1)) {
+        if ((MPI::Intracomm) comm == (MPI::Intracomm) MPI_COMM_NULL) {
+            continue;
+        }
+        size = comm.Get_size();
+        matSize = size;
 
-	/* Only one matrix for now */
-	count = 1;
+        /* Only one matrix for now */
+        count = 1;
 
-	/* A single matrix, the size of the communicator */
-	mattype = MPI::INT.Create_contiguous( size*size );
-	mattype.Commit();
+        /* A single matrix, the size of the communicator */
+        mattype = MPI::INT.Create_contiguous(size * size);
+        mattype.Commit();
 
-	max_offset = count * size * size;
-	buf = new int[max_offset];
-	if (!buf) {
-	    MPI::COMM_WORLD.Abort( 1 );
-	}
-	bufout = new int[max_offset];
-	if (!bufout) {
-	    MPI::COMM_WORLD.Abort( 1 );
-	}
+        max_offset = count * size * size;
+        buf = new int[max_offset];
+        if (!buf) {
+            MPI::COMM_WORLD.Abort(1);
+        }
+        bufout = new int[max_offset];
+        if (!bufout) {
+            MPI::COMM_WORLD.Abort(1);
+        }
 
-	initMat( comm, buf );
-	comm.Allreduce( buf, bufout, count, mattype, op );
-	errs += isIdentity( comm, bufout );
+        initMat(comm, buf);
+        comm.Allreduce(buf, bufout, count, mattype, op);
+        errs += isIdentity(comm, bufout);
 
-	/* Try the same test, but using MPI_IN_PLACE */
-	initMat( comm, bufout );
-	comm.Allreduce( MPI_IN_PLACE, bufout, count, mattype, op );
-	errs += isIdentity( comm, bufout );
+        /* Try the same test, but using MPI_IN_PLACE */
+        initMat(comm, bufout);
+        comm.Allreduce(MPI_IN_PLACE, bufout, count, mattype, op);
+        errs += isIdentity(comm, bufout);
 
-	delete [] buf;
-	delete [] bufout;
+        delete[]buf;
+        delete[]bufout;
 
-	mattype.Free();
-	MTestFreeComm( comm );
+        mattype.Free();
+        MTestFreeComm(comm);
     }
 
     op.Free();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/uexscan.cxx
+++ b/test/mpi/cxx/coll/uexscan.cxx
@@ -19,66 +19,62 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-void uop( const void *invec, void *inoutvec, int count, 
-	  const MPI::Datatype &datatype )
+void uop(const void *invec, void *inoutvec, int count, const MPI::Datatype & datatype)
 {
     int i;
-    int *cin = (int*)invec, *cout = (int*)inoutvec;
+    int *cin = (int *) invec, *cout = (int *) inoutvec;
 
-    for (i=0; i<count; i++) {
-	cout[i] = cin[i] + cout[i];
+    for (i = 0; i < count; i++) {
+        cout[i] = cin[i] + cout[i];
     }
 }
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Op sumop;
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int i, count, rank;
 
-    MTest_Init( );
+    MTest_Init();
 
-    sumop.Init( uop, true );
+    sumop.Init(uop, true);
     rank = comm.Get_rank();
-    
-    for (count = 1; count < 66000; count = count * 2) {
-	int *vin, *vout;
-	vin  = new int[count];
-	vout = new int[count];
 
-	for (i=0; i<count; i++) {
-	    vin[i]  = i;
-	    vout[i] = -1;
-	}
-	comm.Exscan( vin, vout, count, MPI::INT, sumop );
-	if (rank == 0) {
-	    for (i=0; i<count; i++) {
- 		if (vout[i] != -1) {
-		    errs++;
-		    if (errs < 10) {
-			cerr << "vout[" << i << "] = " << vout[i] << 
-			    endl;
-		    }
-		}
-	    }
-	}
-	else {
-	    for (i=0; i<count; i++) {
-		if (vout[i] != i * (rank)) {
-		    errs++;
-		    if (errs < 10) {
-			cerr << "vout[" << i << "] = " << vout[i] << 
-			    endl;
-		    }
-		}
-	    }
-	}
-	delete[] vin;
-	delete[] vout;
+    for (count = 1; count < 66000; count = count * 2) {
+        int *vin, *vout;
+        vin = new int[count];
+        vout = new int[count];
+
+        for (i = 0; i < count; i++) {
+            vin[i] = i;
+            vout[i] = -1;
+        }
+        comm.Exscan(vin, vout, count, MPI::INT, sumop);
+        if (rank == 0) {
+            for (i = 0; i < count; i++) {
+                if (vout[i] != -1) {
+                    errs++;
+                    if (errs < 10) {
+                        cerr << "vout[" << i << "] = " << vout[i] << endl;
+                    }
+                }
+            }
+        } else {
+            for (i = 0; i < count; i++) {
+                if (vout[i] != i * (rank)) {
+                    errs++;
+                    if (errs < 10) {
+                        cerr << "vout[" << i << "] = " << vout[i] << endl;
+                    }
+                }
+            }
+        }
+        delete[]vin;
+        delete[]vout;
     }
-    
+
     sumop.Free();
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/ureduce.cxx
+++ b/test/mpi/cxx/coll/ureduce.cxx
@@ -19,58 +19,56 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-void uop( const void *invec, void *inoutvec, int count, 
-	  const MPI::Datatype &datatype )
+void uop(const void *invec, void *inoutvec, int count, const MPI::Datatype & datatype)
 {
     int i;
-    int *cin = (int*)invec, *cout = (int*)inoutvec;
+    int *cin = (int *) invec, *cout = (int *) inoutvec;
 
-    for (i=0; i<count; i++) {
-	cout[i] = cin[i] + cout[i];
+    for (i = 0; i < count; i++) {
+        cout[i] = cin[i] + cout[i];
     }
 }
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Op sumop;
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int size, i, count, root, rank;
 
-    MTest_Init( );
+    MTest_Init();
 
-    sumop.Init( uop, true );
+    sumop.Init(uop, true);
     size = comm.Get_size();
     rank = comm.Get_rank();
 
     for (count = 1; count < 66000; count = count * 2) {
-	int *vin, *vout;
-	vin  = new int[count];
-	vout = new int[count];
+        int *vin, *vout;
+        vin = new int[count];
+        vout = new int[count];
 
-	for (root = 0; root < size; root++) {
+        for (root = 0; root < size; root++) {
 
-	    for (i=0; i<count; i++) {
-		vin[i]  = i;
-		vout[i] = -1;
-	    }
-	    comm.Reduce( vin, vout, count, MPI::INT, sumop, root );
-	    if (rank == root) {
-		for (i=0; i<count; i++) {
-		    if (vout[i] != i * size) {
-			errs++;
-			if (errs < 10) 
-			    cerr << "vout[" << i << "] = " << vout[i] << 
-				endl;
-		    }
-		}
-	    }
-	}
-	delete[] vin;
-	delete[] vout;
+            for (i = 0; i < count; i++) {
+                vin[i] = i;
+                vout[i] = -1;
+            }
+            comm.Reduce(vin, vout, count, MPI::INT, sumop, root);
+            if (rank == root) {
+                for (i = 0; i < count; i++) {
+                    if (vout[i] != i * size) {
+                        errs++;
+                        if (errs < 10)
+                            cerr << "vout[" << i << "] = " << vout[i] << endl;
+                    }
+                }
+            }
+        }
+        delete[]vin;
+        delete[]vout;
     }
-    
+
     sumop.Free();
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/coll/ureducelocal.cxx
+++ b/test/mpi/cxx/coll/ureducelocal.cxx
@@ -31,9 +31,9 @@ void uop(const void *invec, void *inoutvec, int count, const MPI::Datatype & dat
 
     for (i = 0; i < count; i++) {
         if (datatype == MPI::INT)
-            ((int *)inoutvec)[i] = ((int *)invec)[i] + ((int *)inoutvec)[i];
+            ((int *) inoutvec)[i] = ((int *) invec)[i] + ((int *) inoutvec)[i];
         else if (datatype == MPI::DOUBLE || datatype == my_datatype)
-            ((double *)inoutvec)[i] = ((double *)invec)[i] + ((double *)inoutvec)[i];
+            ((double *) inoutvec)[i] = ((double *) invec)[i] + ((double *) inoutvec)[i];
         else
             return;
     }
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
         /* A vector of MPI::DOUBLEs */
         dvin = new double[count];
         dvout = new double[count];
-        my_datatype = MPI::DOUBLE.Create_vector(count/2, 1, 2);
+        my_datatype = MPI::DOUBLE.Create_vector(count / 2, 1, 2);
         my_datatype.Commit();
         real_count = count;
         for (root = 0; root < size; root++) {

--- a/test/mpi/cxx/coll/uscan.cxx
+++ b/test/mpi/cxx/coll/uscan.cxx
@@ -21,62 +21,60 @@ using namespace std;
 
 static int RealCount = -1;
 static int uopErrs = 0;
-void uop( const void *invec, void *inoutvec, int count, 
-	  const MPI::Datatype &datatype )
+void uop(const void *invec, void *inoutvec, int count, const MPI::Datatype & datatype)
 {
     int i;
-    int *cin = (int*)invec, *cout = (int*)inoutvec;
+    int *cin = (int *) invec, *cout = (int *) inoutvec;
 
     if (count != RealCount) {
-	uopErrs++;
-	if (uopErrs < 2) {
-	    cerr << "Wrong count, got " << count << " expected " << RealCount 
-		 << endl;
-	}
+        uopErrs++;
+        if (uopErrs < 2) {
+            cerr << "Wrong count, got " << count << " expected " << RealCount << endl;
+        }
     }
-    for (i=0; i<count; i++) {
-	cout[i] = cin[i] + cout[i];
+    for (i = 0; i < count; i++) {
+        cout[i] = cin[i] + cout[i];
     }
 }
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Op sumop;
     MPI::Intracomm comm = MPI::COMM_WORLD;
     int errs = 0;
     int size, i, count, rank;
 
-    MTest_Init( );
+    MTest_Init();
 
-    sumop.Init( uop, true );
+    sumop.Init(uop, true);
     size = comm.Get_size();
     rank = comm.Get_rank();
 
     for (count = 1; count < 66000; count = count * 2) {
-	int *vin, *vout;
-	vin  = new int[count];
-	vout = new int[count];
+        int *vin, *vout;
+        vin = new int[count];
+        vout = new int[count];
 
-	for (i=0; i<count; i++) {
-	    vin[i]  = i;
-	    vout[i] = -1;
-	}
-	RealCount = count;
-	comm.Scan( vin, vout, count, MPI::INT, sumop );
-	for (i=0; i<count; i++) {
-	    if (vout[i] != i * (rank+1)) {
-		errs++;
-		if (errs < 10) 
-		    cerr << "vout[" << i << "] = " << vout[i] << 
-			" expected " << i * (rank + 1) << endl;
-	    }
-	}
-	
-	delete[] vin;
-	delete[] vout;
+        for (i = 0; i < count; i++) {
+            vin[i] = i;
+            vout[i] = -1;
+        }
+        RealCount = count;
+        comm.Scan(vin, vout, count, MPI::INT, sumop);
+        for (i = 0; i < count; i++) {
+            if (vout[i] != i * (rank + 1)) {
+                errs++;
+                if (errs < 10)
+                    cerr << "vout[" << i << "] = " << vout[i] <<
+                        " expected " << i * (rank + 1) << endl;
+            }
+        }
+
+        delete[]vin;
+        delete[]vout;
     }
-    
+
     sumop.Free();
-    MTest_Finalize( errs + uopErrs );
+    MTest_Finalize(errs + uopErrs);
     return 0;
 }

--- a/test/mpi/cxx/comm/commname2.cxx
+++ b/test/mpi/cxx/comm/commname2.cxx
@@ -21,62 +21,60 @@ using namespace std;
 #include <stdio.h>
 #include "mpitestcxx.h"
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     int errs = 0;
     char name[MPI_MAX_OBJECT_NAME], tname[MPI_MAX_OBJECT_NAME];
-    int  rlen;
-    int  i, n;
-    MPI::Comm *(comm[10]);
-    
-    MTest_Init( );
+    int rlen;
+    int i, n;
+    MPI::Comm * (comm[10]);
+
+    MTest_Init();
 
     // Test predefined names
-    MPI::COMM_WORLD.Get_name( name, rlen );
-    if (strcmp( name, "MPI_COMM_WORLD" ) != 0) {
-	errs ++;
-	cout << "Name of COMM_WORLD was " << name << "\n";
+    MPI::COMM_WORLD.Get_name(name, rlen);
+    if (strcmp(name, "MPI_COMM_WORLD") != 0) {
+        errs++;
+        cout << "Name of COMM_WORLD was " << name << "\n";
     }
     if (rlen != strlen(name)) {
-	errs++;
-	cout << "Resultlen for COMM_WORLD is incorrect: " << rlen << "\n";
+        errs++;
+        cout << "Resultlen for COMM_WORLD is incorrect: " << rlen << "\n";
     }
 
-    MPI::COMM_SELF.Get_name( name, rlen );
-    if (strcmp( name, "MPI_COMM_SELF" ) != 0) {
-	errs ++;
-	cout << "Name of COMM_SELF was " << name << "\n";
+    MPI::COMM_SELF.Get_name(name, rlen);
+    if (strcmp(name, "MPI_COMM_SELF") != 0) {
+        errs++;
+        cout << "Name of COMM_SELF was " << name << "\n";
     }
     if (rlen != strlen(name)) {
-	errs++;
-	cout << "Resultlen for COMM_SELF is incorrect: " << rlen << "\n";
+        errs++;
+        cout << "Resultlen for COMM_SELF is incorrect: " << rlen << "\n";
     }
-
     // Reset name of comm_world
-    MPI::COMM_WORLD.Set_name( "FooBar !" );
-    MPI::COMM_WORLD.Get_name( name, rlen );
-    if (strcmp( name, "FooBar !" ) != 0) {
-	errs ++;
-	cout << "Changed name of COMM_WORLD was " << name << "\n";
+    MPI::COMM_WORLD.Set_name("FooBar !");
+    MPI::COMM_WORLD.Get_name(name, rlen);
+    if (strcmp(name, "FooBar !") != 0) {
+        errs++;
+        cout << "Changed name of COMM_WORLD was " << name << "\n";
     }
-
     // Test a few other communicators
     n = 0;
-    while (MTestGetComm( &comm[n], 1 ) && n < 4) {
-	sprintf( name, "test%d", n );
-	comm[n]->Set_name( name );
-	n++;
+    while (MTestGetComm(&comm[n], 1) && n < 4) {
+        sprintf(name, "test%d", n);
+        comm[n]->Set_name(name);
+        n++;
     }
-    for (i=0; i<n; i++) {
-	sprintf( tname, "test%d", i );
-	comm[i]->Get_name( name, rlen );
-	if (strcmp( name, tname ) != 0) {
-	    errs++;
-	    cout << "comm[" << i << "] gave name " << name << "\n";
-	}
-        MTestFreeComm ( *comm[i] );
+    for (i = 0; i < n; i++) {
+        sprintf(tname, "test%d", i);
+        comm[i]->Get_name(name, rlen);
+        if (strcmp(name, tname) != 0) {
+            errs++;
+            cout << "comm[" << i << "] gave name " << name << "\n";
+        }
+        MTestFreeComm(*comm[i]);
     }
-    
-    MTest_Finalize( errs );
+
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/datatype/packsizex.cxx
+++ b/test/mpi/cxx/datatype/packsizex.cxx
@@ -19,10 +19,10 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
-    MPI::Datatype  type;
+    MPI::Datatype type;
     MPI::Intracomm comm;
     MTestDatatype mstype, mrtype;
     char dtypename[MPI_MAX_OBJECT_NAME];
@@ -31,56 +31,53 @@ int main( int argc, char *argv[] )
     MTest_Init();
 
     comm = MPI::COMM_WORLD;
-    while (MTestGetDatatypes( &mstype, &mrtype, 1 )) {
-	type = mstype.datatype;
+    while (MTestGetDatatypes(&mstype, &mrtype, 1)) {
+        type = mstype.datatype;
 
-	// Testing the pack size is tricky, since this is the 
-	// size that is stored when packed with type.Pack, and
-	// is not easily defined.  We look for consistency
-	size1 = type.Pack_size( 1, comm );
-	size2 = type.Pack_size( 2, comm );
-	if (size1 <= 0 || size2 <= 0) {
-	    errs++;
-	    type.Get_name( dtypename, tnlen );
-	    cout << "Pack size of datatype " << dtypename << 
-		" is not positive\n";
-	}
-	if (size1 >= size2) {
-	    errs++;
-	    type.Get_name( dtypename, tnlen );
-	    cout << "Pack size of 2 of " << dtypename << 
-		" is smaller or the same as the pack size of 1 instance\n";
-	}
+        // Testing the pack size is tricky, since this is the
+        // size that is stored when packed with type.Pack, and
+        // is not easily defined.  We look for consistency
+        size1 = type.Pack_size(1, comm);
+        size2 = type.Pack_size(2, comm);
+        if (size1 <= 0 || size2 <= 0) {
+            errs++;
+            type.Get_name(dtypename, tnlen);
+            cout << "Pack size of datatype " << dtypename << " is not positive\n";
+        }
+        if (size1 >= size2) {
+            errs++;
+            type.Get_name(dtypename, tnlen);
+            cout << "Pack size of 2 of " << dtypename <<
+                " is smaller or the same as the pack size of 1 instance\n";
+        }
 
-	if (mrtype.datatype != mstype.datatype) {
-	    type = mrtype.datatype;
+        if (mrtype.datatype != mstype.datatype) {
+            type = mrtype.datatype;
 
-	    // Testing the pack size is tricky, since this is the 
-	    // size that is stored when packed with type.Pack, and
-	    // is not easily defined.  We look for consistency
-	    size1 = type.Pack_size( 1, comm );
-	    size2 = type.Pack_size( 2, comm );
-	    if (size1 <= 0 || size2 <= 0) {
-		errs++;
-		type.Get_name( dtypename, tnlen );
-		cout << "Pack size of datatype " << dtypename << 
-		    " is not positive\n";
-	    }
-	    if (size1 >= size2) {
-		errs++;
-		type.Get_name( dtypename, tnlen );
-		cout << "Pack size of 2 of " << dtypename << 
-		    " is smaller or the same as the pack size of 1 instance\n";
-	    }
-	}
+            // Testing the pack size is tricky, since this is the
+            // size that is stored when packed with type.Pack, and
+            // is not easily defined.  We look for consistency
+            size1 = type.Pack_size(1, comm);
+            size2 = type.Pack_size(2, comm);
+            if (size1 <= 0 || size2 <= 0) {
+                errs++;
+                type.Get_name(dtypename, tnlen);
+                cout << "Pack size of datatype " << dtypename << " is not positive\n";
+            }
+            if (size1 >= size2) {
+                errs++;
+                type.Get_name(dtypename, tnlen);
+                cout << "Pack size of 2 of " << dtypename <<
+                    " is smaller or the same as the pack size of 1 instance\n";
+            }
+        }
 
         MTestFreeDatatype(&mrtype);
-	MTestFreeDatatype(&mstype);
+        MTestFreeDatatype(&mstype);
     }
 
-    MTest_Finalize( errs );
-    
+    MTest_Finalize(errs);
+
 
     return 0;
 }
-

--- a/test/mpi/cxx/datatype/typecntsx.cxx
+++ b/test/mpi/cxx/datatype/typecntsx.cxx
@@ -19,29 +19,29 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-void Explore( MPI::Datatype, int, int & );
+void Explore(MPI::Datatype, int, int &);
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Datatype ntype1, ntype2;
 
     MTest_Init();
 
-    Explore( MPI::INT, MPI::COMBINER_NAMED, errs );
-    Explore( MPI::BYTE, MPI::COMBINER_NAMED, errs );
-    
-    ntype1 = MPI::DOUBLE.Create_vector( 10, 1, 30 );
+    Explore(MPI::INT, MPI::COMBINER_NAMED, errs);
+    Explore(MPI::BYTE, MPI::COMBINER_NAMED, errs);
+
+    ntype1 = MPI::DOUBLE.Create_vector(10, 1, 30);
     ntype2 = ntype1.Dup();
 
-    Explore( ntype1, MPI::COMBINER_VECTOR, errs );
-    Explore( ntype2, MPI::COMBINER_DUP, errs );
+    Explore(ntype1, MPI::COMBINER_VECTOR, errs);
+    Explore(ntype2, MPI::COMBINER_DUP, errs);
 
     ntype2.Free();
     ntype1.Free();
 
-    MTest_Finalize( errs );
-    
+    MTest_Finalize(errs);
+
 
     return 0;
 }
@@ -49,49 +49,45 @@ int main( int argc, char *argv[] )
 #define MAX_NINTS 10
 #define MAX_DTYPES 10
 #define MAX_ASIZEV 10
-void Explore( MPI::Datatype dtype, int mycomb, int &errs )
+void Explore(MPI::Datatype dtype, int mycomb, int &errs)
 {
     int nints, nadds, ntype, combiner;
     int intv[MAX_NINTS];
     MPI::Aint aintv[MAX_ASIZEV];
     MPI::Datatype dtypesv[MAX_DTYPES];
 
-    dtype.Get_envelope( nints, nadds, ntype, combiner );
-    
+    dtype.Get_envelope(nints, nadds, ntype, combiner);
+
     if (combiner != MPI::COMBINER_NAMED) {
-	dtype.Get_contents( MAX_NINTS, MAX_ASIZEV, MAX_DTYPES,
-			    intv, aintv, dtypesv );
+        dtype.Get_contents(MAX_NINTS, MAX_ASIZEV, MAX_DTYPES, intv, aintv, dtypesv);
 
-	if (combiner != mycomb) {
-	    errs++;
-	    cout << "Expected combiner " << mycomb << " but got " <<
-		combiner << "\n";
-	}
-
-	// List all combiner types to check that they are defined in mpif.h
-	if (combiner == MPI::COMBINER_NAMED) { ; }
-	else if (combiner == MPI::COMBINER_DUP) { 
-            dtypesv[0].Free(); 
+        if (combiner != mycomb) {
+            errs++;
+            cout << "Expected combiner " << mycomb << " but got " << combiner << "\n";
         }
-	else if (combiner == MPI::COMBINER_CONTIGUOUS) { ; }
-	else if (combiner == MPI::COMBINER_VECTOR) { ; }
-	else if (combiner == MPI::COMBINER_HVECTOR_INTEGER) { ; }
-	else if (combiner == MPI::COMBINER_HVECTOR) { ; }
-	else if (combiner == MPI::COMBINER_INDEXED) { ; }
-	else if (combiner == MPI::COMBINER_HINDEXED_INTEGER) { ; }
-	else if (combiner == MPI::COMBINER_HINDEXED) { ; }
-	else if (combiner == MPI::COMBINER_INDEXED_BLOCK) { ; }
-	else if (combiner == MPI::COMBINER_STRUCT_INTEGER) { ; }
-	else if (combiner == MPI::COMBINER_STRUCT) { ; }
-	else if (combiner == MPI::COMBINER_SUBARRAY) { ; }
-	else if (combiner == MPI::COMBINER_DARRAY) { ; }
-	else if (combiner == MPI::COMBINER_F90_REAL) { ; }
-	else if (combiner == MPI::COMBINER_F90_COMPLEX) { ; }
-	else if (combiner == MPI::COMBINER_F90_INTEGER) { ; }
-	else if (combiner == MPI::COMBINER_RESIZED) { ; }
-	else {
-	   errs++;
-	   cout << "Unknown combiner " << combiner << "\n";
-	}
+        // List all combiner types to check that they are defined in mpif.h
+        if (combiner == MPI::COMBINER_NAMED) {;
+        } else if (combiner == MPI::COMBINER_DUP) {
+            dtypesv[0].Free();
+        } else if (combiner == MPI::COMBINER_CONTIGUOUS) {;
+        } else if (combiner == MPI::COMBINER_VECTOR) {;
+        } else if (combiner == MPI::COMBINER_HVECTOR_INTEGER) {;
+        } else if (combiner == MPI::COMBINER_HVECTOR) {;
+        } else if (combiner == MPI::COMBINER_INDEXED) {;
+        } else if (combiner == MPI::COMBINER_HINDEXED_INTEGER) {;
+        } else if (combiner == MPI::COMBINER_HINDEXED) {;
+        } else if (combiner == MPI::COMBINER_INDEXED_BLOCK) {;
+        } else if (combiner == MPI::COMBINER_STRUCT_INTEGER) {;
+        } else if (combiner == MPI::COMBINER_STRUCT) {;
+        } else if (combiner == MPI::COMBINER_SUBARRAY) {;
+        } else if (combiner == MPI::COMBINER_DARRAY) {;
+        } else if (combiner == MPI::COMBINER_F90_REAL) {;
+        } else if (combiner == MPI::COMBINER_F90_COMPLEX) {;
+        } else if (combiner == MPI::COMBINER_F90_INTEGER) {;
+        } else if (combiner == MPI::COMBINER_RESIZED) {;
+        } else {
+            errs++;
+            cout << "Unknown combiner " << combiner << "\n";
+        }
     }
 }

--- a/test/mpi/cxx/datatype/typemiscx.cxx
+++ b/test/mpi/cxx/datatype/typemiscx.cxx
@@ -23,7 +23,7 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int num_ints, num_adds, num_types, combiner, errs = 0;
 
@@ -33,135 +33,135 @@ int main( int argc, char *argv[] )
 #ifdef HAVE_FORTRAN_BINDING
     /* First, the optional types.  We allow these to be DATATYPE_NULL */
     if (MPI::REAL4 != MPI::DATATYPE_NULL) {
-	MPI::REAL4.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "REAL4 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::REAL4.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "REAL4 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::REAL8 != MPI::DATATYPE_NULL) {
-	MPI::REAL8.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "REAL8 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::REAL8.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "REAL8 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::REAL16 != MPI::DATATYPE_NULL) {
-	MPI::REAL16.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "REAL16 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::REAL16.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "REAL16 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::COMPLEX8 != MPI::DATATYPE_NULL) {
-	MPI::COMPLEX8.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "COMPLEX8 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::COMPLEX8.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "COMPLEX8 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::COMPLEX16 != MPI::DATATYPE_NULL) {
-	MPI::COMPLEX16.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "COMPLEX16 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::COMPLEX16.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "COMPLEX16 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::COMPLEX32 != MPI::DATATYPE_NULL) {
-	MPI::COMPLEX32.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "COMPLEX32 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::COMPLEX32.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "COMPLEX32 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::INTEGER1 != MPI::DATATYPE_NULL) {
-	MPI::INTEGER1.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "INTEGER1 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::INTEGER1.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "INTEGER1 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::INTEGER2 != MPI::DATATYPE_NULL) {
-	MPI::INTEGER2.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "INTEGER2 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::INTEGER2.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "INTEGER2 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::INTEGER4 != MPI::DATATYPE_NULL) {
-	MPI::INTEGER4.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "INTEGER4 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::INTEGER4.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "INTEGER4 not a NAMED type" << "\n";
+            errs++;
+        }
     }
     if (MPI::INTEGER8 != MPI::DATATYPE_NULL) {
-	MPI::INTEGER8.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "INTEGER8 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::INTEGER8.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "INTEGER8 not a NAMED type" << "\n";
+            errs++;
+        }
     }
 #ifdef HAVE_MPI_INTEGER16
     if (MPI::INTEGER16 != MPI::DATATYPE_NULL) {
-	MPI::INTEGER16.Get_envelope( num_ints, num_adds, num_types, combiner );
-	if (combiner != MPI::COMBINER_NAMED) {
-	    cout << "INTEGER16 not a NAMED type" << "\n";
-	    errs++;
-	}
+        MPI::INTEGER16.Get_envelope(num_ints, num_adds, num_types, combiner);
+        if (combiner != MPI::COMBINER_NAMED) {
+            cout << "INTEGER16 not a NAMED type" << "\n";
+            errs++;
+        }
     }
 #endif
     /* Here end the optional types */
 
-    MPI::INTEGER.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::INTEGER.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "INTEGER not a NAMED type" << "\n";
-	errs++;
+        cout << "INTEGER not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::REAL.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::REAL.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "REAL not a NAMED type" << "\n";
-	errs++;
+        cout << "REAL not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::DOUBLE_PRECISION.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::DOUBLE_PRECISION.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "DOUBLE_PRECISION not a NAMED type" << "\n";
-	errs++;
+        cout << "DOUBLE_PRECISION not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::F_COMPLEX.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::F_COMPLEX.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "F_COMPLEX not a NAMED type" << "\n";
-	errs++;
+        cout << "F_COMPLEX not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::F_DOUBLE_COMPLEX.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::F_DOUBLE_COMPLEX.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "F_DOUBLE_COMPLEX not a NAMED type" << "\n";
-	errs++;
+        cout << "F_DOUBLE_COMPLEX not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::LOGICAL.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::LOGICAL.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "LOGICAL not a NAMED type" << "\n";
-	errs++;
+        cout << "LOGICAL not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::CHARACTER.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::CHARACTER.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "CHARACTER not a NAMED type" << "\n";
-	errs++;
+        cout << "CHARACTER not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::TWOREAL.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::TWOREAL.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "TWOREAL not a NAMED type" << "\n";
-	errs++;
+        cout << "TWOREAL not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::TWODOUBLE_PRECISION.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::TWODOUBLE_PRECISION.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "TWODOUBLE_PRECISION not a NAMED type" << "\n";
-	errs++;
+        cout << "TWODOUBLE_PRECISION not a NAMED type" << "\n";
+        errs++;
     }
-    MPI::TWOINTEGER.Get_envelope( num_ints, num_adds, num_types, combiner );
+    MPI::TWOINTEGER.Get_envelope(num_ints, num_adds, num_types, combiner);
     if (combiner != MPI::COMBINER_NAMED) {
-	cout << "TWOINTEGER not a NAMED type" << "\n";
-	errs++;
+        cout << "TWOINTEGER not a NAMED type" << "\n";
+        errs++;
     }
 #endif
 

--- a/test/mpi/cxx/datatype/typenamex.cxx
+++ b/test/mpi/cxx/datatype/typenamex.cxx
@@ -24,14 +24,16 @@ using namespace std;
 
 /* Create an array with all of the MPI names in it */
 
-typedef struct mpi_names_t { 
-    MPI::Datatype dtype; const char *name; } mpi_names_t;
+typedef struct mpi_names_t {
+    MPI::Datatype dtype;
+    const char *name;
+} mpi_names_t;
 
 
 static mpi_names_t *mpi_names = 0;
-void InitMPINames (void);
+void InitMPINames(void);
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     char *name;
     int namelen, i;
@@ -46,45 +48,45 @@ int main( int argc, char **argv )
 
     /* Sample some datatypes */
     /* See 8.4, "Naming Objects" in MPI-2.  The default name is the same
-       as the datatype name */
+     * as the datatype name */
 
-    MPI::DOUBLE.Get_name( name, namelen );
-    if (strncmp( name, "MPI_DOUBLE", MPI::MAX_OBJECT_NAME )) {
-	errs++;
-	cout << "Expected MPI_DOUBLE but got :" << name << ":\n";
+    MPI::DOUBLE.Get_name(name, namelen);
+    if (strncmp(name, "MPI_DOUBLE", MPI::MAX_OBJECT_NAME)) {
+        errs++;
+        cout << "Expected MPI_DOUBLE but got :" << name << ":\n";
     }
 
-    MPI::INT.Get_name( name, namelen );
-    if (strncmp( name, "MPI_INT", MPI::MAX_OBJECT_NAME )) {
-	errs++;
-	cout << "Expected MPI_INT but got :" << name << ":\n";
+    MPI::INT.Get_name(name, namelen);
+    if (strncmp(name, "MPI_INT", MPI::MAX_OBJECT_NAME)) {
+        errs++;
+        cout << "Expected MPI_INT but got :" << name << ":\n";
     }
 
     /* Now we try them ALL */
-    for (i=0; mpi_names[i].name != 0; i++) {
-	/* The size-specific types, as well as the language optional
-	   long long and long double, may be DATATYPE_NULL */
-	if (mpi_names[i].dtype == MPI::DATATYPE_NULL) continue;
-	name[0] = 0;
-	mpi_names[i].dtype.Get_name( name, namelen );
-	if (strncmp( name, mpi_names[i].name, namelen )) {
-	    errs++;
-	    cout << "Expected " << mpi_names[i].name << " but got " <<
-		name << "\n";
-	}
+    for (i = 0; mpi_names[i].name != 0; i++) {
+        /* The size-specific types, as well as the language optional
+         * long long and long double, may be DATATYPE_NULL */
+        if (mpi_names[i].dtype == MPI::DATATYPE_NULL)
+            continue;
+        name[0] = 0;
+        mpi_names[i].dtype.Get_name(name, namelen);
+        if (strncmp(name, mpi_names[i].name, namelen)) {
+            errs++;
+            cout << "Expected " << mpi_names[i].name << " but got " << name << "\n";
+        }
     }
 
     /* Try resetting the name */
-    MPI::INT.Set_name( "int" );
+    MPI::INT.Set_name("int");
     name[0] = 0;
-    MPI::INT.Get_name( name, namelen );
-    if (strncmp( name, "int", MPI::MAX_OBJECT_NAME )) {
-	errs++;
-	cout << "Expected int but got :" << name << ":\n";
+    MPI::INT.Get_name(name, namelen);
+    if (strncmp(name, "int", MPI::MAX_OBJECT_NAME)) {
+        errs++;
+        cout << "Expected int but got :" << name << ":\n";
     }
 
-    delete [] name;
-    delete [] mpi_names;
+    delete[]name;
+    delete[]mpi_names;
 
     MTest_Finalize(errs);
     return 0;
@@ -96,73 +98,74 @@ int main( int argc, char **argv )
 /* The MPI standard specifies that the names must be the MPI names,
    not the related language names (e.g., MPI_CHAR, not char).
 */
-void InitMPINames (void) {
+void InitMPINames(void)
+{
     int i;
     mpi_names_t lmpi_names[] = {
-	{ MPI::CHAR, "MPI_CHAR" },
-	{ MPI::SIGNED_CHAR, "MPI_SIGNED_CHAR" },
-	{ MPI::UNSIGNED_CHAR, "MPI_UNSIGNED_CHAR" },
-	{ MPI::BYTE, "MPI_BYTE" },
-	{ MPI::WCHAR, "MPI_WCHAR" },
-	{ MPI::SHORT, "MPI_SHORT" },
-	{ MPI::UNSIGNED_SHORT, "MPI_UNSIGNED_SHORT" },
-	{ MPI::INT, "MPI_INT" },
-	{ MPI::UNSIGNED, "MPI_UNSIGNED" },
-	{ MPI::LONG, "MPI_LONG" },
-	{ MPI::UNSIGNED_LONG, "MPI_UNSIGNED_LONG" },
-	{ MPI::FLOAT, "MPI_FLOAT" },
-	{ MPI::DOUBLE, "MPI_DOUBLE" },
-	{ MPI::LONG_DOUBLE, "MPI_LONG_DOUBLE" },
-	/*    { MPI::LONG_LONG_INT, "MPI_LONG_LONG_INT" }, */
-	{ MPI::LONG_LONG, "MPI_LONG_LONG" },
-	{ MPI::UNSIGNED_LONG_LONG, "MPI_UNSIGNED_LONG_LONG" }, 
-	{ MPI::PACKED, "MPI_PACKED" },
-	{ MPI::LB, "MPI_LB" },
-	{ MPI::UB, "MPI_UB" },
-	{ MPI::FLOAT_INT, "MPI_FLOAT_INT" },
-	{ MPI::DOUBLE_INT, "MPI_DOUBLE_INT" },
-	{ MPI::LONG_INT, "MPI_LONG_INT" },
-	{ MPI::SHORT_INT, "MPI_SHORT_INT" },
-	{ MPI::TWOINT, "MPI_2INT" },
-	{ MPI::LONG_DOUBLE_INT, "MPI_LONG_DOUBLE_INT" },
-	/* Fortran */
+        {MPI::CHAR, "MPI_CHAR"},
+        {MPI::SIGNED_CHAR, "MPI_SIGNED_CHAR"},
+        {MPI::UNSIGNED_CHAR, "MPI_UNSIGNED_CHAR"},
+        {MPI::BYTE, "MPI_BYTE"},
+        {MPI::WCHAR, "MPI_WCHAR"},
+        {MPI::SHORT, "MPI_SHORT"},
+        {MPI::UNSIGNED_SHORT, "MPI_UNSIGNED_SHORT"},
+        {MPI::INT, "MPI_INT"},
+        {MPI::UNSIGNED, "MPI_UNSIGNED"},
+        {MPI::LONG, "MPI_LONG"},
+        {MPI::UNSIGNED_LONG, "MPI_UNSIGNED_LONG"},
+        {MPI::FLOAT, "MPI_FLOAT"},
+        {MPI::DOUBLE, "MPI_DOUBLE"},
+        {MPI::LONG_DOUBLE, "MPI_LONG_DOUBLE"},
+        /*    { MPI::LONG_LONG_INT, "MPI_LONG_LONG_INT" }, */
+        {MPI::LONG_LONG, "MPI_LONG_LONG"},
+        {MPI::UNSIGNED_LONG_LONG, "MPI_UNSIGNED_LONG_LONG"},
+        {MPI::PACKED, "MPI_PACKED"},
+        {MPI::LB, "MPI_LB"},
+        {MPI::UB, "MPI_UB"},
+        {MPI::FLOAT_INT, "MPI_FLOAT_INT"},
+        {MPI::DOUBLE_INT, "MPI_DOUBLE_INT"},
+        {MPI::LONG_INT, "MPI_LONG_INT"},
+        {MPI::SHORT_INT, "MPI_SHORT_INT"},
+        {MPI::TWOINT, "MPI_2INT"},
+        {MPI::LONG_DOUBLE_INT, "MPI_LONG_DOUBLE_INT"},
+        /* Fortran */
 #ifdef HAVE_FORTRAN_BINDING
-	{ MPI::F_COMPLEX, "MPI_COMPLEX" },
-	{ MPI::F_DOUBLE_COMPLEX, "MPI_DOUBLE_COMPLEX" },
-	{ MPI::LOGICAL, "MPI_LOGICAL" },
-	{ MPI::REAL, "MPI_REAL" },
-	{ MPI::DOUBLE_PRECISION, "MPI_DOUBLE_PRECISION" },
-	{ MPI::INTEGER, "MPI_INTEGER" },
-	{ MPI::TWOINTEGER, "MPI_2INTEGER" },
-	{ MPI::TWOREAL, "MPI_2REAL" },
-	{ MPI::TWODOUBLE_PRECISION, "MPI_2DOUBLE_PRECISION" },
-	{ MPI::CHARACTER, "MPI_CHARACTER" },
-    /* Size-specific (Fortran) types */
-	{ MPI::REAL4, "MPI_REAL4" },
-	{ MPI::REAL8, "MPI_REAL8" },
-	{ MPI::REAL16, "MPI_REAL16" },
-	{ MPI::COMPLEX8, "MPI_COMPLEX8" },
-	{ MPI::COMPLEX16, "MPI_COMPLEX16" },
-	{ MPI::COMPLEX32, "MPI_COMPLEX32" },
-	{ MPI::INTEGER1, "MPI_INTEGER1" },
-	{ MPI::INTEGER2, "MPI_INTEGER2" },
-	{ MPI::INTEGER4, "MPI_INTEGER4" },
-	{ MPI::INTEGER8, "MPI_INTEGER8" },
-	{ MPI::INTEGER16, "MPI_INTEGER16" },
+        {MPI::F_COMPLEX, "MPI_COMPLEX"},
+        {MPI::F_DOUBLE_COMPLEX, "MPI_DOUBLE_COMPLEX"},
+        {MPI::LOGICAL, "MPI_LOGICAL"},
+        {MPI::REAL, "MPI_REAL"},
+        {MPI::DOUBLE_PRECISION, "MPI_DOUBLE_PRECISION"},
+        {MPI::INTEGER, "MPI_INTEGER"},
+        {MPI::TWOINTEGER, "MPI_2INTEGER"},
+        {MPI::TWOREAL, "MPI_2REAL"},
+        {MPI::TWODOUBLE_PRECISION, "MPI_2DOUBLE_PRECISION"},
+        {MPI::CHARACTER, "MPI_CHARACTER"},
+        /* Size-specific (Fortran) types */
+        {MPI::REAL4, "MPI_REAL4"},
+        {MPI::REAL8, "MPI_REAL8"},
+        {MPI::REAL16, "MPI_REAL16"},
+        {MPI::COMPLEX8, "MPI_COMPLEX8"},
+        {MPI::COMPLEX16, "MPI_COMPLEX16"},
+        {MPI::COMPLEX32, "MPI_COMPLEX32"},
+        {MPI::INTEGER1, "MPI_INTEGER1"},
+        {MPI::INTEGER2, "MPI_INTEGER2"},
+        {MPI::INTEGER4, "MPI_INTEGER4"},
+        {MPI::INTEGER8, "MPI_INTEGER8"},
+        {MPI::INTEGER16, "MPI_INTEGER16"},
 #endif
-	/* C++ only types */
-	{ MPI::BOOL, "MPI::BOOL" },
-	{ MPI::COMPLEX, "MPI::COMPLEX" },
-	{ MPI::DOUBLE_COMPLEX, "MPI::DOUBLE_COMPLEX" },
-	{ MPI::LONG_DOUBLE_COMPLEX, "MPI::LONG_DOUBLE_COMPLEX" },
-	{ 0, (char *)0 },  /* Sentinal used to indicate the last element */
+        /* C++ only types */
+        {MPI::BOOL, "MPI::BOOL"},
+        {MPI::COMPLEX, "MPI::COMPLEX"},
+        {MPI::DOUBLE_COMPLEX, "MPI::DOUBLE_COMPLEX"},
+        {MPI::LONG_DOUBLE_COMPLEX, "MPI::LONG_DOUBLE_COMPLEX"},
+        {0, (char *) 0},        /* Sentinal used to indicate the last element */
     };
 
-    mpi_names = new mpi_names_t [sizeof(lmpi_names)/sizeof(mpi_names_t)];
+    mpi_names = new mpi_names_t[sizeof(lmpi_names) / sizeof(mpi_names_t)];
     i = 0;
     while (lmpi_names[i].name) {
-	mpi_names[i] = lmpi_names[i];
-	i++;
+        mpi_names[i] = lmpi_names[i];
+        i++;
     }
     mpi_names[i].name = 0;
     mpi_names[i].dtype = 0;

--- a/test/mpi/cxx/errhan/commcallx.cxx
+++ b/test/mpi/cxx/errhan/commcallx.cxx
@@ -28,85 +28,85 @@ static char MTEST_Descrip[] = "Test comm_call_errhandler";
 static int calls = 0;
 static int errs = 0;
 static MPI::Intracomm mycomm;
-void eh( MPI::Comm &comm, int *err, ... )
+void eh(MPI::Comm & comm, int *err, ...)
 {
     if (*err != MPI_ERR_OTHER) {
-	errs++;
-	cout << "Unexpected error code\n";
+        errs++;
+        cout << "Unexpected error code\n";
     }
     if (comm != mycomm) {
-	char cname[MPI_MAX_OBJECT_NAME];
-	int len;
-	errs++;
-	cout << "Unexpected communicator\n";
-	comm.Get_name( cname, len );
-	cout << "Comm is " << cname << "\n";
-	mycomm.Get_name( cname, len );
-	cout << "mycomm is " << cname << "\n";
+        char cname[MPI_MAX_OBJECT_NAME];
+        int len;
+        errs++;
+        cout << "Unexpected communicator\n";
+        comm.Get_name(cname, len);
+        cout << "Comm is " << cname << "\n";
+        mycomm.Get_name(cname, len);
+        cout << "mycomm is " << cname << "\n";
     }
     calls++;
     return;
 }
-int main( int argc, char *argv[] )
-{
-    MPI::Intracomm  comm;
-    MPI::Errhandler newerr;
-    int            i;
-    int            reset_handler;
 
-    MTest_Init( );
+int main(int argc, char *argv[])
+{
+    MPI::Intracomm comm;
+    MPI::Errhandler newerr;
+    int i;
+    int reset_handler;
+
+    MTest_Init();
 
     comm = MPI::COMM_WORLD;
     mycomm = comm;
-    mycomm.Set_name( "dup of comm_world" );
+    mycomm.Set_name("dup of comm_world");
 
-    newerr = MPI::Comm::Create_errhandler( eh );
+    newerr = MPI::Comm::Create_errhandler(eh);
 
-    comm.Set_errhandler( newerr );
-    comm.Call_errhandler( MPI_ERR_OTHER );
+    comm.Set_errhandler(newerr);
+    comm.Call_errhandler(MPI_ERR_OTHER);
     newerr.Free();
     if (calls != 1) {
-	errs++;
-	cout << "Error handler not called\n";
+        errs++;
+        cout << "Error handler not called\n";
     }
-
-    // Here we apply the test to many copies of a communicator 
+    // Here we apply the test to many copies of a communicator
     for (reset_handler = 0; reset_handler <= 1; ++reset_handler) {
-        for (i=0; i<1000; i++) {
+        for (i = 0; i < 1000; i++) {
             MPI::Intracomm comm2;
             calls = 0;
-	    comm = MPI::COMM_WORLD.Dup();
+            comm = MPI::COMM_WORLD.Dup();
             mycomm = comm;
-	    mycomm.Set_name( "dup of comm_world" );
-            newerr = MPI::Comm::Create_errhandler( eh );
+            mycomm.Set_name("dup of comm_world");
+            newerr = MPI::Comm::Create_errhandler(eh);
 
-	    comm.Set_errhandler( newerr );
-	    comm.Call_errhandler( MPI_ERR_OTHER );
+            comm.Set_errhandler(newerr);
+            comm.Call_errhandler(MPI_ERR_OTHER);
             if (calls != 1) {
                 errs++;
-		cout << "Error handler not called\n";
+                cout << "Error handler not called\n";
             }
-	    comm2 = comm.Dup();
+            comm2 = comm.Dup();
             calls = 0;
             mycomm = comm2;
-	    mycomm.Set_name( "dup of dup of comm_world" );
-            // comm2 must inherit the error handler from comm 
-	    comm2.Call_errhandler( MPI_ERR_OTHER );
+            mycomm.Set_name("dup of dup of comm_world");
+            // comm2 must inherit the error handler from comm
+            comm2.Call_errhandler(MPI_ERR_OTHER);
             if (calls != 1) {
                 errs++;
-		cout << "Error handler not called\n";
+                cout << "Error handler not called\n";
             }
 
             if (reset_handler) {
-                // extra checking of the reference count handling 
-		comm.Set_errhandler( MPI::ERRORS_THROW_EXCEPTIONS );
+                // extra checking of the reference count handling
+                comm.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
             }
-	    newerr.Free();
-	    comm.Free();
-	    comm2.Free();
+            newerr.Free();
+            comm.Free();
+            comm2.Free();
         }
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/info/infodelx.cxx
+++ b/test/mpi/cxx/info/infodelx.cxx
@@ -23,69 +23,69 @@ using namespace std;
 #endif
 
 #define NKEYS 3
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Info info;
     const char *keys[NKEYS] = { "file", "soft", "host" };
-    const char *values[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7", 
-				  "myhost.myorg.org" };
+    const char *values[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7",
+        "myhost.myorg.org"
+    };
     char *value;
     int i, flag, nkeys;
 
-    MTest_Init( );
+    MTest_Init();
 
-    value = new char [MPI::MAX_INFO_VAL];
+    value = new char[MPI::MAX_INFO_VAL];
 
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    for (i=0; i<NKEYS; i++) {
-	info.Set( keys[i], values[i] );
+     * the predefined keys (e.g., IBM) */
+    for (i = 0; i < NKEYS; i++) {
+        info.Set(keys[i], values[i]);
     }
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) { 
-	flag = info.Get( keys[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " <<  keys[i] << "\n";
-	}
-	if (strcmp( value, values[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys[i] << 
-		", got " << value << " expected " << values[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys[i] << "\n";
+        }
+        if (strcmp(value, values[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys[i] <<
+                ", got " << value << " expected " << values[i] << "\n";
+        }
     }
 
     /* Now, change one value and remove another, then check again */
-    info.Delete( keys[NKEYS-1] );
+    info.Delete(keys[NKEYS - 1]);
     nkeys = info.Get_nkeys();
     if (nkeys != NKEYS - 1) {
-	errs++;
-	cout << "Deleting a key did not change the number of keys\n";
+        errs++;
+        cout << "Deleting a key did not change the number of keys\n";
     }
 
-    values[0] = (char *)"backfile.txt";
-    info.Set( keys[0], values[0] );
-    for (i=0; i<NKEYS-1; i++) {
-	flag = info.Get( keys[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "(after reset) No value for key " << keys[i] << "\n";
-	}
-	if (strcmp( value, values[i] )) {
-	    errs++;
-	    cout << "(after reset) Incorrect value for key " << 
-		keys[i] << ", got " << value << " expected " << values[i] <<
-		"\n";
-	}
+    values[0] = (char *) "backfile.txt";
+    info.Set(keys[0], values[0]);
+    for (i = 0; i < NKEYS - 1; i++) {
+        flag = info.Get(keys[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "(after reset) No value for key " << keys[i] << "\n";
+        }
+        if (strcmp(value, values[i])) {
+            errs++;
+            cout << "(after reset) Incorrect value for key " <<
+                keys[i] << ", got " << value << " expected " << values[i] << "\n";
+        }
     }
 
     info.Free();
-    delete [] value;
+    delete[]value;
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
-    return 0;  
+    return 0;
 }

--- a/test/mpi/cxx/info/infodupx.cxx
+++ b/test/mpi/cxx/info/infodupx.cxx
@@ -22,7 +22,7 @@ using namespace std;
 #include <string.h>
 #endif
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Info info1, infodup;
@@ -30,73 +30,70 @@ int main( int argc, char *argv[] )
     char *key, *keydup;
     char *value, *valdup;
 
-    MTest_Init( );
+    MTest_Init();
 
-    key = new char [MPI::MAX_INFO_KEY];
-    keydup = new char [MPI::MAX_INFO_KEY];
-    value = new char [MPI::MAX_INFO_VAL];
-    valdup = new char [MPI::MAX_INFO_VAL];
+    key = new char[MPI::MAX_INFO_KEY];
+    keydup = new char[MPI::MAX_INFO_KEY];
+    value = new char[MPI::MAX_INFO_VAL];
+    valdup = new char[MPI::MAX_INFO_VAL];
 
-    info1 = MPI::Info::Create( );
+    info1 = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    info1.Set( "host", "myhost.myorg.org" );
-    info1.Set( "file", "runfile.txt" );
-    info1.Set( "soft", "2:1000:4,3:1000:7" );
+     * the predefined keys (e.g., IBM) */
+    info1.Set("host", "myhost.myorg.org");
+    info1.Set("file", "runfile.txt");
+    info1.Set("soft", "2:1000:4,3:1000:7");
 
     infodup = info1.Dup();
 
     nkeysdup = infodup.Get_nkeys();
-    nkeys    = info1.Get_nkeys();
+    nkeys = info1.Get_nkeys();
     if (nkeys != nkeysdup) {
-	errs++;
-	cout << "Dup'ed info has a different number of keys; is " <<
-	    nkeysdup << " should be " << nkeys << "\n";
+        errs++;
+        cout << "Dup'ed info has a different number of keys; is " <<
+            nkeysdup << " should be " << nkeys << "\n";
     }
     vallen = MPI::MAX_INFO_VAL;
-    for (i=0; i<nkeys; i++) {
-	/* MPI requires that the keys are in the same order after the dup */
-	info1.Get_nthkey( i, key );
-	infodup.Get_nthkey( i, keydup );
-	if (strcmp(key, keydup)) {
-	    errs++;
-	    cout << "keys do not match: " << keydup << " should be " <<
-		key << "\n";
-	}
+    for (i = 0; i < nkeys; i++) {
+        /* MPI requires that the keys are in the same order after the dup */
+        info1.Get_nthkey(i, key);
+        infodup.Get_nthkey(i, keydup);
+        if (strcmp(key, keydup)) {
+            errs++;
+            cout << "keys do not match: " << keydup << " should be " << key << "\n";
+        }
 
-	vallen = MPI::MAX_INFO_VAL;
-	flag = info1.Get( key, vallen, value );
-	flagdup = infodup.Get( keydup, vallen, valdup );
-	if (!flag || !flagdup) {
-	    errs++;
-	    cout << "Info get failed for key " << key << "\n";
-	}
-	else if (strcmp( value, valdup )) {
-	    errs++;
-	    cout << "Info values for key " << key << 
-		" not the same after dup\n";
-	}
+        vallen = MPI::MAX_INFO_VAL;
+        flag = info1.Get(key, vallen, value);
+        flagdup = infodup.Get(keydup, vallen, valdup);
+        if (!flag || !flagdup) {
+            errs++;
+            cout << "Info get failed for key " << key << "\n";
+        } else if (strcmp(value, valdup)) {
+            errs++;
+            cout << "Info values for key " << key << " not the same after dup\n";
+        }
     }
 
-    /* Change info and check that infodup does NOT have the new value 
-       (ensure that lazy dups are still duped) */
-    info1.Set( "path", "/a:/b:/c/d" );
+    /* Change info and check that infodup does NOT have the new value
+     * (ensure that lazy dups are still duped) */
+    info1.Set("path", "/a:/b:/c/d");
 
-    flag = infodup.Get( "path", vallen, value );
+    flag = infodup.Get("path", vallen, value);
     if (flag) {
-	errs++;
-	cout << "inserting path into info changed infodup\n";
+        errs++;
+        cout << "inserting path into info changed infodup\n";
     }
-    
+
     info1.Free();
     infodup.Free();
-    
-    MTest_Finalize( errs );
-    delete [] key;
-    delete [] keydup;
-    delete [] value;
-    delete [] valdup;
+
+    MTest_Finalize(errs);
+    delete[]key;
+    delete[]keydup;
+    delete[]value;
+    delete[]valdup;
 
 
-    return 0;  
+    return 0;
 }

--- a/test/mpi/cxx/info/infoorderx.cxx
+++ b/test/mpi/cxx/info/infoorderx.cxx
@@ -23,154 +23,155 @@ using namespace std;
 #endif
 
 #define NKEYS 3
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Info info;
     const char *keys1[NKEYS] = { "file", "soft", "host" };
-    const char *values1[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7", 
-				   "myhost.myorg.org" };
+    const char *values1[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7",
+        "myhost.myorg.org"
+    };
 
     char *value;
     int i, flag;
 
     MTest_Init();
 
-    value = new char [MPI::MAX_INFO_VAL];
+    value = new char[MPI::MAX_INFO_VAL];
 
     /* 1,2,3 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    for (i=0; i<NKEYS; i++) {
-	info.Set( keys1[i], values1[i] );
+     * the predefined keys (e.g., IBM) */
+    for (i = 0; i < NKEYS; i++) {
+        info.Set(keys1[i], values1[i]);
     }
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value  );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
     info.Free();
 
     /* 3,2,1 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    for (i=NKEYS-1; i>=0; i--) {
-	info.Set( keys1[i], values1[i] );
+     * the predefined keys (e.g., IBM) */
+    for (i = NKEYS - 1; i >= 0; i--) {
+        info.Set(keys1[i], values1[i]);
     }
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
     info.Free();
 
     /* 1,3,2 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    info.Set( keys1[0], values1[0] );
-    info.Set( keys1[2], values1[2] );
-    info.Set( keys1[1], values1[1] );
+     * the predefined keys (e.g., IBM) */
+    info.Set(keys1[0], values1[0]);
+    info.Set(keys1[2], values1[2]);
+    info.Set(keys1[1], values1[1]);
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
-    info.Free( );
+    info.Free();
 
     /* 2,1,3 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    info.Set( keys1[1], values1[1] );
-    info.Set( keys1[0], values1[0] );
-    info.Set( keys1[2], values1[2] );
+     * the predefined keys (e.g., IBM) */
+    info.Set(keys1[1], values1[1]);
+    info.Set(keys1[0], values1[0]);
+    info.Set(keys1[2], values1[2]);
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
-    info.Free( );
+    info.Free();
 
     /* 2,3,1 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    info.Set( keys1[1], values1[1] );
-    info.Set( keys1[2], values1[2] );
-    info.Set( keys1[0], values1[0] );
+     * the predefined keys (e.g., IBM) */
+    info.Set(keys1[1], values1[1]);
+    info.Set(keys1[2], values1[2]);
+    info.Set(keys1[0], values1[0]);
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
     info.Free();
-    
+
     /* 3,1,2 */
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    info.Set( keys1[2], values1[2] );
-    info.Set( keys1[0], values1[0] );
-    info.Set( keys1[1], values1[1] );
+     * the predefined keys (e.g., IBM) */
+    info.Set(keys1[2], values1[2]);
+    info.Set(keys1[0], values1[0]);
+    info.Set(keys1[1], values1[1]);
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get( keys1[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys1[i] << "\n";
-	}
-	if (strcmp( value, values1[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys1[i] << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get(keys1[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys1[i] << "\n";
+        }
+        if (strcmp(value, values1[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys1[i] << "\n";
+        }
     }
     info.Free();
-    delete [] value;
-    
-    MTest_Finalize( errs );
-    return 0;  
+    delete[]value;
+
+    MTest_Finalize(errs);
+    return 0;
 }

--- a/test/mpi/cxx/info/infovallenx.cxx
+++ b/test/mpi/cxx/info/infovallenx.cxx
@@ -23,54 +23,54 @@ using namespace std;
 #include "mpitestcxx.h"
 
 #define NKEYS 3
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Info info;
     const char *keys[NKEYS] = { "file", "soft", "host" };
-    const char *values[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7", 
-				  "myhost.myorg.org" };
+    const char *values[NKEYS] = { "runfile.txt", "2:1000:4,3:1000:7",
+        "myhost.myorg.org"
+    };
     char *value;
     int i, flag, vallen;
 
-    MTest_Init( );
+    MTest_Init();
 
-    value = new char [MPI::MAX_INFO_VAL];
+    value = new char[MPI::MAX_INFO_VAL];
 
     info = MPI::Info::Create();
     /* Use only named keys incase the info implementation only supports
-       the predefined keys (e.g., IBM) */
-    for (i=0; i<NKEYS; i++) {
-	info.Set( keys[i], values[i] );
+     * the predefined keys (e.g., IBM) */
+    for (i = 0; i < NKEYS; i++) {
+        info.Set(keys[i], values[i]);
     }
 
     /* Check that all values are present */
-    for (i=0; i<NKEYS; i++) {
-	flag = info.Get_valuelen( keys[i], vallen );
-	if (!flag) {
-	    errs++;
-	    cout << "get_valuelen failed for valid key " << 
-		keys[i] << "\n";
-	}
-	flag = info.Get( keys[i], MPI::MAX_INFO_VAL, value );
-	if (!flag) {
-	    errs++;
-	    cout << "No value for key " << keys[i] << "\n";
-	}
-	if (strcmp( value, values[i] )) {
-	    errs++;
-	    cout << "Incorrect value for key " << keys[i] << "\n";
-	}
-	if (strlen(value) != vallen) {
-	    errs++;
-	    cout << "value_len returned " << vallen << 
-		" but actual len is " << strlen(value) << "\n";
-	}
+    for (i = 0; i < NKEYS; i++) {
+        flag = info.Get_valuelen(keys[i], vallen);
+        if (!flag) {
+            errs++;
+            cout << "get_valuelen failed for valid key " << keys[i] << "\n";
+        }
+        flag = info.Get(keys[i], MPI::MAX_INFO_VAL, value);
+        if (!flag) {
+            errs++;
+            cout << "No value for key " << keys[i] << "\n";
+        }
+        if (strcmp(value, values[i])) {
+            errs++;
+            cout << "Incorrect value for key " << keys[i] << "\n";
+        }
+        if (strlen(value) != vallen) {
+            errs++;
+            cout << "value_len returned " << vallen <<
+                " but actual len is " << strlen(value) << "\n";
+        }
     }
 
     info.Free();
-    delete [] value;
-    
-    MTest_Finalize( errs );
+    delete[]value;
+
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/init/baseenv.cxx
+++ b/test/mpi/cxx/init/baseenv.cxx
@@ -19,7 +19,7 @@ using namespace std;
 #endif
 
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     bool flag;
     int errs = 0;
@@ -27,8 +27,8 @@ int main( int argc, char **argv )
     int rank, size;
 
     if (MPI::Is_initialized()) {
-	cout << "Is_initialized returned true before init\n";
-	errs ++;
+        cout << "Is_initialized returned true before init\n";
+        errs++;
     }
 
     MPI::Init();
@@ -37,37 +37,35 @@ int main( int argc, char **argv )
     size = MPI::COMM_WORLD.Get_size();
 
     if (!MPI::Is_initialized()) {
-	cout << "Is_initialized returned false after init\n";
-	errs ++;
+        cout << "Is_initialized returned false after init\n";
+        errs++;
     }
 
-    MPI::Get_version( ver, subver );
+    MPI::Get_version(ver, subver);
     if (ver != MPI_VERSION || subver != MPI_SUBVERSION) {
-	cout << "Inconsistent values for version and/or subversion\n";
-	errs++;
+        cout << "Inconsistent values for version and/or subversion\n";
+        errs++;
     }
 
     if (MPI::Is_finalized()) {
-	cout << "Is_finalized returned true before finalize\n";
-	errs ++;
+        cout << "Is_finalized returned true before finalize\n";
+        errs++;
     }
 
     MPI::Finalize();
 
     if (!MPI::Is_finalized()) {
-	cout << "Is_finalized returned false after finalize\n";
-	errs ++;
+        cout << "Is_finalized returned false after finalize\n";
+        errs++;
     }
-
     // Ignore the other processes for this test, particularly
     // since we need to execute code after the Finalize
     if (rank == 0) {
-	if (errs) {
-	    cout << " Found " << errs << " errors\n";
-	}
-	else {
-	    cout << " No Errors\n"; 
-	}
+        if (errs) {
+            cout << " Found " << errs << " errors\n";
+        } else {
+            cout << " No Errors\n";
+        }
     }
     return 0;
 }

--- a/test/mpi/cxx/init/initstat2x.cxx
+++ b/test/mpi/cxx/init/initstat2x.cxx
@@ -22,45 +22,44 @@ using namespace std;
 /* Needed for strcmp */
 #include <string.h>
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     bool flag;
     int provided, claimed;
 
     // This test must be invoked with two arguments: myarg1 myarg2
-    provided = MPI::Init_thread( argc, argv, MPI::THREAD_MULTIPLE );
-    
+    provided = MPI::Init_thread(argc, argv, MPI::THREAD_MULTIPLE);
+
     if (argc != 3) {
-	errs++;
-	cout << "Expected argc=3 but saw argc=" << argc << "\n";
-    }
-    else {
-	if (strcmp( argv[1], "myarg1" ) != 0) {
-	    errs++;
-	    cout << "Expected myarg1 for 1st argument but saw " << argv[1] 
-		 << "\n";
-	}
-	if (strcmp( argv[2], "myarg2" ) != 0) {
-	    errs++;
-	    cout << "Expected myarg2 for 1st argument but saw " << argv[2] 
-		 << "\n";
-	}
+        errs++;
+        cout << "Expected argc=3 but saw argc=" << argc << "\n";
+    } else {
+        if (strcmp(argv[1], "myarg1") != 0) {
+            errs++;
+            cout << "Expected myarg1 for 1st argument but saw " << argv[1]
+                << "\n";
+        }
+        if (strcmp(argv[2], "myarg2") != 0) {
+            errs++;
+            cout << "Expected myarg2 for 1st argument but saw " << argv[2]
+                << "\n";
+        }
     }
 
     // Confirm that MPI is properly initialized
     flag = MPI::Is_thread_main();
     if (!flag) {
-	errs++;
-	cout << "This thread call init_thread but Is_thread_main gave false\n";
+        errs++;
+        cout << "This thread call init_thread but Is_thread_main gave false\n";
     }
     claimed = MPI::Query_thread();
     if (claimed != provided) {
-	errs++;
-	cout << "Query thread gave thread level " << claimed << 
-	    " but Init_thread gave " << provided << "\n";
+        errs++;
+        cout << "Query thread gave thread level " << claimed <<
+            " but Init_thread gave " << provided << "\n";
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/init/initstatx.cxx
+++ b/test/mpi/cxx/init/initstatx.cxx
@@ -19,26 +19,26 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     bool flag;
     int provided, claimed;
 
-    provided = MPI::Init_thread( MPI::THREAD_MULTIPLE );
-    
+    provided = MPI::Init_thread(MPI::THREAD_MULTIPLE);
+
     flag = MPI::Is_thread_main();
     if (!flag) {
-	errs++;
-	cout << "This thread call init_thread but Is_thread_main gave false\n";
+        errs++;
+        cout << "This thread call init_thread but Is_thread_main gave false\n";
     }
     claimed = MPI::Query_thread();
     if (claimed != provided) {
-	errs++;
-	cout << "Query thread gave thread level " << claimed << 
-	    " but Init_thread gave " << provided << "\n";
+        errs++;
+        cout << "Query thread gave thread level " << claimed <<
+            " but Init_thread gave " << provided << "\n";
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/io/fileerrx.cxx
+++ b/test/mpi/cxx/io/fileerrx.cxx
@@ -24,9 +24,9 @@ using namespace std;
 #include "mpitestcxx.h"
 
 static int codesSeen[3], callcount;
-void myerrhanfunc( MPI::File &fh, int *errcode, ... );
+void myerrhanfunc(MPI::File & fh, int *errcode, ...);
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     int errs = 0;
     MPI::File fh;
@@ -36,120 +36,113 @@ int main( int argc, char **argv )
     char *errstring;
     int code[2], newerrclass, eclass, rlen;
 
-    MTest_Init( );
+    MTest_Init();
 
-    errstring = new char [MPI::MAX_ERROR_STRING];
+    errstring = new char[MPI::MAX_ERROR_STRING];
 
     callcount = 0;
 
     // Setup some new codes and classes
     newerrclass = MPI::Add_error_class();
-    code[0] = MPI::Add_error_code( newerrclass );
-    code[1] = MPI::Add_error_code( newerrclass );
-    MPI::Add_error_string( newerrclass, "New Class" );
-    MPI::Add_error_string( code[0], "First new code" );
-    MPI::Add_error_string( code[1], "Second new code" );
+    code[0] = MPI::Add_error_code(newerrclass);
+    code[1] = MPI::Add_error_code(newerrclass);
+    MPI::Add_error_string(newerrclass, "New Class");
+    MPI::Add_error_string(code[0], "First new code");
+    MPI::Add_error_string(code[1], "Second new code");
 
-    myerrhan = MPI::File::Create_errhandler( myerrhanfunc );
+    myerrhan = MPI::File::Create_errhandler(myerrhanfunc);
 
     // Create a new communicator so that we can leave the default errors-abort
     // on COMM_WORLD.  Use this comm for file_open, just to leave a little
     // more separation from comm_world
 
     comm = MPI::COMM_WORLD.Dup();
-    fh = MPI::File::Open( comm, "testfile.txt", 
-			 MPI::MODE_RDWR | MPI::MODE_CREATE, 
-			 MPI::INFO_NULL );
+    fh = MPI::File::Open(comm, "testfile.txt", MPI::MODE_RDWR | MPI::MODE_CREATE, MPI::INFO_NULL);
 
-    fh.Set_errhandler( myerrhan );
+    fh.Set_errhandler(myerrhan);
     qerr = fh.Get_errhandler();
     if (qerr != myerrhan) {
-	errs++;
-	cout << " Did not get expected error handler\n";
+        errs++;
+        cout << " Did not get expected error handler\n";
     }
     qerr.Free();
 
     // We can free our error handler now
     myerrhan.Free();
 
-    fh.Call_errhandler( newerrclass );
-    fh.Call_errhandler( code[0] );
-    fh.Call_errhandler( code[1] );
+    fh.Call_errhandler(newerrclass);
+    fh.Call_errhandler(code[0]);
+    fh.Call_errhandler(code[1]);
 
     if (callcount != 3) {
-	errs++;
-	cout << " Expected 3 calls to error handler, found " << callcount <<
-	    "\n";
+        errs++;
+        cout << " Expected 3 calls to error handler, found " << callcount << "\n";
+    } else {
+        if (codesSeen[0] != newerrclass) {
+            errs++;
+            cout << "Expected class " << newerrclass << " got " << codesSeen[0] << "\n";
+        }
+        if (codesSeen[1] != code[0]) {
+            errs++;
+            cout << "(1)Expected code " << code[0] << " got " << codesSeen[1] << "\n";
+        }
+        if (codesSeen[2] != code[1]) {
+            errs++;
+            cout << "(2)Expected code " << code[1] << " got " << codesSeen[2] << "\n";
+        }
     }
-    else {
-	if (codesSeen[0] != newerrclass) {
-	    errs++;
-	    cout << "Expected class " << newerrclass << " got " << 
-		codesSeen[0] << "\n";
-	}
-	if (codesSeen[1] != code[0]) {
-	    errs++;
-	    cout << "(1)Expected code " << code[0] << " got " <<
-		codesSeen[1] << "\n";
-	}
-	if (codesSeen[2] != code[1]) {
-	    errs++;
-	    cout << "(2)Expected code " << code[1] << " got " << 
-		codesSeen[2] << "\n";
-	}
-    }
-    
+
     fh.Close();
     comm.Free();
-    MPI::File::Delete( "testfile.txt", MPI::INFO_NULL );
+    MPI::File::Delete("testfile.txt", MPI::INFO_NULL);
 
     // Check error strings while we're here...
-    MPI::Get_error_string( newerrclass, errstring, rlen );
-    if (strcmp(errstring,"New Class") != 0) {
-	errs++;
-	cout << " Wrong string for error class: " << errstring << "\n";
+    MPI::Get_error_string(newerrclass, errstring, rlen);
+    if (strcmp(errstring, "New Class") != 0) {
+        errs++;
+        cout << " Wrong string for error class: " << errstring << "\n";
     }
-    eclass = MPI::Get_error_class( code[0] );
+    eclass = MPI::Get_error_class(code[0]);
     if (eclass != newerrclass) {
-	errs++;
-	cout << " Class for new code is not correct\n";
+        errs++;
+        cout << " Class for new code is not correct\n";
     }
-    MPI::Get_error_string( code[0], errstring, rlen );
-    if (strcmp( errstring, "First new code") != 0) {
-	errs++;
-	cout << " Wrong string for error code: " << errstring << "\n";
+    MPI::Get_error_string(code[0], errstring, rlen);
+    if (strcmp(errstring, "First new code") != 0) {
+        errs++;
+        cout << " Wrong string for error code: " << errstring << "\n";
     }
-    eclass = MPI::Get_error_class( code[1] );
+    eclass = MPI::Get_error_class(code[1]);
     if (eclass != newerrclass) {
-	errs++;
-	cout << " Class for new code is not correct\n";
+        errs++;
+        cout << " Class for new code is not correct\n";
     }
 
-    MPI::Get_error_string( code[1], errstring, rlen );
-    if (strcmp( errstring, "Second new code") != 0) {
-	errs++;
-	cout << " Wrong string for error code: " << errstring << "\n";
+    MPI::Get_error_string(code[1], errstring, rlen);
+    if (strcmp(errstring, "Second new code") != 0) {
+        errs++;
+        cout << " Wrong string for error code: " << errstring << "\n";
     }
-    
-    delete [] errstring;
 
-    MTest_Finalize( errs );
+    delete[]errstring;
+
+    MTest_Finalize(errs);
     return 0;
 }
 
-void myerrhanfunc( MPI::File &fh, int *errcode, ... )
+void myerrhanfunc(MPI::File & fh, int *errcode, ...)
 {
     char *errstring;
-    int  rlen;
+    int rlen;
 
-    errstring =  new char [MPI::MAX_ERROR_STRING];
+    errstring = new char[MPI::MAX_ERROR_STRING];
 
     callcount++;
 
     // Remember the code we've seen
-    if (callcount <  4) {
-	codesSeen[callcount-1] = *errcode;
+    if (callcount < 4) {
+        codesSeen[callcount - 1] = *errcode;
     }
-    MPI::Get_error_string( *errcode, errstring, rlen );
-    delete [] errstring;
+    MPI::Get_error_string(*errcode, errstring, rlen);
+    delete[]errstring;
 }

--- a/test/mpi/cxx/io/fileinfox.cxx
+++ b/test/mpi/cxx/io/fileinfox.cxx
@@ -22,7 +22,7 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     int errs = 0;
     MPI::File fh;
@@ -32,46 +32,45 @@ int main( int argc, char **argv )
     char *mykey;
     char *myvalue;
 
-    MTest_Init( );
+    MTest_Init();
 
-    mykey = new char [MPI::MAX_INFO_KEY];
-    myvalue = new char [MPI::MAX_INFO_VAL];
+    mykey = new char[MPI::MAX_INFO_KEY];
+    myvalue = new char[MPI::MAX_INFO_VAL];
 
     // Open a simple file
-    strcpy( filename, "iotest.txt" );
-    fh = MPI::File::Open( MPI::COMM_WORLD, filename, MPI::MODE_RDWR |
-			  MPI::MODE_CREATE, MPI::INFO_NULL );
+    strcpy(filename, "iotest.txt");
+    fh = MPI::File::Open(MPI::COMM_WORLD, filename, MPI::MODE_RDWR |
+                         MPI::MODE_CREATE, MPI::INFO_NULL);
 
-    // Try to set one of the available info hints  
+    // Try to set one of the available info hints
     info1 = MPI::Info::Create();
-    info1.Set( "access_style", "read_once,write_once" );
-    fh.Set_info( info1 );
+    info1.Set("access_style", "read_once,write_once");
+    fh.Set_info(info1);
     info1.Free();
-      
+
     info2 = fh.Get_info();
-    flag = info2.Get( "filename", MPI::MAX_INFO_VAL, myvalue );
+    flag = info2.Get("filename", MPI::MAX_INFO_VAL, myvalue);
 
     // An implementation isn't required to provide the filename (though
     // a high-quality implementation should)
     if (flag) {
-	// If we find it, we must have the correct name
-	if (strcmp( myvalue, filename ) != 0 ||
-	    strlen(myvalue) != 10) {
+        // If we find it, we must have the correct name
+        if (strcmp(myvalue, filename) != 0 || strlen(myvalue) != 10) {
             errs++;
             cout << " Returned wrong value for the filename\n";
-	}
+        }
     }
     info2.Free();
 
     fh.Close();
-    
-    MPI::COMM_WORLD.Barrier();
-    if (MPI::COMM_WORLD.Get_rank() == 0) 
-	MPI::File::Delete( filename, MPI::INFO_NULL );
-    
-    delete [] mykey;
-    delete [] myvalue;
 
-    MTest_Finalize( errs );
+    MPI::COMM_WORLD.Barrier();
+    if (MPI::COMM_WORLD.Get_rank() == 0)
+        MPI::File::Delete(filename, MPI::INFO_NULL);
+
+    delete[]mykey;
+    delete[]myvalue;
+
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/io/filemiscx.cxx
+++ b/test/mpi/cxx/io/filemiscx.cxx
@@ -43,242 +43,221 @@ int main(int argc, char **argv)
     MPI::Init();
 
     try {
-    mynod = MPI::COMM_WORLD.Get_rank();
+        mynod = MPI::COMM_WORLD.Get_rank();
 
-    /* process 0 takes the file name as a command-line argument and 
-       broadcasts it to other processes */
-    if (!mynod) {
-	i = 1;
-	while ((i < argc) && strcmp("-fname", *argv)) {
-	    i++;
-	    argv++;
-	}
-	if (i >= argc) {
-	    len = (int)strlen("iotest.txt");
-	    filename = new char [len+1];
-	    strcpy( filename, "iotest.txt" );
-	}
-	else {
-	    argv++;
-	    len = (int)strlen(*argv);
-	    filename = new char [len+1];
-	    strcpy(filename, *argv);
-	}
-	MPI::COMM_WORLD.Bcast(&len, 1, MPI::INT, 0 );
-	MPI::COMM_WORLD.Bcast(filename, len+1, MPI::CHAR, 0 );
-    }
-    else {
-	MPI::COMM_WORLD.Bcast(&len, 1, MPI::INT, 0 );
-	filename = new char [len+1];
-	MPI::COMM_WORLD.Bcast(filename, len+1, MPI::CHAR, 0 );
-    }
+        /* process 0 takes the file name as a command-line argument and
+         * broadcasts it to other processes */
+        if (!mynod) {
+            i = 1;
+            while ((i < argc) && strcmp("-fname", *argv)) {
+                i++;
+                argv++;
+            }
+            if (i >= argc) {
+                len = (int) strlen("iotest.txt");
+                filename = new char[len + 1];
+                strcpy(filename, "iotest.txt");
+            } else {
+                argv++;
+                len = (int) strlen(*argv);
+                filename = new char[len + 1];
+                strcpy(filename, *argv);
+            }
+            MPI::COMM_WORLD.Bcast(&len, 1, MPI::INT, 0);
+            MPI::COMM_WORLD.Bcast(filename, len + 1, MPI::CHAR, 0);
+        } else {
+            MPI::COMM_WORLD.Bcast(&len, 1, MPI::INT, 0);
+            filename = new char[len + 1];
+            MPI::COMM_WORLD.Bcast(filename, len + 1, MPI::CHAR, 0);
+        }
 
 
-    fh = MPI::File::Open(MPI::COMM_WORLD, filename, 
-			 MPI::MODE_CREATE | MPI::MODE_RDWR, MPI::INFO_NULL );
+        fh = MPI::File::Open(MPI::COMM_WORLD, filename,
+                             MPI::MODE_CREATE | MPI::MODE_RDWR, MPI::INFO_NULL);
 
-    fh.Write( buf, 1024, MPI::INT );
+        fh.Write(buf, 1024, MPI::INT);
 
-    fh.Sync();
+        fh.Sync();
 
-    amode = fh.Get_amode();
+        amode = fh.Get_amode();
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_get_amode\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "testing File::_get_amode\n";
+            cout.flush();
+        }
 #endif
-    if (amode != (MPI::MODE_CREATE | MPI::MODE_RDWR)) {
-	errs++;
-	cout << "amode is " << amode << ",  should be " << 
-		(int)(MPI::MODE_CREATE | MPI::MODE_RDWR) << "\n";
-	cout.flush();
-    }
+        if (amode != (MPI::MODE_CREATE | MPI::MODE_RDWR)) {
+            errs++;
+            cout << "amode is " << amode << ",  should be " <<
+                (int) (MPI::MODE_CREATE | MPI::MODE_RDWR) << "\n";
+            cout.flush();
+        }
 
-    flag = fh.Get_atomicity();
-    if (flag) {
-	errs++;
-	cout << "atomicity is " << flag << ", should be false\n";
-	cout.flush();
-    }
+        flag = fh.Get_atomicity();
+        if (flag) {
+            errs++;
+            cout << "atomicity is " << flag << ", should be false\n";
+            cout.flush();
+        }
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "setting atomic mode\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "setting atomic mode\n";
+            cout.flush();
+        }
 #endif
-    try
-    {
-	fh.Set_atomicity( true );
-    }
-    catch (MPI::Exception e)
-    {
-	cout << "Exception thrown in Set_atomicity, Error: " << e.Get_error_string() << endl;
-	cout.flush();
-    }
-    try
-    {
-	flag = fh.Get_atomicity();
-    }
-    catch (MPI::Exception e)
-    {
-	cout << "Exception thrown in Get_atomicity, Error: " << e.Get_error_string() << endl;
-	cout.flush();
-	flag = false;
-    }
-    if (!flag) {
-	errs++;
-	cout << "atomicity is " << flag << ", should be true\n";
-	cout.flush();
-    }
-    fh.Set_atomicity( false );
+        try {
+            fh.Set_atomicity(true);
+        }
+        catch(MPI::Exception e) {
+            cout << "Exception thrown in Set_atomicity, Error: " << e.Get_error_string() << endl;
+            cout.flush();
+        }
+        try {
+            flag = fh.Get_atomicity();
+        }
+        catch(MPI::Exception e) {
+            cout << "Exception thrown in Get_atomicity, Error: " << e.Get_error_string() << endl;
+            cout.flush();
+            flag = false;
+        }
+        if (!flag) {
+            errs++;
+            cout << "atomicity is " << flag << ", should be true\n";
+            cout.flush();
+        }
+        fh.Set_atomicity(false);
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "reverting back to nonatomic mode\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "reverting back to nonatomic mode\n";
+            cout.flush();
+        }
 #endif
 
-    newtype = MPI::INT.Create_vector( 10, 10, 20 );
-    newtype.Commit();
+        newtype = MPI::INT.Create_vector(10, 10, 20);
+        newtype.Commit();
 
-    fh.Set_view( 1000, MPI::INT, newtype, "native", MPI::INFO_NULL);
+        fh.Set_view(1000, MPI::INT, newtype, "native", MPI::INFO_NULL);
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_get_view\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "testing File::_get_view\n";
+            cout.flush();
+        }
 #endif
-    fh.Get_view( disp, etype, filetype, datarep );
-    if ((disp != 1000) || strcmp(datarep, "native")) {
-	errs++;
-	cout << "disp = " << disp << " datarep = " << datarep << 
-", should be 1000, native\n\n";
-	cout.flush();
-    }
+        fh.Get_view(disp, etype, filetype, datarep);
+        if ((disp != 1000) || strcmp(datarep, "native")) {
+            errs++;
+            cout << "disp = " << disp << " datarep = " << datarep << ", should be 1000, native\n\n";
+            cout.flush();
+        }
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_get_byte_offset\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "testing File::_get_byte_offset\n";
+            cout.flush();
+        }
 #endif
-    disp = fh.Get_byte_offset( 10 );
-    if (disp != (1000+20*sizeof(int))) {
-	errs++;
-	cout << "byte offset = " << disp << ", should be " <<
-	    (int) (1000+20*sizeof(int)) << "\n";
-	cout.flush();
-    }
+        disp = fh.Get_byte_offset(10);
+        if (disp != (1000 + 20 * sizeof(int))) {
+            errs++;
+            cout << "byte offset = " << disp << ", should be " <<
+                (int) (1000 + 20 * sizeof(int)) << "\n";
+            cout.flush();
+        }
 
-    group = fh.Get_group();
+        group = fh.Get_group();
 
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_set_size\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "testing File::_set_size\n";
+            cout.flush();
+        }
 #endif
-    fh.Set_size( 1000+15*sizeof(int) );
-    MPI::COMM_WORLD.Barrier();
-    fh.Sync();
-    disp = fh.Get_size();
-    if (disp != 1000+15*sizeof(int)) {
-	errs++;
-	cout << "file size = " << disp << ", should be " <<
-	    (int) (1000+15*sizeof(int)) << "\n";
-	cout.flush();
-    }
+        fh.Set_size(1000 + 15 * sizeof(int));
+        MPI::COMM_WORLD.Barrier();
+        fh.Sync();
+        disp = fh.Get_size();
+        if (disp != 1000 + 15 * sizeof(int)) {
+            errs++;
+            cout << "file size = " << disp << ", should be " <<
+                (int) (1000 + 15 * sizeof(int)) << "\n";
+            cout.flush();
+        }
+#if VERBOSE
+        if (!mynod) {
+            cout << "seeking to eof and testing File::_get_position\n";
+            cout.flush();
+        }
+#endif
+        fh.Seek(0, MPI_SEEK_END);
+        disp = fh.Get_position();
+        if (disp != 10) {
+            errs++;
+            cout << "file pointer posn = " << disp << ", should be 10\n\n";
+            cout.flush();
+        }
+#if VERBOSE
+        if (!mynod) {
+            cout << "testing File::_get_byte_offset\n";
+            cout.flush();
+        }
+#endif
+        offset = fh.Get_byte_offset(disp);
+        if (offset != (1000 + 20 * sizeof(int))) {
+            errs++;
+            cout << "byte offset = " << offset << ", should be " <<
+                (int) (1000 + 20 * sizeof(int)) << "\n";
+            cout.flush();
+        }
+        MPI::COMM_WORLD.Barrier();
 
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "seeking to eof and testing File::_get_position\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "testing File::_seek with MPI_SEEK_CUR\n";
+            cout.flush();
+        }
 #endif
-    fh.Seek( 0, MPI_SEEK_END );
-    disp = fh.Get_position();
-    if (disp != 10) {
-	errs++;
-	cout << "file pointer posn = " << disp << ", should be 10\n\n";
-	cout.flush();
-    }
+        fh.Seek(-10, MPI_SEEK_CUR);
+        disp = fh.Get_position();
+        offset = fh.Get_byte_offset(disp);
+        if (offset != 1000) {
+            errs++;
+            cout << "file pointer posn in bytes = " << offset << ", should be 1000\n\n";
+            cout.flush();
+        }
+#if VERBOSE
+        if (!mynod) {
+            cout << "preallocating disk space up to 8192 bytes\n";
+            cout.flush();
+        }
+#endif
+        fh.Preallocate(8192);
 
 #if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_get_byte_offset\n";
-	cout.flush();
-    }
+        if (!mynod) {
+            cout << "closing the file and deleting it\n";
+            cout.flush();
+        }
 #endif
-    offset = fh.Get_byte_offset( disp );
-    if (offset != (1000+20*sizeof(int))) {
-	errs++;
-	cout << "byte offset = " << offset << ", should be " << 
-	    (int) (1000+20*sizeof(int)) << "\n";
-	cout.flush();
-    }
-    MPI::COMM_WORLD.Barrier();
+        fh.Close();
 
-#if VERBOSE
-    if (!mynod)
-    {
-	cout << "testing File::_seek with MPI_SEEK_CUR\n";
-	cout.flush();
-    }
-#endif
-    fh.Seek( -10, MPI_SEEK_CUR );
-    disp = fh.Get_position();
-    offset = fh.Get_byte_offset( disp );
-    if (offset != 1000) {
-	errs++;
-	cout << "file pointer posn in bytes = " << offset << 
-	    ", should be 1000\n\n";
-	cout.flush();
-    }
+        MPI::COMM_WORLD.Barrier();
+        if (!mynod)
+            MPI::File::Delete(filename, MPI::INFO_NULL);
 
-#if VERBOSE
-    if (!mynod)
-    {
-	cout << "preallocating disk space up to 8192 bytes\n";
-	cout.flush();
-    }
-#endif
-    fh.Preallocate( 8192 );
+        newtype.Free();
+        filetype.Free();
+        group.Free();
 
-#if VERBOSE
-    if (!mynod)
-    {
-	cout << "closing the file and deleting it\n";
-	cout.flush();
+        delete[]filename;
     }
-#endif
-    fh.Close();
-    
-    MPI::COMM_WORLD.Barrier();
-    if (!mynod) MPI::File::Delete(filename, MPI::INFO_NULL);
-
-    newtype.Free();
-    filetype.Free();
-    group.Free();
-
-    delete [] filename;
+    catch(MPI::Exception e) {
+        cout << "Unhandled MPI exception caught: code " << e.
+            Get_error_code() << ", class " << e.Get_error_class() << ", string \"" << e.
+            Get_error_string() << "\"" << endl;
+        cout.flush();
     }
-    catch (MPI::Exception e)
-    {
-	cout << "Unhandled MPI exception caught: code " << e.Get_error_code() << ", class " << e.Get_error_class() << ", string \"" << e.Get_error_string() << "\"" << endl;
-	cout.flush();
-    }
-    catch (...)
-    {
-	cout << "Unhandled exception caught.\n";
-	cout.flush();
+    catch(...) {
+        cout << "Unhandled exception caught.\n";
+        cout.flush();
     }
 
     MTest_Finalize(errs);

--- a/test/mpi/cxx/io/seekavail.cxx
+++ b/test/mpi/cxx/io/seekavail.cxx
@@ -5,7 +5,7 @@
  *      See COPYRIGHT in top-level directory.
  */
 /* Include stdio.h first to see if the MPI implementation can handle the
-   conflicting definitions in stdio.h for the SEEK_SET, SEEK_CUR, and 
+   conflicting definitions in stdio.h for the SEEK_SET, SEEK_CUR, and
    SEEK_END */
 #include "mpitestconf.h"
 
@@ -30,38 +30,37 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Test availability of MPI::SEEK_SET and SEEK_SET from stdio.h";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
-    int             errs = 0, err;
-    int             rank;
-    MPI::Intracomm  comm;
-    MPI::Status     status;
-    int             seekValues;
+    int errs = 0, err;
+    int rank;
+    MPI::Intracomm comm;
+    MPI::Status status;
+    int seekValues;
 
-    MTest_Init( );
+    MTest_Init();
     comm = MPI::COMM_WORLD;
 
     // Make sure that we can access each value
     // First, the MPI C++ values
     seekValues = MPI::SEEK_SET;
     if (MPI::SEEK_CUR == seekValues) {
-	errs++;
+        errs++;
     }
     if (MPI::SEEK_END == seekValues) {
-	errs++;
+        errs++;
     }
-
     // Second, the stdio values
     seekValues = SEEK_SET;
     if (SEEK_CUR == seekValues) {
-	errs++;
+        errs++;
     }
     if (SEEK_END == seekValues) {
-	errs++;
+        errs++;
     }
 
     /* some workarounds for the SEEK_SET problem prevent its
-       use as a case label */
+     * use as a case label */
     seekValues = SEEK_SET;
     switch (seekValues) {
         case SEEK_SET:
@@ -73,6 +72,6 @@ int main( int argc, char *argv[] )
             break;
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/io/setinfox.cxx
+++ b/test/mpi/cxx/io/setinfox.cxx
@@ -24,116 +24,116 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Test file_set_view";
 
-/* 
+/*
  * access style is explicitly described as modifiable.  values include
  * read_once, read_mostly, write_once, write_mostlye, random
  *
- * 
+ *
  */
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
-    int             errs = 0, err;
-    int             buf[10];
-    int             rank;
-    MPI::Intracomm  comm;
-    MPI::Status     status;
-    MPI::File       fh;
-    MPI::Info       infoin, infoout;
-    char            value[1024];
-    bool            flag;
-    int             count;
+    int errs = 0, err;
+    int buf[10];
+    int rank;
+    MPI::Intracomm comm;
+    MPI::Status status;
+    MPI::File fh;
+    MPI::Info infoin, infoout;
+    char value[1024];
+    bool flag;
+    int count;
 
-    MTest_Init( );
+    MTest_Init();
     comm = MPI::COMM_WORLD;
 
     rank = comm.Get_rank();
     infoin = MPI::Info::Create();
-    infoin.Set( "access_style", "write_once,random" );
-    fh = MPI::File::Open( comm, "testfile", MPI::MODE_RDWR | MPI::MODE_CREATE,
-			  infoin);
+    infoin.Set("access_style", "write_once,random");
+    fh = MPI::File::Open(comm, "testfile", MPI::MODE_RDWR | MPI::MODE_CREATE, infoin);
     buf[0] = rank;
     try {
-	fh.Write_ordered( buf, 1, MPI::INT );
-    } catch ( MPI::Exception e  ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        fh.Write_ordered(buf, 1, MPI::INT);
+    } catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
     }
 
-    infoin.Set( "access_style", "read_once" );
+    infoin.Set("access_style", "read_once");
     try {
-	fh.Seek_shared( 0, MPI_SEEK_SET );   // Use MPI_xx to avoid problems with SEEK_SET
-    } catch ( MPI::Exception e ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        fh.Seek_shared(0, MPI_SEEK_SET);        // Use MPI_xx to avoid problems with SEEK_SET
+    } catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
     }
 
     try {
-	fh.Set_info( infoin );
-    } catch ( MPI::Exception e ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        fh.Set_info(infoin);
+    } catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
     }
     buf[0] = -1;
-    
+
     try {
-	fh.Read_ordered( buf, 1, MPI::INT, status );
-    } catch ( MPI::Exception e ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        fh.Read_ordered(buf, 1, MPI::INT, status);
+    } catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
     }
-    count = status.Get_count( MPI::INT );
+    count = status.Get_count(MPI::INT);
     if (count != 1) {
-	errs++;
-	cout << "Expected to read one int, read " << count << "\n";
+        errs++;
+        cout << "Expected to read one int, read " << count << "\n";
     }
     if (buf[0] != rank) {
-	errs++;
-	cout << "Did not read expected value (" << buf[0] << ")\n";
+        errs++;
+        cout << "Did not read expected value (" << buf[0] << ")\n";
     }
 
     try {
-	infoout = fh.Get_info();
-    } catch ( MPI::Exception e ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        infoout = fh.Get_info();
     }
-    flag = infoout.Get( "access_style", 1024, value );
+    catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
+    }
+    flag = infoout.Get("access_style", 1024, value);
     /* Note that an implementation is allowed to ignore the set_info,
-       so we'll accept either the original or the updated version */
+     * so we'll accept either the original or the updated version */
     if (!flag) {
-	;
-	/*
-	errs++;
-	printf( "Access style hint not saved\n" );
-	*/
-    }
-    else {
-	if (strcmp( value, "read_once" ) != 0 &&
-	    strcmp( value, "write_once,random" ) != 0) {
-	    errs++;
-	    cout << "value for access_style unexpected; is " << value << "\n";
-	}
+        ;
+        /*
+         * errs++;
+         * printf("Access style hint not saved\n");
+         */
+    } else {
+        if (strcmp(value, "read_once") != 0 && strcmp(value, "write_once,random") != 0) {
+            errs++;
+            cout << "value for access_style unexpected; is " << value << "\n";
+        }
     }
     infoout.Free();
 
     try {
-	fh.Close();
-    } catch ( MPI::Exception e ) {
-	errs ++;
-	MTestPrintError( e.Get_error_code() );
+        fh.Close();
+    }
+    catch(MPI::Exception e) {
+        errs++;
+        MTestPrintError(e.Get_error_code());
     }
     comm.Barrier();
     rank = comm.Get_rank();
     if (rank == 0) {
-	try {
-	    MPI::File::Delete( "testfile", MPI::INFO_NULL );
-	} catch ( MPI::Exception e ) {
-	    errs ++;
-	    MTestPrintError( e.Get_error_code() );
-	}
+        try {
+            MPI::File::Delete("testfile", MPI::INFO_NULL);
+        }
+        catch(MPI::Exception e) {
+            errs++;
+            MTestPrintError(e.Get_error_code());
+        }
     }
-    
-    MTest_Finalize( errs );
-    MPI::Finalize( );
+
+    MTest_Finalize(errs);
+    MPI::Finalize();
     return 0;
 }

--- a/test/mpi/cxx/io/shpositionx.cxx
+++ b/test/mpi/cxx/io/shpositionx.cxx
@@ -22,7 +22,7 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char **argv )
+int main(int argc, char **argv)
 {
     MPI::Intracomm comm;
     MPI::File fh;
@@ -34,38 +34,37 @@ int main( int argc, char **argv )
 
     MTest_Init();
 
-    strcpy( filename,"iotest.txt");
+    strcpy(filename, "iotest.txt");
     comm = MPI::COMM_WORLD;
     s = comm.Get_size();
     r = comm.Get_rank();
     // Try writing the file, then check it
-    fh = MPI::File::Open( comm, filename, MPI::MODE_RDWR | MPI::MODE_CREATE, 
-			  MPI::INFO_NULL );
+    fh = MPI::File::Open(comm, filename, MPI::MODE_RDWR | MPI::MODE_CREATE, MPI::INFO_NULL);
 
     // Get the size of an INT in the file
-    fileintsize = fh.Get_type_extent( MPI::INT );
+    fileintsize = fh.Get_type_extent(MPI::INT);
 
-    // We let each process write in turn, getting the position after each 
+    // We let each process write in turn, getting the position after each
     // write
-    for (i=0; i<s; i++) {
-	if (i == r) {
-	    fh.Write_shared( &i, 1, MPI::INT );
-	}
+    for (i = 0; i < s; i++) {
+        if (i == r) {
+            fh.Write_shared(&i, 1, MPI::INT);
+        }
         comm.Barrier();
-	offset = fh.Get_position_shared();
-	if (offset != fileintsize * (i+1)) {
-	    errs++;
-	    cout << r << " Shared position is " <<  offset <<
-		" should be " << fileintsize * (i+1) << "\n";
-	}
+        offset = fh.Get_position_shared();
+        if (offset != fileintsize * (i + 1)) {
+            errs++;
+            cout << r << " Shared position is " << offset <<
+                " should be " << fileintsize * (i + 1) << "\n";
+        }
         comm.Barrier();
     }
 
     fh.Close();
     comm.Barrier();
     if (r == 0) {
-	MPI::File::Delete( filename, MPI::INFO_NULL );
+        MPI::File::Delete(filename, MPI::INFO_NULL);
     }
-    
-    MTest_Finalize( errs );
+
+    MTest_Finalize(errs);
 }

--- a/test/mpi/cxx/pt2pt/bsend1cxx.cxx
+++ b/test/mpi/cxx/pt2pt/bsend1cxx.cxx
@@ -24,25 +24,26 @@ using namespace std;
 /* Needed for strcmp */
 #include <string.h>
 
-/* Rather than deal with the need to declare strncpy correctly 
-   (avoiding possible conflicts with other header files), we 
+/* Rather than deal with the need to declare strncpy correctly
+   (avoiding possible conflicts with other header files), we
    simply define a copy routine that is used for this example */
-void CopyChars( char *, int, const char * );
-void CopyChars( char *dest, int len, const char *src )
+void CopyChars(char *, int, const char *);
+void CopyChars(char *dest, int len, const char *src)
 {
     int i;
-    for (i=0; i<len && *src; i++) {
-	dest[i] = src[i];
+    for (i = 0; i < len && *src; i++) {
+        dest[i] = src[i];
     }
-    if (i < len) dest[i] = 0;
+    if (i < len)
+        dest[i] = 0;
 }
 
-/* 
+/*
  * This is a simple program that tests bsend.  It may be run as a single
  * process to simplify debugging; in addition, bsend allows send-to-self
  * programs.
  */
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::Intracomm comm;
     int dest = 0, src = 0, tag = 1;
@@ -60,52 +61,52 @@ int main( int argc, char *argv[] )
     comm = MPI::COMM_WORLD;
     rank = comm.Get_rank();
 
-    bufsize = 3 * MPI_BSEND_OVERHEAD + 7 + 17 + 2*sizeof(double);
+    bufsize = 3 * MPI_BSEND_OVERHEAD + 7 + 17 + 2 * sizeof(double);
     buf = new char[bufsize];
-    MPI::Attach_buffer( buf, bufsize );
+    MPI::Attach_buffer(buf, bufsize);
 
-    CopyChars( msg1, sizeof(msg1), "012345" );
-    CopyChars( msg3, sizeof(msg3), "0123401234012341" );
-    msg2[0] = 1.23; msg2[1] = 3.21;
+    CopyChars(msg1, sizeof(msg1), "012345");
+    CopyChars(msg3, sizeof(msg3), "0123401234012341");
+    msg2[0] = 1.23;
+    msg2[1] = 3.21;
 
     if (rank == src) {
-	/* These message sizes are chosen to expose any alignment problems */
-	comm.Bsend( msg1, 7, MPI::CHAR, dest, tag );
-	comm.Bsend( msg2, 2, MPI::DOUBLE, dest, tag );
-	comm.Bsend( msg3, 17, MPI::CHAR, dest, tag );
+        /* These message sizes are chosen to expose any alignment problems */
+        comm.Bsend(msg1, 7, MPI::CHAR, dest, tag);
+        comm.Bsend(msg2, 2, MPI::DOUBLE, dest, tag);
+        comm.Bsend(msg3, 17, MPI::CHAR, dest, tag);
     }
 
     if (rank == dest) {
-	comm.Recv( rmsg1, 7, MPI::CHAR, src, tag, status );
-	comm.Recv( rmsg2, 10, MPI::DOUBLE, src, tag, status );
-	comm.Recv( rmsg3, 17, MPI::CHAR, src, tag, status  );
+        comm.Recv(rmsg1, 7, MPI::CHAR, src, tag, status);
+        comm.Recv(rmsg2, 10, MPI::DOUBLE, src, tag, status);
+        comm.Recv(rmsg3, 17, MPI::CHAR, src, tag, status);
 
-	if (strcmp( rmsg1, msg1 ) != 0) {
-	    errs++;
-	    cerr << "message 1 (" << rmsg1 << ") should be " << msg1 << "\n";
-	}
-	if (rmsg2[0] != msg2[0] || rmsg2[1] != msg2[1]) {
-	    errs++;
-	    cerr << "message 2 incorrect, values are (" << rmsg2[0] << "," 
-		 << rmsg2[1] << ") but should be (" << msg2[0] << "," 
-		 << msg2[1] << "\n";
-	}
-	if (strcmp( rmsg3, msg3 ) != 0) {
-	    errs++;
-	    cerr << "message 3 (" << rmsg3 << ") should be " << msg3 << "\n";
-	}
+        if (strcmp(rmsg1, msg1) != 0) {
+            errs++;
+            cerr << "message 1 (" << rmsg1 << ") should be " << msg1 << "\n";
+        }
+        if (rmsg2[0] != msg2[0] || rmsg2[1] != msg2[1]) {
+            errs++;
+            cerr << "message 2 incorrect, values are (" << rmsg2[0] << ","
+                << rmsg2[1] << ") but should be (" << msg2[0] << "," << msg2[1] << "\n";
+        }
+        if (strcmp(rmsg3, msg3) != 0) {
+            errs++;
+            cerr << "message 3 (" << rmsg3 << ") should be " << msg3 << "\n";
+        }
     }
 
     /* We can't guarantee that messages arrive until the detach */
-    bsize = MPI::Detach_buffer( bbuf );
-    if (bbuf != (void *)buf) {
-	errs++;
-	cerr << "Returned buffer from detach is not the same as the initial buffer\n";
+    bsize = MPI::Detach_buffer(bbuf);
+    if (bbuf != (void *) buf) {
+        errs++;
+        cerr << "Returned buffer from detach is not the same as the initial buffer\n";
     }
 
-    delete[] buf;
+    delete[]buf;
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
 
     return 0;

--- a/test/mpi/cxx/pt2pt/sendrecvx.cxx
+++ b/test/mpi/cxx/pt2pt/sendrecvx.cxx
@@ -1,5 +1,5 @@
 /* -*- Mode: C++; c-basic-offset:4 ; -*- */
-/*  
+/*
  *  (C) 2001 by Argonne National Laboratory.
  *      See COPYRIGHT in top-level directory.
  *
@@ -27,7 +27,7 @@ using namespace std;
 #include <iostream.h>
 #endif
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int rank, size, errs = 0;
 
@@ -43,23 +43,23 @@ int main( int argc, char *argv[] )
     if (rank == 0) {
         int *buf = new int[100];
         int i;
-        for (i=0; i<100; i++) buf[i] = i;
-        MPI::COMM_WORLD.Send( buf, 100, MPI::INT, size-1, 0 );
-        delete[] buf;
-    }
-    else if (rank == size - 1) {
+        for (i = 0; i < 100; i++)
+            buf[i] = i;
+        MPI::COMM_WORLD.Send(buf, 100, MPI::INT, size - 1, 0);
+        delete[]buf;
+    } else if (rank == size - 1) {
         int *buf = new int[100];
         int i;
-        MPI::COMM_WORLD.Recv( buf, 100, MPI::INT, 0, 0 );
-        for (i=0; i<100; i++) {
+        MPI::COMM_WORLD.Recv(buf, 100, MPI::INT, 0, 0);
+        for (i = 0; i < 100; i++) {
             if (buf[i] != i) {
                 errs++;
                 cerr << "Error: buf[" << i << "] = " << buf[i] << "\n";
             }
         }
-        delete[] buf;
+        delete[]buf;
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/rma/fkeyvalwinx.cxx
+++ b/test/mpi/cxx/rma/fkeyvalwinx.cxx
@@ -27,27 +27,25 @@ executed";
 
 /* Copy increments the attribute value */
 /* Note that we can really ignore this because there is no win dup */
-int copy_fn( const MPI::Win &oldwin, int keyval, void *extra_state,
-	     void *attribute_val_in, void *attribute_val_out, 
-	     bool &flag )
+int copy_fn(const MPI::Win & oldwin, int keyval, void *extra_state,
+            void *attribute_val_in, void *attribute_val_out, bool & flag)
 {
     /* Copy the address of the attribute */
-    *(void **)attribute_val_out = attribute_val_in;
+    *(void **) attribute_val_out = attribute_val_in;
     /* Change the value */
-    *(int *)attribute_val_in = *(int *)attribute_val_in + 1;
+    *(int *) attribute_val_in = *(int *) attribute_val_in + 1;
     flag = 1;
     return MPI::SUCCESS;
 }
 
 /* Delete decrements the attribute value */
-int delete_fn( MPI::Win &win, int keyval, void *attribute_val, 
-	       void *extra_state)
+int delete_fn(MPI::Win & win, int keyval, void *attribute_val, void *extra_state)
 {
-    *(int *)attribute_val = *(int *)attribute_val - 1;
+    *(int *) attribute_val = *(int *) attribute_val - 1;
     return MPI::SUCCESS;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int attrval;
@@ -55,37 +53,38 @@ int main( int argc, char *argv[] )
     MPI::Win win;
     MTest_Init();
 
-    while (MTestGetWin( win, 0 )) {
-	if (win == MPI::WIN_NULL) continue;
+    while (MTestGetWin(win, 0)) {
+        if (win == MPI::WIN_NULL)
+            continue;
 
-	keyval = MPI::Win::Create_keyval( copy_fn, delete_fn, (void *)0 );
-	saveKeyval = keyval;   /* in case we need to free explicitly */
-	attrval = 1;
-	win.Set_attr( keyval, &attrval );
-	/* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
-	   is in use in an attribute */
-	MPI::Win::Free_keyval( keyval );
-	
-	/* We create some dummy keyvals here in case the same keyval
-	   is reused */
-	for (i=0; i<32; i++) {
-	    key[i] = MPI::Win::Create_keyval( 
-		MPI::Win::NULL_COPY_FN, MPI::Win::NULL_DELETE_FN, (void *)0 );
-	}
+        keyval = MPI::Win::Create_keyval(copy_fn, delete_fn, (void *) 0);
+        saveKeyval = keyval;    /* in case we need to free explicitly */
+        attrval = 1;
+        win.Set_attr(keyval, &attrval);
+        /* See MPI-1, 5.7.1.  Freeing the keyval does not remove it if it
+         * is in use in an attribute */
+        MPI::Win::Free_keyval(keyval);
 
-	MTestFreeWin( win );
-	/* Check that the original attribute was freed */
-	if (attrval != 0) {
-	    errs++;
-	    cout << "Attribute not decremented when win " << 
-		MTestGetWinName() << " freed\n";
-	}
-	/* Free those other keyvals */
-	for (i=0; i<32; i++) {
-	    MPI::Win::Free_keyval( key[i] );
-	}
+        /* We create some dummy keyvals here in case the same keyval
+         * is reused */
+        for (i = 0; i < 32; i++) {
+            key[i] =
+                MPI::Win::Create_keyval(MPI::Win::NULL_COPY_FN, MPI::Win::NULL_DELETE_FN,
+                                        (void *) 0);
+        }
+
+        MTestFreeWin(win);
+        /* Check that the original attribute was freed */
+        if (attrval != 0) {
+            errs++;
+            cout << "Attribute not decremented when win " << MTestGetWinName() << " freed\n";
+        }
+        /* Free those other keyvals */
+        for (i = 0; i < 32; i++) {
+            MPI::Win::Free_keyval(key[i]);
+        }
     }
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/cxx/rma/getgroupx.cxx
+++ b/test/mpi/cxx/rma/getgroupx.cxx
@@ -24,40 +24,40 @@ using namespace std;
 
 static char MTEST_Descrip[] = "Test of Win_get_group";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int result;
     int buf[10];
-    MPI::Win   win;
+    MPI::Win win;
     MPI::Group group, wingroup;
     int minsize = 2;
-    MPI::Intracomm      comm;
+    MPI::Intracomm comm;
 
     MTest_Init();
 
-    /* The following illustrates the use of the routines to 
-       run through a selection of communicators and datatypes.
-       Use subsets of these for tests that do not involve combinations 
-       of communicators, datatypes, and counts of datatypes */
-    while (MTestGetIntracommGeneral( comm, minsize, true )) {
-	if (comm == MPI::COMM_NULL) continue;
+    /* The following illustrates the use of the routines to
+     * run through a selection of communicators and datatypes.
+     * Use subsets of these for tests that do not involve combinations
+     * of communicators, datatypes, and counts of datatypes */
+    while (MTestGetIntracommGeneral(comm, minsize, true)) {
+        if (comm == MPI::COMM_NULL)
+            continue;
 
-	win = MPI::Win::Create( buf, sizeof(int) * 10, sizeof(int), 
-			MPI::INFO_NULL, comm );
-	wingroup = win.Get_group();
-	group = comm.Get_group();
-	result = MPI::Group::Compare( group, wingroup );
-	if (result != MPI::IDENT) {
-	    errs++;
-	    cout << "Group returned by Win_get_group not the same as the input group\n";
-	}
-	wingroup.Free();
-	group.Free();
-	win.Free();
-	MTestFreeComm( comm );
+        win = MPI::Win::Create(buf, sizeof(int) * 10, sizeof(int), MPI::INFO_NULL, comm);
+        wingroup = win.Get_group();
+        group = comm.Get_group();
+        result = MPI::Group::Compare(group, wingroup);
+        if (result != MPI::IDENT) {
+            errs++;
+            cout << "Group returned by Win_get_group not the same as the input group\n";
+        }
+        wingroup.Free();
+        group.Free();
+        win.Free();
+        MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/rma/wincallx.cxx
+++ b/test/mpi/cxx/rma/wincallx.cxx
@@ -28,50 +28,51 @@ static char MTEST_Descrip[] = "Test win_call_errhandler";
 static int calls = 0;
 static int errs = 0;
 static MPI::Win mywin;
-void eh( MPI::Win &win, int *err, ... )
+void eh(MPI::Win & win, int *err, ...)
 {
     if (*err != MPI_ERR_OTHER) {
-	errs++;
-	cout << "Unexpected error code\n";
+        errs++;
+        cout << "Unexpected error code\n";
     }
     if (win != mywin) {
-	char cname[MPI_MAX_OBJECT_NAME];
-	int len;
-	errs++;
-	cout << "Unexpected window\n";
-	win.Get_name( cname, len );
-	cout << "Win is " << cname << "\n";
-	mywin.Get_name( cname, len );
-	cout << "Mywin is " << cname << "\n";
+        char cname[MPI_MAX_OBJECT_NAME];
+        int len;
+        errs++;
+        cout << "Unexpected window\n";
+        win.Get_name(cname, len);
+        cout << "Win is " << cname << "\n";
+        mywin.Get_name(cname, len);
+        cout << "Mywin is " << cname << "\n";
     }
     calls++;
     return;
 }
-int main( int argc, char *argv[] )
+
+int main(int argc, char *argv[])
 {
-    MPI::Win        win;
+    MPI::Win win;
     MPI::Errhandler newerr;
-    int            i;
-    int            reset_handler;
-    int            buf[10];
+    int i;
+    int reset_handler;
+    int buf[10];
 
-    MTest_Init( );
+    MTest_Init();
 
-    win  = MPI::Win::Create( buf, sizeof(buf), 1, MPI::INFO_NULL, MPI::COMM_WORLD );
+    win = MPI::Win::Create(buf, sizeof(buf), 1, MPI::INFO_NULL, MPI::COMM_WORLD);
     mywin = win;
-    mywin.Set_name( "dup of win_world" );
+    mywin.Set_name("dup of win_world");
 
-    newerr = MPI::Win::Create_errhandler( eh );
+    newerr = MPI::Win::Create_errhandler(eh);
 
-    win.Set_errhandler( newerr );
-    win.Call_errhandler( MPI_ERR_OTHER );
+    win.Set_errhandler(newerr);
+    win.Call_errhandler(MPI_ERR_OTHER);
     newerr.Free();
     if (calls != 1) {
-	errs++;
-	cout << "Error handler not called\n";
+        errs++;
+        cout << "Error handler not called\n";
     }
     win.Free();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/rma/winfencex.cxx
+++ b/test/mpi/cxx/rma/winfencex.cxx
@@ -27,80 +27,76 @@ using namespace std;
  */
 #define MAX_NROWS 25
 #define MAX_NCOLS 12
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::Intracomm comm;
-    int            errs = 0;
-    MPI::Win       win;
-    int            i, j, nrows=MAX_NROWS, ncols=MAX_NCOLS;
-    int            left, right, ans, size, rank;
-    int            buf[MAX_NROWS * (MAX_NCOLS + 2)];
-    MPI::Aint      aint;
-    
-    MTest_Init( );
+    int errs = 0;
+    MPI::Win win;
+    int i, j, nrows = MAX_NROWS, ncols = MAX_NCOLS;
+    int left, right, ans, size, rank;
+    int buf[MAX_NROWS * (MAX_NCOLS + 2)];
+    MPI::Aint aint;
 
-    while( MTestGetIntracommGeneral( comm, 2, false ) ) {
-	aint = nrows * (ncols + 2) * sizeof(int);
-	win = MPI::Win::Create( buf, aint, sizeof(int) * nrows, 
-				MPI::INFO_NULL, comm );
-	size = comm.Get_size();
-	rank = comm.Get_rank();
+    MTest_Init();
 
-	left = rank - 1;
-	if (left < 0)      left = MPI::PROC_NULL;
-	right = rank + 1;
-	if (right >= size) right = MPI::PROC_NULL;
+    while (MTestGetIntracommGeneral(comm, 2, false)) {
+        aint = nrows * (ncols + 2) * sizeof(int);
+        win = MPI::Win::Create(buf, aint, sizeof(int) * nrows, MPI::INFO_NULL, comm);
+        size = comm.Get_size();
+        rank = comm.Get_rank();
 
-	// Initialize the buffer 
-	for (i=0; i<nrows; i++) {
-	    buf[i]                 = -1;
-	    buf[(ncols+1)*nrows+i] = -1;
-	}
-	for (j=0; j<ncols; j++) {
-	    for (i=0; i<nrows; i++) {
-		buf[i + (j+1) * nrows] = 
-		    rank * (ncols * nrows) + i + j * nrows;
-	    }
-	}
-	win.Fence( MPI::MODE_NOPRECEDE );
+        left = rank - 1;
+        if (left < 0)
+            left = MPI::PROC_NULL;
+        right = rank + 1;
+        if (right >= size)
+            right = MPI::PROC_NULL;
 
-	win.Put( &buf[0+nrows], nrows, MPI::INT, left, ncols+1, 
-		 nrows, MPI::INT );
-	win.Put( &buf[0+ncols*nrows], nrows, MPI::INT, right, 0, 
-		 nrows, MPI::INT );
-	win.Fence( MPI::MODE_NOSTORE + MPI::MODE_NOPUT + MPI::MODE_NOSUCCEED );
+        // Initialize the buffer
+        for (i = 0; i < nrows; i++) {
+            buf[i] = -1;
+            buf[(ncols + 1) * nrows + i] = -1;
+        }
+        for (j = 0; j < ncols; j++) {
+            for (i = 0; i < nrows; i++) {
+                buf[i + (j + 1) * nrows] = rank * (ncols * nrows) + i + j * nrows;
+            }
+        }
+        win.Fence(MPI::MODE_NOPRECEDE);
 
-	// Check the results
-	if (left != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = rank * (ncols * nrows) - nrows + i;
-		if (buf[i] != ans) {
-		    errs++;
-		    if (errs != 10) {
-			cout << rank << " buf[" << i << ",0] = " <<
-			    buf[i] << " expected " << ans << "\n";
-		    }
-		}
-	    }
-	}
-	if (right != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = (rank + 1)* (ncols * nrows) + i;
-		if (buf[i + (ncols+1)*nrows] != ans) {
-		    errs++;
-		    if (errs <= 10) {
-			cout << rank << " buf[" << i << ",ncols+1] = " <<
-			    buf[i+(ncols+1)*nrows] << " expected " << 
-			    ans << "\n";
-		    }
-		}
-	    }
-	}
-	win.Free();
-	MTestFreeComm( comm );
+        win.Put(&buf[0 + nrows], nrows, MPI::INT, left, ncols + 1, nrows, MPI::INT);
+        win.Put(&buf[0 + ncols * nrows], nrows, MPI::INT, right, 0, nrows, MPI::INT);
+        win.Fence(MPI::MODE_NOSTORE + MPI::MODE_NOPUT + MPI::MODE_NOSUCCEED);
+
+        // Check the results
+        if (left != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = rank * (ncols * nrows) - nrows + i;
+                if (buf[i] != ans) {
+                    errs++;
+                    if (errs != 10) {
+                        cout << rank << " buf[" << i << ",0] = " <<
+                            buf[i] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
+        if (right != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = (rank + 1) * (ncols * nrows) + i;
+                if (buf[i + (ncols + 1) * nrows] != ans) {
+                    errs++;
+                    if (errs <= 10) {
+                        cout << rank << " buf[" << i << ",ncols+1] = " <<
+                            buf[i + (ncols + 1) * nrows] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
+        win.Free();
+        MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }
-

--- a/test/mpi/cxx/rma/winnamex.cxx
+++ b/test/mpi/cxx/rma/winnamex.cxx
@@ -23,7 +23,7 @@ using namespace std;
 #include <string.h>
 #endif
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Win win;
@@ -32,34 +32,34 @@ int main( int argc, char *argv[] )
 
     MTest_Init();
 
-    name = new char [MPI::MAX_OBJECT_NAME];
-    nameout = new char [MPI::MAX_OBJECT_NAME];
+    name = new char[MPI::MAX_OBJECT_NAME];
+    nameout = new char[MPI::MAX_OBJECT_NAME];
 
     cnt = 0;
-    while (MTestGetWin( win, true )) {
-	if (win == MPI::WIN_NULL) continue;
-    
-	sprintf( name, "win-%d", cnt );
-	cnt++;
-	win.Set_name( name );
-	nameout[0] = 0;
-	win.Get_name( nameout, namelen );
-	if (strcmp( name, nameout )) {
-	    errs++;
-	    cout << "Unexpected name, was " << nameout << 
-		" but should be " << name << "\n";
-	}
+    while (MTestGetWin(win, true)) {
+        if (win == MPI::WIN_NULL)
+            continue;
 
-	MTestFreeWin(win);
+        sprintf(name, "win-%d", cnt);
+        cnt++;
+        win.Set_name(name);
+        nameout[0] = 0;
+        win.Get_name(nameout, namelen);
+        if (strcmp(name, nameout)) {
+            errs++;
+            cout << "Unexpected name, was " << nameout << " but should be " << name << "\n";
+        }
+
+        MTestFreeWin(win);
     }
     if (cnt == 0) {
         errs++;
         cout << "No windows created\n";
     }
 
-    delete [] name;
-    delete [] nameout;
+    delete[]name;
+    delete[]nameout;
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/rma/winscale1x.cxx
+++ b/test/mpi/cxx/rma/winscale1x.cxx
@@ -27,100 +27,97 @@ using namespace std;
  */
 #define MAX_NROWS 25
 #define MAX_NCOLS 12
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::Intracomm comm;
-    int            errs = 0;
-    MPI::Win       win;
-    int            i, j, nrows=MAX_NROWS, ncols=MAX_NCOLS;
-    int            left, right, ans, size, rank;
-    int            buf[MAX_NROWS * (MAX_NCOLS + 2)];
-    MPI::Aint      aint;
-    MPI::Group     group, group2;
-    int            nneighbors, nbrs[2];
-         
-    MTest_Init( );
+    int errs = 0;
+    MPI::Win win;
+    int i, j, nrows = MAX_NROWS, ncols = MAX_NCOLS;
+    int left, right, ans, size, rank;
+    int buf[MAX_NROWS * (MAX_NCOLS + 2)];
+    MPI::Aint aint;
+    MPI::Group group, group2;
+    int nneighbors, nbrs[2];
 
-    while( MTestGetIntracommGeneral( comm, 2, false ) ) {
-	aint = nrows * (ncols + 2) * sizeof(int);
-	win = MPI::Win::Create( buf, aint, sizeof(int) * nrows, 
-				MPI::INFO_NULL, comm );
-	size = comm.Get_size();
-	rank = comm.Get_rank();
+    MTest_Init();
 
-	// Create the group for the neighbors
-	nneighbors = 0;
-	left = rank - 1;
-	if (left < 0)      left = MPI::PROC_NULL;
-	else {
+    while (MTestGetIntracommGeneral(comm, 2, false)) {
+        aint = nrows * (ncols + 2) * sizeof(int);
+        win = MPI::Win::Create(buf, aint, sizeof(int) * nrows, MPI::INFO_NULL, comm);
+        size = comm.Get_size();
+        rank = comm.Get_rank();
+
+        // Create the group for the neighbors
+        nneighbors = 0;
+        left = rank - 1;
+        if (left < 0)
+            left = MPI::PROC_NULL;
+        else {
             nbrs[nneighbors++] = left;
-	}
-	right = rank + 1;
-	if (right >= size) right = MPI::PROC_NULL;
-	else {
+        }
+        right = rank + 1;
+        if (right >= size)
+            right = MPI::PROC_NULL;
+        else {
             nbrs[nneighbors++] = right;
-	}
+        }
 
-	group = comm.Get_group();
-	group2 = group.Incl( nneighbors, nbrs );
-	group.Free();
+        group = comm.Get_group();
+        group2 = group.Incl(nneighbors, nbrs);
+        group.Free();
 
-	// Initialize the buffer 
-	for (i=0; i<nrows; i++) {
-	    buf[i]                 = -1;
-	    buf[(ncols+1)*nrows+i] = -1;
-	}
-	for (j=0; j<ncols; j++) {
-	    for (i=0; i<nrows; i++) {
-		buf[i + (j+1) * nrows] = 
-		    rank * (ncols * nrows) + i + j * nrows;
-	    }
-	}
+        // Initialize the buffer
+        for (i = 0; i < nrows; i++) {
+            buf[i] = -1;
+            buf[(ncols + 1) * nrows + i] = -1;
+        }
+        for (j = 0; j < ncols; j++) {
+            for (i = 0; i < nrows; i++) {
+                buf[i + (j + 1) * nrows] = rank * (ncols * nrows) + i + j * nrows;
+            }
+        }
 
-	// The actual exchange
-	win.Post( group2, 0 );
-	win.Start( group2, 0 );
+        // The actual exchange
+        win.Post(group2, 0);
+        win.Start(group2, 0);
 
-	win.Put( &buf[0+nrows], nrows, MPI::INT, left, ncols+1, 
-		 nrows, MPI::INT );
-	win.Put( &buf[0+ncols*nrows], nrows, MPI::INT, right, 0, 
-		 nrows, MPI::INT );
-	win.Complete( );
-	win.Wait( );
+        win.Put(&buf[0 + nrows], nrows, MPI::INT, left, ncols + 1, nrows, MPI::INT);
+        win.Put(&buf[0 + ncols * nrows], nrows, MPI::INT, right, 0, nrows, MPI::INT);
+        win.Complete();
+        win.Wait();
 
-	// Check the results
-	if (left != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = rank * (ncols * nrows) - nrows + i;
-		if (buf[i] != ans) {
-		    errs++;
-		    if (errs != 10) {
-			cout << rank << " buf[" << i << ",0] = " <<
-			    buf[i] << " expected " << ans << "\n";
-		    }
-		}
-	    }
-	}
-	if (right != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = (rank + 1)* (ncols * nrows) + i;
-		if (buf[i + (ncols+1)*nrows] != ans) {
-		    errs++;
-		    if (errs <= 10) {
-			cout << rank << " buf[" << i << ",ncols+1] = " <<
-			    buf[i+(ncols+1)*nrows] << " expected " << 
-			    ans << "\n";
-		    }
-		}
-	    }
-	}
+        // Check the results
+        if (left != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = rank * (ncols * nrows) - nrows + i;
+                if (buf[i] != ans) {
+                    errs++;
+                    if (errs != 10) {
+                        cout << rank << " buf[" << i << ",0] = " <<
+                            buf[i] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
+        if (right != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = (rank + 1) * (ncols * nrows) + i;
+                if (buf[i + (ncols + 1) * nrows] != ans) {
+                    errs++;
+                    if (errs <= 10) {
+                        cout << rank << " buf[" << i << ",ncols+1] = " <<
+                            buf[i + (ncols + 1) * nrows] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
 
-	
-	group2.Free();
-	win.Free();
-	MTestFreeComm( comm );
+
+        group2.Free();
+        win.Free();
+        MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/rma/winscale2x.cxx
+++ b/test/mpi/cxx/rma/winscale2x.cxx
@@ -27,104 +27,101 @@ using namespace std;
  */
 #define MAX_NROWS 25
 #define MAX_NCOLS 12
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::Intracomm comm;
-    int            errs = 0;
-    MPI::Win       win;
-    int            i, j, nrows=MAX_NROWS, ncols=MAX_NCOLS;
-    int            left, right, ans, size, rank;
-    int            buf[MAX_NROWS * (MAX_NCOLS + 2)];
-    bool           flag;
-    MPI::Aint      aint;
-    MPI::Group     group, group2;
-    int            nneighbors, nbrs[2];
-         
-    MTest_Init( );
+    int errs = 0;
+    MPI::Win win;
+    int i, j, nrows = MAX_NROWS, ncols = MAX_NCOLS;
+    int left, right, ans, size, rank;
+    int buf[MAX_NROWS * (MAX_NCOLS + 2)];
+    bool flag;
+    MPI::Aint aint;
+    MPI::Group group, group2;
+    int nneighbors, nbrs[2];
 
-    while( MTestGetIntracommGeneral( comm, 2, false ) ) {
-	aint = nrows * (ncols + 2) * sizeof(int);
-	win = MPI::Win::Create( buf, aint, sizeof(int) * nrows, 
-				MPI::INFO_NULL, comm );
-	size = comm.Get_size();
-	rank = comm.Get_rank();
+    MTest_Init();
 
-	// Create the group for the neighbors
-	nneighbors = 0;
-	left = rank - 1;
-	if (left < 0)      left = MPI::PROC_NULL;
-	else {
+    while (MTestGetIntracommGeneral(comm, 2, false)) {
+        aint = nrows * (ncols + 2) * sizeof(int);
+        win = MPI::Win::Create(buf, aint, sizeof(int) * nrows, MPI::INFO_NULL, comm);
+        size = comm.Get_size();
+        rank = comm.Get_rank();
+
+        // Create the group for the neighbors
+        nneighbors = 0;
+        left = rank - 1;
+        if (left < 0)
+            left = MPI::PROC_NULL;
+        else {
             nbrs[nneighbors++] = left;
-	}
-	right = rank + 1;
-	if (right >= size) right = MPI::PROC_NULL;
-	else {
+        }
+        right = rank + 1;
+        if (right >= size)
+            right = MPI::PROC_NULL;
+        else {
             nbrs[nneighbors++] = right;
-	}
+        }
 
-	group = comm.Get_group();
-	group2 = group.Incl( nneighbors, nbrs );
-	group.Free();
+        group = comm.Get_group();
+        group2 = group.Incl(nneighbors, nbrs);
+        group.Free();
 
-	// Initialize the buffer 
-	for (i=0; i<nrows; i++) {
-	    buf[i]                 = -1;
-	    buf[(ncols+1)*nrows+i] = -1;
-	}
-	for (j=0; j<ncols; j++) {
-	    for (i=0; i<nrows; i++) {
-		buf[i + (j+1) * nrows] = 
-		    rank * (ncols * nrows) + i + j * nrows;
-	    }
-	}
+        // Initialize the buffer
+        for (i = 0; i < nrows; i++) {
+            buf[i] = -1;
+            buf[(ncols + 1) * nrows + i] = -1;
+        }
+        for (j = 0; j < ncols; j++) {
+            for (i = 0; i < nrows; i++) {
+                buf[i + (j + 1) * nrows] = rank * (ncols * nrows) + i + j * nrows;
+            }
+        }
 
-	// The actual exchange
-	win.Post( group2, 0 );
-	win.Start( group2, 0 );
+        // The actual exchange
+        win.Post(group2, 0);
+        win.Start(group2, 0);
 
-	win.Put( &buf[0+nrows], nrows, MPI::INT, left, ncols+1, 
-		 nrows, MPI::INT );
-	win.Put( &buf[0+ncols*nrows], nrows, MPI::INT, right, 0, 
-		 nrows, MPI::INT );
-	win.Complete( );
-	flag = false;
-	while (!flag) {
-	    flag = win.Test();
-	}
+        win.Put(&buf[0 + nrows], nrows, MPI::INT, left, ncols + 1, nrows, MPI::INT);
+        win.Put(&buf[0 + ncols * nrows], nrows, MPI::INT, right, 0, nrows, MPI::INT);
+        win.Complete();
+        flag = false;
+        while (!flag) {
+            flag = win.Test();
+        }
 
-	// Check the results
-	if (left != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = rank * (ncols * nrows) - nrows + i;
-		if (buf[i] != ans) {
-		    errs++;
-		    if (errs != 10) {
-			cout << rank << " buf[" << i << ",0] = " <<
-			    buf[i] << " expected " << ans << "\n";
-		    }
-		}
-	    }
-	}
-	if (right != MPI::PROC_NULL) {
-	    for (i=0; i<nrows; i++) {
-		ans = (rank + 1)* (ncols * nrows) + i;
-		if (buf[i + (ncols+1)*nrows] != ans) {
-		    errs++;
-		    if (errs <= 10) {
-			cout << rank << " buf[" << i << ",ncols+1] = " <<
-			    buf[i+(ncols+1)*nrows] << " expected " << 
-			    ans << "\n";
-		    }
-		}
-	    }
-	}
+        // Check the results
+        if (left != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = rank * (ncols * nrows) - nrows + i;
+                if (buf[i] != ans) {
+                    errs++;
+                    if (errs != 10) {
+                        cout << rank << " buf[" << i << ",0] = " <<
+                            buf[i] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
+        if (right != MPI::PROC_NULL) {
+            for (i = 0; i < nrows; i++) {
+                ans = (rank + 1) * (ncols * nrows) + i;
+                if (buf[i + (ncols + 1) * nrows] != ans) {
+                    errs++;
+                    if (errs <= 10) {
+                        cout << rank << " buf[" << i << ",ncols+1] = " <<
+                            buf[i + (ncols + 1) * nrows] << " expected " << ans << "\n";
+                    }
+                }
+            }
+        }
 
-	
-	group2.Free();
-	win.Free();
-	MTestFreeComm( comm );
+
+        group2.Free();
+        win.Free();
+        MTestFreeComm(comm);
     }
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/spawn/namepubx.cxx
+++ b/test/mpi/cxx/spawn/namepubx.cxx
@@ -22,7 +22,7 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     char *port_name, *port_name_out;
@@ -32,98 +32,99 @@ int main( int argc, char *argv[] )
     int msglen;
     int rank;
 
-    MTest_Init( );
+    MTest_Init();
 
-    port_name = new char [MPI::MAX_PORT_NAME];
-    port_name_out = new char [MPI::MAX_PORT_NAME];
-  
+    port_name = new char[MPI::MAX_PORT_NAME];
+    port_name_out = new char[MPI::MAX_PORT_NAME];
+
     rank = MPI::COMM_WORLD.Get_rank();
 
     /* Note that according to the MPI standard, port_name must
-       have been created by MPI_Open_port.  For current testing
-       purposes, we'll use a fake name.  This test should eventually use
-       a valid name from Open_port */
+     * have been created by MPI_Open_port.  For current testing
+     * purposes, we'll use a fake name.  This test should eventually use
+     * a valid name from Open_port */
 
-    strcpy( port_name, "otherhost:122" );
-    strcpy( serv_name, "MyTest" );
+    strcpy(port_name, "otherhost:122");
+    strcpy(serv_name, "MyTest");
 
-    MPI::COMM_WORLD.Set_errhandler( MPI::ERRORS_THROW_EXCEPTIONS );
+    MPI::COMM_WORLD.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
 
     if (rank == 0) {
-	try {
-	    MPI::Publish_name( serv_name, MPI::INFO_NULL, port_name );
-	} catch (MPI::Exception e) {
-	    errs++;
-	    errmsg = e.Get_error_string();
-	    cout << "Error in Publish_name " << errmsg << "\n";
-	}
+        try {
+            MPI::Publish_name(serv_name, MPI::INFO_NULL, port_name);
+        }
+        catch(MPI::Exception e) {
+            errs++;
+            errmsg = e.Get_error_string();
+            cout << "Error in Publish_name " << errmsg << "\n";
+        }
 
-	MPI::COMM_WORLD.Barrier();
-	MPI::COMM_WORLD.Barrier();
-	
-	try {
-	    MPI::Unpublish_name( serv_name, MPI::INFO_NULL, port_name );
-	} catch (MPI::Exception e) {
-	    errs++;
-	    errmsg = e.Get_error_string();
-	    cout << "Error in Unpublish name " << errmsg << "\n";
-	}
-    }
-    else {
-	MPI::COMM_WORLD.Barrier();
+        MPI::COMM_WORLD.Barrier();
+        MPI::COMM_WORLD.Barrier();
 
-	merr = MPI::SUCCESS;
-	try {
-	    MPI::Lookup_name( serv_name, MPI::INFO_NULL, port_name_out );
-	} catch ( MPI::Exception e ) {
-	    errs++;
-	    merr   = e.Get_error_code();
-	    errmsg = e.Get_error_string();
-	    cout << "Error in Lookup name " << errmsg << "\n";
-	}
-	if (merr == MPI::SUCCESS) {
-	    if (strcmp( port_name, port_name_out )) {
-		errs++;
-		cout << "Lookup name returned the wrong value (" << 
-		    port_name_out << ")\n";
-	    }
-	}
+        try {
+            MPI::Unpublish_name(serv_name, MPI::INFO_NULL, port_name);
+        }
+        catch(MPI::Exception e) {
+            errs++;
+            errmsg = e.Get_error_string();
+            cout << "Error in Unpublish name " << errmsg << "\n";
+        }
+    } else {
+        MPI::COMM_WORLD.Barrier();
 
-	MPI::COMM_WORLD.Barrier();
+        merr = MPI::SUCCESS;
+        try {
+            MPI::Lookup_name(serv_name, MPI::INFO_NULL, port_name_out);
+        }
+        catch(MPI::Exception e) {
+            errs++;
+            merr = e.Get_error_code();
+            errmsg = e.Get_error_string();
+            cout << "Error in Lookup name " << errmsg << "\n";
+        }
+        if (merr == MPI::SUCCESS) {
+            if (strcmp(port_name, port_name_out)) {
+                errs++;
+                cout << "Lookup name returned the wrong value (" << port_name_out << ")\n";
+            }
+        }
+
+        MPI::COMM_WORLD.Barrier();
     }
 
 
     MPI::COMM_WORLD.Barrier();
-    
+
     merr = MPI::SUCCESS;
     port_name_out[0] = 0;
     try {
-	MPI::Lookup_name( serv_name, MPI::INFO_NULL, port_name_out );
-    } catch (MPI::Exception e) {
-	merr = e.Get_error_code();
+        MPI::Lookup_name(serv_name, MPI::INFO_NULL, port_name_out);
+    }
+    catch(MPI::Exception e) {
+        merr = e.Get_error_code();
     }
     if (!merr) {
-	errs++;
-	cout << "Lookup name returned name after it was unpublished\n";
-	cout << "The name returned was " << port_name_out << "\n";
-    }
-    else {
-	/* Must be class MPI::ERR_NAME */
-	mclass = MPI::Get_error_class( merr );
-	if (mclass != MPI::ERR_NAME) {
-	    char *lerrmsg;
-	    lerrmsg = new char [MPI::MAX_ERROR_STRING];
-	    errs++;
-	    MPI::Get_error_string( merr, lerrmsg, msglen );
-	    cout << "Lookup name returned the wrong error class (" << mclass <<
-		"), msg " << lerrmsg << "\n";
-	    delete [] lerrmsg;
-	}
+        errs++;
+        cout << "Lookup name returned name after it was unpublished\n";
+        cout << "The name returned was " << port_name_out << "\n";
+    } else {
+        /* Must be class MPI::ERR_NAME */
+        mclass = MPI::Get_error_class(merr);
+        if (mclass != MPI::ERR_NAME) {
+            char *lerrmsg;
+            lerrmsg = new char[MPI::MAX_ERROR_STRING];
+            errs++;
+            MPI::Get_error_string(merr, lerrmsg, msglen);
+            cout << "Lookup name returned the wrong error class (" << mclass <<
+                "), msg " << lerrmsg << "\n";
+            delete[]lerrmsg;
+        }
     }
 
-    delete [] port_name;
-    delete [] port_name_out;
+    delete[]port_name;
+    delete[]port_name_out;
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
     return 0;
 }

--- a/test/mpi/cxx/spawn/selfconaccx.cxx
+++ b/test/mpi/cxx/spawn/selfconaccx.cxx
@@ -18,7 +18,7 @@ using namespace std;
 #endif
 #include "mpitestcxx.h"
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int error;
     int rank, size;
@@ -33,24 +33,21 @@ int main( int argc, char *argv[] )
     size = MPI::COMM_WORLD.Get_size();
     rank = MPI::COMM_WORLD.Get_rank();
 
-    if (size < 2)
-    {
-	cout << "Two processes needed.\n"; 
-	return 0;
+    if (size < 2) {
+        cout << "Two processes needed.\n";
+        return 0;
     }
 
-    if (rank == 0)
-    {
-	MPI::Open_port(MPI::INFO_NULL, port);
-	MPI::COMM_WORLD.Send(port, MPI::MAX_PORT_NAME, MPI::CHAR, 1, 0 );
-	comm = MPI::COMM_SELF.Accept(port, MPI::INFO_NULL, 0 );
-	MPI::Close_port(port);
-	comm.Disconnect();
-    }
-    else if (rank == 1) {
-	MPI::COMM_WORLD.Recv(port, MPI::MAX_PORT_NAME, MPI::CHAR, 0, 0 );
-	comm = MPI::COMM_SELF.Connect(port, MPI::INFO_NULL, 0 );
-	comm.Disconnect();
+    if (rank == 0) {
+        MPI::Open_port(MPI::INFO_NULL, port);
+        MPI::COMM_WORLD.Send(port, MPI::MAX_PORT_NAME, MPI::CHAR, 1, 0);
+        comm = MPI::COMM_SELF.Accept(port, MPI::INFO_NULL, 0);
+        MPI::Close_port(port);
+        comm.Disconnect();
+    } else if (rank == 1) {
+        MPI::COMM_WORLD.Recv(port, MPI::MAX_PORT_NAME, MPI::CHAR, 0, 0);
+        comm = MPI::COMM_SELF.Connect(port, MPI::INFO_NULL, 0);
+        comm.Disconnect();
     }
 
     MPI::COMM_WORLD.Barrier();

--- a/test/mpi/cxx/spawn/spawnargvx.cxx
+++ b/test/mpi/cxx/spawn/spawnargvx.cxx
@@ -117,6 +117,8 @@ int main( int argc, char *argv[] )
     /* Note that the MTest_Finalize get errs only over COMM_WORLD */
     if (parentcomm == MPI::COMM_NULL) {
 	MTest_Finalize( errs );
+    } else {
+        MPI_Finalize();
     }
 
     return 0;

--- a/test/mpi/cxx/spawn/spawnargvx.cxx
+++ b/test/mpi/cxx/spawn/spawnargvx.cxx
@@ -24,91 +24,84 @@ using namespace std;
 
 static char MTEST_Descrip[] = "A simple test of Comm_spawn, with complex arguments";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0, err;
     int rank, size, rsize, i;
     int np = 2;
     int errcodes[2];
-    MPI::Intercomm      parentcomm, intercomm;
-    MPI::Status         status;
-    const char * inargv[]  = { "a", "b=c", "d e", "-pf", " Ss", 0 };
-    const char * outargv[] = { "a", "b=c", "d e", "-pf", " Ss", 0 };
+    MPI::Intercomm parentcomm, intercomm;
+    MPI::Status status;
+    const char *inargv[] = { "a", "b=c", "d e", "-pf", " Ss", 0 };
+    const char *outargv[] = { "a", "b=c", "d e", "-pf", " Ss", 0 };
 
-    MTest_Init( );
+    MTest_Init();
 
     parentcomm = MPI::Comm::Get_parent();
 
     if (parentcomm == MPI::COMM_NULL) {
-	/* Create 2 more processes */
-	/* ./ is unix specific .
-	   The more generic approach would be to specify "spawnargv" as the 
-	   executable and pass an info with ("path", ".") */
-	intercomm = MPI::COMM_WORLD.Spawn( "./spawnargvx", inargv, np,
-			MPI::INFO_NULL, 0, errcodes );
-    }
-    else 
-	intercomm = parentcomm;
+        /* Create 2 more processes */
+        /* ./ is unix specific .
+         * The more generic approach would be to specify "spawnargv" as the
+         * executable and pass an info with ("path", ".") */
+        intercomm = MPI::COMM_WORLD.Spawn("./spawnargvx", inargv, np, MPI::INFO_NULL, 0, errcodes);
+    } else
+        intercomm = parentcomm;
 
     /* We now have a valid intercomm */
 
     rsize = intercomm.Get_remote_size();
-    size  = intercomm.Get_size();
-    rank  = intercomm.Get_rank();
+    size = intercomm.Get_size();
+    rank = intercomm.Get_rank();
 
     if (parentcomm == MPI::COMM_NULL) {
-	/* Master */
-	if (rsize != np) {
-	    errs++;
-	    cout << "Did not create " << np << " processes (got " <<
-		rsize << ")\n";
-	}
-	for (i=0; i<rsize; i++) {
-	    intercomm.Send( &i, 1, MPI::INT, i, 0 );
-	}
-	/* We could use intercomm reduce to get the errors from the 
-	   children, but we'll use a simpler loop to make sure that
-	   we get valid data */
-	for (i=0; i<rsize; i++) {
-	    intercomm.Recv( &err, 1, MPI::INT, i, 1 );
-	    errs += err;
-	}
-    }
-    else {
-	/* Child */
-	/* FIXME: This assumes that stdout is handled for the children
-	   (the error count will still be reported to the parent) */
-	if (size != np) {
-	    errs++;
-	    cout << "(Child) Did not create " << np << " (got " <<
-		size << ")\n";
-	}
-	intercomm.Recv( &i, 1, MPI::INT, 0, 0, status );
-	if (i != rank) {
-	    errs++;
-	    cout << "Unexpected rank on child " << rank << " (" << 
-		i << "\n";
-	}
-	/* Check the command line */
-	for (i=1; i<argc; i++) {
-	    if (!outargv[i-1]) {
-		errs++;
-		cout << "Wrong number of arguments (" << argc << ")\n";
-		break;
-	    }
-	    if (strcmp( argv[i], outargv[i-1] ) != 0) {
-		errs++;
-		cout << "Found arg " << argv[i] << " but expected " <<
-		    outargv[i-1] << "\n";
-	    }
-	}
-	if (outargv[i-1]) {
-	    /* We had too few args in the spawned command */
-	    errs++;
-	    cout << "Too few arguments to spawned command\n";
-	}
-	/* Send the errs back to the master process */
-	intercomm.Ssend( &errs, 1, MPI::INT, 0, 1 );
+        /* Master */
+        if (rsize != np) {
+            errs++;
+            cout << "Did not create " << np << " processes (got " << rsize << ")\n";
+        }
+        for (i = 0; i < rsize; i++) {
+            intercomm.Send(&i, 1, MPI::INT, i, 0);
+        }
+        /* We could use intercomm reduce to get the errors from the
+         * children, but we'll use a simpler loop to make sure that
+         * we get valid data */
+        for (i = 0; i < rsize; i++) {
+            intercomm.Recv(&err, 1, MPI::INT, i, 1);
+            errs += err;
+        }
+    } else {
+        /* Child */
+        /* FIXME: This assumes that stdout is handled for the children
+         * (the error count will still be reported to the parent) */
+        if (size != np) {
+            errs++;
+            cout << "(Child) Did not create " << np << " (got " << size << ")\n";
+        }
+        intercomm.Recv(&i, 1, MPI::INT, 0, 0, status);
+        if (i != rank) {
+            errs++;
+            cout << "Unexpected rank on child " << rank << " (" << i << "\n";
+        }
+        /* Check the command line */
+        for (i = 1; i < argc; i++) {
+            if (!outargv[i - 1]) {
+                errs++;
+                cout << "Wrong number of arguments (" << argc << ")\n";
+                break;
+            }
+            if (strcmp(argv[i], outargv[i - 1]) != 0) {
+                errs++;
+                cout << "Found arg " << argv[i] << " but expected " << outargv[i - 1] << "\n";
+            }
+        }
+        if (outargv[i - 1]) {
+            /* We had too few args in the spawned command */
+            errs++;
+            cout << "Too few arguments to spawned command\n";
+        }
+        /* Send the errs back to the master process */
+        intercomm.Ssend(&errs, 1, MPI::INT, 0, 1);
     }
 
     /* It isn't necessary to free the intercomm, but it should not hurt */
@@ -116,7 +109,7 @@ int main( int argc, char *argv[] )
 
     /* Note that the MTest_Finalize get errs only over COMM_WORLD */
     if (parentcomm == MPI::COMM_NULL) {
-	MTest_Finalize( errs );
+        MTest_Finalize(errs);
     } else {
         MPI_Finalize();
     }

--- a/test/mpi/cxx/spawn/spawnintrax.cxx
+++ b/test/mpi/cxx/spawn/spawnintrax.cxx
@@ -203,6 +203,8 @@ int main( int argc, char *argv[] )
        if both call MTest_Finalize */
     if (parentcomm == MPI::COMM_NULL) {
 	MTest_Finalize( errs );
+    } else {
+        MPI_Finalize();
     }
 
     return 0;

--- a/test/mpi/cxx/spawn/spawnintrax.cxx
+++ b/test/mpi/cxx/spawn/spawnintrax.cxx
@@ -21,173 +21,162 @@ using namespace std;
 
 static char MTEST_Descrip[] = "A simple test of Comm_spawn, followed by intercomm merge";
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0, err;
     int rank, size, rsize, i;
     int np = 2;
     int errcodes[2];
-    MPI::Intercomm      parentcomm, intercomm;
-    MPI::Intracomm      intracomm, intracomm2, intracomm3;
-    bool           isChild = false;
-    MPI::Status    status;
+    MPI::Intercomm parentcomm, intercomm;
+    MPI::Intracomm intracomm, intracomm2, intracomm3;
+    bool isChild = false;
+    MPI::Status status;
 
-    MTest_Init( );
+    MTest_Init();
 
     parentcomm = MPI::Comm::Get_parent();
 
     if (parentcomm == MPI::COMM_NULL) {
-	/* Create 2 more processes */
-	intercomm = MPI::COMM_WORLD.Spawn( "./spawnintrax", MPI::ARGV_NULL, np,
-			MPI::INFO_NULL, 0, errcodes );
-    }
-    else 
-	intercomm = parentcomm;
+        /* Create 2 more processes */
+        intercomm = MPI::COMM_WORLD.Spawn("./spawnintrax", MPI::ARGV_NULL, np,
+                                          MPI::INFO_NULL, 0, errcodes);
+    } else
+        intercomm = parentcomm;
 
     /* We now have a valid intercomm */
 
-    rsize = intercomm.Get_remote_size( );
-    size  = intercomm.Get_size();
-    rank  = intercomm.Get_rank();
+    rsize = intercomm.Get_remote_size();
+    size = intercomm.Get_size();
+    rank = intercomm.Get_rank();
 
     if (parentcomm == MPI::COMM_NULL) {
-	/* Master */
-	if (rsize != np) {
-	    errs++;
-	    cout << "Did not create " << np << " processes (got " <<
-		rsize << ")\n";
-	}
-	if (rank == 0) {
-	    for (i=0; i<rsize; i++) {
-		intercomm.Send( &i, 1, MPI::INT, i, 0 );
-	    }
-	}
-    }
-    else {
-	/* Child */
-	isChild = true;
-	if (size != np) {
-	    errs++;
-	    cout << "(Child) Did not create " << np << 
-		" processes (got " << size << ")\n";
-	}
-	intercomm.Recv( &i, 1, MPI::INT, 0, 0, status );
-	if (i != rank) {
-	    errs++;
-	    cout << "Unexpected rank on child " << rank << " (" <<
-		i << ")\n";
-	}
+        /* Master */
+        if (rsize != np) {
+            errs++;
+            cout << "Did not create " << np << " processes (got " << rsize << ")\n";
+        }
+        if (rank == 0) {
+            for (i = 0; i < rsize; i++) {
+                intercomm.Send(&i, 1, MPI::INT, i, 0);
+            }
+        }
+    } else {
+        /* Child */
+        isChild = true;
+        if (size != np) {
+            errs++;
+            cout << "(Child) Did not create " << np << " processes (got " << size << ")\n";
+        }
+        intercomm.Recv(&i, 1, MPI::INT, 0, 0, status);
+        if (i != rank) {
+            errs++;
+            cout << "Unexpected rank on child " << rank << " (" << i << ")\n";
+        }
     }
 
     /* At this point, try to form the intracommunicator */
-    intracomm = intercomm.Merge( isChild );
+    intracomm = intercomm.Merge(isChild);
 
     /* Check on the intra comm */
     {
-	int icsize, icrank, wrank;
-	
-	icsize = intracomm.Get_size();
-	icrank = intracomm.Get_rank();
-	wrank  = MPI::COMM_WORLD.Get_rank();
+        int icsize, icrank, wrank;
 
-	if (icsize != rsize + size) {
-	    errs++;
-	    cout << "Intracomm rank " << icrank << " thinks size is " <<
-		icsize << ", not " << rsize + size << "\n";
-	}
-	/* Make sure that the processes are ordered correctly */
-	if (isChild) {
-	    int psize;
-	    psize = parentcomm.Get_remote_size();
-	    if (icrank != psize + wrank ) {
-		errs++;
-		cout << "Intracomm rank " << icrank << 
-		    " (from child) should have rank " << psize + wrank << "\n";
-	    }
-	}
-	else {
-	    if (icrank != wrank) {
-		errs++;
-		cout << "Intracomm rank " << icrank << 
-		    " (from parent) should have rank " << wrank << "\n";
-	    }
-	}
+        icsize = intracomm.Get_size();
+        icrank = intracomm.Get_rank();
+        wrank = MPI::COMM_WORLD.Get_rank();
+
+        if (icsize != rsize + size) {
+            errs++;
+            cout << "Intracomm rank " << icrank << " thinks size is " <<
+                icsize << ", not " << rsize + size << "\n";
+        }
+        /* Make sure that the processes are ordered correctly */
+        if (isChild) {
+            int psize;
+            psize = parentcomm.Get_remote_size();
+            if (icrank != psize + wrank) {
+                errs++;
+                cout << "Intracomm rank " << icrank <<
+                    " (from child) should have rank " << psize + wrank << "\n";
+            }
+        } else {
+            if (icrank != wrank) {
+                errs++;
+                cout << "Intracomm rank " << icrank <<
+                    " (from parent) should have rank " << wrank << "\n";
+            }
+        }
     }
 
-    /* At this point, try to form the intracommunicator, with the other 
-     processes first */
-    intracomm2 = intercomm.Merge( !isChild );
+    /* At this point, try to form the intracommunicator, with the other
+     * processes first */
+    intracomm2 = intercomm.Merge(!isChild);
 
     /* Check on the intra comm */
     {
-	int icsize, icrank, wrank;
-	
-	icsize = intracomm2.Get_size();
-	icrank = intracomm2.Get_rank();
-	wrank  = MPI::COMM_WORLD.Get_rank();
+        int icsize, icrank, wrank;
 
-	if (icsize != rsize + size) {
-	    errs++;
-	    cout << "(2)Intracomm rank " << icrank << 
-		" thinks size is " << icsize << ", not " << rsize + size << 
-		"\n";
-	}
-	/* Make sure that the processes are ordered correctly */
-	if (isChild) {
-	    if (icrank != wrank ) {
-		errs++;
-		cout << "(2)Intracomm rank " << icrank << 
-		    " (from child) should have rank " << wrank << "\n";
-	    }
-	}
-	else {
-	    int csize;
-	    csize = intercomm.Get_remote_size();
-	    if (icrank != wrank + csize) {
-		errs++;
-		cout << "(2)Intracomm rank " << icrank << 
-		    " (from parent) should have rank " << wrank + csize << 
-		    "\n";
-	    }
-	}
+        icsize = intracomm2.Get_size();
+        icrank = intracomm2.Get_rank();
+        wrank = MPI::COMM_WORLD.Get_rank();
+
+        if (icsize != rsize + size) {
+            errs++;
+            cout << "(2)Intracomm rank " << icrank <<
+                " thinks size is " << icsize << ", not " << rsize + size << "\n";
+        }
+        /* Make sure that the processes are ordered correctly */
+        if (isChild) {
+            if (icrank != wrank) {
+                errs++;
+                cout << "(2)Intracomm rank " << icrank <<
+                    " (from child) should have rank " << wrank << "\n";
+            }
+        } else {
+            int csize;
+            csize = intercomm.Get_remote_size();
+            if (icrank != wrank + csize) {
+                errs++;
+                cout << "(2)Intracomm rank " << icrank <<
+                    " (from parent) should have rank " << wrank + csize << "\n";
+            }
+        }
     }
 
-    /* At this point, try to form the intracommunicator, with an 
-       arbitrary choice for the first group of processes */
-    intracomm3 = intercomm.Merge( false );
+    /* At this point, try to form the intracommunicator, with an
+     * arbitrary choice for the first group of processes */
+    intracomm3 = intercomm.Merge(false);
     /* Check on the intra comm */
     {
-	int icsize, icrank, wrank;
-	
-	icsize = intracomm3.Get_size();
-	icrank = intracomm3.Get_rank();
-	wrank = MPI::COMM_WORLD.Get_rank();
+        int icsize, icrank, wrank;
 
-	if (icsize != rsize + size) {
-	    errs++;
-	    cout << "(3)Intracomm rank " << icrank << 
-		" thinks size is " << icsize << ", not " << rsize + size << 
-		"\n";
-	}
-	/* Eventually, we should test that the processes are ordered 
-	   correctly, by groups (must be one of the two cases above) */
+        icsize = intracomm3.Get_size();
+        icrank = intracomm3.Get_rank();
+        wrank = MPI::COMM_WORLD.Get_rank();
+
+        if (icsize != rsize + size) {
+            errs++;
+            cout << "(3)Intracomm rank " << icrank <<
+                " thinks size is " << icsize << ", not " << rsize + size << "\n";
+        }
+        /* Eventually, we should test that the processes are ordered
+         * correctly, by groups (must be one of the two cases above) */
     }
 
     /* Update error count */
     if (isChild) {
-	/* Send the errs back to the master process */
-	intercomm.Ssend( &errs, 1, MPI::INT, 0, 1 );
-    }
-    else {
-	if (rank == 0) {
-	    /* We could use intercomm reduce to get the errors from the 
-	       children, but we'll use a simpler loop to make sure that
-	       we get valid data */
-	    for (i=0; i<rsize; i++) {
-		intercomm.Recv( &err, 1, MPI::INT, i, 1 );
-		errs += err;
-	    }
-	}
+        /* Send the errs back to the master process */
+        intercomm.Ssend(&errs, 1, MPI::INT, 0, 1);
+    } else {
+        if (rank == 0) {
+            /* We could use intercomm reduce to get the errors from the
+             * children, but we'll use a simpler loop to make sure that
+             * we get valid data */
+            for (i = 0; i < rsize; i++) {
+                intercomm.Recv(&err, 1, MPI::INT, i, 1);
+                errs += err;
+            }
+        }
     }
 
     /* It isn't necessary to free the intracomms, but it should not hurt */
@@ -200,9 +189,9 @@ int main( int argc, char *argv[] )
 
     /* Note that the MTest_Finalize get errs only over COMM_WORLD */
     /* Note also that both the parent and child will generate "No Errors"
-       if both call MTest_Finalize */
+     * if both call MTest_Finalize */
     if (parentcomm == MPI::COMM_NULL) {
-	MTest_Finalize( errs );
+        MTest_Finalize(errs);
     } else {
         MPI_Finalize();
     }

--- a/test/mpi/cxx/topo/distgraphcxx.cxx
+++ b/test/mpi/cxx/topo/distgraphcxx.cxx
@@ -19,7 +19,7 @@ using namespace std;
 #include <iostream.h>
 #endif
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     int indegree, outdegree, sources[4], dests[4], sweights[4], dweights[4];
@@ -32,68 +32,66 @@ int main( int argc, char *argv[] )
     // receives from rank - 2
     wrank = MPI::COMM_WORLD.Get_rank();
     wsize = MPI::COMM_WORLD.Get_size();
-    indegree  = 0;
+    indegree = 0;
     outdegree = 0;
-    if (wrank+1 < wsize) dests[outdegree++] = wrank+1;
-    if (wrank+3 < wsize) dests[outdegree++] = wrank+3;
-    if (wrank-2 >= 0) sources[indegree++] = wrank-2;
+    if (wrank + 1 < wsize)
+        dests[outdegree++] = wrank + 1;
+    if (wrank + 3 < wsize)
+        dests[outdegree++] = wrank + 3;
+    if (wrank - 2 >= 0)
+        sources[indegree++] = wrank - 2;
 
     // Create with no reordering to test final ranks
-    dcomm = MPI::COMM_WORLD.Dist_graph_create_adjacent( indegree, sources,
-				outdegree, dests, MPI::INFO_NULL, false );
-    
-    
+    dcomm = MPI::COMM_WORLD.Dist_graph_create_adjacent(indegree, sources,
+                                                       outdegree, dests, MPI::INFO_NULL, false);
+
+
     // Check that the created communicator has the properties specified
     if (dcomm.Get_topology() != MPI_DIST_GRAPH) {
-	errs++;
-	cout << "Incorrect topology for dist_graph: " << 
-	    dcomm.Get_topology() << "\n";
-    }
-    else {
-	int myindegree, myoutdegree;
-	bool myweighted;
-	dcomm.Get_dist_neighbors_count( myindegree, myoutdegree, myweighted );
-	if (myindegree != indegree) {
-	    errs++;
-	    cout << "Indegree is " << myindegree << " should be " << indegree 
-		 << "\n";
-	}
-	if (myoutdegree != outdegree) {
-	    errs++;
-	    cout << "Outdegree is " << myoutdegree << " should be " << 
-		outdegree << "\n";
-	}
-	if (myweighted) {
-	    errs++;
-	    cout << "Weighted is true, should be false\n";
-	}
+        errs++;
+        cout << "Incorrect topology for dist_graph: " << dcomm.Get_topology() << "\n";
+    } else {
+        int myindegree, myoutdegree;
+        bool myweighted;
+        dcomm.Get_dist_neighbors_count(myindegree, myoutdegree, myweighted);
+        if (myindegree != indegree) {
+            errs++;
+            cout << "Indegree is " << myindegree << " should be " << indegree << "\n";
+        }
+        if (myoutdegree != outdegree) {
+            errs++;
+            cout << "Outdegree is " << myoutdegree << " should be " << outdegree << "\n";
+        }
+        if (myweighted) {
+            errs++;
+            cout << "Weighted is true, should be false\n";
+        }
     }
     if (!errs) {
-	int mysources[4], mysweights[4], mydests[4], mydweights[4], i;
-	dcomm.Get_dist_neighbors( 4, mysources, mysweights, 
-				  4, mydests, mydweights );
-	// May need to sort mysources and mydests first
-	for (i=0; i<indegree; i++) {
-	    if (mysources[i] != sources[i]) {
-		errs++;
-	    }
-	}
-	for (i=0; i<outdegree; i++) {
-	    if (mydests[i] != dests[i]) {
-		errs++;
-	    }
-	}
+        int mysources[4], mysweights[4], mydests[4], mydweights[4], i;
+        dcomm.Get_dist_neighbors(4, mysources, mysweights, 4, mydests, mydweights);
+        // May need to sort mysources and mydests first
+        for (i = 0; i < indegree; i++) {
+            if (mysources[i] != sources[i]) {
+                errs++;
+            }
+        }
+        for (i = 0; i < outdegree; i++) {
+            if (mydests[i] != dests[i]) {
+                errs++;
+            }
+        }
     }
     dcomm.Free();
 
-    // ToDo: 
-    // Test dup and clone.  
-    // Test with weights.  
+    // ToDo:
+    // Test dup and clone.
+    // Test with weights.
     // Test with reorder.
     // Test Dist_graph (not just adjacent) with awkward specification.
     // Note that there is no dist_graph_map function in MPI (!)
-  
-    MTest_Finalize( errs );
+
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/cxx/util/mtest.cxx
+++ b/test/mpi/cxx/util/mtest.cxx
@@ -25,14 +25,14 @@ static int dbgflag = 0;         /* Flag used for debugging */
 static int wrank = -1;          /* World rank */
 static int verbose = 0;         /* Message level (0 is none) */
 
-static void MTestRMACleanup( void );
+static void MTestRMACleanup(void);
 
-/* 
+/*
  * Initialize and Finalize MTest
  */
 
-/* 
-   Initialize MTest, initializing MPI if necessary.  
+/*
+   Initialize MTest, initializing MPI if necessary.
 
  Environment Variables:
 + MPITEST_DEBUG - If set (to any value), turns on debugging output
@@ -40,97 +40,85 @@ static void MTestRMACleanup( void );
   verbose output.
 
  */
-void MTest_Init( void )
+void MTest_Init(void)
 {
     bool flag;
     const char *envval = 0;
-    int        threadLevel, provided;
+    int threadLevel, provided;
 
     threadLevel = MPI::THREAD_SINGLE;
-    envval = getenv( "MTEST_THREADLEVEL_DEFAULT" );
+    envval = getenv("MTEST_THREADLEVEL_DEFAULT");
     if (envval && *envval) {
-	if (strcmp(envval,"MULTIPLE") == 0 || strcmp(envval,"multiple") == 0) {
-	    threadLevel = MPI::THREAD_MULTIPLE;
-	}
-	else if (strcmp(envval,"SERIALIZED") == 0 || 
-		 strcmp(envval,"serialized") == 0) {
-	    threadLevel = MPI::THREAD_SERIALIZED;
-	}
-	else if (strcmp(envval,"FUNNELED") == 0 || 
-		 strcmp(envval,"funneled") == 0) {
-	    threadLevel = MPI::THREAD_FUNNELED;
-	}
-	else if (strcmp(envval,"SINGLE") == 0 || strcmp(envval,"single") == 0) {
-	    threadLevel = MPI::THREAD_SINGLE;
-	}
-	else {
-	    cerr << "Unrecognized thread level " << envval << "\n";
-	    cerr.flush();
-	    /* Use exit since MPI_Init/Init_thread has not been called. */
-	    exit(1);
-	}
+        if (strcmp(envval, "MULTIPLE") == 0 || strcmp(envval, "multiple") == 0) {
+            threadLevel = MPI::THREAD_MULTIPLE;
+        } else if (strcmp(envval, "SERIALIZED") == 0 || strcmp(envval, "serialized") == 0) {
+            threadLevel = MPI::THREAD_SERIALIZED;
+        } else if (strcmp(envval, "FUNNELED") == 0 || strcmp(envval, "funneled") == 0) {
+            threadLevel = MPI::THREAD_FUNNELED;
+        } else if (strcmp(envval, "SINGLE") == 0 || strcmp(envval, "single") == 0) {
+            threadLevel = MPI::THREAD_SINGLE;
+        } else {
+            cerr << "Unrecognized thread level " << envval << "\n";
+            cerr.flush();
+            /* Use exit since MPI_Init/Init_thread has not been called. */
+            exit(1);
+        }
     }
 
-    flag = MPI::Is_initialized( );
+    flag = MPI::Is_initialized();
     if (!flag) {
-	provided = MPI::Init_thread( threadLevel );
+        provided = MPI::Init_thread(threadLevel);
     }
-
 #if defined(HAVE_MPI_IO)
     MPI::FILE_NULL.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
 #endif
 
     /* Check for debugging control */
-    if (getenv( "MPITEST_DEBUG" )) {
-	dbgflag = 1;
-	wrank = MPI::COMM_WORLD.Get_rank();
+    if (getenv("MPITEST_DEBUG")) {
+        dbgflag = 1;
+        wrank = MPI::COMM_WORLD.Get_rank();
     }
 
     /* Check for verbose control */
-    envval = getenv( "MPITEST_VERBOSE" );
+    envval = getenv("MPITEST_VERBOSE");
     if (envval) {
-	char *s;
-	long val = strtol( envval, &s, 0 );
-	if (s == envval) {
-	    /* This is the error case for strtol */
-	    cerr << "Warning: "<< envval << " not valid for MPITEST_VERBOSE\n";
-	    cerr.flush();
-	}
-	else {
-	    if (val >= 0) {
-		verbose = val;
-	    }
-	    else {
-		cerr << "Warning: " << envval << 
-		    " not valid for MPITEST_VERBOSE\n";
-		cerr.flush();
-	    }
-	}
+        char *s;
+        long val = strtol(envval, &s, 0);
+        if (s == envval) {
+            /* This is the error case for strtol */
+            cerr << "Warning: " << envval << " not valid for MPITEST_VERBOSE\n";
+            cerr.flush();
+        } else {
+            if (val >= 0) {
+                verbose = val;
+            } else {
+                cerr << "Warning: " << envval << " not valid for MPITEST_VERBOSE\n";
+                cerr.flush();
+            }
+        }
     }
 }
 
 /*
-  Finalize MTest.  errs is the number of errors on the calling process; 
+  Finalize MTest.  errs is the number of errors on the calling process;
   this routine will write the total number of errors over all of MPI_COMM_WORLD
   to the process with rank zero, or " No Errors".
  */
-void MTest_Finalize( int errs )
+void MTest_Finalize(int errs)
 {
     int rank, toterrs;
 
     rank = MPI::COMM_WORLD.Get_rank();
 
-    MPI::COMM_WORLD.Allreduce( &errs, &toterrs, 1, MPI::INT, MPI::SUM );
+    MPI::COMM_WORLD.Allreduce(&errs, &toterrs, 1, MPI::INT, MPI::SUM);
     if (rank == 0) {
-	if (toterrs) {
-	    cout << " Found " << toterrs << " errors\n";
-	}
-	else {
-	    cout << " No Errors\n";
-	}
-	cout.flush();
+        if (toterrs) {
+            cout << " Found " << toterrs << " errors\n";
+        } else {
+            cout << " No Errors\n";
+        }
+        cout.flush();
     }
-
     // Clean up any persistent objects that we allocated
     MTestRMACleanup();
 
@@ -140,106 +128,105 @@ void MTest_Finalize( int errs )
 /*
  * Datatypes
  *
- * Eventually, this could read a description of a file.  For now, we hard 
+ * Eventually, this could read a description of a file.  For now, we hard
  * code the choices
  *
  */
 static int datatype_index = 0;
 
-/* 
+/*
  * Setup contiguous buffers of n copies of a datatype.
  */
-static void *MTestTypeContigInit( MTestDatatype *mtype )
+static void *MTestTypeContigInit(MTestDatatype * mtype)
 {
     MPI::Aint size, lb;
     if (mtype->count > 0) {
-	signed char *p;
-	int  i;
+        signed char *p;
+        int i;
         MPI::Aint totsize;
-	mtype->datatype.Get_extent( lb, size );
-	totsize = size * mtype->count;
-	if (!mtype->buf) {
-	    mtype->buf = (void *) malloc( totsize );
-	}
-	p = (signed char *)(mtype->buf);
-	if (!p) {
-	    /* Error - out of memory */
-	    MTestError( "Out of memory in type buffer init" );
-	}
-	for (i=0; i<totsize; i++) {
-	    p[i] = 0xff ^ (i & 0xff);
-	}
-    }
-    else {
-	mtype->buf = 0;
+        mtype->datatype.Get_extent(lb, size);
+        totsize = size * mtype->count;
+        if (!mtype->buf) {
+            mtype->buf = (void *) malloc(totsize);
+        }
+        p = (signed char *) (mtype->buf);
+        if (!p) {
+            /* Error - out of memory */
+            MTestError("Out of memory in type buffer init");
+        }
+        for (i = 0; i < totsize; i++) {
+            p[i] = 0xff ^ (i & 0xff);
+        }
+    } else {
+        mtype->buf = 0;
     }
     return mtype->buf;
 }
 
-/* 
+/*
  * Setup contiguous buffers of n copies of a datatype.  Initialize for
  * reception (e.g., set initial data to detect failure)
  */
-static void *MTestTypeContigInitRecv( MTestDatatype *mtype )
+static void *MTestTypeContigInitRecv(MTestDatatype * mtype)
 {
     MPI_Aint size;
     if (mtype->count > 0) {
-	signed char *p;
-	int  i;
+        signed char *p;
+        int i;
         MPI::Aint totsize;
-	MPI_Type_extent( mtype->datatype, &size );
-	totsize = size * mtype->count;
-	if (!mtype->buf) {
-	    mtype->buf = (void *) malloc( totsize );
-	}
-	p = (signed char *)(mtype->buf);
-	if (!p) {
-	    /* Error - out of memory */
-	    MTestError( "Out of memory in type buffer init" );
-	}
-	for (i=0; i<totsize; i++) {
-	    p[i] = 0xff;
-	}
-    }
-    else {
-	if (mtype->buf) {
-	    free( mtype->buf );
-	}
-	mtype->buf = 0;
+        MPI_Type_extent(mtype->datatype, &size);
+        totsize = size * mtype->count;
+        if (!mtype->buf) {
+            mtype->buf = (void *) malloc(totsize);
+        }
+        p = (signed char *) (mtype->buf);
+        if (!p) {
+            /* Error - out of memory */
+            MTestError("Out of memory in type buffer init");
+        }
+        for (i = 0; i < totsize; i++) {
+            p[i] = 0xff;
+        }
+    } else {
+        if (mtype->buf) {
+            free(mtype->buf);
+        }
+        mtype->buf = 0;
     }
     return mtype->buf;
 }
-static void *MTestTypeContigFree( MTestDatatype *mtype )
+
+static void *MTestTypeContigFree(MTestDatatype * mtype)
 {
     if (mtype->buf) {
-	free( mtype->buf );
-	mtype->buf = 0;
+        free(mtype->buf);
+        mtype->buf = 0;
     }
     return 0;
 }
-static int MTestTypeContigCheckbuf( MTestDatatype *mtype )
+
+static int MTestTypeContigCheckbuf(MTestDatatype * mtype)
 {
     unsigned char *p;
     unsigned char expected;
-    int  i, err = 0;
+    int i, err = 0;
     MPI_Aint size, totsize;
 
-    p = (unsigned char *)mtype->buf;
+    p = (unsigned char *) mtype->buf;
     if (p) {
-	MPI_Type_extent( mtype->datatype, &size );
-	totsize = size * mtype->count;
-	for (i=0; i<totsize; i++) {
-	    expected = (0xff ^ (i & 0xff));
-	    if (p[i] != expected) {
-		err++;
-		if (mtype->printErrors && err < 10) {
-		    cout << "Data expected = " << hex << expected << 
-			" but got " << p[i] << " for the " <<
-			 dec << i << "th entry\n";
-		    cout.flush();
-		}
-	    }
-	}
+        MPI_Type_extent(mtype->datatype, &size);
+        totsize = size * mtype->count;
+        for (i = 0; i < totsize; i++) {
+            expected = (0xff ^ (i & 0xff));
+            if (p[i] != expected) {
+                err++;
+                if (mtype->printErrors && err < 10) {
+                    cout << "Data expected = " << hex << expected <<
+                        " but got " << p[i] << " for the " << dec << i << "th entry\n";
+                    cout.flush();
+                }
+            }
+        }
     }
     return err;
 }
@@ -248,56 +235,56 @@ static int MTestTypeContigCheckbuf( MTestDatatype *mtype )
 /* Datatype routines for vector datatypes                                   */
 /* ------------------------------------------------------------------------ */
 
-static void *MTestTypeVectorInit( MTestDatatype *mtype )
+static void *MTestTypeVectorInit(MTestDatatype * mtype)
 {
     MPI::Aint size, lb;
 
     if (mtype->count > 0) {
-	unsigned char *p;
-	int  i, j, k, nc;
+        unsigned char *p;
+        int i, j, k, nc;
         MPI::Aint totsize;
 
-	mtype->datatype.Get_extent( lb, size );
-	totsize	   = mtype->count * size;
-	if (!mtype->buf) {
-	    mtype->buf = (void *) malloc( totsize );
-	}
-	p	   = (unsigned char *)(mtype->buf);
-	if (!p) {
-	    /* Error - out of memory */
-	    MTestError( "Out of memory in type buffer init" );
-	}
+        mtype->datatype.Get_extent(lb, size);
+        totsize = mtype->count * size;
+        if (!mtype->buf) {
+            mtype->buf = (void *) malloc(totsize);
+        }
+        p = (unsigned char *) (mtype->buf);
+        if (!p) {
+            /* Error - out of memory */
+            MTestError("Out of memory in type buffer init");
+        }
 
-	/* First, set to -1 */
-	for (i=0; i<totsize; i++) p[i] = 0xff;
+        /* First, set to -1 */
+        for (i = 0; i < totsize; i++)
+            p[i] = 0xff;
 
-	/* Now, set the actual elements to the successive values.
-	   To do this, we need to run 3 loops */
-	nc = 0;
-	/* count is usually one for a vector type */
-	for (k=0; k<mtype->count; k++) {
-	    /* For each element (block) */
-	    for (i=0; i<mtype->nelm; i++) {
-		/* For each value */
-		for (j=0; j<mtype->blksize; j++) {
-		    p[j] = (0xff ^ (nc & 0xff));
-		    nc++;
-		}
-		p += mtype->stride;
-	    }
-	}
-    }
-    else {
-	mtype->buf = 0;
+        /* Now, set the actual elements to the successive values.
+         * To do this, we need to run 3 loops */
+        nc = 0;
+        /* count is usually one for a vector type */
+        for (k = 0; k < mtype->count; k++) {
+            /* For each element (block) */
+            for (i = 0; i < mtype->nelm; i++) {
+                /* For each value */
+                for (j = 0; j < mtype->blksize; j++) {
+                    p[j] = (0xff ^ (nc & 0xff));
+                    nc++;
+                }
+                p += mtype->stride;
+            }
+        }
+    } else {
+        mtype->buf = 0;
     }
     return mtype->buf;
 }
 
-static void *MTestTypeVectorFree( MTestDatatype *mtype )
+static void *MTestTypeVectorFree(MTestDatatype * mtype)
 {
     if (mtype->buf) {
-	free( mtype->buf );
-	mtype->buf = 0;
+        free(mtype->buf);
+        mtype->buf = 0;
     }
     return 0;
 }
@@ -307,115 +294,114 @@ static void *MTestTypeVectorFree( MTestDatatype *mtype )
 /* routines                                                                 */
 /* ------------------------------------------------------------------------ */
 
-/* 
+/*
    Create a range of datatypes with a given count elements.
    This uses a selection of types, rather than an exhaustive collection.
    It allocates both send and receive types so that they can have the same
    type signature (collection of basic types) but different type maps (layouts
-   in memory) 
+   in memory)
  */
-int MTestGetDatatypes( MTestDatatype *sendtype, MTestDatatype *recvtype,
-		       int count )
+int MTestGetDatatypes(MTestDatatype * sendtype, MTestDatatype * recvtype, int count)
 {
-    sendtype->InitBuf	  = 0;
-    sendtype->FreeBuf	  = 0;
-    sendtype->CheckBuf	  = 0;
-    sendtype->datatype	  = 0;
-    sendtype->isBasic	  = 0;
+    sendtype->InitBuf = 0;
+    sendtype->FreeBuf = 0;
+    sendtype->CheckBuf = 0;
+    sendtype->datatype = 0;
+    sendtype->isBasic = 0;
     sendtype->printErrors = 0;
-    recvtype->InitBuf	  = 0;
-    recvtype->FreeBuf	  = 0;
-    recvtype->CheckBuf	  = 0;
-    recvtype->datatype	  = 0;
-    recvtype->isBasic	  = 0;
+    recvtype->InitBuf = 0;
+    recvtype->FreeBuf = 0;
+    recvtype->CheckBuf = 0;
+    recvtype->datatype = 0;
+    recvtype->isBasic = 0;
     recvtype->printErrors = 0;
 
-    sendtype->buf	  = 0;
-    recvtype->buf	  = 0;
+    sendtype->buf = 0;
+    recvtype->buf = 0;
 
     /* Set the defaults for the message lengths */
-    sendtype->count       = count;
-    recvtype->count       = count;
+    sendtype->count = count;
+    recvtype->count = count;
     /* Use datatype_index to choose a datatype to use.  If at the end of the
-       list, return 0 */
+     * list, return 0 */
     switch (datatype_index) {
-    case 0:
-	sendtype->datatype = MPI::INT;
-	sendtype->isBasic  = 1;
-	recvtype->datatype = MPI::INT;
-	recvtype->isBasic  = 1;
-	break;
-    case 1:
-	sendtype->datatype = MPI::DOUBLE;
-	sendtype->isBasic  = 1;
-	recvtype->datatype = MPI::DOUBLE;
-	recvtype->isBasic  = 1;
-	break;
-    case 2:
-	sendtype->datatype = MPI::INT;
-	sendtype->isBasic  = 1;
-	recvtype->datatype = MPI::BYTE;
-	recvtype->isBasic  = 1;
-	recvtype->count    *= sizeof(int);
-	break;
-    case 3:
-	sendtype->datatype = MPI::FLOAT_INT;
-	sendtype->isBasic  = 1;
-	recvtype->datatype = MPI::FLOAT_INT;
-	recvtype->isBasic  = 1;
-	break;
-    case 4:
-	sendtype->datatype = MPI::INT.Dup();
-	sendtype->datatype.Set_name( "dup of MPI::INT" );
-	recvtype->datatype = MPI::INT.Dup();
-	recvtype->datatype.Set_name( "dup of MPI::INT" );
-	/* dup'ed types are already committed if the original type 
-	   was committed (MPI-2, section 8.8) */
-	break;
-    case 5:
-	/* vector send type and contiguous receive type */
-	/* These sizes are in bytes (see the VectorInit code) */
-	sendtype->stride   = 3 * sizeof(int);
-	sendtype->blksize  = sizeof(int);
-	sendtype->nelm     = recvtype->count;
-	sendtype->datatype = MPI::INT.Create_vector( recvtype->count, 1, sendtype->stride );
-        sendtype->datatype.Commit();
-	sendtype->datatype.Set_name( "int-vector" );
-	sendtype->count    = 1;
-	recvtype->datatype = MPI::INT;
-	recvtype->isBasic  = 1;
-	sendtype->InitBuf  = MTestTypeVectorInit;
-	recvtype->InitBuf  = MTestTypeContigInitRecv;
-	sendtype->FreeBuf  = MTestTypeVectorFree;
-	recvtype->FreeBuf  = MTestTypeContigFree;
-	sendtype->CheckBuf = 0;
-	recvtype->CheckBuf = MTestTypeContigCheckbuf;
-	break;
-    default:
-	datatype_index = -1;
+        case 0:
+            sendtype->datatype = MPI::INT;
+            sendtype->isBasic = 1;
+            recvtype->datatype = MPI::INT;
+            recvtype->isBasic = 1;
+            break;
+        case 1:
+            sendtype->datatype = MPI::DOUBLE;
+            sendtype->isBasic = 1;
+            recvtype->datatype = MPI::DOUBLE;
+            recvtype->isBasic = 1;
+            break;
+        case 2:
+            sendtype->datatype = MPI::INT;
+            sendtype->isBasic = 1;
+            recvtype->datatype = MPI::BYTE;
+            recvtype->isBasic = 1;
+            recvtype->count *= sizeof(int);
+            break;
+        case 3:
+            sendtype->datatype = MPI::FLOAT_INT;
+            sendtype->isBasic = 1;
+            recvtype->datatype = MPI::FLOAT_INT;
+            recvtype->isBasic = 1;
+            break;
+        case 4:
+            sendtype->datatype = MPI::INT.Dup();
+            sendtype->datatype.Set_name("dup of MPI::INT");
+            recvtype->datatype = MPI::INT.Dup();
+            recvtype->datatype.Set_name("dup of MPI::INT");
+            /* dup'ed types are already committed if the original type
+             * was committed (MPI-2, section 8.8) */
+            break;
+        case 5:
+            /* vector send type and contiguous receive type */
+            /* These sizes are in bytes (see the VectorInit code) */
+            sendtype->stride = 3 * sizeof(int);
+            sendtype->blksize = sizeof(int);
+            sendtype->nelm = recvtype->count;
+            sendtype->datatype = MPI::INT.Create_vector(recvtype->count, 1, sendtype->stride);
+            sendtype->datatype.Commit();
+            sendtype->datatype.Set_name("int-vector");
+            sendtype->count = 1;
+            recvtype->datatype = MPI::INT;
+            recvtype->isBasic = 1;
+            sendtype->InitBuf = MTestTypeVectorInit;
+            recvtype->InitBuf = MTestTypeContigInitRecv;
+            sendtype->FreeBuf = MTestTypeVectorFree;
+            recvtype->FreeBuf = MTestTypeContigFree;
+            sendtype->CheckBuf = 0;
+            recvtype->CheckBuf = MTestTypeContigCheckbuf;
+            break;
+        default:
+            datatype_index = -1;
     }
 
     if (!sendtype->InitBuf) {
-	sendtype->InitBuf  = MTestTypeContigInit;
-	recvtype->InitBuf  = MTestTypeContigInitRecv;
-	sendtype->FreeBuf  = MTestTypeContigFree;
-	recvtype->FreeBuf  = MTestTypeContigFree;
-	sendtype->CheckBuf = MTestTypeContigCheckbuf;
-	recvtype->CheckBuf = MTestTypeContigCheckbuf;
+        sendtype->InitBuf = MTestTypeContigInit;
+        recvtype->InitBuf = MTestTypeContigInitRecv;
+        sendtype->FreeBuf = MTestTypeContigFree;
+        recvtype->FreeBuf = MTestTypeContigFree;
+        sendtype->CheckBuf = MTestTypeContigCheckbuf;
+        recvtype->CheckBuf = MTestTypeContigCheckbuf;
     }
     datatype_index++;
 
     if (dbgflag && datatype_index > 0) {
-	int typesize;
-	cout << wrank << ": sendtype is " << MTestGetDatatypeName( sendtype ) 
-	     << "\n";
-	typesize = sendtype->datatype.Get_size();
-	cout << wrank << ": sendtype size = " << typesize << "\n";
-	cout << wrank << ": recvtype is " << MTestGetDatatypeName( recvtype ) 
-	     << "\n";
-	typesize = recvtype->datatype.Get_size();
-	cout << wrank << ": recvtype size = " << typesize << "\n";
-	cout.flush();
+        int typesize;
+        cout << wrank << ": sendtype is " << MTestGetDatatypeName(sendtype)
+            << "\n";
+        typesize = sendtype->datatype.Get_size();
+        cout << wrank << ": sendtype size = " << typesize << "\n";
+        cout << wrank << ": recvtype is " << MTestGetDatatypeName(recvtype)
+            << "\n";
+        typesize = recvtype->datatype.Get_size();
+        cout << wrank << ": recvtype size = " << typesize << "\n";
+        cout.flush();
     }
     return datatype_index;
 }
@@ -424,310 +410,302 @@ int MTestGetDatatypes( MTestDatatype *sendtype, MTestDatatype *recvtype,
    Note: This routine is rarely needed; MTestGetDatatypes automatically
    starts over after the last available datatype is used.
 */
-void MTestResetDatatypes( void )
+void MTestResetDatatypes(void)
 {
     datatype_index = 0;
 }
+
 /* Return the index of the current datatype.  This is rarely needed and
    is provided mostly to enable debugging of the MTest package itself */
-int MTestGetDatatypeIndex( void )
+int MTestGetDatatypeIndex(void)
 {
     return datatype_index;
 }
 
-void MTestFreeDatatype( MTestDatatype *mtype )
+void MTestFreeDatatype(MTestDatatype * mtype)
 {
     /* Invoke a datatype-specific free function to handle
-       both the datatype and the send/receive buffers */
+     * both the datatype and the send/receive buffers */
     if (mtype->FreeBuf) {
-	(mtype->FreeBuf)( mtype );
+        (mtype->FreeBuf) (mtype);
     }
     // Free the datatype itself if it was created
     if (!mtype->isBasic) {
-	mtype->datatype.Free();
+        mtype->datatype.Free();
     }
 }
 
 /* Check that a message was received correctly.  Returns the number of
    errors detected.  Status may be NULL or MPI_STATUS_IGNORE */
-int MTestCheckRecv( MPI::Status &status, MTestDatatype *recvtype )
+int MTestCheckRecv(MPI::Status & status, MTestDatatype * recvtype)
 {
     int count;
     int errs = 0;
 
-    /* Note that status may not be MPI_STATUS_IGNORE; C++ doesn't include 
-       MPI_STATUS_IGNORE, instead using different function prototypes that
-       do not include the status argument */
-    count = status.Get_count( recvtype->datatype );
-    
+    /* Note that status may not be MPI_STATUS_IGNORE; C++ doesn't include
+     * MPI_STATUS_IGNORE, instead using different function prototypes that
+     * do not include the status argument */
+    count = status.Get_count(recvtype->datatype);
+
     /* Check count against expected count */
     if (count != recvtype->count) {
-	errs ++;
+        errs++;
     }
 
     /* Check received data */
-    if (!errs && recvtype->CheckBuf( recvtype )) {
-	errs++;
+    if (!errs && recvtype->CheckBuf(recvtype)) {
+        errs++;
     }
     return errs;
 }
 
 /* This next routine uses a circular buffer of static name arrays just to
    simplify the use of the routine */
-const char *MTestGetDatatypeName( MTestDatatype *dtype )
+const char *MTestGetDatatypeName(MTestDatatype * dtype)
 {
     static char name[4][MPI_MAX_OBJECT_NAME];
-    static int sp=0;
+    static int sp = 0;
     int rlen;
 
-    if (sp >= 4) sp = 0;
-    dtype->datatype.Get_name( name[sp], rlen );
-    return (const char *)name[sp++];
+    if (sp >= 4)
+        sp = 0;
+    dtype->datatype.Get_name(name[sp], rlen);
+    return (const char *) name[sp++];
 }
+
 /* ----------------------------------------------------------------------- */
 
-/* 
+/*
  * Create communicators.  Use separate routines for inter and intra
  * communicators (there is a routine to give both)
  * Note that the routines may return MPI::COMM_NULL, so code should test for
  * that return value as well.
- * 
+ *
  */
 static int interCommIdx = 0;
 static int intraCommIdx = 0;
 static const char *intraCommName = 0;
 static const char *interCommName = 0;
 
-/* 
+/*
  * Get an intracommunicator with at least min_size members.  If "allowSmaller"
  * is true, allow the communicator to be smaller than MPI::COMM_WORLD and
  * for this routine to return MPI::COMM_NULL for some values.  Returns 0 if
  * no more communicators are available.
  */
-int MTestGetIntracommGeneral( MPI::Intracomm &comm, int min_size, 
-			      bool allowSmaller )
+int MTestGetIntracommGeneral(MPI::Intracomm & comm, int min_size, bool allowSmaller)
 {
     int size, rank;
-    bool done=false;
+    bool done = false;
     bool isBasic = false;
 
     /* The while loop allows us to skip communicators that are too small.
-       MPI::COMM_NULL is always considered large enough */
+     * MPI::COMM_NULL is always considered large enough */
     while (!done) {
-	switch (intraCommIdx) {
-	case 0:
-	    comm = MPI::COMM_WORLD;
-	    isBasic = true;
-	    intraCommName = "MPI::COMM_WORLD";
-	    break;
-	case 1:
-	    /* dup of world */
-	    comm = MPI::COMM_WORLD.Dup();
-	    intraCommName = "Dup of MPI::COMM_WORLD";
-	    break;
-	case 2:
-	    /* reverse ranks */
-	    size = MPI::COMM_WORLD.Get_size();
-	    rank = MPI::COMM_WORLD.Get_rank();
-	    comm = MPI::COMM_WORLD.Split( 0, size-rank );
-	    intraCommName = "Rank reverse of MPI::COMM_WORLD";
-	    break;
-	case 3:
-	    /* subset of world, with reversed ranks */
-	    size = MPI::COMM_WORLD.Get_size();
-	    rank = MPI::COMM_WORLD.Get_rank();
-	    comm = MPI::COMM_WORLD.Split( (rank < size/2), size-rank );
-	    intraCommName = "Rank reverse of half of MPI::COMM_WORLD";
-	    break;
-	case 4:
-	    comm = MPI::COMM_SELF;
-	    isBasic = true;
-	    intraCommName = "MPI::COMM_SELF";
-	    break;
+        switch (intraCommIdx) {
+            case 0:
+                comm = MPI::COMM_WORLD;
+                isBasic = true;
+                intraCommName = "MPI::COMM_WORLD";
+                break;
+            case 1:
+                /* dup of world */
+                comm = MPI::COMM_WORLD.Dup();
+                intraCommName = "Dup of MPI::COMM_WORLD";
+                break;
+            case 2:
+                /* reverse ranks */
+                size = MPI::COMM_WORLD.Get_size();
+                rank = MPI::COMM_WORLD.Get_rank();
+                comm = MPI::COMM_WORLD.Split(0, size - rank);
+                intraCommName = "Rank reverse of MPI::COMM_WORLD";
+                break;
+            case 3:
+                /* subset of world, with reversed ranks */
+                size = MPI::COMM_WORLD.Get_size();
+                rank = MPI::COMM_WORLD.Get_rank();
+                comm = MPI::COMM_WORLD.Split((rank < size / 2), size - rank);
+                intraCommName = "Rank reverse of half of MPI::COMM_WORLD";
+                break;
+            case 4:
+                comm = MPI::COMM_SELF;
+                isBasic = true;
+                intraCommName = "MPI::COMM_SELF";
+                break;
 
-	    /* These next cases are communicators that include some
-	       but not all of the processes */
-	case 5:
-	case 6:
-	case 7:
-	case 8:
-	{
-	    int newsize;
-	    size = MPI::COMM_WORLD.Get_size();
-	    newsize = size - (intraCommIdx - 4);
-	    
-	    if (allowSmaller && newsize >= min_size) {
-		rank = MPI::COMM_WORLD.Get_rank();
-		comm = MPI::COMM_WORLD.Split( rank < newsize, rank );
-		if (rank >= newsize) {
-		    comm.Free();
-		    comm = MPI::COMM_NULL;
-		}
-	    }
-	    else {
-		/* Act like default */
-		comm = MPI::COMM_NULL;
-		isBasic = true;
-		intraCommName = "MPI::COMM_NULL";
-		intraCommIdx = -1;
-	    }
-	}
-	break;
-	    
-	    /* Other ideas: dup of self, cart comm, graph comm */
-	default:
-	    comm = MPI::COMM_NULL;
-	    isBasic = true;
-	    intraCommName = "MPI::COMM_NULL";
-	    intraCommIdx = -1;
-	    break;
-	}
+                /* These next cases are communicators that include some
+                 * but not all of the processes */
+            case 5:
+            case 6:
+            case 7:
+            case 8:
+                {
+                    int newsize;
+                    size = MPI::COMM_WORLD.Get_size();
+                    newsize = size - (intraCommIdx - 4);
 
-	if (comm != MPI::COMM_NULL) {
-	    size = comm.Get_size();
-	    if (size >= min_size) 
-		done = true;
-	    else {
-		/* Try again */
-		if (!isBasic) comm.Free();
-		intraCommIdx++;
-	    }
-	}
-	else
-	    done = true;
+                    if (allowSmaller && newsize >= min_size) {
+                        rank = MPI::COMM_WORLD.Get_rank();
+                        comm = MPI::COMM_WORLD.Split(rank < newsize, rank);
+                        if (rank >= newsize) {
+                            comm.Free();
+                            comm = MPI::COMM_NULL;
+                        }
+                    } else {
+                        /* Act like default */
+                        comm = MPI::COMM_NULL;
+                        isBasic = true;
+                        intraCommName = "MPI::COMM_NULL";
+                        intraCommIdx = -1;
+                    }
+                }
+                break;
+
+                /* Other ideas: dup of self, cart comm, graph comm */
+            default:
+                comm = MPI::COMM_NULL;
+                isBasic = true;
+                intraCommName = "MPI::COMM_NULL";
+                intraCommIdx = -1;
+                break;
+        }
+
+        if (comm != MPI::COMM_NULL) {
+            size = comm.Get_size();
+            if (size >= min_size)
+                done = true;
+            else {
+                /* Try again */
+                if (!isBasic)
+                    comm.Free();
+                intraCommIdx++;
+            }
+        } else
+            done = true;
     }
 
     intraCommIdx++;
     return intraCommIdx;
 }
 
-/* 
+/*
  * Get an intracommunicator with at least min_size members.
  */
-int MTestGetIntracomm( MPI::Intracomm &comm, int min_size ) 
+int MTestGetIntracomm(MPI::Intracomm & comm, int min_size)
 {
-    return MTestGetIntracommGeneral( comm, min_size, false );
+    return MTestGetIntracommGeneral(comm, min_size, false);
 }
 
 /* Return the name of an intra communicator */
-const char *MTestGetIntracommName( void )
+const char *MTestGetIntracommName(void)
 {
     return intraCommName;
 }
 
-/* 
- * Return an intercomm; set isLeftGroup to 1 if the calling process is 
+/*
+ * Return an intercomm; set isLeftGroup to 1 if the calling process is
  * a member of the "left" group.
  */
-int MTestGetIntercomm( MPI::Intercomm &comm, int &isLeftGroup, int min_size )
+int MTestGetIntercomm(MPI::Intercomm & comm, int &isLeftGroup, int min_size)
 {
     int size, rank, remsize;
-    bool done=false;
+    bool done = false;
     MPI::Intracomm mcomm;
     int rleader;
 
     /* The while loop allows us to skip communicators that are too small.
-       MPI::COMM_NULL is always considered large enough.  The size is
-       the sum of the sizes of the local and remote groups */
+     * MPI::COMM_NULL is always considered large enough.  The size is
+     * the sum of the sizes of the local and remote groups */
     while (!done) {
-        comm          = MPI::COMM_NULL;
-	isLeftGroup   = 0;
-	interCommName = "MPI_COMM_NULL";
+        comm = MPI::COMM_NULL;
+        isLeftGroup = 0;
+        interCommName = "MPI_COMM_NULL";
 
-	switch (interCommIdx) {
-	case 0:
-	    /* Split comm world in half */
-	    rank = MPI::COMM_WORLD.Get_rank();
-	    size = MPI::COMM_WORLD.Get_size();
-	    if (size > 1) {
-		mcomm = MPI::COMM_WORLD.Split( (rank < size/2), rank );
-		if (rank == 0) {
-		    rleader = size/2;
-		}
-		else if (rank == size/2) {
-		    rleader = 0;
-		}
-		else {
-		    /* Remote leader is signficant only for the processes
-		       designated local leaders */
-		    rleader = -1;
-		}
-		isLeftGroup = rank < size/2;
-		comm = mcomm.Create_intercomm( 0, MPI::COMM_WORLD, rleader, 12345 );
-		mcomm.Free();
-		interCommName = "Intercomm by splitting MPI::COMM_WORLD";
-	    }
-	    else {
-		comm = MPI::COMM_NULL;
-            }
-	    break;
-	case 1:
-	    /* Split comm world in to 1 and the rest */
-	    rank = MPI::COMM_WORLD.Get_rank();
-	    size = MPI::COMM_WORLD.Get_size();
-	    if (size > 1) {
-		mcomm = MPI::COMM_WORLD.Split( rank == 0, rank );
-		if (rank == 0) {
-		    rleader = 1;
-		}
-		else if (rank == 1) {
-		    rleader = 0;
-		}
-		else {
-		    /* Remote leader is signficant only for the processes
-		       designated local leaders */
-		    rleader = -1;
-		}
-		isLeftGroup = rank == 0;
-		comm = mcomm.Create_intercomm( 0, MPI::COMM_WORLD, rleader, 12346 );
-		mcomm.Free();
-		interCommName = "Intercomm by splitting MPI::COMM_WORLD into 1, rest";
-	    }
-	    else {
-		comm = MPI::COMM_NULL;
-            }
-	    break;
+        switch (interCommIdx) {
+            case 0:
+                /* Split comm world in half */
+                rank = MPI::COMM_WORLD.Get_rank();
+                size = MPI::COMM_WORLD.Get_size();
+                if (size > 1) {
+                    mcomm = MPI::COMM_WORLD.Split((rank < size / 2), rank);
+                    if (rank == 0) {
+                        rleader = size / 2;
+                    } else if (rank == size / 2) {
+                        rleader = 0;
+                    } else {
+                        /* Remote leader is signficant only for the processes
+                         * designated local leaders */
+                        rleader = -1;
+                    }
+                    isLeftGroup = rank < size / 2;
+                    comm = mcomm.Create_intercomm(0, MPI::COMM_WORLD, rleader, 12345);
+                    mcomm.Free();
+                    interCommName = "Intercomm by splitting MPI::COMM_WORLD";
+                } else {
+                    comm = MPI::COMM_NULL;
+                }
+                break;
+            case 1:
+                /* Split comm world in to 1 and the rest */
+                rank = MPI::COMM_WORLD.Get_rank();
+                size = MPI::COMM_WORLD.Get_size();
+                if (size > 1) {
+                    mcomm = MPI::COMM_WORLD.Split(rank == 0, rank);
+                    if (rank == 0) {
+                        rleader = 1;
+                    } else if (rank == 1) {
+                        rleader = 0;
+                    } else {
+                        /* Remote leader is signficant only for the processes
+                         * designated local leaders */
+                        rleader = -1;
+                    }
+                    isLeftGroup = rank == 0;
+                    comm = mcomm.Create_intercomm(0, MPI::COMM_WORLD, rleader, 12346);
+                    mcomm.Free();
+                    interCommName = "Intercomm by splitting MPI::COMM_WORLD into 1, rest";
+                } else {
+                    comm = MPI::COMM_NULL;
+                }
+                break;
 
-	case 2:
-	    /* Split comm world in to 2 and the rest */
-	    rank = MPI::COMM_WORLD.Get_rank();
-	    size = MPI::COMM_WORLD.Get_size();
-	    if (size > 3) {
-		mcomm = MPI::COMM_WORLD.Split( rank < 2, rank );
-		if (rank == 0) {
-		    rleader = 2;
-		}
-		else if (rank == 2) {
-		    rleader = 0;
-		}
-		else {
-		    /* Remote leader is signficant only for the processes
-		       designated local leaders */
-		    rleader = -1;
-		}
-		isLeftGroup = rank < 2;
-		comm = mcomm.Create_intercomm( 0, MPI::COMM_WORLD, rleader, 12347 );
-		mcomm.Free();
-		interCommName = "Intercomm by splitting MPI::COMM_WORLD into 2, rest";
-	    }
-	    else {
-		comm = MPI::COMM_NULL;
-            }
-	    break;
+            case 2:
+                /* Split comm world in to 2 and the rest */
+                rank = MPI::COMM_WORLD.Get_rank();
+                size = MPI::COMM_WORLD.Get_size();
+                if (size > 3) {
+                    mcomm = MPI::COMM_WORLD.Split(rank < 2, rank);
+                    if (rank == 0) {
+                        rleader = 2;
+                    } else if (rank == 2) {
+                        rleader = 0;
+                    } else {
+                        /* Remote leader is signficant only for the processes
+                         * designated local leaders */
+                        rleader = -1;
+                    }
+                    isLeftGroup = rank < 2;
+                    comm = mcomm.Create_intercomm(0, MPI::COMM_WORLD, rleader, 12347);
+                    mcomm.Free();
+                    interCommName = "Intercomm by splitting MPI::COMM_WORLD into 2, rest";
+                } else {
+                    comm = MPI::COMM_NULL;
+                }
+                break;
 
-	default:
-	    comm = MPI::COMM_NULL;
-	    interCommName = "MPI::COMM_NULL";
-	    interCommIdx = -1;
-	    break;
-	}
-	if (comm != MPI::COMM_NULL) {
-	    size = comm.Get_size();
-	    remsize = comm.Get_remote_size();
-	    if (size + remsize >= min_size) done = true;
-	}
-	else
-	    done = true;
+            default:
+                comm = MPI::COMM_NULL;
+                interCommName = "MPI::COMM_NULL";
+                interCommIdx = -1;
+                break;
+        }
+        if (comm != MPI::COMM_NULL) {
+            size = comm.Get_size();
+            remsize = comm.Get_remote_size();
+            if (size + remsize >= min_size)
+                done = true;
+        } else
+            done = true;
 
         /* we are only done if all processes are done */
         MPI::COMM_WORLD.Allreduce(MPI_IN_PLACE, &done, 1, MPI::BOOL, MPI::LAND);
@@ -744,43 +722,42 @@ int MTestGetIntercomm( MPI::Intercomm &comm, int &isLeftGroup, int min_size )
 
     return interCommIdx;
 }
+
 /* Return the name of an intercommunicator */
-const char *MTestGetIntercommName( void )
+const char *MTestGetIntercommName(void)
 {
     return interCommName;
 }
 
-/* Get a communicator of a given minimum size.  Both intra and inter 
+/* Get a communicator of a given minimum size.  Both intra and inter
    communicators are provided
-   Because Comm is an abstract base class, you can only have references 
+   Because Comm is an abstract base class, you can only have references
    to a Comm.*/
-int MTestGetComm( MPI::Comm **comm, int min_size )
+int MTestGetComm(MPI::Comm ** comm, int min_size)
 {
     int idx;
     static int getinter = 0;
 
     if (!getinter) {
-	MPI::Intracomm rcomm;
-	idx = MTestGetIntracomm( rcomm, min_size );
-	if (idx == 0) {
-	    getinter = 1;
-	}
-	else {
-	    MPI::Intracomm *ncomm = new MPI::Intracomm(rcomm);
-	    *comm = ncomm;
-	}
+        MPI::Intracomm rcomm;
+        idx = MTestGetIntracomm(rcomm, min_size);
+        if (idx == 0) {
+            getinter = 1;
+        } else {
+            MPI::Intracomm * ncomm = new MPI::Intracomm(rcomm);
+            *comm = ncomm;
+        }
     }
     if (getinter) {
-	MPI::Intercomm icomm;
-	int isLeft;
-	idx = MTestGetIntercomm( icomm, isLeft, min_size );
-	if (idx == 0) {
-	    getinter = 0;
-	}
-	else {
-	    MPI::Intercomm *ncomm = new MPI::Intercomm(icomm);
-	    *comm = ncomm;
-	}
+        MPI::Intercomm icomm;
+        int isLeft;
+        idx = MTestGetIntercomm(icomm, isLeft, min_size);
+        if (idx == 0) {
+            getinter = 0;
+        } else {
+            MPI::Intercomm * ncomm = new MPI::Intercomm(icomm);
+            *comm = ncomm;
+        }
     }
 
     return idx;
@@ -788,39 +765,39 @@ int MTestGetComm( MPI::Comm **comm, int min_size )
 
 /* Free a communicator.  It may be called with a predefined communicator
  or MPI_COMM_NULL */
-void MTestFreeComm( MPI::Comm &comm )
+void MTestFreeComm(MPI::Comm & comm)
 {
-    if (comm != MPI::COMM_WORLD &&
-	comm != MPI::COMM_SELF &&
-	comm != MPI::COMM_NULL) {
-	comm.Free();
+    if (comm != MPI::COMM_WORLD && comm != MPI::COMM_SELF && comm != MPI::COMM_NULL) {
+        comm.Free();
     }
 }
 
 /* ------------------------------------------------------------------------ */
-void MTestPrintError( int errcode )
+void MTestPrintError(int errcode)
 {
     int errclass, slen;
     char string[MPI_MAX_ERROR_STRING];
-    
-    errclass = MPI::Get_error_class( errcode );
-    MPI::Get_error_string( errcode, string, slen );
+
+    errclass = MPI::Get_error_class(errcode);
+    MPI::Get_error_string(errcode, string, slen);
     cout << "Error class " << errclass << "(" << string << ")\n";
     cout.flush();
 }
-void MTestPrintErrorMsg( const char msg[], int errcode )
+
+void MTestPrintErrorMsg(const char msg[], int errcode)
 {
     int errclass, slen;
     char string[MPI_MAX_ERROR_STRING];
-    
-    errclass = MPI::Get_error_class( errcode );
-    MPI::Get_error_string( errcode, string, slen );
+
+    errclass = MPI::Get_error_class(errcode);
+    MPI::Get_error_string(errcode, string, slen);
     cout << msg << ": Error class " << errclass << " (" << string << ")\n";
     cout.flush();
 }
+
 /* ------------------------------------------------------------------------ */
 /* Fatal error.  Report and exit */
-void MTestError( const char *msg )
+void MTestError(const char *msg)
 {
     cerr << msg << "\n";
     cerr.flush();
@@ -836,104 +813,107 @@ static const char *winName;
 /* Use an attribute to remember the type of memory allocation (static,
    malloc, or MPI_Alloc_mem) */
 static int mem_keyval = MPI::KEYVAL_INVALID;
-int MTestGetWin( MPI::Win &win, bool mustBePassive )
+int MTestGetWin(MPI::Win & win, bool mustBePassive)
 {
     static char actbuf[1024];
     static char *pasbuf;
-    char        *buf;
-    int         n, rank;
-    MPI::Info   info;
+    char *buf;
+    int n, rank;
+    MPI::Info info;
 
     if (mem_keyval == MPI::KEYVAL_INVALID) {
-	/* Create the keyval */
-	mem_keyval = MPI::Win::Create_keyval( MPI::Win::NULL_COPY_FN, 
-					      MPI::Win::NULL_DELETE_FN, 0 );
+        /* Create the keyval */
+        mem_keyval = MPI::Win::Create_keyval(MPI::Win::NULL_COPY_FN, MPI::Win::NULL_DELETE_FN, 0);
     }
 
     switch (win_index) {
-    case 0:
-	/* Active target window */
-	win = MPI::Win::Create( actbuf, 1024, 1, MPI::INFO_NULL, MPI::COMM_WORLD );
-	winName = "active-window";
-	win.Set_attr( mem_keyval, (void *)0 );
-	break;
-    case 1:
-	/* Passive target window */
-	pasbuf = (char *)MPI::Alloc_mem( 1024, MPI::INFO_NULL );
-	win = MPI::Win::Create( pasbuf, 1024, 1, MPI::INFO_NULL, MPI::COMM_WORLD );
-	winName = "passive-window";
-	win.Set_attr( mem_keyval, (void *)2 );
-	break;
-    case 2:
-	/* Active target; all windows different sizes */
-	rank = MPI::COMM_WORLD.Get_rank();
-	n = rank * 64;
-	if (n) 
-	    buf = (char *)malloc( n );
-	else
-	    buf = 0;
-	win = MPI::Win::Create( buf, n, 1, MPI::INFO_NULL, MPI::COMM_WORLD );
-	winName = "active-all-different-win";
-	win.Set_attr( mem_keyval, (void *)1 );
-	break;
-    case 3:
-	/* Active target, no locks set */
-	rank = MPI::COMM_WORLD.Get_rank();
-	n = rank * 64;
-	if (n) 
-	    buf = (char *)malloc( n );
-	else
-	    buf = 0;
-	info = MPI::Info::Create( );
-	info.Set( "nolocks", "true" );
-	win = MPI::Win::Create( buf, n, 1, info, MPI::COMM_WORLD );
-	info.Free();
-	winName = "active-nolocks-all-different-win";
-	win.Set_attr( mem_keyval, (void *)1 );
-	break;
-    default:
-	win_index = -1;
+        case 0:
+            /* Active target window */
+            win = MPI::Win::Create(actbuf, 1024, 1, MPI::INFO_NULL, MPI::COMM_WORLD);
+            winName = "active-window";
+            win.Set_attr(mem_keyval, (void *) 0);
+            break;
+        case 1:
+            /* Passive target window */
+            pasbuf = (char *) MPI::Alloc_mem(1024, MPI::INFO_NULL);
+            win = MPI::Win::Create(pasbuf, 1024, 1, MPI::INFO_NULL, MPI::COMM_WORLD);
+            winName = "passive-window";
+            win.Set_attr(mem_keyval, (void *) 2);
+            break;
+        case 2:
+            /* Active target; all windows different sizes */
+            rank = MPI::COMM_WORLD.Get_rank();
+            n = rank * 64;
+            if (n)
+                buf = (char *) malloc(n);
+            else
+                buf = 0;
+            win = MPI::Win::Create(buf, n, 1, MPI::INFO_NULL, MPI::COMM_WORLD);
+            winName = "active-all-different-win";
+            win.Set_attr(mem_keyval, (void *) 1);
+            break;
+        case 3:
+            /* Active target, no locks set */
+            rank = MPI::COMM_WORLD.Get_rank();
+            n = rank * 64;
+            if (n)
+                buf = (char *) malloc(n);
+            else
+                buf = 0;
+            info = MPI::Info::Create();
+            info.Set("nolocks", "true");
+            win = MPI::Win::Create(buf, n, 1, info, MPI::COMM_WORLD);
+            info.Free();
+            winName = "active-nolocks-all-different-win";
+            win.Set_attr(mem_keyval, (void *) 1);
+            break;
+        default:
+            win_index = -1;
     }
     win_index++;
     return win_index;
 }
+
 /* Return a pointer to the name associated with a window object */
-const char *MTestGetWinName( void )
+const char *MTestGetWinName(void)
 {
-    
+
     return winName;
 }
+
 /* Free the storage associated with a window object */
-void MTestFreeWin( MPI::Win &win )
+void MTestFreeWin(MPI::Win & win)
 {
     void *addr;
     bool flag;
 
-    flag = win.Get_attr( MPI_WIN_BASE, &addr );
+    flag = win.Get_attr(MPI_WIN_BASE, &addr);
     if (!flag) {
-	MTestError( "Could not get WIN_BASE from window" );
+        MTestError("Could not get WIN_BASE from window");
     }
     if (addr) {
-	void *val;
-	flag = win.Get_attr( mem_keyval, &val );
-	if (flag) {
-	    if (val == (void *)1) {
-		free( addr );
-	    }
-	    else if (val == (void *)2) {
-		MPI::Free_mem( addr );
-	    }
-	    /* if val == (void *)0, then static data that must not be freed */
-	}
+        void *val;
+        flag = win.Get_attr(mem_keyval, &val);
+        if (flag) {
+            if (val == (void *) 1) {
+                free(addr);
+            } else if (val == (void *) 2) {
+                MPI::Free_mem(addr);
+            }
+            /* if val == (void *)0, then static data that must not be freed */
+        }
     }
     win.Free();
 }
-static void MTestRMACleanup( void )
+
+static void MTestRMACleanup(void)
 {
     if (mem_keyval != MPI::KEYVAL_INVALID) {
-	MPI::Win::Free_keyval( mem_keyval );
+        MPI::Win::Free_keyval(mem_keyval);
     }
 }
-#else 
-static void MTestRMACleanup( void ) {}
+#else
+static void MTestRMACleanup(void)
+{
+}
 #endif

--- a/test/mpi/errors/cxx/errhan/commerrx.cxx
+++ b/test/mpi/errors/cxx/errhan/commerrx.cxx
@@ -6,7 +6,7 @@
 
 /*
   Tests invocation of error handlers on a variety of communicators, including
-  COMM_NULL.  
+  COMM_NULL.
 */
 
 #include "mpitestconf.h"
@@ -15,78 +15,78 @@
 #include "mpitestcxx.h"
 
 /* returns number of errors found */
-int testCommCall( MPI::Comm &comm )
+int testCommCall(MPI::Comm & comm)
 {
     int i;
     bool sawException = false;
 
-    comm.Set_errhandler( MPI::ERRORS_THROW_EXCEPTIONS );
+    comm.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
     try {
-	// Invalid send
-	comm.Send( &i, -1, MPI::DATATYPE_NULL, -1, -10 );
-    } catch (MPI::Exception &ex ) {
-	// This is good
-	sawException = true;
+        // Invalid send
+        comm.Send(&i, -1, MPI::DATATYPE_NULL, -1, -10);
+    } catch(MPI::Exception & ex) {
+        // This is good
+        sawException = true;
     }
-    catch (...) {
-	// This is bad
+    catch(...) {
+        // This is bad
     }
     if (!sawException) {
-	int len;
-	char commname[MPI_MAX_OBJECT_NAME];
-	comm.Get_name( commname, len );
-	std::cout << "Did not see MPI exception on invalid call on communicator " <<
-	    commname << "\n";
+        int len;
+        char commname[MPI_MAX_OBJECT_NAME];
+        comm.Get_name(commname, len);
+        std::cout << "Did not see MPI exception on invalid call on communicator " <<
+            commname << "\n";
     }
     return sawException ? 0 : 1;
 }
 
-int testNullCommCall( void )
+int testNullCommCall(void)
 {
     int i;
     bool sawException = false;
-    const MPI::Comm &comm = MPI::COMM_NULL;
+    const MPI::Comm & comm = MPI::COMM_NULL;
 
-    MPI::COMM_WORLD.Set_errhandler( MPI::ERRORS_THROW_EXCEPTIONS );
+    MPI::COMM_WORLD.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
     try {
-	// Invalid send
-	comm.Send( &i, -1, MPI::DATATYPE_NULL, -1, -10 );
-    } catch (MPI::Exception &ex ) {
-	// This is good
-	sawException = true;
+        // Invalid send
+        comm.Send(&i, -1, MPI::DATATYPE_NULL, -1, -10);
+    } catch(MPI::Exception & ex) {
+        // This is good
+        sawException = true;
     }
-    catch (...) {
-	// This is bad
+    catch(...) {
+        // This is bad
     }
     if (!sawException) {
-	std::cout << "Did not see MPI exception on invalid call on communicator COMM_NULL\n";
+        std::cout << "Did not see MPI exception on invalid call on communicator COMM_NULL\n";
     }
     return sawException ? 0 : 1;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     bool periods[2] = { false, false };
-    int  dims[2] = { 0, 0 };
+    int dims[2] = { 0, 0 };
 
-    MTest_Init( );
+    MTest_Init();
 
-    MPI::Compute_dims( MPI::COMM_WORLD.Get_size(), 2, dims );
-    MPI::Cartcomm cart = MPI::COMM_WORLD.Create_cart( 2, dims, periods, true );
-    cart.Set_name( "Cart comm" );
-    // Graphcomm graph = COMM_WORLD.Create_graph( );
+    MPI::Compute_dims(MPI::COMM_WORLD.Get_size(), 2, dims);
+    MPI::Cartcomm cart = MPI::COMM_WORLD.Create_cart(2, dims, periods, true);
+    cart.Set_name("Cart comm");
+    // Graphcomm graph = COMM_WORLD.Create_graph();
 
-    errs += testCommCall( MPI::COMM_WORLD );
-    errs += testNullCommCall( );
-    errs += testCommCall( MPI::COMM_SELF );
-    errs += testCommCall( cart );
-    //errs += testCommCall( graph );
+    errs += testCommCall(MPI::COMM_WORLD);
+    errs += testNullCommCall();
+    errs += testCommCall(MPI::COMM_SELF);
+    errs += testCommCall(cart);
+    //errs += testCommCall(graph);
 
     cart.Free();
     // graph.Free();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/errors/cxx/errhan/errgetx.cxx
+++ b/test/mpi/errors/cxx/errhan/errgetx.cxx
@@ -19,14 +19,12 @@
 
 /* #define VERBOSE */
 
-template <class T>
-void efn(T &obj, int *, ...)
+template < class T > void efn(T & obj, int *, ...)
 {
 }
 
 /* returns number of errors found */
-template <class T>
-int testRetrieveErrhandler(T &obj)
+template < class T > int testRetrieveErrhandler(T & obj)
 {
     int errs = 0;
     MPI::Errhandler retrieved_handler;
@@ -39,19 +37,23 @@ int testRetrieveErrhandler(T &obj)
 
     obj.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_THROW_EXCEPTIONS) errs++;
+    if (retrieved_handler != MPI::ERRORS_THROW_EXCEPTIONS)
+        errs++;
 
     obj.Set_errhandler(MPI::ERRORS_RETURN);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_RETURN) errs++;
+    if (retrieved_handler != MPI::ERRORS_RETURN)
+        errs++;
 
     obj.Set_errhandler(MPI::ERRORS_ARE_FATAL);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_ARE_FATAL) errs++;
+    if (retrieved_handler != MPI::ERRORS_ARE_FATAL)
+        errs++;
 
     obj.Set_errhandler(custom_handler);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != custom_handler) errs++;
+    if (retrieved_handler != custom_handler)
+        errs++;
     retrieved_handler.Free();
 
     custom_handler.Free();
@@ -59,12 +61,12 @@ int testRetrieveErrhandler(T &obj)
     return errs;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Win win = MPI::WIN_NULL;
 
-    MTest_Init( );
+    MTest_Init();
 
     const unsigned int rank = MPI::COMM_WORLD.Get_rank();
 
@@ -77,7 +79,7 @@ int main( int argc, char *argv[] )
 
     win.Free();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/errors/cxx/errhan/errsetx.cxx
+++ b/test/mpi/errors/cxx/errhan/errsetx.cxx
@@ -24,49 +24,49 @@ using namespace std;
 #include "mpitestcxx.h"
 
 static int ncalls = 0;
-void efn( MPI::Comm &comm, int *code, ... )
+void efn(MPI::Comm & comm, int *code, ...)
 {
-    ncalls ++;
+    ncalls++;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::Errhandler eh;
     int size;
     bool foundMsg;
     int errs = 0;
 
-    MTest_Init( );
+    MTest_Init();
 
     size = MPI::COMM_WORLD.Get_size();
 
     // Test that we can change the default error handler to not throw
     // an exception (our error handler could also throw an exception,
-    // but we want to make sure that the exception is not thrown 
+    // but we want to make sure that the exception is not thrown
     // by the MPI code)
 
-    eh = MPI::Comm::Create_errhandler( efn );
-    MPI::COMM_WORLD.Set_errhandler( eh );
+    eh = MPI::Comm::Create_errhandler(efn);
+    MPI::COMM_WORLD.Set_errhandler(eh);
     try {
-	foundMsg = MPI::COMM_WORLD.Iprobe( size, 0 );
-    } catch (MPI::Exception ex) {
-	cout << "Caught exception from iprobe (should have called error handler instead)\n";
-	errs++;
-	if (ex.Get_error_class() == MPI_SUCCESS) {
-	    errs++;
-	    cout << "Unexpected error from Iprobe" << endl;
-	}
+        foundMsg = MPI::COMM_WORLD.Iprobe(size, 0);
+    } catch(MPI::Exception ex) {
+        cout << "Caught exception from iprobe (should have called error handler instead)\n";
+        errs++;
+        if (ex.Get_error_class() == MPI_SUCCESS) {
+            errs++;
+            cout << "Unexpected error from Iprobe" << endl;
+        }
     }
     if (ncalls != 1) {
-	errs++;
-	cout << "Did not invoke error handler when invoking iprobe with an invalid rank" << endl;
+        errs++;
+        cout << "Did not invoke error handler when invoking iprobe with an invalid rank" << endl;
     }
 
     eh.Free();
 
     // Find out how many errors we saw
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/errors/cxx/errhan/throwtest.cxx
+++ b/test/mpi/errors/cxx/errhan/throwtest.cxx
@@ -21,8 +21,8 @@
 /* #define VERBOSE */
 
 /* returns number of errors found */
-template <class T>
-int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorString)
+template < class T >
+    int testCallErrhandler(T & obj, int errorClass, int errorCode, std::string errorString)
 {
     int errs = 0;
 
@@ -31,7 +31,7 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
         std::cerr << "Do Not See This" << std::endl;
         errs++;
     }
-    catch (MPI::Exception &ex) {
+    catch(MPI::Exception & ex) {
 #ifdef VERBOSE
         std::cerr << "MPI Exception: " << ex.Get_error_string() << std::endl;
 #endif
@@ -48,7 +48,7 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
             errs++;
         }
     }
-    catch (...) {
+    catch(...) {
         std::cerr << "Caught Unknown Exception" << std::endl;
         errs++;
     }
@@ -56,12 +56,12 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
     return errs;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::Win win = MPI::WIN_NULL;
 
-    MTest_Init( );
+    MTest_Init();
 
     const unsigned int rank = MPI::COMM_WORLD.Get_rank();
     const unsigned int size = MPI::COMM_WORLD.Get_size();
@@ -82,7 +82,7 @@ int main( int argc, char *argv[] )
         // Do something that should cause an exception.
         MPI::COMM_WORLD.Get_attr(MPI::KEYVAL_INVALID, NULL);
     }
-    catch (...) {
+    catch(...) {
         std::cerr << "comm threw when it shouldn't have" << std::endl;
         ++errs;
     }
@@ -91,7 +91,7 @@ int main( int argc, char *argv[] )
         // Do something that should cause an exception.
         win.Get_attr(MPI::KEYVAL_INVALID, NULL);
     }
-    catch (...) {
+    catch(...) {
         std::cerr << "win threw when it shouldn't have" << std::endl;
         ++errs;
     }
@@ -102,33 +102,33 @@ int main( int argc, char *argv[] )
 
     if (0 == rank) {
         errs += testCallErrhandler(MPI::COMM_WORLD, errorClass, errorCode, errorString);
-        errs += testCallErrhandler(win,             errorClass, errorCode, errorString);
+        errs += testCallErrhandler(win, errorClass, errorCode, errorString);
 
         // induce actual errors and make sure that they throw
         try {
             char buf[10];
-            MPI::COMM_WORLD.Send(&buf, 1, MPI::CHAR, size+1, 1);
+            MPI::COMM_WORLD.Send(&buf, 1, MPI::CHAR, size + 1, 1);
             std::cout << "Invalid Send did not throw" << std::endl;
             errs++;
         }
-        catch (MPI::Exception &ex) {
+        catch(MPI::Exception & ex) {
             // expected
         }
-        catch (...) {
+        catch(...) {
             std::cout << "Caught Unknown Exception" << std::endl;
             errs++;
         }
 
         try {
             char buf[10];
-            win.Get(&buf, 0, MPI::CHAR, size+1, 0, 0, MPI::CHAR);
+            win.Get(&buf, 0, MPI::CHAR, size + 1, 0, 0, MPI::CHAR);
             std::cout << "Invalid Get did not throw" << std::endl;
             errs++;
         }
-        catch (MPI::Exception &ex) {
+        catch(MPI::Exception & ex) {
             // expected
         }
-        catch (...) {
+        catch(...) {
             std::cout << "Caught Unknown Exception" << std::endl;
             errs++;
         }
@@ -136,7 +136,7 @@ int main( int argc, char *argv[] )
 
     win.Free();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/errors/cxx/io/errgetfilex.cxx
+++ b/test/mpi/errors/cxx/io/errgetfilex.cxx
@@ -19,14 +19,12 @@
 
 /* #define VERBOSE */
 
-template <class T>
-void efn(T &obj, int *, ...)
+template < class T > void efn(T & obj, int *, ...)
 {
 }
 
 /* returns number of errors found */
-template <class T>
-int testRetrieveErrhandler(T &obj)
+template < class T > int testRetrieveErrhandler(T & obj)
 {
     int errs = 0;
     MPI::Errhandler retrieved_handler;
@@ -39,19 +37,23 @@ int testRetrieveErrhandler(T &obj)
 
     obj.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_THROW_EXCEPTIONS) errs++;
+    if (retrieved_handler != MPI::ERRORS_THROW_EXCEPTIONS)
+        errs++;
 
     obj.Set_errhandler(MPI::ERRORS_RETURN);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_RETURN) errs++;
+    if (retrieved_handler != MPI::ERRORS_RETURN)
+        errs++;
 
     obj.Set_errhandler(MPI::ERRORS_ARE_FATAL);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != MPI::ERRORS_ARE_FATAL) errs++;
+    if (retrieved_handler != MPI::ERRORS_ARE_FATAL)
+        errs++;
 
     obj.Set_errhandler(custom_handler);
     retrieved_handler = obj.Get_errhandler();
-    if (retrieved_handler != custom_handler) errs++;
+    if (retrieved_handler != custom_handler)
+        errs++;
     retrieved_handler.Free();
 
     custom_handler.Free();
@@ -59,18 +61,18 @@ int testRetrieveErrhandler(T &obj)
     return errs;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::File file = MPI::FILE_NULL;
 
-    MTest_Init( );
+    MTest_Init();
 
     const unsigned int rank = MPI::COMM_WORLD.Get_rank();
 
-    file = MPI::File::Open(MPI::COMM_WORLD, "testfile", 
-	   MPI::MODE_WRONLY | MPI::MODE_CREATE | MPI::MODE_DELETE_ON_CLOSE, 
-	   MPI::INFO_NULL);
+    file = MPI::File::Open(MPI::COMM_WORLD, "testfile",
+                           MPI::MODE_WRONLY | MPI::MODE_CREATE | MPI::MODE_DELETE_ON_CLOSE,
+                           MPI::INFO_NULL);
 
     if (0 == rank) {
         errs += testRetrieveErrhandler(MPI::COMM_WORLD);
@@ -79,7 +81,7 @@ int main( int argc, char *argv[] )
 
     file.Close();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/errors/cxx/io/fileerrretx.cxx
+++ b/test/mpi/errors/cxx/io/fileerrretx.cxx
@@ -26,12 +26,12 @@ using namespace std;
 static int verbose = 0;
 
 static int ncalls = 0;
-void efn( MPI::File &fh, int *code, ... )
+void efn(MPI::File & fh, int *code, ...)
 {
-    ncalls ++;
+    ncalls++;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     MPI::File fh;
     MPI::Errhandler eh;
@@ -43,52 +43,54 @@ int main( int argc, char *argv[] )
     // Test that the default error handler is errors return for files
 
     filename = new char[10];
-    strncpy( filename, "t1", 10 );
+    strncpy(filename, "t1", 10);
 
     MPI::FILE_NULL.Set_errhandler(MPI::ERRORS_THROW_EXCEPTIONS);
     sawErr = 0;
     try {
-	fh = MPI::File::Open(MPI::COMM_WORLD, filename, 
-			 MPI::MODE_RDWR, MPI::INFO_NULL );
-    } catch (MPI::Exception ex) {
-	if (verbose) cout << "Caught exception from open\n";
-	if (ex.Get_error_class() == MPI_SUCCESS) {
-	    errs++;
-	    cout << "Unexpected error from Open" << endl;
-	}
-	sawErr = 1;
+        fh = MPI::File::Open(MPI::COMM_WORLD, filename, MPI::MODE_RDWR, MPI::INFO_NULL);
+    } catch(MPI::Exception ex) {
+        if (verbose)
+            cout << "Caught exception from open\n";
+        if (ex.Get_error_class() == MPI_SUCCESS) {
+            errs++;
+            cout << "Unexpected error from Open" << endl;
+        }
+        sawErr = 1;
     }
     if (!sawErr) {
-	errs++;
-	cout << "Did not see error when opening a non-existent file for writing and reading (without MODE_CREATE)\n";
+        errs++;
+        cout <<
+            "Did not see error when opening a non-existent file for writing and reading (without MODE_CREATE)\n";
     }
-
     // Test that we can change the default error handler by changing
     // the error handler on MPI::FILE_NULL.
-    eh = MPI::File::Create_errhandler( efn );
-    MPI::FILE_NULL.Set_errhandler( eh );
+    eh = MPI::File::Create_errhandler(efn);
+    MPI::FILE_NULL.Set_errhandler(eh);
     eh.Free();
     sawErr = 0;
     try {
-	fh = MPI::File::Open(MPI::COMM_WORLD, filename, 
-			 MPI::MODE_RDWR, MPI::INFO_NULL );
-    } catch (MPI::Exception ex) {
-	cout << "Caught exception from open (should have called error handler instead)\n";
-	errs++;
-	if (ex.Get_error_class() == MPI_SUCCESS) {
-	    errs++;
-	    cout << "Unexpected error from Open" << endl;
-	}
-	sawErr = 1;
+        fh = MPI::File::Open(MPI::COMM_WORLD, filename, MPI::MODE_RDWR, MPI::INFO_NULL);
+    }
+    catch(MPI::Exception ex) {
+        cout << "Caught exception from open (should have called error handler instead)\n";
+        errs++;
+        if (ex.Get_error_class() == MPI_SUCCESS) {
+            errs++;
+            cout << "Unexpected error from Open" << endl;
+        }
+        sawErr = 1;
     }
     if (ncalls != 1) {
-	errs++;
-	cout << "Did not invoke error handler when opening a non-existent file for writing and reading (without MODE_CREATE)" << endl;
+        errs++;
+        cout <<
+            "Did not invoke error handler when opening a non-existent file for writing and reading (without MODE_CREATE)"
+            << endl;
     }
 
     MTest_Finalize(errs);
 
-    delete[] filename;
+    delete[]filename;
 
     return 0;
 }

--- a/test/mpi/errors/cxx/io/throwtestfilex.cxx
+++ b/test/mpi/errors/cxx/io/throwtestfilex.cxx
@@ -21,8 +21,8 @@
 /* #define VERBOSE */
 
 /* returns number of errors found */
-template <class T>
-int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorString)
+template < class T >
+    int testCallErrhandler(T & obj, int errorClass, int errorCode, std::string errorString)
 {
     int errs = 0;
 
@@ -31,7 +31,7 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
         std::cerr << "Do Not See This" << std::endl;
         errs++;
     }
-    catch (MPI::Exception &ex) {
+    catch(MPI::Exception & ex) {
 #ifdef VERBOSE
         std::cerr << "MPI Exception: " << ex.Get_error_string() << std::endl;
 #endif
@@ -48,7 +48,7 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
             errs++;
         }
     }
-    catch (...) {
+    catch(...) {
         std::cerr << "Caught Unknown Exception" << std::endl;
         errs++;
     }
@@ -56,12 +56,12 @@ int testCallErrhandler(T &obj, int errorClass, int errorCode, std::string errorS
     return errs;
 }
 
-int main( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     int errs = 0;
     MPI::File file = MPI::FILE_NULL;
 
-    MTest_Init( );
+    MTest_Init();
 
     const unsigned int rank = MPI::COMM_WORLD.Get_rank();
     const unsigned int size = MPI::COMM_WORLD.Get_size();
@@ -71,9 +71,9 @@ int main( int argc, char *argv[] )
     std::string errorString = "Internal-use Error Code";
     MPI::Add_error_string(errorCode, errorString.c_str());
 
-    file = MPI::File::Open(MPI::COMM_WORLD, "testfile", 
-	   MPI::MODE_WRONLY | MPI::MODE_CREATE | MPI::MODE_DELETE_ON_CLOSE, 
-	   MPI::INFO_NULL);
+    file = MPI::File::Open(MPI::COMM_WORLD, "testfile",
+                           MPI::MODE_WRONLY | MPI::MODE_CREATE | MPI::MODE_DELETE_ON_CLOSE,
+                           MPI::INFO_NULL);
 
     // first sanity check that ERRORS_RETURN actually returns in erroneous
     // conditions and doesn't throw an exception
@@ -84,7 +84,7 @@ int main( int argc, char *argv[] )
         // Do something that should cause an exception.
         file.Write(NULL, -1, MPI_DATATYPE_NULL);
     }
-    catch (...) {
+    catch(...) {
         std::cerr << "file threw when it shouldn't have" << std::endl;
         ++errs;
     }
@@ -95,7 +95,7 @@ int main( int argc, char *argv[] )
 
     if (0 == rank) {
         errs += testCallErrhandler(MPI::COMM_WORLD, errorClass, errorCode, errorString);
-        errs += testCallErrhandler(file,            errorClass, errorCode, errorString);
+        errs += testCallErrhandler(file, errorClass, errorCode, errorString);
 
         try {
             int buf[10];
@@ -103,10 +103,10 @@ int main( int argc, char *argv[] )
             std::cout << "Invalid Send did not throw" << std::endl;
             errs++;
         }
-        catch (MPI::Exception &ex) {
+        catch(MPI::Exception & ex) {
             // expected
         }
-        catch (...) {
+        catch(...) {
             std::cout << "Caught Unknown Exception" << std::endl;
             errs++;
         }
@@ -114,7 +114,7 @@ int main( int argc, char *argv[] )
 
     file.Close();
 
-    MTest_Finalize( errs );
+    MTest_Finalize(errs);
 
     return 0;
 }

--- a/test/mpi/f08/datatype/structf.f90
+++ b/test/mpi/f08/datatype/structf.f90
@@ -37,7 +37,7 @@
 
       errs = 0
 !     Enroll in MPI
-      call mpi_init(ierr)
+      call mtest_init(ierr)
 
 !     get my rank
       call mpi_comm_rank(MPI_COMM_WORLD, me, ierr)
@@ -98,15 +98,6 @@
       endif
 !
 !     Sum up errs and report the result
-      call mpi_reduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM, 0,         &
-     &                 MPI_COMM_WORLD, ierr )
-      if (me .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, " No Errors"
-         else
-            print *, " Found ", toterrs, " errors"
-         endif
-      endif
-
+      call mtest_finalize(errs)
 
       end

--- a/test/mpi/f90/datatype/structf.f90
+++ b/test/mpi/f90/datatype/structf.f90
@@ -37,7 +37,7 @@
 
       errs = 0
 !     Enroll in MPI
-      call mpi_init(ierr)
+      call mtest_init(ierr)
 
 !     get my rank
       call mpi_comm_rank(MPI_COMM_WORLD, me, ierr)
@@ -98,15 +98,6 @@
       endif
 !
 !     Sum up errs and report the result
-      call mpi_reduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM, 0,         &
-     &                 MPI_COMM_WORLD, ierr )
-      if (me .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, " No Errors"
-         else
-            print *, " Found ", toterrs, " errors"
-         endif
-      endif
-
+      call mtest_finalize(errs)
 
       end

--- a/test/mpi/spawn/concurrent_spawns.c
+++ b/test/mpi/spawn/concurrent_spawns.c
@@ -113,6 +113,7 @@ int main(int argc, char *argv[])
         if (parentcomm != MPI_COMM_NULL) {
             MPI_Send(&errs, 1, MPI_INT, 0, 0, parentcomm);
             MPI_Comm_disconnect(&parentcomm);
+            MPI_Finalize();
         } else {
             /* Note that the MTest_Finalize get errs only over COMM_WORLD */
             /* Note also that both the parent and child will generate "No Errors"

--- a/test/mpi/spawn/disconnect.c
+++ b/test/mpi/spawn/disconnect.c
@@ -101,6 +101,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spaiccreate.c
+++ b/test/mpi/spawn/spaiccreate.c
@@ -87,6 +87,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spaiccreate2.c
+++ b/test/mpi/spawn/spaiccreate2.c
@@ -80,6 +80,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawn1.c
+++ b/test/mpi/spawn/spawn1.c
@@ -111,6 +111,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawn2.c
+++ b/test/mpi/spawn/spawn2.c
@@ -150,6 +150,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawnargv.c
+++ b/test/mpi/spawn/spawnargv.c
@@ -110,6 +110,8 @@ int main(int argc, char *argv[])
         /* Note that the MTest_Finalize get errs only over COMM_WORLD */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawninfo1.c
+++ b/test/mpi/spawn/spawninfo1.c
@@ -140,6 +140,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawnintra.c
+++ b/test/mpi/spawn/spawnintra.c
@@ -185,6 +185,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);

--- a/test/mpi/spawn/spawnmanyarg.c
+++ b/test/mpi/spawn/spawnmanyarg.c
@@ -105,6 +105,7 @@ int main(int argc, char *argv[])
             /* Note that worker also send errs to the parent */
             errs += worker(argc, argv, parentcomm, outargv, np);
             MPI_Comm_free(&parentcomm);
+            MPI_Finalize();
             return MTestReturnValue(errs);
         }
 

--- a/test/mpi/spawn/spawnminfo1.c
+++ b/test/mpi/spawn/spawnminfo1.c
@@ -153,6 +153,8 @@ int main(int argc, char *argv[])
          * if both call MTest_Finalize */
         if (parentcomm == MPI_COMM_NULL) {
             MTest_Finalize(errs);
+        } else {
+            MPI_Finalize();
         }
     } else {
         MTest_Finalize(errs);


### PR DESCRIPTION
The return value patch merged as part of pmodels/mpich#2640 was missing
some code for spawn tests where the spawned processes would call
`MPI_Finalize`. This caused all of those tests to hang.

Add the appropriate calls here to make sure the tests complete properly.