### PR TITLE
opa: Create a pause operation to support spin locks

### DIFF
--- a/src/openpa/src/opa_primitives.h
+++ b/src/openpa/src/opa_primitives.h
@@ -79,6 +79,9 @@
    // reordering (may be a macro):
    static _opa_inline void OPA_compiler_barrier();
 
+   // Pause function (for spin locks, may be a macro)
+   static _opa_inline void OPA_pause();
+
    // The following need to be ported only for architectures supporting LL/SC:
    static _opa_inline int OPA_LL_int(OPA_int_t *ptr);
    static _opa_inline int OPA_SC_int(OPA_int_t *ptr, int val);

--- a/src/openpa/src/primitives/opa_gcc_arm.h
+++ b/src/openpa/src/primitives/opa_gcc_arm.h
@@ -54,6 +54,7 @@ static _opa_inline void OPA_store_ptr(OPA_ptr_t * ptr, void *val)
 #define OPA_read_barrier()       OPA_arm_dmb_()
 #define OPA_read_write_barrier() OPA_arm_dsb_()
 #define OPA_compiler_barrier()   __asm__ __volatile__  ("" ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("yield" ::: "memory")
 
 
 static _opa_inline int OPA_load_acquire_int(_opa_const OPA_int_t * ptr)

--- a/src/openpa/src/primitives/opa_gcc_ia64.h
+++ b/src/openpa/src/primitives/opa_gcc_ia64.h
@@ -204,6 +204,7 @@ static _opa_inline int OPA_swap_int(OPA_int_t * ptr, int val)
 #define OPA_read_barrier()       __asm__ __volatile__  ("mf" ::: "memory")
 #define OPA_read_write_barrier() __asm__ __volatile__  ("mf" ::: "memory")
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""   ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("pause"   ::: "memory")
 
 #include "opa_emulated.h"
 

--- a/src/openpa/src/primitives/opa_gcc_intel_32_64_barrier.h
+++ b/src/openpa/src/primitives/opa_gcc_intel_32_64_barrier.h
@@ -8,6 +8,7 @@
 #define OPA_GCC_INTEL_32_64_BARRIER_H_INCLUDED
 
 #define OPA_compiler_barrier()   __asm__ __volatile__  ("" ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("pause" ::: "memory")
 
 /* For all regular memory (write-back cacheable, not driver/graphics
  * memory), there is only one general ordering relaxation permitted by

--- a/src/openpa/src/primitives/opa_gcc_intel_32_64_p3barrier.h
+++ b/src/openpa/src/primitives/opa_gcc_intel_32_64_p3barrier.h
@@ -8,6 +8,7 @@
 #define OPA_GCC_INTEL_32_64_P3BARRIER_H_INCLUDED
 
 #define OPA_compiler_barrier() __asm__ __volatile__ ("" ::: "memory")
+#define OPA_pause() __asm__ __volatile__ ("pause" ::: "memory")
 
 /* For all regular memory (write-back cacheable, not driver/graphics
  * memory), there is only one general ordering relaxation permitted by

--- a/src/openpa/src/primitives/opa_gcc_intrinsics.h
+++ b/src/openpa/src/primitives/opa_gcc_intrinsics.h
@@ -125,6 +125,7 @@ static _opa_inline int OPA_swap_int(OPA_int_t * ptr, int val)
 #define OPA_read_barrier()       __sync_synchronize()
 #define OPA_read_write_barrier() __sync_synchronize()
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""  ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("pause"  ::: "memory")
 
 
 

--- a/src/openpa/src/primitives/opa_gcc_ppc.h
+++ b/src/openpa/src/primitives/opa_gcc_ppc.h
@@ -60,6 +60,7 @@ static _opa_inline void OPA_store_ptr(OPA_ptr_t * ptr, void *val)
 #define OPA_read_barrier()       OPA_ppc_lwsync_()
 #define OPA_read_write_barrier() OPA_ppc_hwsync_()
 #define OPA_compiler_barrier()   __asm__ __volatile__  ("" ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("pause" ::: "memory")
 
 /* NOTE-PPC-1 we use lwsync, although I think we might be able to use
  * conditional-branch+isync in some cases (load_acquire?) once we understand it

--- a/src/openpa/src/primitives/opa_gcc_sicortex.h
+++ b/src/openpa/src/primitives/opa_gcc_sicortex.h
@@ -26,6 +26,7 @@ typedef struct {
 #define OPA_read_barrier()       __asm__ __volatile__  ("sync" ::: "memory")
 #define OPA_read_write_barrier() __asm__ __volatile__  ("sync" ::: "memory")
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""    ::: "memory")
+#define OPA_pause()   __asm__ __volatile__  ("pause"    ::: "memory")
 
 /* Aligned loads and stores are atomic. */
 static _opa_inline int OPA_load_int(_opa_const OPA_int_t * ptr)

--- a/src/openpa/src/primitives/opa_nt_intrinsics.h
+++ b/src/openpa/src/primitives/opa_nt_intrinsics.h
@@ -30,6 +30,7 @@ typedef struct {
 /* FIXME there mut be a more efficient way to implement this.  Is "asm {};"
  * sufficient? */
 #define OPA_compiler_barrier()   _ReadWriteBarrier()
+#define OPA_pause()              do {} while (0)
 
 static _opa_inline int OPA_load_int(_opa_const OPA_int_t * ptr)
 {

--- a/src/openpa/src/primitives/opa_sun_atomic_ops.h
+++ b/src/openpa/src/primitives/opa_sun_atomic_ops.h
@@ -135,5 +135,6 @@ static _opa_inline int OPA_swap_int(OPA_int_t * ptr, int val)
 
 /* is this portable enough? */
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""  ::: "memory")
+#define OPA_compiler_barrier()   __asm__ __volatile__  ("pause"  ::: "memory")
 
 #endif /* OPA_SUN_ATOMIC_OPS_H_INCLUDED */

--- a/src/openpa/src/primitives/opa_unsafe.h
+++ b/src/openpa/src/primitives/opa_unsafe.h
@@ -152,5 +152,6 @@ static _opa_inline int OPA_swap_int(OPA_int_t * ptr, int val)
 #define OPA_read_barrier()       do {} while (0)
 #define OPA_read_write_barrier() do {} while (0)
 #define OPA_compiler_barrier()   do {} while (0)
+#define OPA_pause()              do {} while (0)
 
 #endif /* OPA_UNSAFE_H_INCLUDED */


### PR DESCRIPTION
There are a few PRs coming down the pipeline that would benefit from using this operation for efficient spinlocks. Add a portable pause/yield function to make it available later.