### PR TITLE
Ch4 win shared cleanup

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -312,7 +312,6 @@ typedef struct MPIDI_CH4U_win_t {
     MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */
     MPIR_cc_t remote_acc_cmpl_cnts;     /* for acc only, increase at OP issuing, decrease at remote completion */
 
-    MPI_Aint *sizes;
     MPIDI_CH4U_win_sync_t sync;
     MPIDI_CH4U_win_info_args_t info_args;
     MPIDI_CH4U_win_shared_info_t *shared_table;

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -203,6 +203,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_destroy_hook(struct MPIR_Request *req
 typedef struct MPIDI_CH4U_win_shared_info {
     uint32_t disp_unit;
     size_t size;
+    void *shm_base_addr;
 } MPIDI_CH4U_win_shared_info_t;
 
 #define MPIDI_CH4I_ACCU_ORDER_RAR (1)

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -305,6 +305,8 @@ typedef struct MPIDI_CH4U_win_t {
     void *mmap_addr;
     int64_t mmap_sz;
 
+    MPL_shm_hnd_t shm_segment_handle;
+
     /* per-window OP completion for fence */
     MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */
     MPIR_cc_t remote_cmpl_cnts; /* increase at OP issuing, decrease at remote completion */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -851,11 +851,10 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
                                                    MPIR_Comm * comm_ptr,
                                                    void **base_ptr, MPIR_Win ** win_ptr)
 {
-    int i = 0, fd = -1, rc, first = 0, mpi_errno = MPI_SUCCESS, shm_key_size;
+    int i = 0, mpi_errno = MPI_SUCCESS;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Win *win = NULL;
     ssize_t total_size = 0LL;
-    char *shm_key = NULL;
     void *map_ptr;
     MPIDI_CH4U_win_shared_info_t *shared_table = NULL;
 
@@ -901,124 +900,15 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
     if (total_size == 0)
         goto fn_zero;
 
-    /* Note that two distinct process groups may share the same context id,
-     * thus the window id may be duplicated on a node if windows are owned
-     * by distinct process groups. Therefore, we use [jobid + root_rank + win_id]
-     * as unique shm_key for window, where root_rank is the world rank of the
-     * first process in the group. */
-    int root_rank = 0;
-
-    if (comm_ptr->rank == 0)
-        root_rank = MPIR_Process.comm_world->rank;
-    mpi_errno = MPIR_Bcast(&root_rank, 1, MPI_INT, 0, comm_ptr, &errflag);
-    if (mpi_errno != MPI_SUCCESS)
-        goto fn_fail;
-
-    shm_key_size = snprintf(NULL, 0, "/mpi-%s-%X-%" PRIx64,
-                            MPIDI_CH4_Global.jobid, root_rank, MPIDI_OFI_WIN(win).win_id);
-    shm_key = (char *) MPL_malloc(shm_key_size, MPL_MEM_SHM);
-    MPIR_Assert(shm_key);
-    snprintf(shm_key, shm_key_size, "/mpi-%s-%X-%" PRIx64,
-             MPIDI_CH4_Global.jobid, root_rank, MPIDI_OFI_WIN(win).win_id);
-
-    rc = shm_open(shm_key, O_CREAT | O_EXCL | O_RDWR, 0600);
-    first = (rc != -1);
-
-    if (!first) {
-        rc = shm_open(shm_key, O_RDWR, 0);
-
-        if (rc == -1) {
-            shm_unlink(shm_key);
-            MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
-        }
-    }
-
-    /* Make the addresses symmetric by using MAP_FIXED */
+    /* allocate symmetric shared window memory */
     size_t page_sz, mapsize;
 
     mapsize = MPIDI_CH4R_get_mapsize(total_size, &page_sz);
-    fd = rc;
-    rc = ftruncate(fd, mapsize);
 
-    if (rc == -1) {
-        close(fd);
-
-        if (first)
-            shm_unlink(shm_key);
-
-        MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
-    }
-
-    int iter = MPIR_CVAR_CH4_SHM_SYMHEAP_RETRY;
-    unsigned anyfail = 1;
-
-    while (anyfail && --iter > 0) {
-        if (comm_ptr->rank == 0) {
-            int map_flags = MAP_SHARED;
-
-            map_ptr = MPIDI_CH4R_generate_random_addr(mapsize);
-#ifdef USE_SYM_HEAP
-            if (MPIDI_CH4R_is_valid_mapaddr(map_ptr))
-                map_flags |= MAP_FIXED; /* Set fixed only when generated a valid address.
-                                         * Otherwise we allow system to pick up one. */
-#endif
-            map_ptr = mmap(map_ptr, mapsize, PROT_READ | PROT_WRITE, map_flags, fd, 0);
-
-            if (map_ptr == NULL || map_ptr == MAP_FAILED) {
-                close(fd);
-
-                if (first)
-                    shm_unlink(shm_key);
-
-                mpi_errno = MPIR_Bcast_impl(&map_ptr, 1, MPI_UNSIGNED_LONG, 0, comm_ptr, &errflag);
-                MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
-            }
-        }
-
-        mpi_errno = MPIR_Bcast(&map_ptr, 1, MPI_UNSIGNED_LONG, 0, comm_ptr, &errflag);
-
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-        MPIR_ERR_CHKANDSTMT(map_ptr == NULL ||
-                            map_ptr == MAP_FAILED, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail,
-                            "**nomem");
-
-        unsigned map_fail = 0;
-        if (comm_ptr->rank != 0) {
-            int map_flags = MAP_SHARED;
-
-#ifdef USE_SYM_HEAP
-            rc = MPIDI_CH4R_check_maprange_ok(map_ptr, mapsize);
-            map_fail = (rc == 1) ? 0 : 1;
-            map_flags |= MAP_FIXED;     /* Set fixed only when symmetric heap is enabled. */
-#endif
-
-            if (map_fail == 0) {
-                map_ptr = mmap(map_ptr, mapsize, PROT_READ | PROT_WRITE, map_flags, fd, 0);
-                if (map_ptr == NULL || map_ptr == MAP_FAILED)
-                    map_fail = 1;
-            }
-        }
-
-        /* If any local process fails to sync range or mmap, then try more
-         * addresses on rank 0. */
-        mpi_errno = MPIR_Allreduce(&map_fail,
-                                   &anyfail, 1, MPI_UNSIGNED, MPI_BOR, comm_ptr, &errflag);
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-
-        if (anyfail && map_ptr != NULL && map_ptr != MAP_FAILED)
-            MPL_munmap(map_ptr, mapsize, MPL_MEM_RMA);
-    }
-
-    if (anyfail) {      /* Still fails after retry, report error. */
-        close(fd);
-
-        if (first)
-            shm_unlink(shm_key);
-
-        MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
-    }
+    mpi_errno = MPIDI_CH4U_allocate_shm_segment(comm_ptr, mapsize, 1 /* symmetric_flag */ ,
+                                                &MPIDI_CH4U_WIN(win, shm_segment_handle), &map_ptr);
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
 
     MPIDI_CH4U_WIN(win, mmap_addr) = map_ptr;
     MPIDI_CH4U_WIN(win, mmap_sz) = mapsize;
@@ -1048,15 +938,7 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
     *(void **) base_ptr = (void *) win->base;
     mpi_errno = MPIR_Barrier(comm_ptr, &errflag);
 
-    if (fd >= 0)
-        close(fd);
-
-    if (first)
-        shm_unlink(shm_key);
-
   fn_exit:
-    if (shm_key != NULL)
-        MPL_free(shm_key);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE_SHARED);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -935,4 +935,89 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_wait_am_acc(MPIR_Win * win, int target_r
   fn_fail:
     goto fn_exit;
 }
+
+/* Collectively allocate shared memory region.
+ * MPL_shm routines and MPI collectives are internally used.
+ *
+ * TODO: If symmetric_flag is true, then the routine will try to get
+ * a symmetric address and give up after tried predefined times. */
+#undef FUNCNAME
+#define FUNCNAME MPIDI_CH4U_allocate_shm_segment
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+static inline int MPIDI_CH4U_allocate_shm_segment(MPIR_Comm * shm_comm_ptr,
+                                                  MPI_Aint shm_segment_len, int symmetric_flag,
+                                                  MPL_shm_hnd_t * shm_segment_hdl_ptr,
+                                                  void **base_ptr)
+{
+    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int mpi_errno = MPI_SUCCESS;
+    MPL_shm_hnd_t shm_segment_handle;
+    void *map_ptr = NULL;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4R_ALLOCATE_SHM_SEGMENT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4R_ALLOCATE_SHM_SEGMENT);
+
+    mpi_errno = MPL_shm_hnd_init(&shm_segment_handle);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    if (shm_comm_ptr->rank == 0) {
+        char *serialized_hnd_ptr = NULL;
+
+        /* create shared memory region for all processes in win and map */
+        mpi_errno = MPL_shm_seg_create_and_attach(shm_segment_handle,
+                                                  shm_segment_len, (char **) &map_ptr, 0);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        /* serialize handle and broadcast it to the other processes in win */
+        mpi_errno = MPL_shm_hnd_get_serialized_by_ref(shm_segment_handle, &serialized_hnd_ptr);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
+                               shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+
+        /* wait for other processes to attach to win */
+        mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+
+        /* unlink shared memory region so it gets deleted when all processes exit */
+        mpi_errno = MPL_shm_seg_remove(shm_segment_handle);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    } else {
+        char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
+
+        /* get serialized handle from rank 0 and deserialize it */
+        mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
+                               shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+
+        mpi_errno = MPL_shm_hnd_deserialize(shm_segment_handle, serialized_hnd,
+                                            strlen(serialized_hnd));
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        /* attach to shared memory region created by rank 0 */
+        mpi_errno = MPL_shm_seg_attach(shm_segment_handle, shm_segment_len, (char **) &map_ptr, 0);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+    }
+
+    *shm_segment_hdl_ptr = shm_segment_handle;
+    *base_ptr = map_ptr;
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_ALLOCATE_SHM_SEGMENT);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 #endif /* CH4_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -761,14 +761,12 @@ static inline int MPIDI_CH4R_win_finalize(MPIR_Win ** win_ptr)
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
-        MPL_free(MPIDI_CH4U_WIN(win, sizes));
+
+
+        MPL_free(MPIDI_CH4U_WIN(win, shared_table));
     }
 
     MPIDI_CH4U_map_erase(MPIDI_CH4_Global.win_map, MPIDI_CH4U_WIN(win, win_id));
-
-    if (win->create_flavor == MPI_WIN_FLAVOR_SHARED) {
-        MPL_free(MPIDI_CH4U_WIN(win, shared_table));
-    }
 
     MPIR_Comm_release(win->comm_ptr);
     MPIR_Handle_obj_free(&MPIR_Win_mem, win);

--- a/test/mpi/rma/fence_shm.c
+++ b/test/mpi/rma/fence_shm.c
@@ -59,6 +59,12 @@ int main(int argc, char *argv[])
             MPI_Win_fence(0, shm_win);
         }
 
+        /* Other ranks simply join fence */
+        if (shm_rank > 1) {
+            MPI_Win_fence(0, shm_win);
+            MPI_Win_fence(0, shm_win);
+        }
+
         /* Test for FENCE with assert MPI_MODE_NOPRECEDE. */
 
         if (shm_rank == 1) {
@@ -80,6 +86,12 @@ int main(int argc, char *argv[])
                 errs++;
                 printf("Expected: result_data = %d   Actual: result_data = %d\n", one, result_data);
             }
+        }
+
+        /* Other ranks simply join fence */
+        if (shm_rank > 1) {
+            MPI_Win_fence(MPI_MODE_NOPRECEDE, shm_win);
+            MPI_Win_fence(0, shm_win);
         }
 
         MPI_Win_free(&shm_win);


### PR DESCRIPTION
This PR cleans up win_allocater_shared function in both CH4 fallback and OFI. 
- Always store base addrs at allocation time, this will help noncontig allocation which will be implemented in future work.
- Replaces mmap-based allocation with MPL_shm*.
- Removes unused window struct member.
- Improves a test program 

[PR #3027](https://github.com/pmodels/mpich/pull/3027) depends on this PR.