### PR TITLE
ROMIO bug: for blocklens[i] <= INT_MAX, we can reuse oldtype

### DIFF
--- a/src/mpi/romio/adio/common/utils.c
+++ b/src/mpi/romio/adio/common/utils.c
@@ -88,7 +88,7 @@ int ADIOI_Type_create_hindexed_x(int count,
         } else {
             /* OK to cast: checked for "bigness" above */
             blocklens[i] = (int) array_of_blocklengths[i];
-            MPI_Type_contiguous(blocklens[i], oldtype, &(types[i]));
+            types[i] = oldtype;
         }
     }
 
@@ -98,7 +98,8 @@ int ADIOI_Type_create_hindexed_x(int count,
         ret = MPI_Type_create_hindexed(count, blocklens, array_of_displacements, oldtype, newtype);
     }
     for (i = 0; i < count; i++)
-        MPI_Type_free(&(types[i]));
+        if (types[i] != oldtype)
+            MPI_Type_free(&(types[i]));
     ADIOI_Free(types);
     ADIOI_Free(blocklens);
 


### PR DESCRIPTION
In addition, for large count, calling MPI_Type_contiguous can be expensive.

If line 91, MPI_Type_contiguous is used, then blocklens[i] needs to be set to 1 afterward.