### PR TITLE
test/dataalign: add missing casting to operand

### DIFF
--- a/test/mpi/datatype/dataalign.c
+++ b/test/mpi/datatype/dataalign.c
@@ -79,7 +79,7 @@ int main(int argc, char *argv[])
             errs++;
             fprintf(stderr, "Got s[%d].i = %d; expected %d\n", j, s1[j].i, j + status.MPI_SOURCE);
         }
-        if (s1[j].c != 'a' + j + status.MPI_SOURCE) {
+        if (s1[j].c != (char) ('a' + j + status.MPI_SOURCE)) {
             errs++;
             /* If the character is not a printing character,
              * this can generate a file that diff, for example,


### PR DESCRIPTION
This patch fixes issue pmodels/mpich#3095. The issue reports a missing
operand casting in `test/mpi/dataalign.c:82` that causes tests to fail
erroneously.