### PR TITLE
ch4/ofi: fix creating scalable endpoint for AM-only path

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1376,7 +1376,7 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
 
         tx_attr = *prov_use->tx_attr;
         tx_attr.op_flags = FI_COMPLETION;
-        if (MPIDI_OFI_ENABLE_RMA)
+        if (MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_ENABLE_ATOMICS)
             tx_attr.op_flags |= FI_DELIVERY_COMPLETE;
         tx_attr.caps = 0;
 
@@ -1768,7 +1768,7 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
     hints->tx_attr->msg_order = FI_ORDER_SAS;
     /* direct RMA operations supported only with delivery complete mode,
      * else (AM mode) delivery complete is not required */
-    if (MPIDI_OFI_ENABLE_RMA) {
+    if (MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_ENABLE_ATOMICS) {
         hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
         /* Apply most restricted msg order in hints for RMA ATOMICS. */
         if (MPIDI_OFI_ENABLE_ATOMICS)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1375,15 +1375,19 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
                                   &cq_attr, &MPIDI_Global.ctx[index].cq, NULL), opencq);
 
         tx_attr = *prov_use->tx_attr;
-        tx_attr.op_flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
+        tx_attr.op_flags = FI_COMPLETION;
+        if (MPIDI_OFI_ENABLE_RMA)
+            tx_attr.op_flags |= FI_DELIVERY_COMPLETE;
         tx_attr.caps = 0;
 
         if (MPIDI_OFI_ENABLE_TAGGED)
             tx_attr.caps = FI_TAGGED | FI_SEND;
 
         /* RMA */
-        tx_attr.caps |= FI_RMA | FI_WRITE | FI_READ;
-        tx_attr.caps |= FI_ATOMICS;
+        if (MPIDI_OFI_ENABLE_RMA)
+            tx_attr.caps |= FI_RMA | FI_WRITE | FI_READ;
+        if (MPIDI_OFI_ENABLE_ATOMICS)
+            tx_attr.caps |= FI_ATOMICS;
         /* MSG */
         tx_attr.caps |= FI_MSG | FI_SEND;
 
@@ -1402,8 +1406,10 @@ static inline int MPIDI_OFI_create_endpoint(struct fi_info *prov_use,
         if (MPIDI_OFI_ENABLE_DATA)
             rx_attr.caps |= FI_DIRECTED_RECV;
 
-        rx_attr.caps |= FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE;
-        rx_attr.caps |= FI_ATOMICS;
+        if (MPIDI_OFI_ENABLE_RMA)
+            rx_attr.caps |= FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE;
+        if (MPIDI_OFI_ENABLE_ATOMICS)
+            rx_attr.caps |= FI_ATOMICS;
         rx_attr.caps |= FI_MSG | FI_RECV;
         rx_attr.caps |= FI_MULTI_RECV;
 


### PR DESCRIPTION
When creating scalable endpoints, respect `MPIDI_OFI_ENABLE_RMA`
and `MPIDI_OFI_ENABLE_ATOMICS` when creating send and recv contexts.
These macros may be turned off by forced AM.