### PR TITLE
pm/hydra: Improve memory allocation macros

### DIFF
--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -619,10 +619,8 @@ HYD_status HYDU_sock_cloexec(int fd);
 
 #define HYDU_MALLOC_OR_JUMP(p, type, size, status)                      \
     {                                                                   \
-        (p) = NULL; /* initialize p in case assert fails */             \
-        HYDU_ASSERT(size, status);                                      \
         (p) = (type) MPL_malloc((size), MPL_MEM_PM);                 \
-        if ((p) == NULL)                                                \
+        if ((size) && (p) == NULL)                                      \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \
@@ -630,9 +628,8 @@ HYD_status HYDU_sock_cloexec(int fd);
 
 #define HYDU_REALLOC_OR_JUMP(p, type, size, status)                     \
     {                                                                   \
-        HYDU_ASSERT(size, status);                                      \
         (p) = (type) MPL_realloc((p),(size), MPL_MEM_PM);            \
-        if ((p) == NULL)                                                \
+        if ((size) && (p) == NULL)                                      \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \


### PR DESCRIPTION
Modify macros to allow 0-byte allocations, which aligns them with the
standard libc versions.