### PR TITLE
ch4/ofi: Specify iovec alignment for CAS

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -725,7 +725,9 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     size_t offset, max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb;
     void *buffer, *tbuffer, *rbuffer;
-    struct fi_ioc originv, resultv, comparev;
+    struct fi_ioc originv MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+    struct fi_ioc resultv MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+    struct fi_ioc comparev MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
     struct fi_rma_ioc targetv;
     struct fi_msg_atomic msg;
 


### PR DESCRIPTION
In the compare and swap implementation of OFI netmod, there was an
implicit assumption on alignment of stack-placed variables.

This patch explicitly adds an attribute to specify required
alignment.

Fixes csr/mpich-ofi#1007