### PR TITLE
#Network level hints 1: Comm split type: minimum communicator size hint

### DIFF
--- a/src/include/netloc_util.h
+++ b/src/include/netloc_util.h
@@ -42,4 +42,9 @@ int MPIR_Netloc_get_switches_at_level(netloc_topology_t netloc_topology,
                                       MPIR_Netloc_network_attributes attributes, int level,
                                       netloc_node_t *** switches_at_level, int *switch_count);
 
+int MPIR_Netloc_get_hostnode_index_in_tree(MPIR_Netloc_network_attributes attributes,
+                                           netloc_topology_t topology,
+                                           netloc_node_t * network_endpoint,
+                                           int *index, int *num_nodes);
+
 #endif /* NETLOC_UTIL_H_INCLUDED */

--- a/src/include/netloc_util.h
+++ b/src/include/netloc_util.h
@@ -26,6 +26,8 @@ typedef struct {
             int *node_levels;
         } tree;
     } u;
+
+    netloc_node_t *network_endpoint;
 } MPIR_Netloc_network_attributes;
 
 int MPIR_Netloc_parse_topology(netloc_topology_t topology,

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -385,13 +385,8 @@ static int network_split_switch_level(MPIR_Comm * comm_ptr, int key,
         traversal_stack =
             (netloc_node_t **) MPL_malloc(sizeof(netloc_node_t *) *
                                           MPIR_Process.netloc_topology->num_nodes, MPL_MEM_OTHER);
-        mpi_errno =
-            MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
-                                              MPIR_Process.netloc_topology,
-                                              MPIR_Process.hwloc_topology, MPIR_Process.bindset,
-                                              &network_node);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+
+        network_node = MPIR_Process.network_attr.network_endpoint;
 
         traversal_begin = 0;
         traversal_end = 0;

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -363,15 +363,23 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
 #ifdef HAVE_NETLOC
     MPIR_Process.network_attr.u.tree.node_levels = NULL;
+    MPIR_Process.network_attr.network_endpoint = NULL;
+    MPIR_Process.netloc_topology = NULL;
+    MPIR_Process.network_attr.type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
     if (strlen(MPIR_CVAR_NETLOC_NODE_FILE)) {
         mpi_errno =
             netloc_parse_topology(&MPIR_Process.netloc_topology, MPIR_CVAR_NETLOC_NODE_FILE);
         if (mpi_errno == NETLOC_SUCCESS) {
-            MPIR_Netloc_parse_topology(MPIR_Process.netloc_topology, &MPIR_Process.network_attr);
+            mpi_errno =
+                MPIR_Netloc_parse_topology(MPIR_Process.netloc_topology,
+                                           &MPIR_Process.network_attr);
+            if (mpi_errno == MPI_SUCCESS) {
+                MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
+                                                  MPIR_Process.netloc_topology,
+                                                  MPIR_Process.hwloc_topology, MPIR_Process.bindset,
+                                                  &MPIR_Process.network_attr.network_endpoint);
+            }
         }
-    } else {
-        MPIR_Process.netloc_topology = NULL;
-        MPIR_Process.network_attr.type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
     }
 #endif
     /* For any code in the device that wants to check for runtime

--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -22,7 +22,7 @@ static const char *split_topo[] = {
 };
 
 static const char *split_topo_network[] = {
-    "switch_level:2", NULL
+    "switch_level:2", "subcomm_min_size:2", NULL
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR contains the minimum communicator size hint for tree topology. When the user supplies a hint indicating the minimum communicator size, subcommunicators are created such that each contains atleast as many processes are the hint. The algorithm works as follows:

1. step 1 indexes leaf nodes of tree topology from left to right and identifies the leaf node (host node) each process is attached to. 
2. The index leaf node for each process is communicated to all processes such that every process now has its own index and the number of processes attached with each leaf node in the tree.
3. Unique color for comm split type is computed by counting how many processes are attached to each leaf node from left to right, in the indexed leaf node array.

Subcommunicator creation first works at network level, splitting further at node level. Once the subcommunicator is identified to be local to a node, assuming that the hint is 3 and the number of processes per node is 4, the algorithm tries to split further within the node to see if it can get closer to 3 per subcommunicator.  If the hint is 5 and number of processes on the node is 4, the subcommunicator is created such that it covers two nodes, instead of one.