### PR TITLE
dtpools: Fix autoconf to allow separated autotools

### DIFF
--- a/test/mpi/dtpools/Makefile.am
+++ b/test/mpi/dtpools/Makefile.am
@@ -3,6 +3,5 @@
 # (C) 2018 by Argonne National Laboratory.
 #     See COPYRIGHT in top-level directory.
 #
-ACLOCAL_AMFLAGS = -I confdb
 SUBDIRS = src include
 EXTRA_DIST = basictypelist.txt

--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -8,7 +8,6 @@
 AC_PREREQ([2.67])
 AC_INIT([dtpools], [0.0], [discuss@mpich.org])
 AC_CONFIG_SRCDIR([include/dtpools.h])
-AC_CONFIG_MACRO_DIRS([confdb])
 
 AC_CONFIG_HEADER(dtpoolsconf.h)
 AH_TOP([/* -*- Mode: C; c-basic-offset:4 ; -*- */


### PR DESCRIPTION
Re-enable separated autotools by removing the unnecessary usage of
confdb usage inside the dtpools code.

The original dtpools patch broke the ability to run `autogen.sh` with
automake/autoconf/libtool in separate locations. While this isn't
necessarily supported (there's a warning against it), there's apparently
quite a few folks who do it anyway and the fix in dtpools is trivial.