### PR TITLE
ch4/ofi: Set FI_WAIT_UNSPEC for RMA per-window sync counters

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -109,6 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_set_per_win_sync(MPIR_Win * win)
     struct fi_cntr_attr cntr_attr;
     memset(&cntr_attr, 0, sizeof(cntr_attr));
     cntr_attr.events = FI_CNTR_EVENTS_COMP;
+    cntr_attr.wait_obj = FI_WAIT_UNSPEC;
     MPIDI_OFI_CALL_RETURN(fi_cntr_open(MPIDI_Global.domain,     /* In:  Domain Object        */
                                        &cntr_attr,      /* In:  Configuration object */
                                        &MPIDI_OFI_WIN(win).cmpl_cntr,   /* Out: Counter Object       */


### PR DESCRIPTION
FI_WAIT_UNSPEC was introduced before in commit
ba71745d02476350f10e1c8d78805f967bcd5671. It
somehow got removed and this patch brings this attribute back to window
counter.