### PR TITLE
Fix mpi tests

### DIFF
--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -139,8 +139,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -17,7 +17,7 @@ executed";
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -90,18 +90,15 @@ int main(int argc, char *argv[])
     int obj_idx;
     int count;
     int tnlen;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Datatype type, duptype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t dtp;
     char typename[MPI_MAX_OBJECT_NAME];
-    MPI_Comm comm = MPI_COMM_WORLD;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -134,6 +131,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int basic_type_num;
+    int *basic_type_counts = NULL;
     int k;
     char *input_string, *token;
 
@@ -182,6 +182,8 @@ int main(int argc, char *argv[])
         fprintf(stdout, "Error while creating struct pool\n");
         fflush(stdout);
     }
+
+    count = 0;
 #endif
 
     for (obj_idx = 0; obj_idx < dtp->DTP_num_objs; obj_idx++) {
@@ -241,6 +243,7 @@ int main(int argc, char *argv[])
 
     DTP_pool_free(dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -248,6 +251,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
 

--- a/test/mpi/basictypetest.txt
+++ b/test/mpi/basictypetest.txt
@@ -32,7 +32,7 @@ rma/accfence1.c::1 8 64 512 32768 262144:timeLimit=900:4
 rma/accpscw1.c::1 8 64 512 32768 262144:timeLimit=900:4
 rma/epochtest.c::1 8 64 512 32768 262144:timeLimit=900:4
 rma/getfence1.c::1 8 64 512 32768 262144::2
-rma/getfence1.c:LARGE_CNT:16000000:timeLimit=1800:2
+rma/getfence1.c::16000000:timeLimit=1800:2
 rma/lock_contention_dt.c::1 8 64 512 32768 262144:timeLimit=600:4
 rma/lock_dt.c::1 8 64 512 32768 262144::2
 rma/lock_dt_flush.c::1 8 64 512 32768 262144::2
@@ -43,5 +43,5 @@ rma/lockall_dt_flushall.c::1 8 64 512 32768 262144:timeLimit=1800:4
 rma/lockall_dt_flushlocal.c::1 8 64 512 32768 262144:timeLimit=1800:4
 rma/lockall_dt_flushlocalall.c::1 8 64 512 32768 262144:timeLimit=1800:4
 rma/putfence1.c::1 8 64 512 32768 262144::2
-rma/putfence1.c:LARGE_CNT:16000000:timeLimit=1800:2
+rma/putfence1.c::16000000:timeLimit=1800:2
 rma/putpscw1.c::1 8 64 512 32768 262144:timeLimit=900:4

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -124,8 +124,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Test of broadcast with various roots and datatype
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -62,15 +62,10 @@ int main(int argc, char *argv[])
     int rank, size, root;
     int minsize = 2, count;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint sendcount, recvcount;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t send_dtp, recv_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char send_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char recv_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *sendbuf, *recvbuf;
@@ -78,6 +73,9 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -118,6 +116,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -263,6 +264,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(send_dtp);
     DTP_pool_free(recv_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -270,6 +272,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -193,7 +193,6 @@ int DTP_obj_create(DTP_t dtp, int obj_idx, int val_start, int val_stride, MPI_Ai
     int err = DTP_SUCCESS;
     int basic_type_count;
     int factor;
-    MPI_Datatype basic_type;
     struct DTPI_Par par;
 
     /* init user defined params */
@@ -204,7 +203,6 @@ int DTP_obj_create(DTP_t dtp, int obj_idx, int val_start, int val_stride, MPI_Ai
 
     if (dtp->DTP_pool_type == DTP_POOL_TYPE__BASIC) {
         /* get type signature for pool */
-        basic_type = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type;
         basic_type_count = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type_count;
 
         /* get biggest factor for count */

--- a/test/mpi/dtpools/src/dtpools_internal.c
+++ b/test/mpi/dtpools/src/dtpools_internal.c
@@ -1561,7 +1561,7 @@ int DTPI_Subarray_c_create(struct DTPI_Par *par, DTP_t dtp)
         free(buf);
     }
 
-    goto fn_fail;
+    goto fn_exit;
 }
 
 int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp)
@@ -1682,7 +1682,7 @@ int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp)
         free(buf);
     }
 
-    goto fn_fail;
+    goto fn_exit;
 }
 
 

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -128,8 +128,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -18,7 +18,7 @@ static char MTEST_Descrip[] = "Send flood test";
 #define MAX_COUNT    4000
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -65,15 +65,10 @@ int main(int argc, char *argv[])
     int rank, size, source, dest;
     int minsize = 2, count[2], nmsg, maxmsg;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint sendcount, recvcount;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t send_dtp, recv_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char send_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char recv_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *sendbuf, *recvbuf;
@@ -81,6 +76,9 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -sendcnt=[COUNT] -recvcnt=[COUNT]\n", argv[0]);
@@ -122,6 +120,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -280,6 +281,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(send_dtp);
     DTP_pool_free(recv_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -287,6 +289,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -124,8 +124,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -14,7 +14,7 @@
 static char MTEST_Descrip[] = "Send-Recv";
 */
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -61,23 +61,20 @@ int main(int argc, char *argv[])
     int rank, size, source, dest;
     int minsize = 2, count[2];
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint sendcount, recvcount;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t send_dtp, recv_dtp;
     void *sendbuf, *recvbuf;
-    char *max_num_objs_str = NULL;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char send_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char recv_name[MPI_MAX_OBJECT_NAME] = { 0 };
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -sendcnt=[COUNT] -recvcnt=[COUNT]\n", argv[0]);
@@ -119,6 +116,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -259,6 +259,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(send_dtp);
     DTP_pool_free(recv_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -266,6 +267,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -14,7 +14,7 @@ static char MTEST_Descrip[] = "Test of sending to self (with a preposted receive
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -61,16 +61,11 @@ int main(int argc, char *argv[])
     int rank, size;
     int count[2];
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint sendcount, recvcount;
     MPI_Comm comm;
     MPI_Datatype sendtype, recvtype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     MPI_Request req;
     DTP_t send_dtp, recv_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char send_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char recv_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *sendbuf, *recvbuf;
@@ -82,6 +77,9 @@ int main(int argc, char *argv[])
     MPI_Comm_size(comm, &size);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -sendcnt=[COUNT] -recvcnt=[COUNT]\n", argv[0]);
@@ -123,6 +121,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -304,6 +305,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(send_dtp);
     DTP_pool_free(recv_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -311,6 +313,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -129,8 +129,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -126,8 +126,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Accumulate/Replace with Fence";
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -62,17 +62,12 @@ int main(int argc, char *argv[])
     int rank, size, orig, target;
     int minsize = 2, count;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint extent, lb;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char orig_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char target_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
@@ -80,6 +75,9 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -120,6 +118,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -278,6 +279,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -285,6 +287,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Accumulate/replace with Post/Start/Complete/Wait"
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -62,18 +62,13 @@ int main(int argc, char *argv[])
     int rank, size, orig, target;
     int minsize = 2, count;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint extent, lb;
     MPI_Group wingroup, neighbors;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char orig_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char target_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
@@ -81,6 +76,9 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -121,6 +119,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -286,6 +287,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -293,6 +295,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -127,8 +127,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -148,8 +148,7 @@ int main(int argc, char **argv)
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -34,7 +34,7 @@ static char MTEST_Descrip[] = "Put with Fences used to separate epochs";
 #define MAX_PERR 10
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -83,25 +83,23 @@ int main(int argc, char **argv)
     int rank, size, orig, target;
     int minsize = 2, count;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     int onlyInt = 0;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint extent, lb;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
     char orig_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char target_name[MPI_MAX_OBJECT_NAME] = { 0 };
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -142,6 +140,9 @@ int main(int argc, char **argv)
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -367,6 +368,7 @@ int main(int argc, char **argv)
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -374,6 +376,7 @@ int main(int argc, char **argv)
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/getfence1.c
+++ b/test/mpi/rma/getfence1.c
@@ -20,7 +20,7 @@ static char MTEST_Descrip[] = "Get with Fence";
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -146,20 +146,18 @@ int main(int argc, char *argv[])
     int minsize = 2;
     int i, j;
     int count;
-    int len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint bufsize;
-    MPI_Aint lb, extent;
     MPI_Comm comm;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    MPI_Aint lb, extent;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -204,6 +202,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -312,6 +313,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -319,6 +321,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/getfence1.c
+++ b/test/mpi/rma/getfence1.c
@@ -210,8 +210,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lock_contention_dt.c
+++ b/test/mpi/rma/lock_contention_dt.c
@@ -134,8 +134,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lock_contention_dt.c
+++ b/test/mpi/rma/lock_contention_dt.c
@@ -18,7 +18,7 @@ static char MTEST_Descrip[] = "Test lock contention while streaming ACC-like ope
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -65,25 +65,23 @@ int main(int argc, char *argv[])
     int rank, size;
     int target = 1;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -128,6 +126,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -288,6 +289,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -295,6 +297,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lock_dt.c
+++ b/test/mpi/rma/lock_dt.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock"
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -61,24 +61,22 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size, orig, target;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -119,6 +117,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -271,6 +272,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -278,6 +280,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lock_dt.c
+++ b/test/mpi/rma/lock_dt.c
@@ -125,8 +125,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lock_dt_flush.c
+++ b/test/mpi/rma/lock_dt_flush.c
@@ -126,8 +126,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lock_dt_flush.c
+++ b/test/mpi/rma/lock_dt_flush.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock+
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -62,24 +62,22 @@ int main(int argc, char *argv[])
     int err = 0;
     int rank, size, orig, target;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -120,6 +118,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -281,6 +282,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -288,6 +290,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lock_dt_flushlocal.c
+++ b/test/mpi/rma/lock_dt_flushlocal.c
@@ -127,8 +127,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lock_dt_flushlocal.c
+++ b/test/mpi/rma/lock_dt_flushlocal.c
@@ -16,7 +16,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock+
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -63,24 +63,22 @@ int main(int argc, char *argv[])
     int err = 0;
     int rank, size, orig, target;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -121,6 +119,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -291,6 +292,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -298,6 +300,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt.c
+++ b/test/mpi/rma/lockall_dt.c
@@ -133,8 +133,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lockall_dt.c
+++ b/test/mpi/rma/lockall_dt.c
@@ -18,7 +18,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock_
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -64,25 +64,23 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -127,6 +125,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -298,6 +299,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -305,6 +307,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt_flush.c
+++ b/test/mpi/rma/lockall_dt_flush.c
@@ -133,8 +133,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lockall_dt_flush.c
+++ b/test/mpi/rma/lockall_dt_flush.c
@@ -18,7 +18,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock_
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -64,25 +64,23 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -127,6 +125,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -309,6 +310,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -316,6 +318,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt_flushall.c
+++ b/test/mpi/rma/lockall_dt_flushall.c
@@ -133,8 +133,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lockall_dt_flushall.c
+++ b/test/mpi/rma/lockall_dt_flushall.c
@@ -18,7 +18,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock_
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -64,25 +64,23 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -127,6 +125,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -310,6 +311,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -317,6 +319,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt_flushlocal.c
+++ b/test/mpi/rma/lockall_dt_flushlocal.c
@@ -134,8 +134,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/lockall_dt_flushlocal.c
+++ b/test/mpi/rma/lockall_dt_flushlocal.c
@@ -19,7 +19,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock_
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -65,25 +65,23 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -128,6 +126,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -317,6 +318,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -324,6 +326,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt_flushlocalall.c
+++ b/test/mpi/rma/lockall_dt_flushlocalall.c
@@ -19,7 +19,7 @@ static char MTEST_Descrip[] = "Test for streaming ACC-like operations with lock_
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -65,25 +65,23 @@ int main(int argc, char *argv[])
     int err, errs = 0;
     int rank, size;
     int minsize = 2, count;
-    int len;
     int i, j;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Aint bufsize;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint lb, extent;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -128,6 +126,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -318,6 +319,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -325,6 +327,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/lockall_dt_flushlocalall.c
+++ b/test/mpi/rma/lockall_dt_flushlocalall.c
@@ -134,8 +134,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/putfence1.c
+++ b/test/mpi/rma/putfence1.c
@@ -20,7 +20,7 @@ static char MTEST_Descrip[] = "Put with Fence";
 #define MAX_TYPE_SIZE  (16)
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -144,20 +144,18 @@ int main(int argc, char *argv[])
     int minsize = 2;
     int i, j;
     int count;
-    int len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint bufsize;
-    MPI_Aint lb, extent;
     MPI_Comm comm;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
 
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    MPI_Aint lb, extent;
+    int len;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -202,6 +200,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -310,6 +311,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -317,6 +319,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/rma/putfence1.c
+++ b/test/mpi/rma/putfence1.c
@@ -208,8 +208,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -127,8 +127,7 @@ int main(int argc, char *argv[])
 
     /* TODO: parse input parameters using optarg */
     if (argc < 4) {
-        fprintf(stdout, "Usage: %s -type=[TYPE] -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n",
-                argv[0]);
+        fprintf(stdout, "Usage: %s -numtypes=[NUM] -types=[TYPES] -counts=[COUNTS]\n", argv[0]);
         return MTestReturnValue(1);
     } else {
         for (i = 1; i < argc; i++) {

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -15,7 +15,7 @@ static char MTEST_Descrip[] = "Put with Post/Start/Complete/Wait";
 */
 
 typedef struct {
-    char *typename;
+    const char *typename;
     MPI_Datatype type;
 } Type_t;
 
@@ -62,18 +62,13 @@ int main(int argc, char *argv[])
     int rank, size, orig, target;
     int minsize = 2, count;
     int i, j, len;
-    int basic_type_num;
-    int *basic_type_counts = NULL;
     MPI_Aint origcount, targetcount;
     MPI_Comm comm;
     MPI_Win win;
     MPI_Aint extent, lb;
     MPI_Group wingroup, neighbors;
     MPI_Datatype origtype, targettype;
-    MPI_Datatype basic_type;
-    MPI_Datatype *basic_types = NULL;
     DTP_t orig_dtp, target_dtp;
-    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char orig_name[MPI_MAX_OBJECT_NAME] = { 0 };
     char target_name[MPI_MAX_OBJECT_NAME] = { 0 };
     void *origbuf, *targetbuf;
@@ -81,6 +76,9 @@ int main(int argc, char *argv[])
     MTest_Init(&argc, &argv);
 
 #ifndef USE_DTP_POOL_TYPE__STRUCT       /* set in 'test/mpi/structtypetest.txt' to split tests */
+    MPI_Datatype basic_type;
+    char type_name[MPI_MAX_OBJECT_NAME] = { 0 };
+
     /* TODO: parse input parameters using optarg */
     if (argc < 3) {
         fprintf(stdout, "Usage: %s -type=[TYPE] -count=[COUNT]\n", argv[0]);
@@ -121,6 +119,9 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
 #else
+    MPI_Datatype *basic_types = NULL;
+    int *basic_type_counts = NULL;
+    int basic_type_num;
     int k;
     char *input_string, *token;
 
@@ -286,6 +287,7 @@ int main(int argc, char *argv[])
     DTP_pool_free(orig_dtp);
     DTP_pool_free(target_dtp);
 
+#ifdef USE_DTP_POOL_TYPE__STRUCT
     /* cleanup array if any */
     if (basic_types) {
         free(basic_types);
@@ -293,6 +295,7 @@ int main(int argc, char *argv[])
     if (basic_type_counts) {
         free(basic_type_counts);
     }
+#endif
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);


### PR DESCRIPTION
This PR fixes several warnings detected when compiling tests with `--enable-stricttest`. It also fixes the help message of datatype tests and removes an unused line in the `basictypetest.txt` configuration file.