### PR TITLE
MPID_Wait will not progress generalized requests

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -366,7 +366,6 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Request_completion_processing_fastpath(MPI_Req
 
 int MPIR_Request_completion_processing(MPIR_Request *, MPI_Status *, int *);
 int MPIR_Request_get_error(MPIR_Request *);
-int MPIR_Progress_wait_request(MPIR_Request * req);
 
 /* The following routines perform the callouts to the user routines registered
    as part of a generalized request.  They handle any language binding issues

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -65,18 +65,9 @@ int MPIC_Wait(MPIR_Request * request_ptr, MPIR_Errflag_t * errflag)
     if (request_ptr->kind == MPIR_REQUEST_KIND__SEND)
         request_ptr->status.MPI_TAG = 0;
 
-    if (!MPIR_Request_is_complete(request_ptr)) {
-        MPID_Progress_state progress_state;
-
-        MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(request_ptr)) {
-            mpi_errno = MPID_Progress_wait(&progress_state);
-            if (mpi_errno) {
-                MPIR_ERR_POP(mpi_errno);
-            }
-        }
-        MPID_Progress_end(&progress_state);
-    }
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     if (request_ptr->kind == MPIR_REQUEST_KIND__RECV)
         MPIR_Process_status(&request_ptr->status, errflag);

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -131,21 +131,9 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
 
     /* If a request was returned, then we need to block until the request
      * is complete */
-    if (!MPIR_Request_is_complete(request_ptr)) {
-        MPID_Progress_state progress_state;
-
-        MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(request_ptr)) {
-            mpi_errno = MPID_Progress_wait(&progress_state);
-            if (mpi_errno != MPI_SUCCESS) {
-                /* --BEGIN ERROR HANDLING-- */
-                MPID_Progress_end(&progress_state);
-                goto fn_fail;
-                /* --END ERROR HANDLING-- */
-            }
-        }
-        MPID_Progress_end(&progress_state);
-    }
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -134,23 +134,9 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
         goto fn_exit;
     }
 
-    /* If a request was returned, then we need to block until the request
-     * is complete */
-    if (!MPIR_Request_is_complete(request_ptr)) {
-        MPID_Progress_state progress_state;
-
-        MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(request_ptr)) {
-            mpi_errno = MPID_Progress_wait(&progress_state);
-            if (mpi_errno != MPI_SUCCESS) {
-                /* --BEGIN ERROR HANDLING-- */
-                MPID_Progress_end(&progress_state);
-                goto fn_fail;
-                /* --END ERROR HANDLING-- */
-            }
-        }
-        MPID_Progress_end(&progress_state);
-    }
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -172,22 +172,13 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
             /* --END ERROR HANDLING-- */
         }
 
-        if (!MPIR_Request_is_complete(sreq) || !MPIR_Request_is_complete(rreq)) {
-            MPID_Progress_state progress_state;
+        mpi_errno = MPID_Wait(rreq, MPI_STATUS_IGNORE);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
 
-            MPID_Progress_start(&progress_state);
-            while (!MPIR_Request_is_complete(sreq) || !MPIR_Request_is_complete(rreq)) {
-                mpi_errno = MPID_Progress_wait(&progress_state);
-                if (mpi_errno != MPI_SUCCESS) {
-                    /* --BEGIN ERROR HANDLING-- */
-                    MPID_Progress_end(&progress_state);
-                    goto fn_fail;
-                    /* --END ERROR HANDLING-- */
-                }
-            }
-            MPID_Progress_end(&progress_state);
-
-        }
+        mpi_errno = MPID_Wait(sreq, MPI_STATUS_IGNORE);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
 
         if (status != MPI_STATUS_IGNORE) {
             *status = rreq->status;

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -130,7 +130,7 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
 
     /* If a request was returned, then we need to block until the request
      * is complete */
-    mpi_errno = MPIR_Progress_wait_request(request_ptr);
+    mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -18,41 +18,6 @@ MPIR_Object_alloc_t MPIR_Request_mem = {
 };
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Progress_wait_request
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-/*@
-  MPIR_Progress_wait_request
-
-  A helper routine that implements the very common case of running the progress
-  engine until the given request is complete.
-  @*/
-int MPIR_Progress_wait_request(MPIR_Request * req)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    if (!MPIR_Request_is_complete(req)) {
-        MPID_Progress_state progress_state;
-
-        MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(req)) {
-            mpi_errno = MPID_Progress_wait(&progress_state);
-            if (mpi_errno != MPI_SUCCESS) {
-                /* --BEGIN ERROR HANDLING-- */
-                MPID_Progress_end(&progress_state);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
-                /* --END ERROR HANDLING-- */
-            }
-        }
-        MPID_Progress_end(&progress_state);
-    }
-
-  fn_fail:
-    return mpi_errno;
-}
-
-#undef FUNCNAME
 #define FUNCNAME MPIR_Request_completion_processing
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)


### PR DESCRIPTION
This enables `MPID_Wait` to be used in other places, and allows MDTA patch to be more consistent (the main purpose is to make all these blocking calls to use MDTA, and therefore perform better). The extended generalized requests should be processed by a "runtime layer" i.e. `MPIR_Wait`