### PR TITLE
Ofi subconfigure

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -69,7 +69,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_sockets="no"
         enable_verbs="no"
         enable_usnic="no"
-        enable_mxm="no"
         enable_gni="no"
         enable_bgq="no"
         enable_udp="no"
@@ -83,7 +82,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_sockets="yes"
         enable_verbs="yes"
         enable_usnic="yes"
-        enable_mxm="yes"
         enable_gni="yes"
         enable_bgq="yes"
         enable_udp="yes"
@@ -122,10 +120,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
                 ;;
             "usnic")
                 enable_usnic="yes"
-                runtime_capabilities="yes"
-                ;;
-            "mxm")
-                enable_mxm="yes"
                 runtime_capabilities="yes"
                 ;;
             "udp")
@@ -185,10 +179,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
                 AC_DEFINE([MPIDI_CH4_OFI_USE_SET_RUNTIME], [1], [Define to use runtime capability set])
                 enable_usnic="yes"
                 ;;
-            "mxm")
-                AC_DEFINE([MPIDI_CH4_OFI_USE_SET_RUNTIME], [1], [Define to use runtime capability set])
-                enable_mxm="yes"
-                ;;
             "udp")
                 AC_DEFINE([MPIDI_CH4_OFI_USE_SET_RUNTIME], [1], [Define to use runtime capability set])
                 enable_udp="yes"
@@ -225,7 +215,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
             prov_config+=" --enable-sockets=${enable_sockets}"
             prov_config+=" --enable-verbs=${enable_verbs}"
             prov_config+=" --enable-usnic=${enable_usnic}"
-            prov_config+=" --enable-mxm=${enable_mxm}"
             prov_config+=" --enable-gni=${enable_gni}"
             prov_config+=" --enable-bgq=${enable_bgq}"
             prov_config+=" --enable-udp=${enable_udp}"

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -76,6 +76,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_rxd="no"
         enable_tcp="no"
         enable_shm="no"
+        enable_mlx="no"
     else
         enable_psm="yes"
         enable_psm2="yes"
@@ -89,6 +90,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_rxd="yes"
         enable_tcp="yes"
         enable_shm="yes"
+        enable_mlx="yes"
     fi
 
     for provider in $netmod_args ; do
@@ -140,6 +142,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
                 ;;
             "shm")
                 enable_shm="yes"
+                runtime_capabilities="yes"
+                ;;
+            "mlx")
+                enable_mlx="yes"
                 runtime_capabilities="yes"
                 ;;
             *)
@@ -199,6 +205,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
                 AC_DEFINE([MPIDI_CH4_OFI_USE_SET_RUNTIME], [1], [Define to use runtime capability set])
                 enable_shm="yes"
                 ;;
+            "mlx")
+                AC_DEFINE([MPIDI_CH4_OFI_USE_SET_RUNTIME], [1], [Define to use runtime capability set])
+                enable_mlx="yes"
+                ;;
             *)
                 AC_MSG_WARN("Invalid provider $netmod_args")
         esac
@@ -222,6 +232,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
             prov_config+=" --enable-rxd=${enable_rxd}"
             prov_config+=" --enable-tcp=${enable_tcp}"
             prov_config+=" --enable-shm=${enable_shm}"
+            prov_config+=" --enable-mlx=${enable_mlx}"
         fi
 
         if test "x${ofi_direct_provider}" != "x" ; then


### PR DESCRIPTION
The mxm provider is removed from the latest libfabric release.

Notes: The only thing left in libfabric is a `mlx` provider, which looks like a renaming from the `ucx` provider. The second commit just adds the options to explicitly disable it during configure.