### PR TITLE
ch4/ofi: Set count to 0 when only am header is sent

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -112,6 +112,7 @@ static inline int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t * msg_hdr,
         goto fn_exit;
 
     if (target_cmpl_cb) {
+        MPIR_STATUS_SET_COUNT(rreq->status, 0);
         target_cmpl_cb(rreq);
     }
 


### PR DESCRIPTION
When count is 0 in MPI_Send, only the am header is sent. In this case,
the count in status should be set to 0 as well.
Fixes `pt2pt/isendself` in `force-am-enabled` with `shm-yes` and
`shm-no` configurations.