### PR TITLE
coll: clean up unnecessary TLS access in MPIR_Reduce_local

### DIFF
--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -59,8 +59,6 @@ extern OPA_int_t num_server_thread;
  * structure must be externally cleaned up.
  * */
 typedef struct {
-    int op_errno;               /* For errors in predefined MPI_Ops */
-
     /* error string storage for MPIR_Strerror */
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
 

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -67,17 +67,6 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     is_commutative = MPIR_Op_is_commutative(op);
 
     /* need to allocate temporary buffer to store partial scan */
@@ -165,18 +154,6 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
             }
         }
         mask <<= 1;
-    }
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
     }
 
   fn_exit:

--- a/src/mpi/coll/ireduce/ireduce_intra_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_binomial.c
@@ -25,17 +25,6 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     /* Create a temporary buffer */
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/op/opband.c
+++ b/src/mpi/coll/op/opband.c
@@ -32,23 +32,9 @@ void MPIR_BAND(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
                 MPIR_OP_TYPE_GROUP(BYTE_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_BAND");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opbor.c
+++ b/src/mpi/coll/op/opbor.c
@@ -32,23 +32,9 @@ void MPIR_BOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
                 MPIR_OP_TYPE_GROUP(BYTE_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_BOR");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opbxor.c
+++ b/src/mpi/coll/op/opbxor.c
@@ -32,23 +32,9 @@ void MPIR_BXOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
                 MPIR_OP_TYPE_GROUP(BYTE_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_BXOR");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opland.c
+++ b/src/mpi/coll/op/opland.c
@@ -58,23 +58,9 @@ void MPIR_LAND(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_LAND");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/oplor.c
+++ b/src/mpi/coll/op/oplor.c
@@ -58,23 +58,9 @@ void MPIR_LOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_LOR");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/oplxor.c
+++ b/src/mpi/coll/op/oplxor.c
@@ -62,23 +62,9 @@ void MPIR_LXOR(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FLOATING_POINT)
                 MPIR_OP_TYPE_GROUP(FLOATING_POINT_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_LXOR");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opmax.c
+++ b/src/mpi/coll/op/opmax.c
@@ -29,23 +29,9 @@ void MPIR_MAXF(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
                 MPIR_OP_TYPE_GROUP(FLOATING_POINT_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_MAX");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opmaxloc.c
+++ b/src/mpi/coll/op/opmaxloc.c
@@ -111,22 +111,9 @@ void MPIR_MAXLOC(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
             MPIR_MAXLOC_F_CASE(MPIR_FC_DOUBLE_CTYPE);
 #endif
 #endif
-            /* --BEGIN ERROR HANDLING-- */
-        default:{
-                MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                              "MPI_MAXLOC");
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno = mpi_errno;
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 
 }

--- a/src/mpi/coll/op/opmin.c
+++ b/src/mpi/coll/op/opmin.c
@@ -28,23 +28,9 @@ void MPIR_MINF(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
                 MPIR_OP_TYPE_GROUP(FORTRAN_INTEGER_EXTRA)
                 MPIR_OP_TYPE_GROUP(FLOATING_POINT_EXTRA)
 #undef MPIR_OP_TYPE_MACRO
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_MIN");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/op/opminloc.c
+++ b/src/mpi/coll/op/opminloc.c
@@ -110,22 +110,9 @@ void MPIR_MINLOC(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
             MPIR_MINLOC_F_CASE(MPIR_FC_DOUBLE_CTYPE);
 #endif
 #endif
-            /* --BEGIN ERROR HANDLING-- */
-        default:{
-                MPIR_ERR_SET1(mpi_errno, MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                              "MPI_MINLOC");
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno = mpi_errno;
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 
 }

--- a/src/mpi/coll/op/opprod.c
+++ b/src/mpi/coll/op/opprod.c
@@ -52,23 +52,9 @@ void MPIR_PROD(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
 #undef MPIR_OP_TYPE_MACRO
 #undef MPIR_OP_C_COMPLEX_TYPE_MACRO
 #define MPIR_OP_C_COMPLEX_TYPE_MACRO(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_PROD");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 
     /* NOTE: the coll/allred test may report uninitialized bytes originating

--- a/src/mpi/coll/op/opsum.c
+++ b/src/mpi/coll/op/opsum.c
@@ -51,23 +51,9 @@ void MPIR_SUM(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
 #undef MPIR_OP_TYPE_MACRO
 #undef MPIR_OP_C_COMPLEX_TYPE_MACRO
 #define MPIR_OP_C_COMPLEX_TYPE_MACRO(mpi_type_,c_type_,type_name_) MPIR_OP_TYPE_MACRO(mpi_type_,c_type_,type_name_)
-                /* --BEGIN ERROR HANDLING-- */
-        default:{
-                {
-                    MPIR_Per_thread_t *per_thread = NULL;
-                    int err = 0;
-
-                    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                                 MPIR_Per_thread, per_thread, &err);
-                    MPIR_Assert(err == 0);
-                    per_thread->op_errno =
-                        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                             MPI_ERR_OP, "**opundefined", "**opundefined %s",
-                                             "MPI_SUM");
-                }
-                break;
-            }
-            /* --END ERROR HANDLING-- */
+        default:
+            MPIR_Assert(0);
+            break;
     }
 }
 

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -56,17 +56,6 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     /* Create a temporary buffer */
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
@@ -393,23 +382,6 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             j--;
         }
     }
-
-    /* FIXME does this need to be checked after each uop invocation for
-     * predefined operators? */
-    /* --BEGIN ERROR HANDLING-- */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno) {
-            mpi_errno = per_thread->op_errno;
-            goto fn_fail;
-        }
-    }
-    /* --END ERROR HANDLING-- */
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -144,6 +144,8 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
             mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
             /* change the rank */
             newrank = rank / 2;
         }
@@ -226,6 +228,8 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             mpi_errno = MPIR_Reduce_local((char *) tmp_buf + disps[recv_idx] * extent,
                                           (char *) recvbuf + disps[recv_idx] * extent,
                                           recv_cnt, datatype, op);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
             /* update send_idx for next iteration */
             send_idx = recv_idx;
             mask <<= 1;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -44,16 +44,6 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype
     if (count == 0)
         goto fn_exit;
 
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = MPI_SUCCESS;
-    }
-
     if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(op);
@@ -99,19 +89,6 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype
         (*uop) ((void *) inbuf, inoutbuf, &count, &datatype);
 #endif
     }
-
-    /* --BEGIN ERROR HANDLING-- */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
-    /* --END ERROR HANDLING-- */
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -45,6 +45,11 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype
         goto fn_exit;
 
     if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+        /* --BEGIN ERROR HANDLING-- */
+        mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
+        if (mpi_errno != MPI_SUCCESS)
+            goto fn_exit;
+        /* --END ERROR HANDLING-- */
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(op);
     } else {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -115,17 +115,6 @@ int MPIR_Reduce_scatter_intra_auto(const void *sendbuf, void *recvbuf, const int
 
     comm_size = comm_ptr->local_size;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     is_commutative = MPIR_Op_is_commutative(op);
@@ -204,17 +193,6 @@ int MPIR_Reduce_scatter_intra_auto(const void *sendbuf, void *recvbuf, const int
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -31,17 +31,6 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
@@ -138,17 +127,6 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -113,6 +113,8 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
              * end, we will copy back the result to the
              * beginning of recvbuf. */
         }
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
     }
 
     /* if MPI_IN_PLACE, move output data to the beginning of

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -40,17 +40,6 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
@@ -305,17 +294,6 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -64,17 +64,6 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     }
 #endif /* HAVE_ERROR_CHECKING */
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
@@ -317,17 +306,6 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -149,6 +149,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, total_count, datatype, op);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -247,6 +249,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIR_Reduce_local((char *) tmp_recvbuf + newdisps[recv_idx] * extent,
                                               (char *) tmp_results + newdisps[recv_idx] * extent,
                                               recv_cnt, datatype, op);
+                if (mpi_errno)
+                    MPIR_ERR_POP(mpi_errno);
             }
 
             /* update send_idx for next iteration */

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -107,17 +107,6 @@ int MPIR_Reduce_scatter_block_intra_auto(const void *sendbuf,
 
     comm_size = comm_ptr->local_size;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     if (recvcount == 0) {
         goto fn_exit;
     }
@@ -164,17 +153,6 @@ int MPIR_Reduce_scatter_block_intra_auto(const void *sendbuf,
     }
 
   fn_exit:
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -13,8 +13,6 @@
 
 #include "mpiimpl.h"
 
-/* FIXME should we be checking the op_errno here? */
-
 /* Algorithm: Noncommutative
  *
  * Restrictions: Only power-of-two and noncommutative

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -120,6 +120,8 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
              * end, we will copy back the result to the
              * beginning of recvbuf. */
         }
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
     }
 
     /* if MPI_IN_PLACE, move output data to the beginning of

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -41,17 +41,6 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     if (recvcount == 0) {
         goto fn_exit;
     }
@@ -145,17 +134,6 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -46,17 +46,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     if (recvcount == 0) {
         goto fn_exit;
     }
@@ -301,18 +290,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
 
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
     else if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -68,17 +68,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     if (recvcount == 0) {
         goto fn_exit;
     }
@@ -307,17 +296,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno)
-            mpi_errno = per_thread->op_errno;
-    }
 
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno_ret)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -154,6 +154,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, total_count, datatype, op);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -253,6 +255,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                 mpi_errno = MPIR_Reduce_local((char *) tmp_recvbuf + newdisps[recv_idx] * extent,
                                               (char *) tmp_results + newdisps[recv_idx] * extent,
                                               recv_cnt, datatype, op);
+                if (mpi_errno)
+                    MPIR_ERR_POP(mpi_errno);
             }
 
             /* update send_idx for next iteration */

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -63,17 +63,6 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    /* set op_errno to 0. stored in perthread structure */
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        per_thread->op_errno = 0;
-    }
-
     is_commutative = MPIR_Op_is_commutative(op);
 
     /* need to allocate temporary buffer to store partial scan */
@@ -150,20 +139,6 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
             }
         }
         mask <<= 1;
-    }
-
-    {
-        MPIR_Per_thread_t *per_thread = NULL;
-        int err = 0;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        if (per_thread->op_errno) {
-            mpi_errno = per_thread->op_errno;
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
-        }
     }
 
   fn_exit:

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -631,6 +631,9 @@ static inline int MPIDI_CH3I_Shm_fop_op(const void *origin_addr, void *result_ad
 
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_MPIDI_CH3I_SHM_FOP_OP);
 
+    if ((*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype) != MPI_SUCCESS)
+        goto fn_exit;
+
     if (win_ptr->shm_allocated == TRUE) {
         int local_target_rank = win_ptr->comm_ptr->intranode_table[target_rank];
         MPIR_Assert(local_target_rank >= 0);

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -853,7 +853,8 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
         MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
     }
 
-    if (HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN) {
+    if ((HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN)
+        && ((*MPIR_OP_HDL_TO_DTYPE_FN(acc_op)) (source_dtp) == MPI_SUCCESS)){
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(acc_op);
     }

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -912,7 +912,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
         MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
     }
 
-    if (HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN) {
+    if ((HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN)
+        && ((*MPIR_OP_HDL_TO_DTYPE_FN(acc_op)) (source_dtp) == MPI_SUCCESS)) {
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(acc_op);
     } else {

--- a/test/mpi/rma/large_acc_flush_local.c
+++ b/test/mpi/rma/large_acc_flush_local.c
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
         if (rank != 0) {
             for (data_size = MIN_DATA_SIZE; data_size <= MAX_DATA_SIZE; data_size *= 2) {
                 for (i = 0; i < OPS_NUM; i++) {
-                    MPI_Accumulate(orig_buf, data_size, MPI_BYTE,
-                                   0, 0, data_size, MPI_BYTE, MPI_SUM, win);
+                    MPI_Accumulate(orig_buf, data_size, MPI_CHAR,
+                                   0, 0, data_size, MPI_CHAR, MPI_SUM, win);
                     MPI_Win_flush_local(0, win);
                 }
                 MPI_Win_flush(0, win);


### PR DESCRIPTION
106 instructions (of 194 total) of each MPIR_Reduce_local call are used for TLS access.
Error handling logic works for built-in datatypes and checks type support for given operation only, and may be replaced by ` (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype) ` call (which contains of ~12 instructions).

```
[ 194 ]-||MPIR_Reduce_local  
|MPIR_Reduce_local : 17 
|
|-[ 53  ]-||.plt,__GI___tls_get_addr,update_get_addr  
|         |.plt       : 1 
|         |__GI___tls_get_addr : 5 
|         |update_get_addr : 4 
|         |
|         |-[ 33  ]-||_dl_update_slotinfo  
|         |         |_dl_update_slotinfo : 33 
|         |
|         |update_get_addr : 10 
|
|MPIR_Reduce_local : 15 
|
|-[ 43  ]-||MPIR_SUM  
|         |MPIR_SUM   : 43 
|
|MPIR_Reduce_local : 3 
|
|-[ 53  ]-||.plt,__GI___tls_get_addr,update_get_addr  
|         |.plt       : 1 
|         |__GI___tls_get_addr : 5 
|         |update_get_addr : 4 
|         |
|         |-[ 33  ]-||_dl_update_slotinfo  
|         |         |_dl_update_slotinfo : 33 
|         |
|         |update_get_addr : 10 
|
|MPIR_Reduce_local : 10 
```

@raffenet, @wesbland, @hajimefu am I miss any specific scenarios when TLS is required here? What do you think about this PR?