### PR TITLE
ch3/init: Fix tag upper limit initialization

### DIFF
--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -157,7 +157,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
      * Set global process attributes.  These can be overridden by the channel 
      * if necessary.
      */
-    MPIR_Process.attrs.tag_ub = INT_MAX;
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
     /*


### PR DESCRIPTION
The value of tag_ub is initialized in MPIR_Init_thread, but was
incorrectly reset in ch3 device initialization. The device should
compare the initial value with the device-specific value and use the
smaller one. This patch fixes it.