### PR TITLE
test/dtpools: small fixes

### DIFF
--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -170,13 +170,3 @@ do
     rm -f ${dir}/testlist.dtp
     printf "done\n"
 done
-
-printf "Generate basictypelist.txt for dtpools ... "
-printf "" > dtpools/basictypelist.txt
-while read -r line; do
-    if [ ! `echo $line | head -c 1` = "#" ]; then
-        echo "$line," >> dtpools/basictypelist.txt
-    fi
-done < basictypelist.txt
-echo "MPI_DATATYPE_NULL" >> dtpools/basictypelist.txt
-printf "done\n"

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -33,7 +33,6 @@ VERSION=MPICH_VERSION_m4
 AC_SUBST(VERSION)
 AC_CONFIG_AUX_DIR([confdb])
 AC_CONFIG_MACRO_DIR([confdb])
-AC_CONFIG_SUBDIRS([dtpools])
 dnl
 echo "RUNNING CONFIGURE FOR MPI TESTS"
 
@@ -594,6 +593,11 @@ else
         AC_PATH_PROG(MPIEXEC,$MPIEXEC_NAME)
     fi
 fi
+
+# Make sure we export this before configuring DTPools since MPI is needed
+# to build the library.
+export CC
+AC_CONFIG_SUBDIRS([dtpools])
 
 # Running C compiler tests
 PAC_PROG_CC

--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -49,11 +49,11 @@ AC_ARG_VAR([DTP_DATATYPE_FILE],
            [used to pass MPI datatypes to the DTPools framework (default: "basictypelist.txt")])
 
 # we must have a valid file containing MPI datatypes for framework initialization
-DTP_DATATYPE_FILE=${DTP_DATATYPE_FILE:-$srcdir/basictypelist.txt}
+DTP_DATATYPE_FILE=${DTP_DATATYPE_FILE:-$srcdir/../basictypelist.txt}
 AC_CHECK_FILE([$DTP_DATATYPE_FILE],,[AC_MSG_ERROR([Need a valid file for MPI datatypes.])])
 
 # get comma separated list of MPI datatypes for static datatype array initialization in src/dtpools.c
-DTP_DATATYPES=$(types=""; while read -r line; do types+="$line"; done < $DTP_DATATYPE_FILE; echo "$types")
+DTP_DATATYPES=$(types=""; while read -r line; do types+="$line,"; done < $DTP_DATATYPE_FILE; types+="MPI_DATATYPE_NULL"; echo "$types")
 AC_SUBST([DTP_DATATYPES])
 # end of framework initialization
 

--- a/test/mpi/dtpools/include/Makefile.am
+++ b/test/mpi/dtpools/include/Makefile.am
@@ -4,3 +4,5 @@
 #     See COPYRIGHT in top-level directory.
 #
 include_HEADERS = dtpools.h
+noinst_HEADERS = dtpools_internal.h
+


### PR DESCRIPTION
This PR fixes a few problems with current DTPools implementation:
- use a static file from mpich to configure DTPools basic types
- configure DTPools after selecting compiler
- add noninst headers