### PR TITLE
report the actual number of bytes read/written

### DIFF
--- a/src/mpi/romio/adio/common/ad_iread_fake.c
+++ b/src/mpi/romio/adio/common/ad_iread_fake.c
@@ -29,6 +29,8 @@ void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, int count,
     ADIO_ReadContig(fd, buf, (int) len, MPI_BYTE, file_ptr_type, offset, &status, error_code);
     if (*error_code != MPI_SUCCESS) {
         len = 0;
+    } else {
+        MPI_Get_count(&status, MPI_BYTE, &len);
     }
     MPIO_Completed_request_create(&fd, len, error_code, request);
 }

--- a/src/mpi/romio/adio/common/ad_iwrite_fake.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_fake.c
@@ -18,7 +18,7 @@ void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
 {
     ADIO_Status status;
     MPI_Offset len;
-    MPI_Count typesize;
+    MPI_Count typesize, write_count;
     MPI_Offset nbytes = 0;
 
     MPI_Type_size_x(datatype, &typesize);
@@ -30,8 +30,8 @@ void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
     ADIOI_Assert(len == (int) len);     /* the count is an int parm */
     ADIO_WriteContig(fd, buf, (int) len, MPI_BYTE, file_ptr_type, offset, &status, error_code);
     if (*error_code == MPI_SUCCESS) {
-        MPI_Type_size_x(datatype, &typesize);
-        nbytes = (MPI_Offset) count *(MPI_Offset) typesize;
+        MPI_Get_count(&status, MPI_BYTE, &write_count);
+        nbytes = (MPI_Offset) write_count *(MPI_Offset) typesize;
     }
     MPIO_Completed_request_create(&fd, nbytes, error_code, request);
 


### PR DESCRIPTION
non-blocking requests were setting the reuqested number of bytes in the
status object, not the actual bytes transfered.

Looking at this, though, it will need more work.  Pasing an int coun
of bytes means we will fail for large transfers.  Passing in a count of
larger datatypes is the usual solution, but the ReadCongig calls are
setting bytes, not counts.  In any case, this is good enough to...

Close pmrs/mpich#2348