### PR TITLE
Collective Selection JSON Mockup

### DIFF
--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -12,3 +12,4 @@ include $(top_srcdir)/src/util/procmap/Makefile.mk
 include $(top_srcdir)/src/util/nodemap/Makefile.mk
 include $(top_srcdir)/src/util/wrappers/Makefile.mk
 include $(top_srcdir)/src/util/assert/Makefile.mk
+include $(top_srcdir)/src/util/decision_tree/Makefile.mk

--- a/src/util/decision_tree/Makefile.mk
+++ b/src/util/decision_tree/Makefile.mk
@@ -1,0 +1,6 @@
+AM_CPPFLAGS += -I$(top_srcdir)/src/util/decision_tree
+
+noinst_HEADERS +=                                    \
+    src/util/decision_tree/decision_tree_types.h
+
+mpi_core_sources += src/util/decision_tree/decision_tree.c

--- a/src/util/decision_tree/decision_tree.c
+++ b/src/util/decision_tree/decision_tree.c
@@ -1,0 +1,9 @@
+#ifndef MPIU_DECISION_TREE_H_INCLUDED
+#define MPIU_DECISION_TREE_H_INCLUDED
+
+#include "mpiimpl.h"
+#include "decision_tree_types.h"
+
+cJSON *mpiu_decision_tree;
+
+#endif /* MPIU_DECISION_TREE_H_INCLUDED */

--- a/src/util/decision_tree/decision_tree_types.h
+++ b/src/util/decision_tree/decision_tree_types.h
@@ -1,0 +1,22 @@
+#ifndef MPIU_DECISION_TREE_TYPES_H_INCLUDED
+#define MPIU_DECISION_TREE_TYPES_H_INCLUDED
+
+/* Uses JSON parser from this repository (MIT license):
+ * https://github.com/DaveGamble/cJSON
+ */
+extern cJSON *mpiu_decision_tree;
+
+int MPIU_Decision_tree_parse(char *filename);
+
+/* Function to traverse the JSON object to find the appropriate algorithm for the particular input:
+ *
+ * coll_name - The stringified name of the collective
+ * comm_ptr - The communicator being used in the collective
+ * msg_size - The size of messages that will be sent by the collective
+ * datatype - The datatype being used by the collective (for 'W' collectives, this value is ignored)
+ * coll_info - The JSON node with the information about which algorithm to use.
+ */
+int MPIU_Decision_tree_traverse(const char *coll_name, MPIR_Comm * comm_ptr, size_t msg_size,
+                                MPI_Datatype datatype, const cJSON * coll_info);
+
+#endif /* MPIU_DECISION_TREE_TYPES_H_INCLUDED */

--- a/src/util/decision_tree/sample.json
+++ b/src/util/decision_tree/sample.json
@@ -1,0 +1,99 @@
+{ "collective": "reduce",
+    "children":
+    [
+        {
+            "type": "comm_size", "comparison": "lt", "value": 32,
+            "children":
+            [
+                {
+                    "type": "node_size", "comparison": "lte", "value": 8, "algorithm":
+                    {
+                        "mpir": "device",
+                        "device":
+                        {
+                            "algorithm": "alpha",
+                            "netmod":
+                            {
+                                "algorithm": "binomial", "kval": 4
+                            },
+                            "shm":
+                            {
+                                "algorithm": "one"
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "node_size", "comparison": "gt", "value": 8, "algorithm":
+                    {
+                        "mpir": "device",
+                        "device":
+                        {
+                            "algorithm": "netmod",
+                            "netmod":
+                            {
+                                "algorithm": "binomial", "kval": 8
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "type": "msg_size", "comparison": "gt", "value": 1024,
+            "children":
+            [
+                {
+                    "type": "comm_kind", "comparison": "eq", "value": "intra", "algorithm":
+                    {
+                        "mpir": "device",
+                        "device":
+                        {
+                            "algorithm": "beta",
+                            "netmod":
+                            {
+                                "algorithm": "binomial", "kval": 8
+                            },
+                            "shm":
+                            {
+                                "algorithm": "one", "buffer_size": 128
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+},
+
+{ "collective": "bcast",
+    "children":
+    [
+        {
+            "type": "comm_kind", "comparison": "eq", "value": "intra", "algorithm":
+            {
+                "mpir": "device",
+                "device":
+                {
+                    "algorithm": "gamma",
+                    "netmod":
+                    {
+                        "algorithm": "recursive_doubling"
+                    },
+                    "shm":
+                    {
+                        "algorithm": "two", "buffer_size": 256
+                    }
+                }
+            }
+        },
+        {
+            "__COMMENT__": "Having no type means this is the catchall else statement",
+            "algorithm":
+            {
+                "mpir": "device",
+                "__COMMENT__": "Having nothing under mpir means the device should do it's own seleciton"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR obviously still has a lot of TODO items, but it is a pretty good, short example of what the collective selection code could look like.

It relies on the external C JSON parser found here: https://github.com/DaveGamble/cJSON

The general structure is that there would be a new CVAR to turn on the decision tree code, otherwise the existing collective selection code will be used (CVARs, if statements, and `MPIR` -> `MPID` -> netmod` code).

The JSON object is completely parsed and traversed in the `MPIR_Reduce_decision_tree` function. However, if the decision tree says that a device-level algorithm or below should be used, that part of the JSON object will be passed down to the device, which should grab any important information from the object and call the appropriate algorithm.

Note that this does not require any additional decision making at the device or netmod/shmod layer as all of that is included in the decision tree itself (we don't support multiple devices or netmods so this shouldn't be a problem).

A sample version of the JSON file is also included with a few comments sprinkled through.

Things to be discussed and/or done:
* [ ] Move the CVAR to some common file
* [ ] Calculate the size of the data buffers
* [ ] Combine the intra and inter algorithm enums into a single enum
* [ ] Generalize string matching for algorithm names (remove from `MPII_Coll_init`)
* [ ] Separate enum `switch` statement for algorithm selection
* [ ] Potentially combine `MPID_Reduce_decision_tree` and `MPID_Reduce` to avoid duplication