### PR TITLE
mtest: Fix configure option variable name

### DIFF
--- a/maint/release.pl
+++ b/maint/release.pl
@@ -164,7 +164,7 @@ my $local_git_clone = "${tdir}/mpich-clone";
 
 # clone git repo
 print("===> Cloning git repo... ");
-run_cmd("git clone --recursive ${git_repo} ${local_git_clone}");
+run_cmd("git clone --recursive -b ${branch} ${git_repo} ${local_git_clone}");
 print("done\n");
 
 # chdirs to $local_git_clone if valid

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -706,7 +706,7 @@ fi
 AC_SUBST(largetest)
 
 # Extended collectives test
-if test "$enable_collective_algorithms" = "yes" ; then
+if test "$enable_collalgo_tests" = "yes" ; then
     source $srcdir/coll/test_coll_algos.sh
 else
     coll_algo_tests=""


### PR DESCRIPTION
We changed the configure option from --enable-collective-algorithms
to --enable-collalgo-tests, but forgot to change the corresponding
variable. No collective algorithm tests were running because of this.