### PR TITLE
test/bugfix: persistent receive with anysource.

### DIFF
--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -28,18 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Startall(int count, MPIR_Request * requests[])
     int i;
     for (i = 0; i < count; i++) {
         MPIR_Request *req = requests[i];
-        /* This is sub-optimal, can we do better? */
-        if (MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req)) {
-            mpi_errno = MPIDI_SHM_mpi_startall(1, &req);
-            if (mpi_errno == MPI_SUCCESS) {
-                mpi_errno = MPIDI_NM_mpi_startall(1, &MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req));
-                MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req->u.persist.real_request) =
-                    MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req)->u.persist.real_request;
-                MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER
-                                                     (req)->u.persist.real_request) =
-                    req->u.persist.real_request;
-            }
-        } else if (MPIDI_CH4I_REQUEST(req, is_local))
+        if (MPIDI_CH4I_REQUEST(req, is_local))
             mpi_errno = MPIDI_SHM_mpi_startall(1, &req);
         else
             mpi_errno = MPIDI_NM_mpi_startall(1, &req);

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -58,7 +58,9 @@ noinst_PROGRAMS =  \
     huge_dupcomm   \
     dtype_send		 \
     recv_any		\
-    irecv_any
+    irecv_any		\
+    precv_anysrc	\
+    precv_anysrc_exp
 
 irecv_any_CPPFLAGS = -DTEST_NB $(AM_CPPFLAGS)
 irecv_any_SOURCES  = recv_any.c

--- a/test/mpi/pt2pt/precv_anysrc.c
+++ b/test/mpi/pt2pt/precv_anysrc.c
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <mpi.h>
+#include "mpitest.h"
+
+int sizes[] = { 64, 32768, 2000000 };
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    int rank, i, j, msg_size;
+    char *buf;
+    MPI_Request req;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    for (i = 0; i < 3; i++) {
+        msg_size = sizes[i];
+        buf = malloc(msg_size);
+        memset(buf, 0, msg_size);
+
+        if (rank == 0) {
+            MTestPrintfMsg(1, "Begin testing size = %d\n", msg_size);
+            MPI_Recv_init(buf, msg_size, MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD,
+                          &req);
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Start(&req);
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+
+            MPI_Request_free(&req);
+        } else if (rank == 1) {
+            for (j = 0; j < msg_size; j++)
+                buf[j] = j % 100;
+
+            MPI_Isend(buf, msg_size, MPI_BYTE, 0, 1, MPI_COMM_WORLD, &req);
+            MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+        }
+
+        for (j = 0; j < msg_size; j++)
+            errs += (buf[j] != (j % 100));
+
+        free(buf);
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/pt2pt/precv_anysrc_exp.c
+++ b/test/mpi/pt2pt/precv_anysrc_exp.c
@@ -1,0 +1,50 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <mpi.h>
+#include "mpitest.h"
+
+int sizes[] = { 64, 32768, 2000000 };
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    int rank, i, j, msg_size;
+    char *buf;
+    MPI_Request req;
+
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    for (i = 0; i < 3; i++) {
+        msg_size = sizes[i];
+        buf = malloc(msg_size);
+        memset(buf, 0, msg_size);
+
+        if (rank == 0) {
+            MTestPrintfMsg(1, "Begin testing size = %d\n", msg_size);
+            MPI_Recv_init(buf, msg_size, MPI_BYTE, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD,
+                          &req);
+
+            MPI_Start(&req);
+            MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Wait(&req, MPI_STATUS_IGNORE);
+
+            MPI_Request_free(&req);
+        } else if (rank == 1) {
+            for (j = 0; j < msg_size; j++)
+                buf[j] = j % 100;
+
+            MPI_Barrier(MPI_COMM_WORLD);
+            MPI_Send(buf, msg_size, MPI_BYTE, 0, 1, MPI_COMM_WORLD);
+        }
+
+        for (j = 0; j < msg_size; j++)
+            errs += (buf[j] != (j % 100));
+
+        free(buf);
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/pt2pt/testlist.def
+++ b/test/mpi/pt2pt/testlist.def
@@ -47,3 +47,5 @@ huge_dupcomm 2
 dtype_send 2
 recv_any 2
 irecv_any 2
+precv_anysrc 2 timeLimit=60
+precv_anysrc_exp 2 timeLimit=60


### PR DESCRIPTION
This test hangs ch4/ofi/psm2 on an omnipath, found while testing graph500 new reference implementation.
This PR is for checking with other ch3/ch4 and fixing.
Update: Two independent bugs are found:
1) The ch4 MPID_Startall originally did startall for both SHM and NM layer if `MPI_ANY_SOURCE` is specified, which then posted `Irecv` twice for SHM, one in the `MPIDI_SHM_mpi_startall`, and one in ch4 `MPID_Irecv` of `MPIDI_NM_mpi_startall`.
2) When AM layer of OFI is used, Irecv can complete immediately if the message is already arrived (in unexpected queue), in this case the implementation did not clear the partner request causing hang (because `MPID_Waitall` only check the partner request).