### PR TITLE
request: create helper routines for anysource mismatch ULFM.

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -394,6 +394,24 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Request_completion_processing_fastpath(MPI_Req
 int MPIR_Request_completion_processing(MPIR_Request *, MPI_Status *, int *);
 int MPIR_Request_get_error(MPIR_Request *);
 
+MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request *);
+MPL_STATIC_INLINE_PREFIX int MPID_Comm_AS_enabled(MPIR_Comm *);
+extern int MPIR_CVAR_ENABLE_FT;
+
+/* The following routines are ULFM helpers. */
+
+/* This routine check if the request is "anysource" but the communicator is not,
+ * which happens usually due to a failure of a process in the communicator. */
+MPL_STATIC_INLINE_PREFIX int MPIR_Request_is_anysrc_mismatched(MPIR_Request * req_ptr)
+{
+    return (MPIR_CVAR_ENABLE_FT &&
+            !MPIR_Request_is_complete(req_ptr) &&
+            MPID_Request_is_anysource(req_ptr) && !MPID_Comm_AS_enabled((req_ptr)->comm));
+}
+
+/* This routine handle the request when its associated process failed. */
+int MPIR_Request_handle_proc_failed(MPIR_Request * request_ptr);
+
 /* The following routines perform the callouts to the user routines registered
    as part of a generalized request.  They handle any language binding issues
    that are necessary. They are used when completing, freeing, cancelling or

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -195,14 +195,9 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 /* --END ERROR HANDLING-- */
             }
 
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         !MPIR_Request_is_complete(rreq) &&
-                         MPID_Request_is_anysource(rreq) && !MPID_Comm_AS_enabled(rreq->comm))) {
+            if (unlikely(MPIR_Request_is_anysrc_mismatched(rreq))) {
                 /* --BEGIN ERROR HANDLING-- */
-                MPID_Cancel_recv(rreq);
-                MPIR_STATUS_SET_CANCEL_BIT(rreq->status, FALSE);
-                MPIR_ERR_SET(rreq->status.MPI_ERROR, MPIX_ERR_PROC_FAILED, "**proc_failed");
-                mpi_errno = rreq->status.MPI_ERROR;
+                mpi_errno = MPIR_Request_handle_proc_failed(rreq);
                 if (!MPIR_Request_is_complete(sreq)) {
                     MPID_Cancel_send(sreq);
                     MPIR_STATUS_SET_CANCEL_BIT(sreq->status, FALSE);

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -180,6 +180,20 @@ int MPIR_Request_completion_processing(MPIR_Request * request_ptr, MPI_Status * 
     return mpi_errno;
 }
 
+#undef FUNCNAME
+#define FUNCNAME MPIR_Request_handle_proc_failed
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Request_handle_proc_failed(MPIR_Request * request_ptr)
+{
+    if (request_ptr->kind == MPIR_REQUEST_KIND__RECV) {
+        /* We only handle receive request at the moment. */
+        MPID_Cancel_recv(request_ptr);
+        MPIR_STATUS_SET_CANCEL_BIT(request_ptr->status, FALSE);
+    }
+    MPIR_ERR_SET(request_ptr->status.MPI_ERROR, MPIX_ERR_PROC_FAILED, "**proc_failed");
+    return request_ptr->status.MPI_ERROR;
+}
 
 #undef FUNCNAME
 #define FUNCNAME MPIR_Request_get_error

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -88,9 +88,7 @@ int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status)
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* Fall through to the exit */
-    } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                        MPID_Request_is_anysource(request_ptr) &&
-                        !MPID_Comm_AS_enabled(request_ptr->comm))) {
+    } else if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptr))) {
         MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
         if (status != MPI_STATUS_IGNORE)
             status->MPI_ERROR = mpi_errno;

--- a/src/mpi/request/testall.c
+++ b/src/mpi/request/testall.c
@@ -179,9 +179,7 @@ int MPIR_Testall(int count, MPI_Request array_of_requests[], int *flag,
                                 proc_failure = TRUE;
                             mpi_errno = MPI_ERR_IN_STATUS;
                         }
-                    } else if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                                        MPID_Request_is_anysource(request_ptrs[i]) &&
-                                        !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+                    } else if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                         mpi_errno = MPI_ERR_IN_STATUS;
                         MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                         if (!ignoring_status)

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -183,10 +183,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
                 MPID_END_ERROR_CHECKS;
             }
 #endif
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm) &&
-                         !MPIR_Request_is_complete(request_ptrs[i]))) {
+            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                 last_disabled_anysource = i;
             }
 

--- a/src/mpi/request/testsome.c
+++ b/src/mpi/request/testsome.c
@@ -186,10 +186,7 @@ int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount,
                 MPID_END_ERROR_CHECKS;
             }
 #endif
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm) &&
-                         !MPIR_Request_is_complete(request_ptrs[i]))) {
+            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                 proc_failure = TRUE;
                 MPIR_ERR_SET(rc, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");
                 if (array_of_statuses != MPI_STATUSES_IGNORE)

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -140,10 +140,7 @@ int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of
                 /* If one of the requests is an anysource on a communicator that's
                  * disabled such communication, convert this operation to a testall
                  * instead to prevent getting stuck in the progress engine. */
-                if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                             MPID_Request_is_anysource(request_ptrs[i]) &&
-                             !MPIR_Request_is_complete(request_ptrs[i]) &&
-                             !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+                if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                     disabled_anysource = TRUE;
                 }
 

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -213,10 +213,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
             }
 #endif
 
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm) &&
-                         !MPIR_Request_is_complete(request_ptrs[i]))) {
+            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                 last_disabled_anysource = i;
             }
 

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -243,10 +243,7 @@ int MPI_Waitsome(int incount, MPI_Request array_of_requests[],
             /* If one of the requests is an anysource on a communicator that's
              * disabled such communication, convert this operation to a testall
              * instead to prevent getting stuck in the progress engine. */
-            if (unlikely(MPIR_CVAR_ENABLE_FT &&
-                         MPID_Request_is_anysource(request_ptrs[i]) &&
-                         !MPIR_Request_is_complete(request_ptrs[i]) &&
-                         !MPID_Comm_AS_enabled(request_ptrs[i]->comm))) {
+            if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptrs[i]))) {
                 disabled_anysource = TRUE;
             }
         } else {

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -194,6 +194,22 @@ int MPID_Create_intercomm_from_lpids( MPIR_Comm *newcomm_ptr,
 
 #define MPID_INTERCOMM_NO_DYNPROC(comm) (0)
 
+/* ULFM support */
+MPL_STATIC_INLINE_PREFIX int MPID_Comm_AS_enabled(MPIR_Comm * comm_ptr)
+{
+    return comm_ptr->dev.anysource_enabled;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request * request_ptr)
+{
+    int ret = 0;
+
+    if (request_ptr->kind == MPIR_REQUEST_KIND__RECV)
+        ret = request_ptr->dev.match.parts.rank == MPI_ANY_SOURCE;
+
+    return ret;
+}
+
 /* communicator hooks */
 int MPIDI_CH3I_Comm_create_hook(struct MPIR_Comm *);
 int MPIDI_CH3I_Comm_destroy_hook(struct MPIR_Comm *);

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -627,10 +627,6 @@ int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
 int MPID_Cancel_send(MPIR_Request *);
 int MPID_Cancel_recv(MPIR_Request *);
 
-int MPID_Comm_AS_enabled(MPIR_Comm *);
-
-int MPID_Request_is_anysource(MPIR_Request *);
-
 MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp);
 
 MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);

--- a/src/mpid/ch3/src/mpid_comm_failure_ack.c
+++ b/src/mpid/ch3/src/mpid_comm_failure_ack.c
@@ -72,25 +72,3 @@ fn_exit:
 fn_fail:
     goto fn_exit;
 }
-
-#undef FUNCNAME
-#define FUNCNAME MPID_Comm_AS_enabled
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-int MPID_Comm_AS_enabled(MPIR_Comm *comm_ptr) {
-    return comm_ptr->dev.anysource_enabled;
-}
-
-
-#undef FUNCNAME
-#define FUNCNAME MPID_Request_is_anysource
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-int MPID_Request_is_anysource(MPIR_Request *request_ptr) {
-    int ret = 0;
-
-    if (request_ptr->kind == MPIR_REQUEST_KIND__RECV)
-        ret = request_ptr->dev.match.parts.rank == MPI_ANY_SOURCE;
-
-    return ret;
-}


### PR DESCRIPTION
This cleanup the check whether the communicator stops support anysource at runtime, which means a process in that comm has failed.