### PR TITLE
ch4/ofi: Handle case when MPIDI_OFI_MAJOR_VERSION is not set

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1744,6 +1744,7 @@ static inline int MPIDI_OFI_init_global_settings(const char *prov_name)
 
 static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
 {
+    int fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
     MPIR_Assert(hints != NULL);
 
     /* ------------------------------------------------------------------------ */
@@ -1772,7 +1773,11 @@ static inline int MPIDI_OFI_init_hints(struct fi_info *hints)
     /*           endpoint, so the netmod requires dynamic memory regions        */
     /* ------------------------------------------------------------------------ */
     hints->mode = FI_CONTEXT | FI_ASYNC_IOV | FI_RX_CQ_DATA;    /* We can handle contexts  */
-    if (FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION) >= FI_VERSION(1, 5)) {
+
+    if (MPIDI_OFI_MAJOR_VERSION != -1 && MPIDI_OFI_MINOR_VERSION != -1)
+        fi_version = FI_VERSION(MPIDI_OFI_MAJOR_VERSION, MPIDI_OFI_MINOR_VERSION);
+
+    if (fi_version >= FI_VERSION(1, 5)) {
 #ifdef FI_CONTEXT2
         hints->mode |= FI_CONTEXT2;
 #endif


### PR DESCRIPTION
This patch correctly handles OFI version specifiers when
the runtime capability set is used (no provider specified for
the `--with-device=ch4:ofi` option.)

Signed-off-by: Michael Blocksome <michael.blocksome@intel.com>