### PR TITLE
hydra: fix -disable-auto-cleanup

### DIFF
--- a/src/pm/hydra/pm/pmiserv/pmip_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_cb.c
@@ -260,8 +260,8 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
                  * information upstream */
 
                 /* FIXME: This code needs to change from sending the
-                 * SIGUSR1 signal to a PMI-2 notification message. */
-                HYD_pmcd_pmip_send_signal(SIGUSR1);
+                 * SIGCHLD signal to a PMI-2 notification message. */
+                HYD_pmcd_pmip_send_signal(SIGCHLD);
 
                 hdr.cmd = PROCESS_TERMINATED;
                 hdr.pid = HYD_pmcd_pmip.downstream.pmi_rank[pid];

--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -384,8 +384,8 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                     if (tproxy->pg->pgid == proxy->pg->pgid && tproxy->proxy_id == proxy->proxy_id)
                         continue;
 
-                    status = HYD_pmcd_pmiserv_send_signal(tproxy, SIGUSR1);
-                    HYDU_ERR_POP(status, "unable to send SIGUSR1 downstream\n");
+                    status = HYD_pmcd_pmiserv_send_signal(tproxy, SIGCHLD);
+                    HYDU_ERR_POP(status, "unable to send SIGCHLD downstream\n");
                 }
             }
         }

--- a/src/pm/hydra/utils/signals/signals.c
+++ b/src/pm/hydra/utils/signals/signals.c
@@ -53,8 +53,8 @@ HYD_status HYDU_set_common_signals(void (*handler) (int))
     status = HYDU_set_signal(SIGTERM, handler);
     HYDU_ERR_POP(status, "unable to set SIGTERM\n");
 
-    status = HYDU_set_signal(SIGUSR1, handler);
-    HYDU_ERR_POP(status, "unable to set SIGUSR1\n");
+    status = HYDU_set_signal(SIGCHLD, handler);
+    HYDU_ERR_POP(status, "unable to set SIGCHLD\n");
 
     status = HYDU_set_signal(SIGALRM, handler);
     HYDU_ERR_POP(status, "unable to set SIGALRM\n");


### PR DESCRIPTION
As `man 7 signal` explains, the default action for a process that
receives `SIGUSR1` is terminate. Sending the `SIGUSR1` in the
`-disable-auto-cleanup` mode will kill the child MPI processes as they
do not ignore that signal by default. This results in unexpected killing
all processes.

The only signal that is ignored by default is `SIGCHLD`, therefore we
should send it when auto cleanup is disabled.