### PR TITLE
test/dtpools: fix pool size when DTP_NUM_OBJS is -1 and count is 1

### DIFF
--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -57,8 +57,9 @@ int DTP_pool_create(MPI_Datatype basic_type, MPI_Aint basic_type_count, DTP_t * 
     }
 
     if (basic_type_count == 1) {
-        num_objs = (env_num_objs < DTPI_OBJ_LAYOUT_SIMPLE__NUM) ?
-            env_num_objs : DTPI_OBJ_LAYOUT_SIMPLE__NUM;
+        num_objs =
+            (env_num_objs < DTPI_OBJ_LAYOUT_SIMPLE__NUM &&
+             env_num_objs > 0) ? env_num_objs : DTPI_OBJ_LAYOUT_SIMPLE__NUM;
     } else {
         num_objs =
             (env_num_objs < DTPI_OBJ_LAYOUT_LARGE__NUM &&


### PR DESCRIPTION
This patch fixes the case in which the `DTP_NUM_OBJS` variable is set to
-1. For this case, when the count is 1 a negative number of objects is
allowed while the max pool size should be selected instead.