### PR TITLE
ch4: Introduce work queue infrastructure

### DIFF
--- a/maint/decode_handle
+++ b/maint/decode_handle
@@ -27,6 +27,7 @@ my @kind_table = qw(
     REQUEST
     PROCGROUP
     VCONN
+    WORKQ_ELEM
     GREQ_CLASS
 );
 
@@ -74,6 +75,7 @@ while (scalar @ARGV) {
 ##   MPIR_REQUEST    = 0xb,
 ##   MPIR_PROCGROUP  = 0xc,               /* These are internal device objects */
 ##   MPIR_VCONN      = 0xd,
+##   MPIR_WORKQ_ELEM = 0xe,
 ##   MPIR_GREQ_CLASS = 0xf
 ##   } MPII_Object_kind;
 ##

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -155,6 +155,7 @@ typedef enum MPII_Object_kind {
     MPIR_REQUEST = 0xb,
     MPIR_PROCGROUP = 0xc,       /* These are internal device objects */
     MPIR_VCONN = 0xd,
+    MPIR_WORKQ_ELEM = 0xe,      /* Work queue element, currently only meaningful in CH4 */
     MPIR_GREQ_CLASS = 0xf
 } MPII_Object_kind;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -429,7 +429,7 @@ typedef struct {
 #define MPID_DEV_COMM_DECL       MPIDI_Devcomm_t dev;
 #define MPID_DEV_OP_DECL         MPIDI_Devop_t   dev;
 
-typedef struct {
+typedef struct MPIDI_av_entry {
     union {
     MPIDI_NM_ADDR_DECL} netmod;
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -184,6 +184,10 @@ typedef struct {
 
         union {
         MPIDI_SHM_REQUEST_DECL} shm;
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+        MPIDI_workq_elemt_t command;
+#endif
     } ch4;
 } MPIDI_Devreq_t;
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -22,6 +22,16 @@ MPIDI_av_table_t *MPIDI_av_table0;
 MPIDI_NM_funcs_t *MPIDI_NM_func;
 MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 
+#if defined(MPIDI_CH4_USE_WORK_QUEUES)
+struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC] = { {0}
+};
+
+MPIR_Object_alloc_t MPIDI_workq_elemt_mem = {
+    0, 0, 0, 0, MPIR_WORKQ_ELEM, sizeof(struct MPIDI_workq_elemt), MPIDI_workq_elemt_direct,
+    MPIDI_WORKQ_ELEMT_PREALLOC
+};
+#endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
+
 unsigned PVAR_LEVEL_posted_recvq_length ATTRIBUTE((unused));
 unsigned PVAR_LEVEL_unexpected_recvq_length ATTRIBUTE((unused));
 unsigned long long PVAR_COUNTER_posted_recvq_match_attempts ATTRIBUTE((unused));

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -13,5 +13,133 @@
 #define CH4I_WORKQ_H_INCLUDED
 
 #include "ch4i_workq_types.h"
+#include <utlist.h>
+
+#if defined(MPIDI_CH4_USE_WORK_QUEUES)
+struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
+extern MPIR_Object_alloc_t MPIDI_workq_elemt_mem;
+
+MPL_STATIC_INLINE_PREFIX struct MPIDI_workq_elemt *MPIDI_workq_elemt_create(void)
+{
+    return MPIR_Handle_obj_alloc(&MPIDI_workq_elemt_mem);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_elemt_free(struct MPIDI_workq_elemt *elemt)
+{
+    MPIR_Handle_obj_free(&MPIDI_workq_elemt_mem, elemt);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_t * workq,
+                                                        MPIDI_workq_op_t op,
+                                                        const void *send_buf,
+                                                        void *recv_buf,
+                                                        MPI_Aint count,
+                                                        MPI_Datatype datatype,
+                                                        int rank,
+                                                        int tag,
+                                                        MPIR_Comm * comm_ptr,
+                                                        int context_offset,
+                                                        MPIDI_av_entry_t * addr,
+                                                        MPI_Status * status,
+                                                        MPIR_Request * request,
+                                                        int *flag,
+                                                        MPIR_Request ** message,
+                                                        OPA_int_t * processed)
+{
+    MPIDI_workq_elemt_t *pt2pt_elemt;
+
+    MPIR_Assert(request != NULL);
+
+    MPIR_Request_add_ref(request);
+    pt2pt_elemt = &request->dev.ch4.command;
+    pt2pt_elemt->op = op;
+    pt2pt_elemt->processed = processed;
+    pt2pt_elemt->pt2pt.send_buf = send_buf;
+    pt2pt_elemt->pt2pt.recv_buf = recv_buf;
+    pt2pt_elemt->pt2pt.count = count;
+    pt2pt_elemt->pt2pt.datatype = datatype;
+    pt2pt_elemt->pt2pt.rank = rank;
+    pt2pt_elemt->pt2pt.tag = tag;
+    pt2pt_elemt->pt2pt.comm_ptr = comm_ptr;
+    pt2pt_elemt->pt2pt.context_offset = context_offset;
+    pt2pt_elemt->pt2pt.addr = addr;
+    pt2pt_elemt->pt2pt.status = status;
+    pt2pt_elemt->pt2pt.request = request;
+    pt2pt_elemt->pt2pt.flag = flag;
+    pt2pt_elemt->pt2pt.message = message;
+
+    MPIDI_workq_enqueue(workq, pt2pt_elemt);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_t * workq,
+                                                      MPIDI_workq_op_t op,
+                                                      const void *origin_addr,
+                                                      int origin_count,
+                                                      MPI_Datatype origin_datatype,
+                                                      void *result_addr,
+                                                      int result_count,
+                                                      MPI_Datatype result_datatype,
+                                                      int target_rank,
+                                                      MPI_Aint target_disp,
+                                                      int target_count,
+                                                      MPI_Datatype target_datatype,
+                                                      MPI_Op acc_op,
+                                                      MPIR_Group * group,
+                                                      int lock_type,
+                                                      int assert,
+                                                      MPIR_Win * win_ptr,
+                                                      MPIDI_av_entry_t * addr,
+                                                      OPA_int_t * processed)
+{
+    MPIDI_workq_elemt_t *rma_elemt = NULL;
+    rma_elemt = MPIDI_workq_elemt_create();
+    rma_elemt->op = op;
+    rma_elemt->processed = processed;
+    rma_elemt->rma.origin_addr = origin_addr;
+    rma_elemt->rma.origin_count = origin_count;
+    rma_elemt->rma.origin_datatype = origin_datatype;
+    rma_elemt->rma.result_addr = result_addr;
+    rma_elemt->rma.result_count = result_count;
+    rma_elemt->rma.result_datatype = result_datatype;
+    rma_elemt->rma.target_rank = target_rank;
+    rma_elemt->rma.target_disp = target_disp;
+    rma_elemt->rma.target_count = target_count;
+    rma_elemt->rma.target_datatype = target_datatype;
+    rma_elemt->rma.acc_op = acc_op;
+    rma_elemt->rma.group = group;
+    rma_elemt->rma.lock_type = lock_type;
+    rma_elemt->rma.assert = assert;
+    rma_elemt->rma.win_ptr = win_ptr;
+    rma_elemt->rma.addr = addr;
+
+    MPIDI_workq_enqueue(workq, rma_elemt);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_release_pt2pt_elemt(MPIDI_workq_elemt_t * workq_elemt)
+{
+    MPIR_Request *req;
+    req = MPL_container_of(workq_elemt, MPIR_Request, dev.ch4.command);
+    MPIR_Request_free(req);
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_elemt)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *req;
+
+    switch (workq_elemt->op) {
+        default:
+            mpi_errno = MPI_ERR_OTHER;
+            goto fn_fail;
+    }
+
+  fn_fail:
+    return mpi_errno;
+}
+
+#else /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
+#define MPIDI_workq_pt2pt_enqueue(...)
+#define MPIDI_workq_rma_enqueue(...)
+#endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
 
 #endif /* CH4I_WORKQ_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -1,0 +1,17 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#ifndef CH4I_WORKQ_H_INCLUDED
+#define CH4I_WORKQ_H_INCLUDED
+
+#include "ch4i_workq_types.h"
+
+#endif /* CH4I_WORKQ_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -25,6 +25,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_dequeue(MPIDI_workq_t * q, void **pp)
 {
 }
 
+#define MPIDI_WORKQ_ELEMT_PREALLOC 64   /* Number of elements to preallocate in the "direct" block */
+
 typedef enum MPIDI_workq_op MPIDI_workq_op_t;
 
 /* Indentifies the delegated operation */

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -1,0 +1,91 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+#ifndef CH4I_WORKQ_TYPES_H_INCLUDED
+#define CH4I_WORKQ_TYPES_H_INCLUDED
+
+/* Stub implementation for an atomic queue */
+typedef void *MPIDI_workq_t;
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_init(MPIDI_workq_t * q)
+{
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_enqueue(MPIDI_workq_t * q, void *p)
+{
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_workq_dequeue(MPIDI_workq_t * q, void **pp)
+{
+}
+
+typedef enum MPIDI_workq_op MPIDI_workq_op_t;
+
+/* Indentifies the delegated operation */
+enum MPIDI_workq_op { SEND, ISEND, SSEND, ISSEND, RSEND, IRSEND, RECV, IRECV, IPROBE,
+    IMPROBE, PUT, GET, POST, COMPLETE, FENCE, LOCK, UNLOCK, LOCK_ALL, UNLOCK_ALL,
+    FLUSH, FLUSH_ALL, FLUSH_LOCAL, FLUSH_LOCAL_ALL
+};
+
+typedef struct MPIDI_workq_elemt MPIDI_workq_elemt_t;
+typedef struct MPIDI_workq_list MPIDI_workq_list_t;
+
+typedef struct MPIDI_av_entry MPIDI_av_entry_t;
+
+/* Structure to encapsulate MPI operations that are delegated to another thread
+ * Can be allocated from an MPI object pool or embedded in another object (e.g. request) */
+struct MPIDI_workq_elemt {
+    MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
+    MPIDI_workq_op_t op;
+    OPA_int_t *processed;       /* set to true by the progress thread when
+                                 * this work item is done */
+    union {
+        struct {
+            const void *send_buf;
+            void *recv_buf;
+            MPI_Aint count;
+            MPI_Datatype datatype;
+            int rank;
+            int tag;
+            MPIR_Comm *comm_ptr;
+            int context_offset;
+            MPIDI_av_entry_t *addr;
+            MPI_Status *status;
+            MPIR_Request *request;
+            int *flag;          /* needed for the probe routines */
+            MPIR_Request **message;     /* used for mprobe */
+        } pt2pt;
+        struct {
+            const void *origin_addr;
+            int origin_count;
+            MPI_Datatype origin_datatype;
+            void *result_addr;
+            int result_count;
+            MPI_Datatype result_datatype;
+            int target_rank;
+            MPI_Aint target_disp;
+            int target_count;
+            MPI_Datatype target_datatype;
+            MPI_Op acc_op;
+            MPIR_Group *group;
+            int lock_type;
+            int assert;         /* assert for sync functions */
+            MPIR_Win *win_ptr;
+            MPIDI_av_entry_t *addr;
+        } rma;
+    };
+};
+
+/* List structure to implement per-object (e.g. per-communicator, per-window) work queues */
+struct MPIDI_workq_list {
+    MPIDI_workq_t pend_ops;
+    MPIDI_workq_list_t *next, *prev;
+};
+
+#endif /* CH4I_WORKQ_TYPES_H_INCLUDED */

--- a/src/util/mem/handlemem.c
+++ b/src/util/mem/handlemem.c
@@ -165,6 +165,7 @@ const char *MPIR_Handle_get_kind_str(int kind)
             mpiu_name_case_(REQUEST);
             mpiu_name_case_(PROCGROUP);
             mpiu_name_case_(VCONN);
+            mpiu_name_case_(WORKQ_ELEM);
             mpiu_name_case_(GREQ_CLASS);
         default:
             return "unknown";


### PR DESCRIPTION
This PR introduces a work queue type definitions and enqueue/dequeue functions.

This is a break down of #3117.  This PR implements the first one of the following topics to introduce better multi-threading to MPICH/CH4.
1. **work queue infrastructure** (this PR)
2. per-VNI critical section
3. CH4 multi-threading models (direct, trylock, handoff)
4. CH4-level support for handoff (indirectly supports trylock-enqueue as well); only supports single VNI
5. OFI-level support for handoff (similarly, indirectly supports trylock-enqueue as well); only supports single VNI
6. Enhancement of 4 and 6 to support multiple VNIs.

Tagging @raffenet for review.