### PR TITLE
make ROMIO aio code large-request safe

### DIFF
--- a/src/mpi/romio/adio/common/ad_iread.c
+++ b/src/mpi/romio/adio/common/ad_iread.c
@@ -44,12 +44,11 @@ void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
     static char myname[] = "ADIOI_GEN_IREADCONTIG";
 
     MPI_Type_size_x(datatype, &typesize);
-    ADIOI_Assert((count * typesize) == ((ADIO_Offset) (unsigned) count * (ADIO_Offset) typesize));
     len = count * typesize;
 
     if (file_ptr_type == ADIO_INDIVIDUAL)
         offset = fd->fp_ind;
-    aio_errno = ADIOI_GEN_aio(fd, buf, len, offset, 0, request);
+    aio_errno = ADIOI_GEN_aio(fd, buf, count, datatype, offset, 0, request);
     if (file_ptr_type == ADIO_INDIVIDUAL)
         fd->fp_ind += len;
 

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -371,8 +371,8 @@ void ADIOI_GEN_Delete(const char *filename, int *error_code);
 void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, int count,
                           MPI_Datatype datatype, int file_ptr_type,
                           ADIO_Offset offset, ADIO_Status * status, int *error_code);
-int ADIOI_GEN_aio(ADIO_File fd, void *buf, int len, ADIO_Offset offset,
-                  int wr, MPI_Request * request);
+int ADIOI_GEN_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+                  ADIO_Offset offset, int wr, MPI_Request * request);
 void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
                            MPI_Datatype datatype, int file_ptr_type,
                            ADIO_Offset offset, ADIO_Request * request, int *error_code);


### PR DESCRIPTION
Required tweaking internally-used ADIOI_GEN_aio to take the classic
(buff, count, datatype) tuple instead of a straight size.

closes pmrs/mpich#2731