### PR TITLE
Update collective algorithm testing

### DIFF
--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -26,9 +26,6 @@ for algo_name in ${algo_names}; do
         env+="env=MPIR_CVAR_IBCAST_TREE_KVAL=${kval}"
 
         coll_algo_tests+="bcasttest 10 ${env}${nl}"
-        coll_algo_tests+="bcast_full 4 timeLimit=600 ${env}${nl}"
-        coll_algo_tests+="bcast_min_datatypes 10 timeLimit=1200 ${env}${nl}"
-        coll_algo_tests+="bcast_comm_world 10 timeLimit=1200 ${env}${nl}"
         coll_algo_tests+="bcastzerotype 5 ${env}${nl}"
     done
 done

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -233,10 +233,10 @@ AC_ARG_ENABLE(xfail,
 		[Run tests marked for expected failure])],,
 	[enable_xfail=no])
 
-AC_ARG_ENABLE(collective-algorithms,
-              [AC_HELP_STRING([--enable-collective-algorithms],
+AC_ARG_ENABLE(collalgo-tests,
+              [AC_HELP_STRING([--enable-collalgo-tests],
                               [Run extended collective algorithm tests])],,
-              [enable_collective_algorithms=no])
+              [enable_collalgo_tests=no])
 
 AC_ARG_WITH(mpi,
 	[AC_HELP_STRING([--with-mpi=dir],


### PR DESCRIPTION
Some binaries were removed from the collectives test suite after Giuseppe's DTPools patch. Removed those binaries from collective algorithms tests as well. @raffenet this needs to go in as soon as possible as jenkins jobs is having test failures since we enabled collective algorithm testing.

Also changed the name of the configure time option to run these extended tests. @raffenet please update the configure option in jenkins jobs as well.