### PR TITLE
test/mpi: Allow fine-grained control of f08 tests

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -632,6 +632,7 @@
 /f08/topo/cartcrf90
 /f08/topo/dgraph_unwgtf90
 /f08/topo/dgraph_wgtf90
+/f08/testlist
 /f77/attr/attraints.h
 /f77/attr/attrmpi1f
 /f77/attr/baseattr

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1690,6 +1690,7 @@ AC_OUTPUT(maint/testmerge \
 	  cxx/topo/testlist \
           f77/testlist \
           f90/testlist \
+          f08/testlist \
           threads/testlist \
           errors/testlist \
           errors/cxx/testlist \

--- a/test/mpi/f08/testlist.in
+++ b/test/mpi/f08/testlist.in
@@ -3,14 +3,14 @@ pt2pt
 coll
 datatype
 comm
-rma
+@rmadir@
 subarray
 topo
 ext
 info
 init
-io
+@iodir@
 misc
-spawn
+@spawndir@
 timer
 profile


### PR DESCRIPTION
The Fortran 2008 test directory lacked the ability to disable spawn
tests like other parts of the test suite. Move testlist -> testlist.in
and add substitution for the spawn tests directory.