### PR TITLE
test/dtpools: Remove configure check for C++ compiler

### DIFF
--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -25,7 +25,6 @@ AH_BOTTOM([
 ])
 
 # Checks for programs.
-AC_PROG_CXX
 AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_CPP


### PR DESCRIPTION
There is no C++ code in DTPools. This fixes a build issue when MPICH
is configured with --disable-cxx.

No reviewer.