### PR TITLE
ch4: add handler for SIGUSR1

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -489,6 +489,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Type_free_hook(MPIR_Datatype * type);
 #define MPID_INTERCOMM_NO_DYNPROC(comm) \
     (MPIDI_COMM((comm),map).avtid == 0 && MPIDI_COMM((comm),local_map).avtid == 0)
 
+int MPIDI_check_for_failed_procs(void);
+
+#ifdef HAVE_SIGNAL
+void MPIDI_sigusr1_handler(int sig);
+#endif
 
 #include "mpidu_pre.h"
 

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -56,6 +56,15 @@ MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unused));
 pthread_mutex_t MPIDI_Mutex_lock[MPIDI_NUM_LOCKS];
 #endif
 
+#ifdef HAVE_SIGNAL
+void MPIDI_sigusr1_handler(int sig)
+{
+    MPIDI_CH4_Global.sigusr1_count++;
+    if (MPIDI_CH4_Global.prev_sighandler)
+        MPIDI_CH4_Global.prev_sighandler(sig);
+}
+#endif
+
 #undef FUNCNAME
 #define FUNCNAME MPID_Abort
 #undef FCNAME
@@ -105,6 +114,67 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error
     PMI_Abort(exit_code, error_msg);
 #endif
     return 0;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_check_for_failed_procs
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIDI_check_for_failed_procs(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    int len;
+    char *kvsname;
+    char *failed_procs_string = NULL;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);
+
+    /* FIXME: Currently this only handles failed processes in
+     * comm_world.  We need to fix hydra to include the pgid along
+     * with the rank, then we need to create the failed group from
+     * something bigger than comm_world. */
+#ifdef USE_PMI2_API
+    len = PMI2_MAX_VALLEN;
+#elif defined(USE_PMIX_API)
+    len = 1024;
+#else
+    pmi_errno = PMI_KVS_Get_value_length_max(&len);
+    if (pmi_errno != PMI_SUCCESS) {
+        mpi_errno = MPI_ERR_OTHER;
+        MPIR_ERR_POP(mpi_errno);
+    }
+#endif
+
+#ifndef USE_PMIX_API
+    pmi_errno = PMI_KVS_Get_my_name(kvsname, len);
+    MPIR_ERR_CHKANDJUMP(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get_value_length_max");
+#endif
+#ifdef USE_PMI2_API
+    {
+        int vallen = 0;
+        pmi_errno =
+            PMI2_KVS_Get(kvsname, PMI2_ID_NULL, "PMI_dead_processes", failed_procs_string,
+                         len, &vallen);
+        MPIR_ERR_CHKANDJUMP(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get");
+    }
+#elif defined(USE_PMIX_API)
+    MPIR_Assert(0);
+#else
+    pmi_errno = PMI_KVS_Get(kvsname, "PMI_dead_processes", failed_procs_string, len);
+    MPIR_ERR_CHKANDJUMP(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get");
+#endif
+
+    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    (MPL_DBG_FDEST, "Received proc fail notification: %s", failed_procs_string));
+
+    /* FIXME: handle ULFM failed groups here */
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_dbg_class MPIDI_CH4_DBG_GENERAL;

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -25,6 +25,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PROGRESS_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PROGRESS_TEST);
 
+#ifdef HAVE_SIGNAL
+    if (MPIDI_CH4_Global.sigusr1_count > MPIDI_CH4_Global.my_sigusr1_count) {
+        MPIDI_CH4_Global.my_sigusr1_count = MPIDI_CH4_Global.sigusr1_count;
+        mpi_errno = MPIDI_check_for_failed_procs();
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    }
+#endif
+
     if (OPA_load_int(&MPIDI_CH4_Global.active_progress_hooks) && (flags & MPIDI_PROGRESS_HOOKS)) {
         MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_PROGRESS_MUTEX);
         for (i = 0; i < MAX_PROGRESS_HOOKS; i++) {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -288,6 +288,12 @@ typedef struct MPIDI_CH4_Global_t {
     OPA_int_t exp_seq_no;
     OPA_int_t nxt_seq_no;
     MPIU_buf_pool_t *buf_pool;
+#ifdef HAVE_SIGNAL
+    void (*prev_sighandler) (int);
+    volatile int sigusr1_count;
+    int my_sigusr1_count;
+#endif
+
 } MPIDI_CH4_Global_t;
 extern MPIDI_CH4_Global_t MPIDI_CH4_Global;
 #ifdef MPL_USE_DBG_LOGGING

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -451,6 +451,10 @@ if test "$ac_cv_func_gethostname" = "yes" ; then
     PAC_FUNC_NEEDS_DECL([#include <unistd.h>],gethostname)
 fi
 
+# make sure we support signal
+AC_CHECK_HEADERS(signal.h)
+AC_CHECK_FUNCS(signal)
+
 AC_CONFIG_FILES([
 src/mpid/ch4/src/mpid_ch4_net_array.c
 src/mpid/ch4/include/netmodpre.h


### PR DESCRIPTION
SIGUSR1 is a signal sent by PMI when there is a process failure
somewhere in the process tree. The handler of SIGUSR1 is set in
MPID_Init. The handler just record the number of SIGUSR1 received. We
check the number of the received SIGUSR1.  If there is a new SIGUSR1, we
will try to get failed groups from PMI and return an error.