### PR TITLE
init: Check MPI state first in MPI_Finalize

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -152,18 +152,17 @@ thread that initialized MPI with either 'MPI_Init' or 'MPI_Init_thread'.
 int MPI_Finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
-
-#ifdef HAVE_HWLOC
-    hwloc_topology_destroy(MPIR_Process.topology);
-    hwloc_bitmap_free(MPIR_Process.bindset);
-#endif
-
 #if defined(HAVE_USLEEP) && defined(USE_COVERAGE)
     int rank = 0;
 #endif
     MPIR_FUNC_TERSE_FINALIZE_STATE_DECL(MPID_STATE_MPI_FINALIZE);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
+
+#ifdef HAVE_HWLOC
+    hwloc_topology_destroy(MPIR_Process.topology);
+    hwloc_bitmap_free(MPIR_Process.bindset);
+#endif
 
     /* Note: Only one thread may ever call MPI_Finalize (MPI_Finalize may
      * be called at most once in any program) */


### PR DESCRIPTION
This patch moves an error check to the top of the function to see
if the MPICH is initialized first.

In the current code, hwloc cleanup is executed first, which would
end up with a weird assertion failure from hwloc if a user calls
MPI_Finalize twice by mistake.