### PR TITLE
CH4 Netmod Small Fixes

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -2483,16 +2483,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_op_free_hook(MPIR_Op * op_p)
 #else
 #define __netmod_direct_stubnm__   0
 #define __netmod_direct_ofi__    1
-#define __netmod_direct_shm__    2
-#define __netmod_direct_ucx__    3
-#define __netmod_direct_portals4__ 4
+#define __netmod_direct_ucx__    2
+#define __netmod_direct_portals4__ 3
 
 #if NETMOD_DIRECT==__netmod_direct_stubnm__
 #include "../stubnm/netmod_direct.h"
 #elif NETMOD_DIRECT==__netmod_direct_ofi__
 #include "../ofi/netmod_direct.h"
-#elif NETMOD_DIRECT==__netmod_direct_shm__
-#include "../shm/netmod_direct.h"
 #elif NETMOD_DIRECT==__netmod_direct_ucx__
 #include "../ucx/netmod_direct.h"
 #elif NETMOD_DIRECT==__netmod_direct_portals4__

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -337,6 +337,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_set_rma_fi_info(MPIR_Win * win, struct f
         finfo->tx_attr->msg_order |= FI_ORDER_WAW;
 }
 
+#undef FUNCNAME
+#define FUNCNAME MPIDI_OFI_win_request_alloc_and_init
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_alloc_and_init(int extra)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -243,9 +243,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         ofi_subdir_args+=" $prov_config"
 
         dnl Unset all of these env vars so they don't pollute the libfabric configuration
-        PAC_PUSH_FLAG(CPPFLAGS)
+        PAC_PUSH_ALL_FLAGS()
+        PAC_RESET_ALL_FLAGS()
         PAC_CONFIG_SUBDIR_ARGS([src/mpid/ch4/netmod/ofi/libfabric],[$ofi_subdir_args],[],[AC_MSG_ERROR(libfabric configure failed)])
-        PAC_POP_FLAG(CPPFLAGS)
+        PAC_POP_ALL_FLAGS()
         PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpid/ch4/netmod/ofi/libfabric/include], [CPPFLAGS])
         PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpid/ch4/netmod/ofi/libfabric/include], [CPPFLAGS])
 


### PR DESCRIPTION
* Add missing `FCNAME` macros to allow `--enable-ch4-netmod-direct=yes` (Fixes pmodels/mpich#3105)
* Stash internal flags when configuring OFI
* Remove non-existent shm netmod