### PR TITLE
Ch4 rma cleanup

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -227,6 +227,14 @@ typedef struct MPIDI_CH4U_win_info_args_t {
     int accumulate_ordering;
     int alloc_shared_noncontig;
     MPIDI_CH4U_win_info_accumulate_ops accumulate_ops;
+
+    /* alloc_shm: MPICH specific hint (same in CH3).
+     * If true, MPICH will try to use shared memory routines for the window.
+     * Default is true for allocate-based windows, and false for other
+     * windows. Note that this hint can be also used in create-based windows,
+     * and it means the user window buffer is allocated over shared memory,
+     * thus RMA operation can use shm routines. */
+    int alloc_shm;
 } MPIDI_CH4U_win_info_args_t;
 
 struct MPIDI_CH4U_win_lock {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -419,13 +419,9 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count,
                                         target_contig, target_bytes, target_true_lb);
@@ -586,13 +582,9 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
                                         origin_bytes, origin_true_lb);
@@ -672,6 +664,8 @@ static inline int MPIDI_NM_mpi_rput(const void *origin_addr,
         goto fn_exit;
     }
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
 
     if (unlikely((origin_bytes == 0) || (target_rank == MPI_PROC_NULL))) {
@@ -741,13 +735,9 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
-    if (target_rank == MPI_PROC_NULL)
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+    if (unlikely(target_rank == MPI_PROC_NULL))
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
 
@@ -906,13 +896,9 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     if (!MPIDI_OFI_ENABLE_ATOMICS)
         goto am_fallback;
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto null_op_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
     if (origin_bytes == 0)
@@ -1058,13 +1044,9 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     if (!MPIDI_OFI_ENABLE_ATOMICS)
         goto am_fallback;
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto null_op_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
     if (target_bytes == 0)
@@ -1350,6 +1332,8 @@ static inline int MPIDI_NM_mpi_rget(void *origin_addr,
                                         win, request);
         goto fn_exit;
     }
+
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -134,13 +134,9 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
         return MPIDI_CH4U_mpi_put(origin_addr, origin_count, origin_datatype,
                                   target_rank, target_disp, target_count, target_datatype, win);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count,
                                         target_contig, target_bytes, target_true_lb);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1020,4 +1020,150 @@ static inline int MPIDI_CH4U_allocate_shm_segment(MPIR_Comm * shm_comm_ptr,
     goto fn_exit;
 }
 
+/* Compute accumulate operation.
+ * The source datatype can be only predefined; the target datatype can be
+ * predefined or derived. */
+#undef FUNCNAME
+#define FUNCNAME MPIDI_CH4U_compute_acc_op
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_compute_acc_op(void *source_buf, int source_count,
+                                                       MPI_Datatype source_dtp, void *target_buf,
+                                                       int target_count, MPI_Datatype target_dtp,
+                                                       MPI_Aint stream_offset, MPI_Op acc_op)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPI_User_function *uop = NULL;
+    MPI_Aint source_dtp_size = 0, source_dtp_extent = 0;
+    int is_empty_source = FALSE;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_COMPUTE_ACC_OP);
+
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_COMPUTE_ACC_OP);
+
+    /* first Judge if source buffer is empty */
+    if (acc_op == MPI_NO_OP)
+        is_empty_source = TRUE;
+
+    if (is_empty_source == FALSE) {
+        MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(source_dtp));
+        MPIR_Datatype_get_size_macro(source_dtp, source_dtp_size);
+        MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
+    }
+
+    if (HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN) {
+        /* get the function by indexing into the op table */
+        uop = MPIR_OP_HDL_TO_FN(acc_op);
+    } else {
+        /* --BEGIN ERROR HANDLING-- */
+        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                         FCNAME, __LINE__, MPI_ERR_OP,
+                                         "**opnotpredefined", "**opnotpredefined %d", acc_op);
+        return mpi_errno;
+        /* --END ERROR HANDLING-- */
+    }
+
+
+    if (is_empty_source == TRUE || MPIR_DATATYPE_IS_PREDEFINED(target_dtp)) {
+        /* directly apply op if target dtp is predefined dtp OR source buffer is empty */
+        MPI_Aint real_stream_offset;
+        void *curr_target_buf;
+
+        if (is_empty_source == FALSE) {
+            MPIR_Assert(source_dtp == target_dtp);
+            real_stream_offset = (stream_offset / source_dtp_size) * source_dtp_extent;
+            curr_target_buf = (void *) ((char *) target_buf + real_stream_offset);
+        } else {
+            curr_target_buf = target_buf;
+        }
+
+        (*uop) (source_buf, curr_target_buf, &source_count, &source_dtp);
+    } else {
+        /* derived datatype */
+        MPIR_Segment *segp;
+        DLOOP_VECTOR *dloop_vec;
+        MPI_Aint first, last;
+        int vec_len, i, count;
+        MPI_Aint type_extent, type_size;
+        MPI_Datatype type;
+        MPIR_Datatype *dtp;
+        MPI_Aint curr_len;
+        void *curr_loc;
+        int accumulated_count;
+
+        segp = MPIR_Segment_alloc();
+        /* --BEGIN ERROR HANDLING-- */
+        if (!segp) {
+            mpi_errno =
+                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
+                                     MPI_ERR_OTHER, "**nomem", 0);
+            goto fn_exit;
+        }
+        /* --END ERROR HANDLING-- */
+        MPIR_Segment_init(NULL, target_count, target_dtp, segp);
+        first = stream_offset;
+        last = first + source_count * source_dtp_size;
+
+        MPIR_Datatype_get_ptr(target_dtp, dtp);
+        vec_len = dtp->max_contig_blocks * target_count + 1;
+        /* +1 needed because Rob says so */
+        dloop_vec = (DLOOP_VECTOR *)
+            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR), MPL_MEM_RMA);
+        /* --BEGIN ERROR HANDLING-- */
+        if (!dloop_vec) {
+            mpi_errno =
+                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
+                                     MPI_ERR_OTHER, "**nomem", 0);
+            goto fn_exit;
+        }
+        /* --END ERROR HANDLING-- */
+
+        MPIR_Segment_pack_vector(segp, first, &last, dloop_vec, &vec_len);
+
+        type = dtp->basic_type;
+        MPIR_Assert(type != MPI_DATATYPE_NULL);
+
+        MPIR_Assert(type == source_dtp);
+        type_size = source_dtp_size;
+        type_extent = source_dtp_extent;
+
+        i = 0;
+        curr_loc = dloop_vec[0].DLOOP_VECTOR_BUF;
+        curr_len = dloop_vec[0].DLOOP_VECTOR_LEN;
+        accumulated_count = 0;
+        while (i != vec_len) {
+            if (curr_len < type_size) {
+                MPIR_Assert(i != vec_len);
+                i++;
+                curr_len += dloop_vec[i].DLOOP_VECTOR_LEN;
+                continue;
+            }
+
+            MPIR_Assign_trunc(count, curr_len / type_size, int);
+
+            (*uop) ((char *) source_buf + type_extent * accumulated_count,
+                    (char *) target_buf + MPIR_Ptr_to_aint(curr_loc), &count, &type);
+
+            if (curr_len % type_size == 0) {
+                i++;
+                if (i != vec_len) {
+                    curr_loc = dloop_vec[i].DLOOP_VECTOR_BUF;
+                    curr_len = dloop_vec[i].DLOOP_VECTOR_LEN;
+                }
+            } else {
+                curr_loc = (void *) ((char *) curr_loc + type_extent * count);
+                curr_len -= type_size * count;
+            }
+
+            accumulated_count += count;
+        }
+
+        MPIR_Segment_free(segp);
+        MPL_free(dloop_vec);
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4U_COMPUTE_ACC_OP);
+    return mpi_errno;
+}
+
 #endif /* CH4_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -617,6 +617,17 @@ static inline int MPIDI_CH4I_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_G
         }                                                               \
     } while (0)
 
+/* Generic routine for checking synchronization at every RMA operation.*/
+#define MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win)                                 \
+    do {                                                                               \
+        MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);                     \
+        MPIDI_CH4U_EPOCH_OP_REFENCE(win);                                              \
+        /* Check target sync status for any target_rank except PROC_NULL. */           \
+        if (target_rank != MPI_PROC_NULL)                                              \
+            MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno,            \
+                                               goto fn_fail);                          \
+    } while (0);
+
 /*
   Calculate base address of the target window at the origin side
   Return zero to let the target side calculate the actual address

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -40,13 +40,9 @@ static inline int MPIDI_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_DO_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_PUT);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0)
@@ -177,13 +173,9 @@ static inline int MPIDI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_DO_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_GET);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0)
@@ -301,13 +293,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_DO_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_ACCUMULATE);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -452,13 +440,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_DO_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_GET_ACCUMULATE);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -914,13 +898,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_compare_and_swap(const void *origin_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4U_MPI_COMPARE_AND_SWAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4U_MPI_COMPARE_AND_SWAP);
 
-    MPIDI_CH4U_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);
-    MPIDI_CH4U_EPOCH_OP_REFENCE(win);
-
-    /* Check target sync status for any target_rank except PROC_NULL. */
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
-    MPIDI_CH4U_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);
 
     MPIDI_Datatype_check_size(datatype, 1, data_sz);
     if (data_sz == 0)

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -549,150 +549,6 @@ static inline void MPIDI_win_unlock_done(const MPIDI_CH4U_win_cntrl_msg_t * info
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_WIN_UNLOCK_DONE);
 }
 
-
-#undef FUNCNAME
-#define FUNCNAME MPIDI_do_accumulate_op
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_do_accumulate_op(void *source_buf, int source_count,
-                                         MPI_Datatype source_dtp, void *target_buf,
-                                         int target_count, MPI_Datatype target_dtp,
-                                         MPI_Aint stream_offset, MPI_Op acc_op)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPI_User_function *uop = NULL;
-    MPI_Aint source_dtp_size = 0, source_dtp_extent = 0;
-    int is_empty_source = FALSE;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_DO_ACCUMULATE_OP);
-
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_DO_ACCUMULATE_OP);
-
-    /* first Judge if source buffer is empty */
-    if (acc_op == MPI_NO_OP)
-        is_empty_source = TRUE;
-
-    if (is_empty_source == FALSE) {
-        MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(source_dtp));
-        MPIR_Datatype_get_size_macro(source_dtp, source_dtp_size);
-        MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
-    }
-
-    if (HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN) {
-        /* get the function by indexing into the op table */
-        uop = MPIR_OP_HDL_TO_FN(acc_op);
-    } else {
-        /* --BEGIN ERROR HANDLING-- */
-        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                         FCNAME, __LINE__, MPI_ERR_OP,
-                                         "**opnotpredefined", "**opnotpredefined %d", acc_op);
-        return mpi_errno;
-        /* --END ERROR HANDLING-- */
-    }
-
-
-    if (is_empty_source == TRUE || MPIR_DATATYPE_IS_PREDEFINED(target_dtp)) {
-        /* directly apply op if target dtp is predefined dtp OR source buffer is empty */
-        MPI_Aint real_stream_offset;
-        void *curr_target_buf;
-
-        if (is_empty_source == FALSE) {
-            MPIR_Assert(source_dtp == target_dtp);
-            real_stream_offset = (stream_offset / source_dtp_size) * source_dtp_extent;
-            curr_target_buf = (void *) ((char *) target_buf + real_stream_offset);
-        } else {
-            curr_target_buf = target_buf;
-        }
-
-        (*uop) (source_buf, curr_target_buf, &source_count, &source_dtp);
-    } else {
-        /* derived datatype */
-        MPIR_Segment *segp;
-        DLOOP_VECTOR *dloop_vec;
-        MPI_Aint first, last;
-        int vec_len, i, count;
-        MPI_Aint type_extent, type_size;
-        MPI_Datatype type;
-        MPIR_Datatype *dtp;
-        MPI_Aint curr_len;
-        void *curr_loc;
-        int accumulated_count;
-
-        segp = MPIR_Segment_alloc();
-        /* --BEGIN ERROR HANDLING-- */
-        if (!segp) {
-            mpi_errno =
-                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
-                                     MPI_ERR_OTHER, "**nomem", 0);
-            goto fn_exit;
-        }
-        /* --END ERROR HANDLING-- */
-        MPIR_Segment_init(NULL, target_count, target_dtp, segp);
-        first = stream_offset;
-        last = first + source_count * source_dtp_size;
-
-        MPIR_Datatype_get_ptr(target_dtp, dtp);
-        vec_len = dtp->max_contig_blocks * target_count + 1;
-        /* +1 needed because Rob says so */
-        dloop_vec = (DLOOP_VECTOR *)
-            MPL_malloc(vec_len * sizeof(DLOOP_VECTOR), MPL_MEM_RMA);
-        /* --BEGIN ERROR HANDLING-- */
-        if (!dloop_vec) {
-            mpi_errno =
-                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
-                                     MPI_ERR_OTHER, "**nomem", 0);
-            goto fn_exit;
-        }
-        /* --END ERROR HANDLING-- */
-
-        MPIR_Segment_pack_vector(segp, first, &last, dloop_vec, &vec_len);
-
-        type = dtp->basic_type;
-        MPIR_Assert(type != MPI_DATATYPE_NULL);
-
-        MPIR_Assert(type == source_dtp);
-        type_size = source_dtp_size;
-        type_extent = source_dtp_extent;
-
-        i = 0;
-        curr_loc = dloop_vec[0].DLOOP_VECTOR_BUF;
-        curr_len = dloop_vec[0].DLOOP_VECTOR_LEN;
-        accumulated_count = 0;
-        while (i != vec_len) {
-            if (curr_len < type_size) {
-                MPIR_Assert(i != vec_len);
-                i++;
-                curr_len += dloop_vec[i].DLOOP_VECTOR_LEN;
-                continue;
-            }
-
-            MPIR_Assign_trunc(count, curr_len / type_size, int);
-
-            (*uop) ((char *) source_buf + type_extent * accumulated_count,
-                    (char *) target_buf + MPIR_Ptr_to_aint(curr_loc), &count, &type);
-
-            if (curr_len % type_size == 0) {
-                i++;
-                if (i != vec_len) {
-                    curr_loc = dloop_vec[i].DLOOP_VECTOR_BUF;
-                    curr_len = dloop_vec[i].DLOOP_VECTOR_LEN;
-                }
-            } else {
-                curr_loc = (void *) ((char *) curr_loc + type_extent * count);
-                curr_len -= type_size * count;
-            }
-
-            accumulated_count += count;
-        }
-
-        MPIR_Segment_free(segp);
-        MPL_free(dloop_vec);
-    }
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_DO_ACCUMULATE_OP);
-    return mpi_errno;
-}
-
 #undef FUNCNAME
 #define FUNCNAME MPIDI_handle_acc_cmpl
 #undef FCNAME
@@ -721,13 +577,13 @@ static inline int MPIDI_handle_acc_cmpl(MPIR_Request * rreq)
     }
 
     if (MPIDI_CH4U_REQUEST(rreq, req->areq.dt_iov) == NULL) {
-        mpi_errno = MPIDI_do_accumulate_op(MPIDI_CH4U_REQUEST(rreq, req->areq.data),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.origin_count),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_addr),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_count),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
-                                           0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
+        mpi_errno = MPIDI_CH4U_compute_acc_op(MPIDI_CH4U_REQUEST(rreq, req->areq.data),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.origin_count),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_addr),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_count),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
+                                              0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -737,11 +593,13 @@ static inline int MPIDI_handle_acc_cmpl(MPIR_Request * rreq)
             count = iov[i].iov_len / basic_sz;
             MPIR_Assert(count > 0);
 
-            mpi_errno = MPIDI_do_accumulate_op(src_ptr, count,
-                                               MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
-                                               iov[i].iov_base, count,
-                                               MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
-                                               0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
+            mpi_errno = MPIDI_CH4U_compute_acc_op(src_ptr, count,
+                                                  MPIDI_CH4U_REQUEST(rreq,
+                                                                     req->areq.origin_datatype),
+                                                  iov[i].iov_base, count,
+                                                  MPIDI_CH4U_REQUEST(rreq,
+                                                                     req->areq.target_datatype), 0,
+                                                  MPIDI_CH4U_REQUEST(rreq, req->areq.op));
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             src_ptr += count * basic_sz;
@@ -801,13 +659,13 @@ static inline int MPIDI_handle_get_acc_cmpl(MPIR_Request * rreq)
         MPIR_Memcpy(original, MPIDI_CH4U_REQUEST(rreq, req->areq.target_addr),
                     basic_sz * MPIDI_CH4U_REQUEST(rreq, req->areq.target_count));
 
-        mpi_errno = MPIDI_do_accumulate_op(MPIDI_CH4U_REQUEST(rreq, req->areq.data),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.origin_count),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_addr),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_count),
-                                           MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
-                                           0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
+        mpi_errno = MPIDI_CH4U_compute_acc_op(MPIDI_CH4U_REQUEST(rreq, req->areq.data),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.origin_count),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_addr),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_count),
+                                              MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
+                                              0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -820,11 +678,13 @@ static inline int MPIDI_handle_get_acc_cmpl(MPIR_Request * rreq)
             MPIR_Memcpy(original + offset, iov[i].iov_base, count * basic_sz);
             offset += count * basic_sz;
 
-            mpi_errno = MPIDI_do_accumulate_op(src_ptr, count,
-                                               MPIDI_CH4U_REQUEST(rreq, req->areq.origin_datatype),
-                                               iov[i].iov_base, count,
-                                               MPIDI_CH4U_REQUEST(rreq, req->areq.target_datatype),
-                                               0, MPIDI_CH4U_REQUEST(rreq, req->areq.op));
+            mpi_errno = MPIDI_CH4U_compute_acc_op(src_ptr, count,
+                                                  MPIDI_CH4U_REQUEST(rreq,
+                                                                     req->areq.origin_datatype),
+                                                  iov[i].iov_base, count,
+                                                  MPIDI_CH4U_REQUEST(rreq,
+                                                                     req->areq.target_datatype), 0,
+                                                  MPIDI_CH4U_REQUEST(rreq, req->areq.op));
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             src_ptr += count * basic_sz;

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -159,6 +159,11 @@ static inline int MPIDI_CH4R_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
                 MPIDI_CH4U_WIN(win, info_args).alloc_shared_noncontig = 1;
             else if (!strcmp(curr_ptr->value, "false"))
                 MPIDI_CH4U_WIN(win, info_args).alloc_shared_noncontig = 0;
+        } else if (!strcmp(curr_ptr->key, "alloc_shm")) {
+            if (!strcmp(curr_ptr->value, "true"))
+                MPIDI_CH4U_WIN(win, info_args).alloc_shm = 1;
+            else if (!strcmp(curr_ptr->value, "false"))
+                MPIDI_CH4U_WIN(win, info_args).alloc_shm = 0;
         }
       next:
         curr_ptr = curr_ptr->next;
@@ -228,6 +233,12 @@ static inline int MPIDI_CH4R_win_init(MPI_Aint length,
     MPIDI_CH4U_WIN(win, info_args).same_size = 0;
     MPIDI_CH4U_WIN(win, info_args).same_disp_unit = 0;
     MPIDI_CH4U_WIN(win, info_args).alloc_shared_noncontig = 0;
+    if (win->create_flavor == MPI_WIN_FLAVOR_ALLOCATE
+        || win->create_flavor == MPI_WIN_FLAVOR_SHARED) {
+        MPIDI_CH4U_WIN(win, info_args).alloc_shm = 1;
+    } else {
+        MPIDI_CH4U_WIN(win, info_args).alloc_shm = 0;
+    }
 
     if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
         mpi_errno = MPIDI_CH4R_mpi_win_set_info(win, info);
@@ -699,6 +710,11 @@ static inline int MPIDI_CH4R_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_disp_unit", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_disp_unit", "false");
+
+    if (MPIDI_CH4U_WIN(win, info_args).alloc_shm)
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shm", "true");
+    else
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shm", "false");
 
     MPIR_Assert(mpi_errno == MPI_SUCCESS);
 

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -162,7 +162,8 @@ noinst_PROGRAMS =          \
     overlap_wins_cas  \
     rget_unlock  \
     lock_nested  \
-    rget_testall
+    rget_testall \
+    win_shared_query_null
 
 if BUILD_MPIX_TESTS
 noinst_PROGRAMS += aint

--- a/test/mpi/rma/testlist.def
+++ b/test/mpi/rma/testlist.def
@@ -151,6 +151,7 @@ overlap_wins_fop 3
 overlap_wins_cas 3
 lock_nested 3
 rget_testall 2
+win_shared_query_null 4 mpiversion=3.0
 
 ## This test is not strictly correct.  This was meant to test out the
 ## case when MPI_Test is not nonblocking.  However, we ended up

--- a/test/mpi/rma/win_shared_query_null.c
+++ b/test/mpi/rma/win_shared_query_null.c
@@ -1,0 +1,86 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+/*
+ * Check return values of MPI_Win_allocate_shared with MPI_PROC_NULL.
+ * It should return the first non-zero window segments on the node.
+ * In this test, rank 0 allocates zero window and others allocate non-zero.
+ * Thus, it should return the segment belonging to rank 1.
+ */
+
+int main(int argc, char **argv)
+{
+    int rank, errors = 0;
+    int shm_rank, shm_nproc;
+    MPI_Aint size, query_size;
+    int *query_base, *my_base;
+    int query_disp_unit;
+    MPI_Win shm_win;
+    MPI_Comm shm_comm;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, rank, MPI_INFO_NULL, &shm_comm);
+
+    MPI_Comm_rank(shm_comm, &shm_rank);
+    MPI_Comm_size(shm_comm, &shm_nproc);
+
+    /* Only single process is on the node or the platform does not support shared memory.
+     * Just wait for others' completion*/
+    if (shm_nproc < 2)
+        goto exit;
+
+    size = sizeof(int) * 4;
+
+    /* Allocate zero-byte window on rank 0 and non-zero for others */
+    if (shm_rank == 0) {
+        MPI_Win_allocate_shared(0, sizeof(int), MPI_INFO_NULL, shm_comm, &my_base, &shm_win);
+    } else {
+        MPI_Win_allocate_shared(size, sizeof(int), MPI_INFO_NULL, shm_comm, &my_base, &shm_win);
+    }
+
+    /* Query the segment belonging the lowest rank with size > 0 */
+    MPI_Win_shared_query(shm_win, MPI_PROC_NULL, &query_size, &query_disp_unit, &query_base);
+    MTestPrintfMsg(1, "%d --   shared query with PROC_NULL: base %p, size %ld, unit %d\n",
+                   shm_rank, query_base, query_size, query_disp_unit);
+
+    if (query_base == NULL) {
+        fprintf(stderr, "%d --   shared query with PROC_NULL: base %p, expected non-NULL pointer\n",
+                shm_rank, query_base);
+        fflush(stderr);
+        errors++;
+    }
+
+    if (query_size != size) {
+        fprintf(stderr, "%d --   shared query with PROC_NULL: size %ld, expected %ld\n",
+                shm_rank, query_size, size);
+        fflush(stderr);
+        errors++;
+    }
+
+    if (query_disp_unit != sizeof(int)) {
+        fprintf(stderr, "%d --   shared query with PROC_NULL: disp_unit %d, expected %ld\n",
+                shm_rank, query_disp_unit, sizeof(int));
+        fflush(stderr);
+        errors++;
+    }
+
+    MPI_Win_free(&shm_win);
+
+  exit:
+
+    MPI_Comm_free(&shm_comm);
+    MTest_Finalize(errors);
+
+    return MTestReturnValue(errors);
+}

--- a/test/mpi/rma/win_shared_zerobyte.c
+++ b/test/mpi/rma/win_shared_zerobyte.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     int i, rank, nproc;
     int shm_rank, shm_nproc, last_shm_rank_w;
     MPI_Aint size;
-    int errors = 0, all_errors = 0;
+    int errors = 0;
     int **bases = NULL, *abs_base, *my_base;
     int disp_unit;
     MPI_Win shm_win;
@@ -115,5 +115,5 @@ int main(int argc, char **argv)
     if (bases)
         free(bases);
 
-    return MTestReturnValue(all_errors);
+    return MTestReturnValue(errors);
 }


### PR DESCRIPTION
This PR fixes several minor issues in ch4/rma.
1. Defined two generic routines
2. Introduce alloc_shm hint similar to CH3 (no actual optimization is added, only info hint is added in this PR)
3. Fix bug when calling win_shared_query with MPI_PROC_NULL and add a test to check it.
4. A minor bug fix for test `win_shared_zerobyte`.

This is separated from [PR #3027].