### PR TITLE
ch4: Fix compile warnings when PMI2 is not in use

### DIFF
--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -455,7 +455,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_universe_size(int *universe_size)
         *universe_size = pvalue->data.uint32;
         PMIX_VALUE_RELEASE(pvalue);
     }
-#elif USE_PMI2_API
+#elif defined(USE_PMI2_API)
     {
         char val[PMI2_MAX_VALLEN];
         int found = 0;


### PR DESCRIPTION
Quick fix for compile warning