### PR TITLE
ch4/ofi: Clean ssendack request alloc/free

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -360,7 +360,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_ssend_ack_event(struct fi_cq_tagged_entry
     mpi_errno =
         MPIDI_OFI_send_event(NULL, req->signal_req, MPIDI_OFI_REQUEST(req->signal_req, event_id));
 
-    MPIDI_OFI_ssendack_request_t_tls_free(req);
+    MPL_free(req);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_SSEND_ACK_EVENT);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -48,28 +48,6 @@
 #define MPIDI_OFI_ssendack_request_t_tls_free(req) \
   MPIR_Handle_obj_free(&MPIR_Request_mem, (req))
 
-#define MPIDI_OFI_ssendack_request_t_alloc_and_init(req)        \
-    do {                                                                \
-        MPIDI_OFI_ssendack_request_t_tls_alloc(req);            \
-        MPIR_Assert(req != NULL);                                       \
-        MPIR_Assert(HANDLE_GET_MPI_KIND(req->handle)                    \
-                    == MPID_SSENDACK_REQUEST);                          \
-    } while (0)
-
-#define MPIDI_OFI_request_create_null_rreq(rreq_, mpi_errno_, FAIL_) \
-  do {                                                                  \
-    (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);             \
-    if ((rreq_) != NULL) {                                              \
-      MPIR_cc_set(&(rreq_)->cc, 0);                                     \
-      (rreq_)->kind = MPIR_REQUEST_KIND__RECV;                                \
-      MPIR_Status_set_procnull(&(rreq_)->status);                       \
-    }                                                                   \
-    else {                                                              \
-      MPIR_ERR_SETANDJUMP(mpi_errno_,MPIX_ERR_NOREQ,"**nomemreq");       \
-    }                                                                   \
-  } while (0)
-
-
 #define MPIDI_OFI_PROGRESS()                                      \
     do {                                                          \
         mpi_errno = MPID_Progress_test();                        \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -36,18 +36,6 @@
 /*
  * Helper routines and macros for request completion
  */
-#define MPIDI_OFI_ssendack_request_t_tls_alloc(req)             \
-    do {                                                                \
-        (req) = (MPIDI_OFI_ssendack_request_t*)                 \
-            MPIR_Request_create(MPIR_REQUEST_KIND__SEND);               \
-        if (req == NULL)                                                \
-            MPID_Abort(NULL, MPI_ERR_NO_SPACE, -1,                      \
-                       "Cannot allocate Ssendack Request");             \
-    } while (0)
-
-#define MPIDI_OFI_ssendack_request_t_tls_free(req) \
-  MPIR_Handle_obj_free(&MPIR_Request_mem, (req))
-
 #define MPIDI_OFI_PROGRESS()                                      \
     do {                                                          \
         mpi_errno = MPID_Progress_test();                        \
@@ -217,11 +205,6 @@
         MPIR_cc_set(&(req)->cc, 0);                                     \
     } while (0)
 #endif
-
-#define MPIDI_OFI_SSEND_ACKREQUEST_CREATE(req)            \
-    do {                                                          \
-        MPIDI_OFI_ssendack_request_t_tls_alloc(req);      \
-    } while (0)
 
 #define WINFO(w,rank) MPIDI_CH4U_WINFO(w,rank)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -260,7 +260,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         int c = 1;
         uint64_t ssend_match, ssend_mask;
         MPIDI_OFI_ssendack_request_t *ackreq;
-        MPIDI_OFI_SSEND_ACKREQUEST_CREATE(ackreq);
+        ackreq = MPL_malloc(sizeof(MPIDI_OFI_ssendack_request_t), MPL_MEM_OTHER);
+        MPIR_ERR_CHKANDJUMP1(ackreq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem",
+                             "**nomem %s", "Ssend ack request alloc");
         ackreq->event_id = MPIDI_OFI_EVENT_SSEND_ACK;
         ackreq->signal_req = sreq;
         MPIR_cc_incr(sreq->cc_ptr, &c);


### PR DESCRIPTION
This PR is a cleanup around OFI ssend ack request allocation/free routines. It includes

* Removing unused macros
* Shortening the function names
* Removing unnecessary wrapper macro