### PR TITLE
Alignment of mpi- and device-level tags.

### DIFF
--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -225,7 +225,6 @@ typedef struct MPIR_Topology MPIR_Topology;
 #include "mpir_dataloop.h"
 #include "mpir_datatype.h"
 #include "mpir_cvars.h"
-#include "mpir_misc_post.h"
 #include "mpit.h"
 #include "mpir_handlemem.h"
 
@@ -234,6 +233,12 @@ typedef struct MPIR_Topology MPIR_Topology;
 /*****************************************************************************/
 
 #include "mpidpost.h"
+
+/*****************************************************************************/
+/*********** PART 7: DEVICE IMPLEMENTATION DEPENDENT HEADERS *****************/
+/*****************************************************************************/
+
+#include "mpir_misc_post.h"
 
 /* avoid conflicts in source files with old-style "char FCNAME[]" vars */
 #undef FUNCNAME

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -26,6 +26,7 @@ typedef struct PreDefined_attrs {
     int host;                   /* host */
     int io;                     /* standard io allowed */
     int lastusedcode;           /* last used error code (MPI-2) */
+    int tag_bits;               /* number of tag bits */
     int tag_ub;                 /* Maximum message tag */
     int universe;               /* Universe size from mpiexec (MPI-2) */
     int wtime_is_global;        /* Wtime is global over processes in COMM_WORLD */

--- a/src/include/mpir_tags.h
+++ b/src/include/mpir_tags.h
@@ -44,35 +44,32 @@
 #define MPIR_LAST_HCOLL_TAG           (MPIR_FIRST_HCOLL_TAG + 255)
 #define MPIR_FIRST_NBC_TAG            (MPIR_LAST_HCOLL_TAG + 1)
 
+#define MPIR_TAG_BITS_DEFAULT (31)
+
 /* These macros must be used carefully. These macros will not work with
  * negative tags. By definition, users are not to use negative tags and the
  * only negative tag in MPICH is MPI_ANY_TAG which is checked seperately, but
  * if there is a time where negative tags become more common, this setup won't
  * work anymore. */
 
+/* MPID_TAG_BITS should be declared by device later */
+#ifdef HAVE_TAG_ERROR_BITS
 /* This bitmask can be used to manually mask the tag space wherever it might
  * be necessary to do so (for instance in the receive queue */
-#ifdef HAVE_TAG_ERROR_BITS
-#define MPIR_TAG_ERROR_BIT (1 << 30)
-#else
-#define MPIR_TAG_ERROR_BIT
-#endif
-
+#define MPIR_TAG_ERROR_BIT (1 << (MPID_TAG_BITS-1))
 /* This bitmask is used to differentiate between a process failure
  * (MPIX_ERR_PROC_FAILED) and any other kind of failure (MPI_ERR_OTHER). */
-#ifdef HAVE_TAG_ERROR_BITS
-#define MPIR_TAG_PROC_FAILURE_BIT (1 << 29)
+#define MPIR_TAG_PROC_FAILURE_BIT (1 << (MPID_TAG_BITS-2))
+#define MPIR_TAG_ERROR_BITS (2)
 #else
+#define MPIR_TAG_ERROR_BIT
 #define MPIR_TAG_PROC_FAILURE_BIT
+#define MPIR_TAG_ERROR_BITS (0)
 #endif
 
 /* This bitmask is used to differentiate between collective operations
    with user-supplied tags and internally-defined tags. */
-#ifdef HAVE_TAG_ERROR_BITS
-#define MPIR_TAG_COLL_BIT (1 << 28)
-#else
-#define MPIR_TAG_COLL_BIT (1 << 30)
-#endif
+#define MPIR_TAG_COLL_BIT (1 << (MPID_TAG_BITS-MPIR_TAG_ERROR_BITS-1))
 
 /* This macro checks the value of the error bit in the MPI tag and returns 1
  * if the tag is set and 0 if it is not. */
@@ -120,9 +117,9 @@
 
 /* This macro defines tags bits which are reserved by the MPI layer */
 #ifdef HAVE_TAG_ERROR_BITS
-#define MPIR_TAG_USABLE_BITS (INT_MAX & ~(MPIR_TAG_ERROR_BIT | MPIR_TAG_PROC_FAILURE_BIT | MPIR_TAG_COLL_BIT))
+#define MPIR_TAG_USABLE_BITS ((1 << (MPID_TAG_BITS - MPIR_TAG_ERROR_BITS - 1)) - 1)
 #else
-#define MPIR_TAG_USABLE_BITS (INT_MAX & ~MPIR_TAG_COLL_BIT)
+#define MPIR_TAG_USABLE_BITS ((1 << (MPID_TAG_BITS - 1)) - 1)
 #endif
 
 #endif /* MPIR_TAGS_H_INCLUDED */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -430,7 +430,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_Process.attrs.host = MPI_PROC_NULL;
     MPIR_Process.attrs.io = MPI_PROC_NULL;
     MPIR_Process.attrs.lastusedcode = MPI_ERR_LASTCODE;
-    MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;
+    MPIR_Process.attrs.tag_bits = MPIR_TAG_BITS_DEFAULT;
     MPIR_Process.attrs.universe = MPIR_UNIVERSE_SIZE_NOT_SET;
     MPIR_Process.attrs.wtime_is_global = 0;
 
@@ -548,6 +548,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPII_Coll_init();
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
+
+    /* Setup tag_ub as function of tag_bits set by netmod */
+    MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;
 
     /* Assert: tag_ub should be a power of 2 minus 1 */
     MPIR_Assert(((unsigned) MPIR_Process.

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -113,7 +113,7 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
                    OFI_KVSAPPSTRLEN,
                    gl_data.mr,
                    FI_ADDR_UNSPEC,
-                   MPID_CONN_REQ,
+                   MPID_OFI_CONN_REQ,
                    GET_RCD_IGNORE_MASK(),
                    (void *) &(REQ_OFI(gl_data.conn_req)->ofi_context)), trecv);
 
@@ -236,7 +236,7 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
                        REQ_OFI(new_rreq)->pack_buffer_size,
                        gl_data.mr,
                        VC_OFI(vc)->direct_addr,
-                       wc->tag | MPID_MSG_CTS | MPID_MSG_DATA, 0, &(REQ_OFI(new_rreq)->ofi_context)), trecv);
+                       wc->tag | MPID_OFI_MSG_CTS | MPID_OFI_MSG_DATA, 0, &(REQ_OFI(new_rreq)->ofi_context)), trecv);
 
     MPID_nem_ofi_create_req(&sreq, 1);
     sreq->dev.OnDataAvail = NULL;
@@ -248,7 +248,7 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
                      0,
                      gl_data.mr,
                      VC_OFI(vc)->direct_addr,
-                     wc->tag | MPID_MSG_CTS, &(REQ_OFI(sreq)->ofi_context)), tsend);
+                     wc->tag | MPID_OFI_MSG_CTS, &(REQ_OFI(sreq)->ofi_context)), tsend);
     MPIR_Assert(gl_data.persistent_req == rreq);
 
     FI_RC_RETRY(fi_trecv(gl_data.endpoint,
@@ -256,7 +256,7 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
                    sizeof REQ_OFI(rreq)->msg_bytes,
                    gl_data.mr,
                    FI_ADDR_UNSPEC,
-                   MPID_MSG_RTS,
+                   MPID_OFI_MSG_RTS,
                    GET_RCD_IGNORE_MASK(),
                    &(REQ_OFI(rreq)->ofi_context)), trecv);
     /* Return a proper error to MPI to indicate out of memory condition */
@@ -328,7 +328,7 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
                    sizeof REQ_OFI(persistent_req)->msg_bytes,
                    gl_data.mr,
                    FI_ADDR_UNSPEC,
-                   MPID_MSG_RTS,
+                   MPID_OFI_MSG_RTS,
                    GET_RCD_IGNORE_MASK(),
                    (void *) &(REQ_OFI(persistent_req)->ofi_context)), trecv);
     gl_data.persistent_req = persistent_req;
@@ -347,7 +347,7 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
                    OFI_KVSAPPSTRLEN,
                    gl_data.mr,
                    FI_ADDR_UNSPEC,
-                   MPID_CONN_REQ,
+                   MPID_OFI_CONN_REQ,
                    GET_RCD_IGNORE_MASK(),
                    (void *) &(REQ_OFI(conn_req)->ofi_context)), trecv);
     gl_data.conn_req = conn_req;
@@ -557,7 +557,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     REQ_OFI(sreq)->event_callback = MPID_nem_ofi_connect_to_root_callback;
     REQ_OFI(sreq)->pack_buffer = my_bc;
     if (gl_data.api_set == API_SET_1) {
-        conn_req_send_bits = init_sendtag(0, MPIR_Process.comm_world->rank, 0, MPID_CONN_REQ);
+        conn_req_send_bits = init_sendtag(0, MPIR_Process.comm_world->rank, 0, MPID_OFI_CONN_REQ);
         FI_RC_RETRY(fi_tsend(gl_data.endpoint,
                        REQ_OFI(sreq)->pack_buffer,
                        my_bc_len,
@@ -565,7 +565,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
                        VC_OFI(new_vc)->direct_addr,
                        conn_req_send_bits, &(REQ_OFI(sreq)->ofi_context)), tsend);
     } else {
-        conn_req_send_bits = init_sendtag_2(0, 0, MPID_CONN_REQ);
+        conn_req_send_bits = init_sendtag_2(0, 0, MPID_OFI_CONN_REQ);
         FI_RC_RETRY(fi_tsenddata(gl_data.endpoint,
                            REQ_OFI(sreq)->pack_buffer,
                            my_bc_len,

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -89,7 +89,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     hints->rx_attr->msg_order = FI_ORDER_SAS;
 
     hints->ep_attr->mem_tag_format = MEM_TAG_FORMAT;
-    MPIR_Assert(pg_p->size < ((1 << MPID_RANK_BITS) - 1));
+    MPIR_Assert(pg_p->size < ((1 << MPID_OFI_RANK_BITS) - 1));
 
     /* ------------------------------------------------------------------------ */
     /* FI_VERSION provides binary backward and forward compatibility support    */
@@ -236,7 +236,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* -------------------------------- */
     /* Set the MPI maximum tag value    */
     /* -------------------------------- */
-    MPIR_Process.attrs.tag_ub = (1 << MPID_TAG_BITS) - 1;
+    MPIR_Process.attrs.tag_ub = (1 << MPID_OFI_TAG_BITS) - 1;
 
     /* --------------------------------- */
     /* Wait for all the ranks to publish */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -238,11 +238,6 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* -------------------------------- */
     MPIR_Process.attrs.tag_bits = MPID_OFI_TAG_BITS;
 
-    /* -------------------------------- */
-    /* Set the MPI maximum tag value    */
-    /* -------------------------------- */
-    MPIR_Process.attrs.tag_ub = (1 << (MPID_OFI_TAG_BITS - MPIR_TAG_ERROR_BITS - 1)) - 1;
-
     /* --------------------------------- */
     /* Wait for all the ranks to publish */
     /* their business card               */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -234,9 +234,14 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     PMI_RC(PMI_KVS_Commit(kvsname), pmi);
 
     /* -------------------------------- */
+    /* Set the number of tag bits       */
+    /* -------------------------------- */
+    MPIR_Process.attrs.tag_bits = MPID_OFI_TAG_BITS;
+
+    /* -------------------------------- */
     /* Set the MPI maximum tag value    */
     /* -------------------------------- */
-    MPIR_Process.attrs.tag_ub = (1 << MPID_OFI_TAG_BITS) - 1;
+    MPIR_Process.attrs.tag_ub = (1 << (MPID_OFI_TAG_BITS - MPIR_TAG_ERROR_BITS - 1)) - 1;
 
     /* --------------------------------- */
     /* Wait for all the ranks to publish */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tag_layout.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tag_layout.h
@@ -12,28 +12,28 @@
  *       source      |       ctxid       |  col |           message tag          |
  *
  *********************************************************************************/
-#define MPID_PROTOCOL_MASK       (0x00000000F0000000ULL)
-#define MPIR_CONTEXT_MASK        (0x0000FFFF00000000ULL)
-#define MPID_SOURCE_MASK         (0xFFFF000000000000ULL)
-#define MPID_TAG_MASK            (0x000000000FFFFFFFULL)
-#define MPID_PGID_MASK           (0xFFFFFFFF00000000ULL)
-#define MPID_PSOURCE_MASK        (0x000000000000FFFFULL)
-#define MPID_PORT_NAME_MASK      (0x000000000000FFFFULL)
-#define MPID_SYNC_SEND           (0x0000000080000000ULL)
-#define MPID_SYNC_SEND_ACK       (0x0000000090000000ULL)
-#define MPID_MSG_RTS             (0x0000000010000000ULL)
-#define MPID_MSG_CTS             (0x0000000020000000ULL)
-#define MPID_MSG_DATA            (0x0000000040000000ULL)
-#define MPID_CONN_REQ            (0x00000000A0000000ULL)
-#define MPID_SOURCE_SHIFT        (48)
-#define MPID_CTXID_SHIFT         (32)
-#define MPID_PGID_SHIFT          (32)
-#define MPID_PSOURCE_SHIFT       (0)
-#define MPID_PORT_SHIFT          (0)
-#define MPID_TAG_BITS            (28)
-#define MPID_RANK_BITS           (16)
-#define MPID_RCD_IGNORE_MASK     (0xFFFFFFFF0FFFFFFFULL)
-#define OFI_KVSAPPSTRLEN         1024
+#define MPID_OFI_PROTOCOL_MASK       (0x00000000F0000000ULL)
+#define MPIR_OFI_CONTEXT_MASK        (0x0000FFFF00000000ULL)
+#define MPID_OFI_SOURCE_MASK         (0xFFFF000000000000ULL)
+#define MPID_OFI_TAG_MASK            (0x000000000FFFFFFFULL)
+#define MPID_OFI_PGID_MASK           (0xFFFFFFFF00000000ULL)
+#define MPID_OFI_PSOURCE_MASK        (0x000000000000FFFFULL)
+#define MPID_OFI_PORT_NAME_MASK      (0x000000000000FFFFULL)
+#define MPID_OFI_SYNC_SEND           (0x0000000080000000ULL)
+#define MPID_OFI_SYNC_SEND_ACK       (0x0000000090000000ULL)
+#define MPID_OFI_MSG_RTS             (0x0000000010000000ULL)
+#define MPID_OFI_MSG_CTS             (0x0000000020000000ULL)
+#define MPID_OFI_MSG_DATA            (0x0000000040000000ULL)
+#define MPID_OFI_CONN_REQ            (0x00000000A0000000ULL)
+#define MPID_OFI_SOURCE_SHIFT        (48)
+#define MPID_OFI_CTXID_SHIFT         (32)
+#define MPID_OFI_PGID_SHIFT          (32)
+#define MPID_OFI_PSOURCE_SHIFT       (0)
+#define MPID_OFI_PORT_SHIFT          (0)
+#define MPID_OFI_TAG_BITS            (28)
+#define MPID_OFI_RANK_BITS           (16)
+#define MPID_OFI_RCD_IGNORE_MASK     (0xFFFFFFFF0FFFFFFFULL)
+#define OFI_KVSAPPSTRLEN             1024
 
 
 /* ******************************** */
@@ -42,9 +42,9 @@
 static inline uint64_t init_sendtag(MPIR_Context_id_t contextid, int source, int tag, uint64_t type)
 {
     uint64_t match_bits = 0;
-    match_bits |= ((uint64_t)source) << MPID_SOURCE_SHIFT;
-    match_bits |= ((uint64_t)contextid) << MPID_CTXID_SHIFT;
-    match_bits |= (MPID_TAG_MASK & tag) | type;
+    match_bits |= ((uint64_t)source) << MPID_OFI_SOURCE_SHIFT;
+    match_bits |= ((uint64_t)contextid) << MPID_OFI_CTXID_SHIFT;
+    match_bits |= (MPID_OFI_TAG_MASK & tag) | type;
     return match_bits;
 }
 
@@ -53,46 +53,46 @@ static inline uint64_t init_recvtag(uint64_t * mask_bits,
                                     MPIR_Context_id_t contextid, int source, int tag)
 {
     uint64_t match_bits = 0;
-    *mask_bits = MPID_SYNC_SEND;
-    match_bits |= ((uint64_t)contextid) << MPID_CTXID_SHIFT;
+    *mask_bits = MPID_OFI_SYNC_SEND;
+    match_bits |= ((uint64_t)contextid) << MPID_OFI_CTXID_SHIFT;
 
     if (MPI_ANY_SOURCE == source) {
-        *mask_bits |= MPID_SOURCE_MASK;
+        *mask_bits |= MPID_OFI_SOURCE_MASK;
     }
     else {
-        match_bits |= ((uint64_t)source) << MPID_SOURCE_SHIFT;
+        match_bits |= ((uint64_t)source) << MPID_OFI_SOURCE_SHIFT;
     }
     if (MPI_ANY_TAG == tag)
-        *mask_bits |= MPID_TAG_MASK;
+        *mask_bits |= MPID_OFI_TAG_MASK;
     else
-        match_bits |= (MPID_TAG_MASK & tag);
+        match_bits |= (MPID_OFI_TAG_MASK & tag);
 
     return match_bits;
 }
 
 static inline int get_tag(uint64_t match_bits)
 {
-    return ((int) (match_bits & MPID_TAG_MASK));
+    return ((int) (match_bits & MPID_OFI_TAG_MASK));
 }
 
 static inline int get_source(uint64_t match_bits)
 {
-    return ((int) ((match_bits & MPID_SOURCE_MASK) >> (MPID_SOURCE_SHIFT)));
+    return ((int) ((match_bits & MPID_OFI_SOURCE_MASK) >> (MPID_OFI_SOURCE_SHIFT)));
 }
 
 static inline int get_psource(uint64_t match_bits)
 {
-    return ((int) ((match_bits & MPID_PSOURCE_MASK) >> (MPID_PSOURCE_SHIFT)));
+    return ((int) ((match_bits & MPID_OFI_PSOURCE_MASK) >> (MPID_OFI_PSOURCE_SHIFT)));
 }
 
 static inline int get_pgid(uint64_t match_bits)
 {
-    return ((int) ((match_bits & MPID_PGID_MASK) >> MPID_PGID_SHIFT));
+    return ((int) ((match_bits & MPID_OFI_PGID_MASK) >> MPID_OFI_PGID_SHIFT));
 }
 
 static inline int get_port(uint64_t match_bits)
 {
-    return ((int) ((match_bits & MPID_PORT_NAME_MASK) >> MPID_PORT_SHIFT));
+    return ((int) ((match_bits & MPID_OFI_PORT_NAME_MASK) >> MPID_OFI_PORT_SHIFT));
 }
 
 
@@ -106,7 +106,7 @@ static inline int get_port(uint64_t match_bits)
  *       Not used    |       ctxid       |  col |           message tag          |
  *
  *********************************************************************************/
-#define MPID_RCD_IGNORE_MASK_M2     (0x000000000FFFFFFFULL)
+#define MPID_OFI_RCD_IGNORE_MASK_M2     (0x000000000FFFFFFFULL)
 
 
 /* ******************************** */
@@ -115,8 +115,8 @@ static inline int get_port(uint64_t match_bits)
 static inline uint64_t init_sendtag_2(MPIR_Context_id_t contextid, int tag, uint64_t type)
 {
     uint64_t match_bits = 0;
-    match_bits |= ((uint64_t)contextid) << MPID_CTXID_SHIFT;
-    match_bits |= (MPID_TAG_MASK & tag) | type;
+    match_bits |= ((uint64_t)contextid) << MPID_OFI_CTXID_SHIFT;
+    match_bits |= (MPID_OFI_TAG_MASK & tag) | type;
     return match_bits;
 }
 
@@ -125,19 +125,19 @@ static inline uint64_t init_recvtag_2(uint64_t * mask_bits,
                                     MPIR_Context_id_t contextid, int tag)
 {
     uint64_t match_bits = 0;
-    *mask_bits = MPID_SYNC_SEND;
-    match_bits |= ((uint64_t)contextid) << MPID_CTXID_SHIFT;
+    *mask_bits = MPID_OFI_SYNC_SEND;
+    match_bits |= ((uint64_t)contextid) << MPID_OFI_CTXID_SHIFT;
 
     if (MPI_ANY_TAG == tag)
-        *mask_bits |= MPID_TAG_MASK;
+        *mask_bits |= MPID_OFI_TAG_MASK;
     else
-        match_bits |= (MPID_TAG_MASK & tag);
+        match_bits |= (MPID_OFI_TAG_MASK & tag);
 
     return match_bits;
 }
 
 #define GET_RCD_IGNORE_MASK() (gl_data.api_set == API_SET_1 ? \
-                               MPID_RCD_IGNORE_MASK : MPID_RCD_IGNORE_MASK_M2)
+                               MPID_OFI_RCD_IGNORE_MASK : MPID_OFI_RCD_IGNORE_MASK_M2)
 #define API_SET_1 1
 #define API_SET_2 2
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
@@ -54,11 +54,11 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_callback)(cq_tagged_entry_t * wc, MPIR_Request 
         }
     }
 
-    if ((wc->tag & MPID_PROTOCOL_MASK) == MPID_SYNC_SEND) {
+    if ((wc->tag & MPID_OFI_PROTOCOL_MASK) == MPID_OFI_SYNC_SEND) {
         /* ---------------------------------------------------- */
         /* Ack the sync send and wait for the send request      */
         /* completion(when callback executed.  A protocol bit   */
-        /* MPID_SYNC_SEND_ACK is set in the tag bits to provide */
+        /* MPID_OFI_SYNC_SEND_ACK is set in the tag bits to provide */
         /* separation of MPI messages and protocol messages     */
         /* ---------------------------------------------------- */
         vc = REQ_OFI(rreq)->vc;
@@ -68,10 +68,10 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_callback)(cq_tagged_entry_t * wc, MPIR_Request 
         }
 #if API_SET == API_SET_1
         ssend_bits = init_sendtag(rreq->dev.match.parts.context_id,
-                                  rreq->comm->rank, rreq->status.MPI_TAG, MPID_SYNC_SEND_ACK);
+                                  rreq->comm->rank, rreq->status.MPI_TAG, MPID_OFI_SYNC_SEND_ACK);
 #elif API_SET == API_SET_2
         ssend_bits = init_sendtag_2(rreq->dev.match.parts.context_id,
-                                    rreq->status.MPI_TAG, MPID_SYNC_SEND_ACK);
+                                    rreq->status.MPI_TAG, MPID_OFI_SYNC_SEND_ACK);
 #endif
         MPID_nem_ofi_create_req(&sync_req, 1);
         sync_req->dev.OnDataAvail = NULL;
@@ -150,7 +150,7 @@ static inline int ADD_SUFFIX(send_normal)(struct MPIDI_VC *vc,
         REQ_OFI(sreq)->pack_buffer = send_buffer;
     }
 
-    if (send_type == MPID_SYNC_SEND) {
+    if (send_type == MPID_OFI_SYNC_SEND) {
         /* ---------------------------------------------------- */
         /* For syncronous send, we post a receive to catch the  */
         /* match ack, but use the tag protocol bits to avoid    */
@@ -168,7 +168,7 @@ static inline int ADD_SUFFIX(send_normal)(struct MPIDI_VC *vc,
 #elif API_SET == API_SET_2
         ssend_match = init_recvtag_2(&ssend_mask, comm->context_id + context_offset, tag);
 #endif
-        ssend_match |= MPID_SYNC_SEND_ACK;
+        ssend_match |= MPID_OFI_SYNC_SEND_ACK;
         FI_RC_RETRY(fi_trecv(gl_data.endpoint,      /* endpoint    */
                            NULL,                    /* recvbuf     */
                            0,                       /* data sz     */
@@ -284,7 +284,7 @@ ADD_SUFFIX(do_isend)(struct MPIDI_VC *vc,
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
-    if (likely((send_type != MPID_SYNC_SEND) &&
+    if (likely((send_type != MPID_OFI_SYNC_SEND) &&
                 dt_contig &&
                 (data_sz <= gl_data.max_buffered_send)))
     {
@@ -349,7 +349,7 @@ int ADD_SUFFIX(MPID_nem_ofi_ssend)(struct MPIDI_VC *vc,
     int mpi_errno = MPI_SUCCESS;
     BEGIN_FUNC(FCNAME);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest,
-                         tag, comm, context_offset, request, MPID_CREATE_REQ, MPID_SYNC_SEND);
+                         tag, comm, context_offset, request, MPID_CREATE_REQ, MPID_OFI_SYNC_SEND);
     END_FUNC(FCNAME);
     return mpi_errno;
 }
@@ -367,7 +367,7 @@ int ADD_SUFFIX(MPID_nem_ofi_issend)(struct MPIDI_VC *vc,
     int mpi_errno = MPI_SUCCESS;
     BEGIN_FUNC(FCNAME);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest,
-                         tag, comm, context_offset, request, MPID_CREATE_REQ, MPID_SYNC_SEND);
+                         tag, comm, context_offset, request, MPID_CREATE_REQ, MPID_OFI_SYNC_SEND);
     END_FUNC(FCNAME);
     return mpi_errno;
 }

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -74,6 +74,7 @@ typedef int16_t MPIDI_Rank_t;
 #elif CH3_RANK_BITS == 32
 typedef int32_t MPIDI_Rank_t;
 #endif /* CH3_RANK_BITS */
+#define MPID_TAG_BITS (MPIR_Process.attrs.tag_bits)
 
 /* For the typical communication system for which the ch3 channel is
    appropriate, 16 bits is sufficient for the rank.  By also using 16

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -161,6 +161,11 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
 #endif
 
     /*
+     * Set default number of tag bits (overwritten by netmod)
+     */
+    MPIR_Process.attrs.tag_bits = MPIR_TAG_BITS_DEFAULT;
+
+    /*
      * Set global process attributes.  These can be overridden by the channel 
      * if necessary.
      */

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -161,11 +161,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
 #endif
 
     /*
-     * Set default number of tag bits (overwritten by netmod)
-     */
-    MPIR_Process.attrs.tag_bits = MPIR_TAG_BITS_DEFAULT;
-
-    /*
      * Set global process attributes.  These can be overridden by the channel 
      * if necessary.
      */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -24,6 +24,8 @@
 #include "uthash.h"
 #include "ch4_coll_params.h"
 
+#define MPID_TAG_BITS (MPIR_Process.attrs.tag_bits)
+
 typedef struct {
     union {
     MPIDI_NM_DT_DECL} netmod;

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -16,7 +16,7 @@
 
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
-typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_ub,
+typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
                                     int *n_vnis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
@@ -653,7 +653,7 @@ extern MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 extern int MPIDI_num_netmods;
 extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
                                                     int spawned, int *n_vnis_provided)
     MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -16,7 +16,7 @@
 #ifndef NETMOD_INLINE
 #ifndef NETMOD_DISABLE_INLINES
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_ub,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
                                                     int spawned, int *n_vnis_provided)
 {
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
-    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_ub, comm_world, comm_self, spawned,
+    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, comm_world, comm_self, spawned,
                                   n_vnis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -644,7 +644,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     if (MPIR_CVAR_OFI_DUMP_PROVIDERS)
         MPIDI_OFI_dump_providers(prov);
 
-    *tag_ub = (1ULL << MPIDI_OFI_TAG_BITS) - 1;
+    *tag_ub = (1ULL << (MPIDI_OFI_TAG_BITS - (MPIR_TAG_ERROR_BITS + 1))) - 1;
+    MPIR_Process.attrs.tag_bits = MPIDI_OFI_TAG_BITS;
 
     if (MPIDI_OFI_ENABLE_RUNTIME_CHECKS) {
         /* ------------------------------------------------------------------------ */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -418,7 +418,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
 static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int size,
                                          int appnum,
-                                         int *tag_ub,
+                                         int *tag_bits,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {
@@ -644,8 +644,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     if (MPIR_CVAR_OFI_DUMP_PROVIDERS)
         MPIDI_OFI_dump_providers(prov);
 
-    *tag_ub = (1ULL << (MPIDI_OFI_TAG_BITS - (MPIR_TAG_ERROR_BITS + 1))) - 1;
-    MPIR_Process.attrs.tag_bits = MPIDI_OFI_TAG_BITS;
+    *tag_bits = MPIDI_OFI_TAG_BITS;
 
     if (MPIDI_OFI_ENABLE_RUNTIME_CHECKS) {
         /* ------------------------------------------------------------------------ */

--- a/src/mpid/ch4/netmod/portals4/ptl_init.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_init.h
@@ -46,7 +46,7 @@ static inline int MPIDI_PTL_append_overflow(size_t i)
 static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int size,
                                          int appnum,
-                                         int *tag_ub,
+                                         int *tag_bits,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -16,7 +16,7 @@
 static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int size,
                                          int appnum,
-                                         int *tag_ub,
+                                         int *tag_bits,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -101,7 +101,7 @@ static inline int MPIDI_NM_am_isend(int rank,
     }
 
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_MASK);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
@@ -187,7 +187,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
 
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_MASK);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     for (i = 0; i < iov_len; i++) {
@@ -278,7 +278,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
 
     use_comm = MPIDI_CH4U_context_id_to_comm(context_id);
     ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_MASK);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
@@ -361,7 +361,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
 
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_MASK);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
@@ -409,7 +409,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
 
     use_comm = MPIDI_CH4U_context_id_to_comm(context_id);
     ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_MASK);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -33,7 +33,7 @@ static inline uint64_t MPIDI_UCX_init_tag(MPIR_Context_id_t contextid, int sourc
     ucp_tag = (ucp_tag << MPIDI_UCX_SOURCE_SHIFT);
     ucp_tag |= source;
     ucp_tag = (ucp_tag << MPIDI_UCX_TAG_SHIFT);
-    ucp_tag |= (MPIDI_UCX_TAG_MASK & tag);
+    ucp_tag |= tag;
     return ucp_tag;
 }
 
@@ -42,7 +42,7 @@ static inline uint64_t MPIDI_UCX_tag_mask(int mpi_tag, int src)
     uint64_t tag_mask = 0xffffffffffffffff;
     MPIR_TAG_CLEAR_ERROR_BITS(tag_mask);
     if (mpi_tag == MPI_ANY_TAG)
-        tag_mask &= ~MPIDI_UCX_TAG_USABLE_BITS;
+        tag_mask &= ~MPIR_TAG_USABLE_BITS;
 
     if (src == MPI_ANY_SOURCE)
         tag_mask &= ~(MPIDI_UCX_SOURCE_MASK);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -21,7 +21,7 @@
 static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int size,
                                          int appnum,
-                                         int *tag_ub,
+                                         int *tag_bits,
                                          MPIR_Comm * comm_world,
                                          MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {
@@ -112,8 +112,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_cc_set(&MPIDI_UCX_global.lw_send_req->cc, 0);
 #endif
 
-    /* we reserve one bit to differentiate AMs from native messages */
-    *tag_ub = MPIR_TAG_USABLE_BITS;
+    *tag_bits = UCX_TAG_BITS;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_EXIT);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -113,7 +113,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
 #endif
 
     /* we reserve one bit to differentiate AMs from native messages */
-    *tag_ub = MPIDI_UCX_TAG_USABLE_BITS;
+    *tag_ub = MPIR_TAG_USABLE_BITS;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_EXIT);

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -103,7 +103,7 @@ static inline int MPIDI_NM_progress(int vni, int blocking)
     ucp_tag_message_h message_handle;
     /* check for active messages */
     message_handle =
-        ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
+        ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_MASK, MPIDI_UCX_AM_MASK, 1, &info);
     while (message_handle) {
         am_buf = MPL_malloc(info.length, MPL_MEM_BUFFER);
         ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
@@ -120,7 +120,8 @@ static inline int MPIDI_NM_progress(int vni, int blocking)
         MPIDI_UCX_am_handler(am_buf, info.length);
         MPL_free(am_buf);
         message_handle =
-            ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
+            ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_MASK, MPIDI_UCX_AM_MASK, 1,
+                             &info);
 
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -23,8 +23,6 @@
 /* Active Message Stuff */
 #define MPIDI_UCX_NUM_AM_BUFFERS       (64)
 #define MPIDI_UCX_MAX_AM_EAGER_SZ      (16*1024)
-#define MPIDI_UCX_TAG_USABLE_BITS      (MPIR_TAG_USABLE_BITS >> 1)
-#define MPIDI_UCX_AM_TAG               (MPIDI_UCX_TAG_USABLE_BITS + 1)
 
 typedef struct {
     int avtid;
@@ -48,16 +46,17 @@ extern ucp_generic_dt_ops_t MPIDI_UCX_datatype_ops;
 /* UCX TAG Layout */
 
 /* 01234567 01234567 01234567 01234567 01234567 01234567 01234567 01234567
- *  context_id (16) |source rank (16) | Message Tag (32)+ERROR BITS
+ *  Active Message (1) | context_id (16) |source rank (16) | Message Tag (31)+ERROR BITS
  */
 
 #define MPIDI_UCX_CONTEXT_TAG_BITS 16
 #define MPIDI_UCX_CONTEXT_RANK_BITS 16
-#define UCX_TAG_BITS 32
+#define UCX_TAG_BITS 31
 
-#define MPIDI_UCX_TAG_MASK      (0x00000000FFFFFFFFULL)
-#define MPIDI_UCX_SOURCE_MASK   (0x0000FFFF00000000ULL)
-#define MPIDI_UCX_TAG_SHIFT     (32)
+#define MPIDI_UCX_TAG_MASK      (0x000000007FFFFFFFULL)
+#define MPIDI_UCX_SOURCE_MASK   (0x00007FFF80000000ULL)
+#define MPIDI_UCX_AM_MASK       (0x8000000000000000ULL)
+#define MPIDI_UCX_TAG_SHIFT     (31)
 #define MPIDI_UCX_SOURCE_SHIFT  (16)
 
 #endif /* UCX_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -16,7 +16,7 @@
 
 #define MPIDI_MAX_SHM_STRING_LEN 64
 
-typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vnis_provided, int *tag_ub);
+typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vnis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
 typedef int (*MPIDI_SHM_get_vni_attr_t) (int vni);
 typedef int (*MPIDI_SHM_progress_t) (int vni, int blocking);
@@ -582,7 +582,7 @@ extern MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
                                                      int *n_vnis_provided,
-                                                     int *tag_ub) MPL_STATIC_INLINE_SUFFIX;
+                                                     int *tag_bits) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vni_attr(int vni) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -23,7 +23,7 @@ extern char *MPIDI_POSIX_asym_base_addr;
 
 #undef FCNAME
 #define FCNAME MPL_QUOTE(MPIDI_POSIX_mpi_init_hook)
-static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_provided, int *tag_ub)
+static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     int num_local = 0;
@@ -223,8 +223,8 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vnis_prov
 
 #undef MPIDI_POSIX_MAILBOX_INDEX
 
-    /* There is no restriction on the tag_ub from the posix shmod side */
-    *tag_ub = INT_MAX;
+    /* There is no restriction on the tag_bits from the posix shmod side */
+    *tag_bits = MPIR_TAG_BITS_DEFAULT;
 
     MPIR_CHKPMEM_COMMIT();
   fn_exit:

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -12,14 +12,14 @@
 #ifndef SHM_DISABLE_INLINES
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided,
-                                                     int *tag_ub)
+                                                     int *tag_bits)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
 
-    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vnis_provided, tag_ub);
+    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vnis_provided, tag_bits);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_init.h
+++ b/src/mpid/ch4/shm/src/shm_init.h
@@ -12,14 +12,14 @@
 #include "../posix/shm_inline.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vnis_provided,
-                                                     int *tag_ub)
+                                                     int *tag_bits)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
 
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vnis_provided, tag_ub);
+    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vnis_provided, tag_bits);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     return ret;

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -160,9 +160,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
         MPIDI_CH4_Global.prev_sighandler = NULL;
 #endif
 
-    /* Setup default tag size. Will be redefined by netmod if necessary. */
-    MPIR_Process.attrs.tag_bits = MPIR_TAG_BITS_DEFAULT;
-
     MPIDI_choose_netmod();
 #ifdef USE_PMI2_API
     pmi_errno = PMI2_Init(&has_parent, &size, &rank, &appnum);
@@ -346,24 +343,24 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 #endif
 
     {
-        int shm_tag_ub = MPIR_Process.attrs.tag_ub, nm_tag_ub = MPIR_Process.attrs.tag_ub;
+        int shm_tag_bits = MPIR_Process.attrs.tag_bits, nm_tag_bits = MPIR_Process.attrs.tag_bits;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vnis_provided, &shm_tag_ub);
+        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vnis_provided, &shm_tag_bits);
 
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }
 #endif
 
-        mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_ub,
+        mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits,
                                            MPIR_Process.comm_world,
                                            MPIR_Process.comm_self, has_parent, &n_nm_vnis_provided);
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }
 
-        /* Use the minimum tag_ub from the netmod and shmod */
-        MPIR_Process.attrs.tag_ub = MPL_MIN(shm_tag_ub, nm_tag_ub);
+        /* Use the minimum tag_bits from the netmod and shmod */
+        MPIR_Process.attrs.tag_bits = MPL_MIN(shm_tag_bits, nm_tag_bits);
     }
 
     /* Override split_type */

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -160,6 +160,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
         MPIDI_CH4_Global.prev_sighandler = NULL;
 #endif
 
+    /* Setup default tag size. Will be redefined by netmod if necessary. */
+    MPIR_Process.attrs.tag_bits = MPIR_TAG_BITS_DEFAULT;
+
     MPIDI_choose_netmod();
 #ifdef USE_PMI2_API
     pmi_errno = PMI2_Init(&has_parent, &size, &rank, &appnum);


### PR DESCRIPTION
Device level is provided with an abillity to adjust tag size on MPI-level.

`MPIR_TAG_ERROR_BIT/MPIR_TAG_PROC_FAILURE_BIT/MPIR_TAG_COLL_BIT` are  always placed into 31st - 29-th bits of user-provided tag (e.g.: [comm_create_group.c#L54](https://github.com/pmodels/mpich/blob/master/src/mpi/comm/comm_create_group.c#L54)), meanwhile device/netmod may provide less than 32 bits. That leads to utility-bits trimming from the tag on the device level and problems with tag matching on the reciever side:
`
Assertion failed in file ./src/mpi/coll/helper_fns.c at line 227: status->MPI_TAG == tag
`