### PR TITLE
coll: Add recursive exchange algorithm for barrier

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -742,6 +742,7 @@ int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 /* sched-based intracomm-only functions */
 int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
 int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_intra_recexch(MPIR_Comm * comm, MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);

--- a/src/mpi/coll/ibarrier/Makefile.mk
+++ b/src/mpi/coll/ibarrier/Makefile.mk
@@ -17,4 +17,5 @@ mpi_sources +=                                  \
 
 mpi_core_sources +=                                      \
     src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c  \
-    src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
+    src/mpi/coll/ibarrier/ibarrier_inter_bcast.c  \
+    src/mpi/coll/ibarrier/ibarrier_intra_recexch.c

--- a/src/mpi/coll/ibarrier/ibarrier_gentran_algos.c
+++ b/src/mpi/coll/ibarrier/ibarrier_gentran_algos.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *  See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *   Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "mpiimpl.h"
+
+#include "tsp_gentran.h"
+
+/* instantiate ibarrier recexch algorithms for the gentran transport */
+#include "ibarrier_tsp_recexch_algos_prototypes.h"
+#include "ibarrier_tsp_recexch_algos.h"
+#include "ibarrier_tsp_recexch_algos_undef.h"
+
+#include "tsp_undef.h"

--- a/src/mpi/coll/ibarrier/ibarrier_intra_recexch.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_recexch.c
@@ -1,0 +1,34 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "mpiimpl.h"
+
+/* generate gentran algo prototypes */
+#include "tsp_gentran.h"
+#include "../iallreduce/iallreduce_tsp_recexch_algos_prototypes.h"
+#include "tsp_undef.h"
+
+#undef FUNCNAME
+#define FUNCNAME MPIR_Ibarrier_intra_recexch
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Ibarrier_intra_recexch(MPIR_Comm * comm, MPIR_Request ** req)
+{
+    int mpi_errno = MPI_SUCCESS;
+    void *recvbuf = NULL;
+
+    mpi_errno =
+        MPII_Gentran_Iallreduce_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE, MPI_SUM, comm,
+                                              req, IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
+                                              MPIR_CVAR_IBARRIER_RECEXCH_KVAL);
+
+    return mpi_errno;
+}

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -276,6 +276,7 @@ extern MPIR_Ialltoallw_inter_algo_t MPIR_Ialltoallw_inter_algo_choice;
 typedef enum MPIR_Ibarrier_intra_algo_t {
     MPIR_IBARRIER_INTRA_ALGO_AUTO,
     MPIR_IBARRIER_INTRA_ALGO_RECURSIVE_DOUBLING,
+    MPIR_IBARRIER_INTRA_ALGO_GENTRAN_RECEXCH,
 } MPIR_Ibarrier_intra_algo_t;
 extern MPIR_Ibarrier_intra_algo_t MPIR_Ibarrier_intra_algo_choice;
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -471,6 +471,8 @@ int MPII_Coll_init(void)
     /* Ibarrier Intra */
     if (0 == strcmp(MPIR_CVAR_IBARRIER_INTRA_ALGORITHM, "recursive_doubling"))
         MPIR_Ibarrier_intra_algo_choice = MPIR_IBARRIER_INTRA_ALGO_RECURSIVE_DOUBLING;
+    if (0 == strcmp(MPIR_CVAR_IBARRIER_INTRA_ALGORITHM, "recexch"))
+        MPIR_Ibarrier_intra_algo_choice = MPIR_IBARRIER_INTRA_ALGO_GENTRAN_RECEXCH;
     else
         MPIR_Ibarrier_intra_algo_choice = MPIR_IBARRIER_INTRA_ALGO_AUTO;
 


### PR DESCRIPTION
We implement recursive exchange barrier as recursive
exchange allreduce with zero data. There are no
tests for barrier collective, so we are not adding
any test for this algorithm.