### PR TITLE
ch4/shm: Add const to remaining collective APIs

### DIFF
--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -207,105 +207,100 @@ typedef int (*MPIDI_SHM_mpi_get_accumulate_t) (const void *origin_addr,
                                                MPIR_Win * win);
 typedef int (*MPIDI_SHM_mpi_win_lock_all_t) (int assert, MPIR_Win * win);
 typedef int (*MPIDI_SHM_mpi_barrier_t) (MPIR_Comm * comm,
-                                        MPIR_Errflag_t * errflag, void *algo_parameters_container);
-typedef int (*MPIDI_SHM_mpi_bcast_t) (void *buffer, int count, MPI_Datatype datatype,
-                                      int root, MPIR_Comm * comm,
-                                      MPIR_Errflag_t * errflag, void *algo_parameters_container);
+                                        MPIR_Errflag_t * errflag,
+                                        const void *algo_parameters_container);
+typedef int (*MPIDI_SHM_mpi_bcast_t) (void *buffer, int count, MPI_Datatype datatype, int root,
+                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                      const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_allreduce_t) (const void *sendbuf, void *recvbuf, int count,
-                                          MPI_Datatype datatype, MPI_Op op,
+                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                          MPIR_Errflag_t * errflag,
+                                          const void *algo_parameters_container);
+typedef int (*MPIDI_SHM_mpi_allgather_t) (const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                           MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                          void *algo_parameters_container);
-typedef int (*MPIDI_SHM_mpi_allgather_t) (const void *sendbuf, int sendcount,
-                                          MPI_Datatype sendtype, void *recvbuf,
-                                          int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm,
-                                          MPIR_Errflag_t *
-                                          errflag, void *algo_parameters_container);
+                                          const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_allgatherv_t) (const void *sendbuf, int sendcount,
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const int *recvcounts, const int *displs,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
                                            MPIR_Errflag_t * errflag,
-                                           void *algo_parameters_container);
-typedef int (*MPIDI_SHM_mpi_scatter_t) (const void *sendbuf, int sendcount,
-                                        MPI_Datatype sendtype, void *recvbuf,
-                                        int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                        void *algo_parameters_container);
+                                           const void *algo_parameters_container);
+typedef int (*MPIDI_SHM_mpi_scatter_t) (const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                                        int root, MPIR_Comm * comm, MPIR_Errflag_t * errflag,
+                                        const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_scatterv_t) (const void *sendbuf, const int *sendcounts,
-                                         const int *displs, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount,
-                                         MPI_Datatype recvtype, int root,
+                                         const int *displs, MPI_Datatype sendtype, void *recvbuf,
+                                         int recvcount, MPI_Datatype recvtype, int root,
                                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                         void *algo_parameters_container);
+                                         const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_gather_t) (const void *sendbuf, int sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
                                        int recvcount, MPI_Datatype recvtype, int root,
                                        MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                       void *algo_parameters_container);
+                                       const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_gatherv_t) (const void *sendbuf, int sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
                                         const int *recvcounts, const int *displs,
                                         MPI_Datatype recvtype, int root,
                                         MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                        void *algo_parameters_container);
+                                        const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_alltoall_t) (const void *sendbuf, int sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
                                          int recvcount, MPI_Datatype recvtype,
                                          MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                         void *algo_parameters_container);
+                                         const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_alltoallv_t) (const void *sendbuf, const int *sendcounts,
                                           const int *sdispls, MPI_Datatype sendtype,
                                           void *recvbuf, const int *recvcounts,
                                           const int *rdispls, MPI_Datatype recvtype,
                                           MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                          void *algo_parameters_container);
+                                          const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_alltoallw_t) (const void *sendbuf, const int *sendcounts,
                                           const int *sdispls,
                                           const MPI_Datatype sendtypes[], void *recvbuf,
                                           const int *recvcounts, const int *rdispls,
                                           const MPI_Datatype recvtypes[],
                                           MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                          void *algo_parameters_container);
+                                          const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_reduce_t) (const void *sendbuf, void *recvbuf, int count,
                                        MPI_Datatype datatype, MPI_Op op, int root,
                                        MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                       void *algo_parameters_container);
+                                       const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_reduce_scatter_t) (const void *sendbuf, void *recvbuf,
                                                const int *recvcounts,
                                                MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr,
                                                MPIR_Errflag_t * errflag,
-                                               void *algo_parameters_container);
+                                               const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_reduce_scatter_block_t) (const void *sendbuf, void *recvbuf,
                                                      int recvcount,
                                                      MPI_Datatype datatype, MPI_Op op,
                                                      MPIR_Comm * comm_ptr,
                                                      MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_container);
+                                                     const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_scan_t) (const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                     MPIR_Errflag_t * errflag, void *algo_parameters_container);
+                                     MPIR_Errflag_t * errflag,
+                                     const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_exscan_t) (const void *sendbuf, void *recvbuf, int count,
-                                       MPI_Datatype datatype, MPI_Op op,
-                                       MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                       void *algo_parameters_container);
+                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
+                                       MPIR_Errflag_t * errflag,
+                                       const void *algo_parameters_container);
 typedef int (*MPIDI_SHM_mpi_neighbor_allgather_t) (const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm);
 typedef int (*MPIDI_SHM_mpi_neighbor_allgatherv_t) (const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts,
-                                                    const int *displs,
+                                                    const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm);
-typedef int (*MPIDI_SHM_mpi_neighbor_alltoallv_t) (const void *sendbuf,
-                                                   const int *sendcounts,
-                                                   const int *sdispls,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int *recvcounts,
-                                                   const int *rdispls,
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm);
+typedef int (*MPIDI_SHM_mpi_neighbor_alltoallv_t) (const void *sendbuf, const int *sendcounts,
+                                                   const int *sdispls, MPI_Datatype sendtype,
+                                                   void *recvbuf, const int *recvcounts,
+                                                   const int *rdispls, MPI_Datatype recvtype,
+                                                   MPIR_Comm * comm);
 typedef int (*MPIDI_SHM_mpi_neighbor_alltoallw_t) (const void *sendbuf,
                                                    const int *sendcounts,
                                                    const MPI_Aint * sdispls,

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -1185,7 +1185,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_win_lock_all(int assert, MPIR_Win * w
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_container)
+                                                   const void *algo_parameters_container)
 {
     int ret;
 
@@ -1201,7 +1201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Datatype datatype,
                                                  int root, MPIR_Comm * comm,
                                                  MPIR_Errflag_t * errflag,
-                                                 void *algo_parameters_container)
+                                                 const void *algo_parameters_container)
 {
     int ret;
 
@@ -1219,7 +1219,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, int count, MPI_Da
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf, int count,
                                                      MPI_Datatype datatype, MPI_Op op,
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_container)
+                                                     const void *algo_parameters_container)
 {
     int ret;
 
@@ -1238,7 +1238,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, int se
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      int recvcount, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_container)
+                                                     const void *algo_parameters_container)
 {
     int ret;
 
@@ -1258,7 +1258,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, int s
                                                       const int *recvcounts, const int *displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
                                                       MPIR_Errflag_t * errflag,
-                                                      void *algo_parameters_container)
+                                                      const void *algo_parameters_container)
 {
     int ret;
 
@@ -1278,7 +1278,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, int send
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_container)
+                                                   const void *algo_parameters_container)
 {
     int ret;
 
@@ -1298,7 +1298,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf, const i
                                                     void *recvbuf, int recvcount,
                                                     MPI_Datatype recvtype, int root,
                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                    void *algo_parameters_container)
+                                                    const void *algo_parameters_container)
 {
     int ret;
 
@@ -1317,7 +1317,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, int sendc
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype, int root,
                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_container)
+                                                  const void *algo_parameters_container)
 {
     int ret;
 
@@ -1337,7 +1337,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, int send
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, int root,
                                                    MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                   void *algo_parameters_container)
+                                                   const void *algo_parameters_container)
 {
     int ret;
 
@@ -1356,7 +1356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, int sen
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
                                                     MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                    void *algo_parameters_container)
+                                                    const void *algo_parameters_container)
 {
     int ret;
 
@@ -1376,7 +1376,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf, const 
                                                      void *recvbuf, const int *recvcounts,
                                                      const int *rdispls, MPI_Datatype recvtype,
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_container)
+                                                     const void *algo_parameters_container)
 {
     int ret;
 
@@ -1397,7 +1397,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const 
                                                      const int *recvcounts, const int *rdispls,
                                                      const MPI_Datatype recvtypes[],
                                                      MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                     void *algo_parameters_container)
+                                                     const void *algo_parameters_container)
 {
     int ret;
 
@@ -1415,7 +1415,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf, const 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op, int root,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_container)
+                                                  const void *algo_parameters_container)
 {
     int ret;
 
@@ -1435,7 +1435,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
                                                           MPI_Datatype datatype, MPI_Op op,
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t * errflag,
-                                                          void *algo_parameters_container)
+                                                          const void *algo_parameters_container)
 {
     int ret;
 
@@ -1454,8 +1454,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
                                                                 int recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag,
-                                                                void *algo_parameters_container)
+                                                                MPIR_Errflag_t * errflag, const void
+                                                                *algo_parameters_container)
 {
     int ret;
 
@@ -1474,7 +1474,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
                                                 MPIR_Errflag_t * errflag,
-                                                void *algo_parameters_container)
+                                                const void *algo_parameters_container)
 {
     int ret;
 
@@ -1492,7 +1492,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf, int count,
                                                   MPI_Datatype datatype, MPI_Op op,
                                                   MPIR_Comm * comm, MPIR_Errflag_t * errflag,
-                                                  void *algo_parameters_container)
+                                                  const void *algo_parameters_container)
 {
     int ret;
 


### PR DESCRIPTION
9bb8831c changed the function prototypes in shm.h to add the `const`
qualifier for `algo_parameters_container`, but it missed several
other prototypes mainly for function table-based implementations.
Therefore there was a conflict in function prototype declarations
when `--enable-ch4-shm-direct=no` is specified.

This patch updates remaining prototypes to correct the issue.