### PR TITLE
ch4: Use same cacheline size macro throughout

### DIFF
--- a/src/mpid/ch4/include/mpid_ticketlock.h
+++ b/src/mpid/ch4/include/mpid_ticketlock.h
@@ -10,16 +10,14 @@
 #ifndef MPID_TICKETLOCK_H_INCLUDED
 #define MPID_TICKETLOCK_H_INCLUDED
 
-#define MPIDI_CH4_CACHELINE_SIZE 64
-
 typedef union MPIDI_CH4_Ticket_lock {
     unsigned u;
-    char cacheline[MPIDI_CH4_CACHELINE_SIZE];
+    char cacheline[OPA_QUEUE_CACHELINE_PADDING];
     struct {
         unsigned short ticket;
         unsigned short clients;
     } s;
-} MPIDI_CH4_Ticket_lock MPL_ATTR_ALIGNED(MPIDI_CH4_CACHELINE_SIZE);
+} MPIDI_CH4_Ticket_lock MPL_ATTR_ALIGNED(OPA_QUEUE_CACHELINE_PADDING);
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_Thread_mutex_acquire(MPIDI_CH4_Ticket_lock * m)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -20,6 +20,7 @@
 #include "ofi_pre.h"
 #include "ch4_types.h"
 #include "mpidch4r.h"
+#include "opa_queue.h"
 
 #define __SHORT_FILE__                          \
     (strrchr(__FILE__,'/')                      \
@@ -30,7 +31,6 @@
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
 #define MPIDI_OFI_NUM_AM_BUFFERS           (8)
 #define MPIDI_OFI_AM_BUFF_SZ               (1 * 1024 * 1024)
-#define MPIDI_OFI_CACHELINE_SIZE           (64)
 #define MPIDI_OFI_IOV_MAX                  (32)
 #define MPIDI_OFI_BUF_POOL_SIZE            (1024)
 #define MPIDI_OFI_BUF_POOL_NUM             (1024)
@@ -276,8 +276,8 @@ typedef struct {
 
 typedef union {
     MPID_Thread_mutex_t m;
-    char cacheline[MPIDI_OFI_CACHELINE_SIZE];
-} MPIDI_OFI_cacheline_mutex_t MPL_ATTR_ALIGNED(MPIDI_OFI_CACHELINE_SIZE);
+    char cacheline[OPA_QUEUE_CACHELINE_PADDING];
+} MPIDI_OFI_cacheline_mutex_t MPL_ATTR_ALIGNED(OPA_QUEUE_CACHELINE_PADDING);
 
 typedef struct MPIDI_OFI_cq_list_t {
     struct fi_cq_tagged_entry cq_entry;

--- a/src/openpa/src/opa_queue.h
+++ b/src/openpa/src/opa_queue.h
@@ -139,7 +139,7 @@ static _opa_inline
 /* Pick an arbitrary cacheline size for now, we can setup a mechanism to detect
    it at build time later on.  This should work well on most intel systems at
    the very least. */
-#define OPA_QUEUE_CACHELINE_PADDING 128
+#define OPA_QUEUE_CACHELINE_PADDING 64
 
 /* All absolute and relative pointers point to the start of the enclosing element. */
 typedef struct OPA_Queue_info_t {


### PR DESCRIPTION
Reuse the cacheline size macro from openpa, instead of defining a new one.
Set the value of cacheline size to `64` instead of `128` bytes, which is probably a more common size of cacheline, especially for Intel architectures.