### PR TITLE
Mpl proc mutex

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -686,30 +686,6 @@ void f1(void *a) { return; }],
 
         fi
 
-        # Check for PTHREAD_MUTEX_ERRORCHECK_NP and PTHREAD_MUTEX_ERRORCHECK
-        AC_CACHE_CHECK([whether pthread.h defines PTHREAD_MUTEX_ERRORCHECK_NP],
-        pac_cv_has_pthread_mutex_errorcheck_np,[
-        AC_TRY_COMPILE([#include <pthread.h>],
-                       [int a=PTHREAD_MUTEX_ERRORCHECK_NP;],
-                       pac_cv_has_pthread_mutex_errorcheck_np=yes,
-                       pac_cv_has_pthread_mutex_errorcheck_np=no)])
-        AC_CACHE_CHECK([whether pthread.h defines PTHREAD_MUTEX_ERRORCHECK],
-        pac_cv_has_pthread_mutex_errorcheck,[
-        AC_TRY_COMPILE([#include <pthread.h>],
-                       [int a=PTHREAD_MUTEX_ERRORCHECK;],
-                       pac_cv_has_pthread_mutex_errorcheck=yes,
-                       pac_cv_has_pthread_mutex_errorcheck=no)])
-
-        if test "$pac_cv_has_pthread_mutex_errorcheck" = yes ; then
-            AC_DEFINE(PTHREAD_MUTEX_ERRORCHECK_VALUE,PTHREAD_MUTEX_ERRORCHECK,
-                      [Define to an expression that will result in an error checking mutex type.])
-        elif test "$pac_cv_has_pthread_mutex_errorcheck_np" = yes ; then
-            AC_DEFINE(PTHREAD_MUTEX_ERRORCHECK_VALUE,PTHREAD_MUTEX_ERRORCHECK_NP,
-                      [Define to an expression that will result in an error checking mutex type.])
-        fi
-
-	PAC_FUNC_NEEDS_DECL([#include <pthread.h>],pthread_mutexattr_settype)
-
 	if test "${with_thread_package}" = "uti" ; then
 	    PAC_CHECK_HEADER_LIB(uti.h,uti,uti_attr_init,have_uti=yes,have_uti=no)
 	    if test "${have_uti}" = "yes" ; then
@@ -772,6 +748,37 @@ fi
 ## END OF THREADS CODE
 #######################################################################
 
+#######################################################################
+## START OF PTHREAD MUTEX COMMON CHECK
+#######################################################################
+if test "${with_thread_package}" = "pthreads"; then
+  # Check for PTHREAD_MUTEX_ERRORCHECK_NP and PTHREAD_MUTEX_ERRORCHECK
+  AC_CACHE_CHECK([whether pthread.h defines PTHREAD_MUTEX_ERRORCHECK_NP],
+  pac_cv_has_pthread_mutex_errorcheck_np,[
+  AC_TRY_COMPILE([#include <pthread.h>],
+                 [int a=PTHREAD_MUTEX_ERRORCHECK_NP;],
+                 pac_cv_has_pthread_mutex_errorcheck_np=yes,
+                 pac_cv_has_pthread_mutex_errorcheck_np=no)])
+  AC_CACHE_CHECK([whether pthread.h defines PTHREAD_MUTEX_ERRORCHECK],
+  pac_cv_has_pthread_mutex_errorcheck,[
+  AC_TRY_COMPILE([#include <pthread.h>],
+                 [int a=PTHREAD_MUTEX_ERRORCHECK;],
+                 pac_cv_has_pthread_mutex_errorcheck=yes,
+                 pac_cv_has_pthread_mutex_errorcheck=no)])
+
+  if test "$pac_cv_has_pthread_mutex_errorcheck" = yes ; then
+      AC_DEFINE(PTHREAD_MUTEX_ERRORCHECK_VALUE,PTHREAD_MUTEX_ERRORCHECK_NPRRORCHECK,
+                [Define to an expression that will result in an error checking mutex type.])
+  elif test "$pac_cv_has_pthread_mutex_errorcheck_np" = yes ; then
+      AC_DEFINE(PTHREAD_MUTEX_ERRORCHECK_VALUE,PTHREAD_MUTEX_ERRORCHECK_NP,
+                [Define to an expression that will result in an error checking mutex type.])
+  fi
+
+  PAC_FUNC_NEEDS_DECL([#include <pthread.h>],pthread_mutexattr_settype)
+fi
+#######################################################################
+## END OF PTHREAD MUTEX COMMON CHECK
+#######################################################################
 
 #######################################################################
 ## START OF DBG CODE

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -749,9 +749,74 @@ fi
 #######################################################################
 
 #######################################################################
+## START OF PROCESS MUTEX CODE
+#######################################################################
+
+AC_ARG_WITH([proc-mutex-package],
+[  --with-proc-mutex-package=package     Interprocess mutex package to use. Supported packages include:
+        posix or pthreads - POSIX threads (default, if required)
+        none - no interprocess mutex support
+],,with_proc_mutex_package=posix)
+
+if test "${with_proc_mutex_package}" = "no" ; then
+   with_proc_mutex_package=none
+fi
+if test "${with_proc_mutex_package}" = "yes" ; then
+   with_proc_mutex_package=posix
+fi
+
+PROC_MUTEX_PACKAGE_NAME=MPL_PROC_MUTEX_PACKAGE_INVALID
+case $with_proc_mutex_package in
+  posix|pthreads)
+    if test "${with_proc_mutex_package}" = "pthreads" ; then
+        with_proc_mutex_package=posix
+    fi
+
+    # Do not prepend -lpthread again if already checked by thread package
+    if test "${with_thread_package}" != "posix" ; then
+        AC_CHECK_HEADERS(pthread.h)
+
+        # If pthreads library is found, just include it on the link line. We don't try
+        # to test if the C compiler needs it or not, since the C++ or Fortran
+        # compilers might need it even if the C compiler doesn't
+        # (nvcc with gfortran, for example).
+        AC_CHECK_LIB([pthread],[pthread_mutex_init],have_pthreads=yes)
+        if test "$have_pthreads" = "yes" ; then
+           PAC_PREPEND_FLAG([-lpthread],[LIBS])
+        fi
+    fi
+
+    # this check should come after the AC_CHECK_LIB for -lpthread
+    AC_CHECK_FUNC([pthread_mutex_init],[],[AC_MSG_ERROR([unable to find pthreads library])])
+    # pthread_mutexattr_setpshared is first released in Issue 5
+    AC_CHECK_FUNCS(pthread_mutexattr_setpshared)
+    if test "$ac_cv_func_pthread_mutexattr_setpshared" = "no" ; then
+      AC_DEFINE(HAVE_PTHREAD_MUTEXATTR_SETPSHARED,1, [Define if pthread_mutexattr_setpshared is available.])
+    fi
+
+    AC_MSG_NOTICE([POSIX will be used for interprocess mutex package.])
+    PROC_MUTEX_PACKAGE_NAME=MPL_PROC_MUTEX_PACKAGE_POSIX
+  ;;
+  no|none)
+    with_proc_mutex_package=none
+    PROC_MUTEX_PACKAGE_NAME=MPL_PROC_MUTEX_PACKAGE_NONE
+  ;;
+  *)
+    AC_MSG_ERROR([The specified interprocess mutex package, $with_proc_mutex_package, is not supported.])
+  ;;
+esac
+
+# Define and export the selected interprocess mutex package so that other packages
+# know what's used in MPL
+AC_DEFINE_UNQUOTED([PROC_MUTEX_PACKAGE_NAME],[$PROC_MUTEX_PACKAGE_NAME],[set to the name of the interprocess mutex package])
+#######################################################################
+## END OF PROCESS MUTEX CODE
+#######################################################################
+
+#######################################################################
 ## START OF PTHREAD MUTEX COMMON CHECK
 #######################################################################
-if test "${with_thread_package}" = "pthreads"; then
+if test "${with_thread_package}" = "pthreads" -o "${with_proc_mutex_package}" = "pthreads"; then
   # Check for PTHREAD_MUTEX_ERRORCHECK_NP and PTHREAD_MUTEX_ERRORCHECK
   AC_CACHE_CHECK([whether pthread.h defines PTHREAD_MUTEX_ERRORCHECK_NP],
   pac_cv_has_pthread_mutex_errorcheck_np,[

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -24,5 +24,6 @@
 #include "mpl_dbg.h"
 #include "mpl_shm.h"
 #include "mpl_math.h"
+#include "mpl_proc_mutex.h"
 
 #endif /* MPL_H_INCLUDED */

--- a/src/mpl/include/mpl_proc_mutex.h
+++ b/src/mpl/include/mpl_proc_mutex.h
@@ -1,0 +1,46 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_PROC_MUTEX_H_INCLUDED
+#define MPL_PROC_MUTEX_H_INCLUDED
+
+#include "mplconfig.h"
+
+/* Define interprocess mutex interface.
+ *
+ * The user should always call MPL_proc_mutex_enabled(void) to check if
+ * the functionality of interprocess mutex is enabled before use.
+ * It returns 1 if the functionality is enabled, otherwise returns 0.
+ */
+
+/* _INVALID exists to avoid accidental macro evaluations to 0 */
+#define MPL_PROC_MUTEX_PACKAGE_INVALID 0
+#define MPL_PROC_MUTEX_PACKAGE_NONE    1
+#define MPL_PROC_MUTEX_PACKAGE_POSIX   2
+
+/* Return values */
+#define MPL_PROC_MUTEX_SUCCESS 0
+#define MPL_PROC_MUTEX_EINTR   -1
+#define MPL_PROC_MUTEX_EINVAL  -2
+
+#if defined(MPL_PROC_MUTEX_PACKAGE_NAME) && (MPL_PROC_MUTEX_PACKAGE_NAME == MPL_PROC_MUTEX_PACKAGE_POSIX)
+#include "mpl_proc_mutex_posix.h"
+#elif defined(MPL_PROC_MUTEX_PACKAGE_NAME) && (MPL_PROC_MUTEX_PACKAGE_NAME == MPL_PROC_MUTEX_PACKAGE_NONE)
+typedef int MPL_proc_mutex_t;
+static inline int MPL_proc_mutex_enabled(void)
+{
+    return 0;   /* always disabled */
+}
+
+#define MPL_proc_mutex_create(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_lock(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_unlock(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#else
+#error "proc package (MPL_PROC_MUTEX_PACKAGE_NAME) not defined or unknown"
+#endif
+
+#endif /* MPL_PROC_MUTEX_H_INCLUDED */

--- a/src/mpl/include/mpl_proc_mutex_posix.h
+++ b/src/mpl/include/mpl_proc_mutex_posix.h
@@ -1,0 +1,118 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+/*
+ * Interprocess Mutex
+ */
+#ifndef MPL_PROC_MUTEX_POSIX_H_INCLUDED
+#define MPL_PROC_MUTEX_POSIX_H_INCLUDED
+
+#include <errno.h>
+#include <pthread.h>
+
+typedef pthread_mutex_t MPL_proc_mutex_t;
+
+#if defined(MPL_NEEDS_PTHREAD_MUTEXATTR_SETTYPE_DECL)
+int pthread_mutexattr_settype(pthread_mutexattr_t * attr, int kind);
+#endif /* MPL_NEEDS_PTHREAD_MUTEXATTR_SETTYPE_DECL */
+
+#ifdef MPL_HAVE_PTHREAD_MUTEXATTR_SETPSHARED
+static inline int MPL_proc_mutex_enabled(void)
+{
+    int mutex_err;
+    pthread_mutexattr_t attr;
+
+    /* Test for PTHREAD_PROCESS_SHARED support.  Some platforms do not support
+     * this capability even though it is a part of the pthreads core API (e.g.,
+     * FreeBSD does not support this as of version 9.1) */
+    pthread_mutexattr_init(&attr);
+    mutex_err = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+    pthread_mutexattr_destroy(&attr);
+    return !mutex_err;  /* if no error, return 1 */
+}
+
+#define PROC_MUTEX_EINTR_PRINT_BREAK(func_name, err__, err_ptr_) {           \
+        MPL_internal_sys_error_printf(func_name, err__,                      \
+                                      "    %s:%d\n", __FILE__, __LINE__);    \
+        *(int *)(err_ptr_) = MPL_PROC_MUTEX_EINTR;                           \
+        break; /* do not wrap by do-while (0) to break from caller's loop.*/  \
+    }
+
+#ifdef MPL_PTHREAD_MUTEX_ERRORCHECK_VALUE
+#define PROC_MUTEX_SET_MUTEXATTR_SETTYPE                                                \
+    do {                                                                                \
+        err__ = pthread_mutexattr_settype(&attr__, MPL_PTHREAD_MUTEX_ERRORCHECK_VALUE); \
+    } while (0)
+#else
+#define PROC_MUTEX_SET_MUTEXATTR_SETTYPE do {} while (0)
+#endif /* MPL_PTHREAD_MUTEX_ERRORCHECK_VALUE */
+
+#define MPL_proc_mutex_create(mutex_ptr_, err_ptr_)                                         \
+    do {                                                                                    \
+        int err__;                                                                          \
+        pthread_mutexattr_t attr__;                                                         \
+        *(int *)(err_ptr_) = MPL_PROC_MUTEX_SUCCESS;                                        \
+                                                                                            \
+        err__ = pthread_mutexattr_init(&attr__);                                            \
+        if (unlikely(err__))                                                                \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutexattr_init", err__, err_ptr_);        \
+        err__ = pthread_mutexattr_setpshared(&attr__, PTHREAD_PROCESS_SHARED);              \
+        if (unlikely(err__))                                                                \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutexattr_setpshared", err__, err_ptr_);  \
+        PROC_MUTEX_SET_MUTEXATTR_SETTYPE;                                                   \
+        if (unlikely(err__))                                                                \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutexattr_settype", err__, err_ptr_);     \
+        err__ = pthread_mutex_init(mutex_ptr_, &attr__);                                    \
+        if (unlikely(err__))                                                                \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutex_init", err__, err_ptr_);            \
+        err__ = pthread_mutexattr_destroy(&attr__);                                         \
+        if (unlikely(err__))                                                                \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutexattr_destroy", err__, err_ptr_);     \
+    } while (0)
+
+#define MPL_proc_mutex_destroy(mutex_ptr_, err_ptr_)                                \
+    do {                                                                            \
+        int err__;                                                                  \
+        *(int *)(err_ptr_) = MPL_PROC_MUTEX_SUCCESS;                                \
+        err__ = pthread_mutex_destroy(mutex_ptr_);                                  \
+        if (unlikely(err__))                                                        \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutex_destroy", err__, err_ptr_); \
+    } while (0)
+
+
+#define MPL_proc_mutex_lock(mutex_ptr_, err_ptr_)                                 \
+    do {                                                                          \
+        int err__;                                                                \
+        *(int *)(err_ptr_) = MPL_PROC_MUTEX_SUCCESS;                              \
+        err__ = pthread_mutex_lock(mutex_ptr_);                                   \
+        if (unlikely(err__))                                                      \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutex_lock", err__, err_ptr_);  \
+    } while (0)
+
+
+#define MPL_proc_mutex_unlock(mutex_ptr_, err_ptr_)                                 \
+    do {                                                                            \
+        int err__;                                                                  \
+        *(int *)(err_ptr_) = MPL_PROC_MUTEX_SUCCESS;                                \
+        err__ = pthread_mutex_unlock(mutex_ptr_);                                   \
+        if (unlikely(err__))                                                        \
+            PROC_MUTEX_EINTR_PRINT_BREAK("pthread_mutex_unlock", err__, err_ptr_);  \
+    } while (0)
+
+#else
+static inline int MPL_proc_mutex_enabled(void)
+{
+    return 0;   /* always disabled */
+}
+
+#define MPL_proc_mutex_create(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_lock(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#define MPL_proc_mutex_unlock(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = MPL_PROC_MUTEX_EINVAL;}
+#endif /* MPL_HAVE_PTHREAD_MUTEXATTR_SETPSHARED */
+
+#endif /* MPL_PROC_MUTEX_POSIX_H_INCLUDED */


### PR DESCRIPTION
Define interprocess mutex routines in MPL. This is separated from [PR #3027](https://github.com/pmodels/mpich/pull/3027)

The interprocess mutex are needed for CH4/SHM RMA routines.