### PR TITLE
mpir: Move function declaration across files

### DIFF
--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -10,25 +10,5 @@
 
 int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
                      MPIR_Comm * comm_ptr, MPI_Request * request);
-int MPIR_Test_impl(MPIR_Request * request, int *flag, MPI_Status * status);
-int MPIR_Testall_impl(int count, MPIR_Request * request_ptrs[], int *flag,
-                      MPI_Status array_of_statuses[], int requests_property);
-int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[],
-                      int *indx, int *flag, MPI_Status * status);
-int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[],
-                       int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
-
-int MPIR_Wait_impl(MPIR_Request * request_ptr, MPI_Status * status);
-int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[],
-                      int request_properties);
-int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_Status * status);
-int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[],
-                       int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
-
-int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status);
-int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
-                 MPI_Status array_of_statuses[]);
-int MPIR_Wait(MPI_Request * request, MPI_Status * status);
-int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);
 
 #endif /* MPIR_PT2PT_H_INCLUDED */

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -413,4 +413,25 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Grequest_poll(MPIR_Request * request_ptr, MPI_
                                                     greq_fns->grequest_extra_state, status);
 }
 
+int MPIR_Test_impl(MPIR_Request * request, int *flag, MPI_Status * status);
+int MPIR_Testall_impl(int count, MPIR_Request * request_ptrs[], int *flag,
+                      MPI_Status array_of_statuses[], int requests_property);
+int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[],
+                      int *indx, int *flag, MPI_Status * status);
+int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[],
+                       int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
+
+int MPIR_Wait_impl(MPIR_Request * request_ptr, MPI_Status * status);
+int MPIR_Waitall_impl(int count, MPIR_Request * request_ptrs[], MPI_Status array_of_statuses[],
+                      int request_properties);
+int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_Status * status);
+int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[],
+                       int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
+
+int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status);
+int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
+                 MPI_Status array_of_statuses[]);
+int MPIR_Wait(MPI_Request * request, MPI_Status * status);
+int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of_statuses[]);
+
 #endif /* MPIR_REQUEST_H_INCLUDED */


### PR DESCRIPTION
This is a simple pull request. Since request function implementations moved to its own request folder, move these function declarations also to the appropriate file. Tagging @raffenet for review.