### PR TITLE
#Network level hints 4: Torus network detection and split hints for torus topology

### DIFF
--- a/src/include/netloc_util.h
+++ b/src/include/netloc_util.h
@@ -21,7 +21,7 @@ typedef struct {
 
     union {
         struct {
-            /* the levels at which the host and switch nodes are in
+            /* The levels at which the host and switch nodes are in
              * the network */
             int *node_levels;
         } tree;

--- a/src/include/netloc_util.h
+++ b/src/include/netloc_util.h
@@ -13,6 +13,7 @@
 typedef enum {
     MPIR_NETLOC_NETWORK_TYPE__FAT_TREE,
     MPIR_NETLOC_NETWORK_TYPE__CLOS_NETWORK,
+    MPIR_NETLOC_NETWORK_TYPE__TORUS,
     MPIR_NETLOC_NETWORK_TYPE__INVALID,
 } MPIR_Netloc_network_topo_type;
 
@@ -25,6 +26,13 @@ typedef struct {
              * the network */
             int *node_levels;
         } tree;
+        struct {
+            int dimension;
+            int *geometry;
+            /* Flat index of the node the current
+             * rank is mapped to */
+            int node_idx;
+        } torus;
     } u;
 
     netloc_node_t *network_endpoint;

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -511,7 +511,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
 
         /* Send the count to processes */
         mpi_errno =
-            MPIR_Allreduce(MPI_IN_PLACE, num_processes_at_node, num_nodes, MPI_INT,
+            MPID_Allreduce(MPI_IN_PLACE, num_processes_at_node, num_nodes, MPI_INT,
                            MPI_SUM, comm_ptr, &errflag);
 
         color =
@@ -542,7 +542,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
 
             /* Send the bindset to processes in node communicator */
             mpi_errno =
-                MPIR_Allreduce(MPI_IN_PLACE, node_comm_bindset,
+                MPID_Allreduce(MPI_IN_PLACE, node_comm_bindset,
                                num_procs * sizeof(hwloc_cpuset_t), MPI_BYTE,
                                MPI_NO_OP, node_comm, &errflag);
 
@@ -667,14 +667,14 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
      * its hintval size to the global max, and makes sure that this
      * comparison is successful on all processes. */
     mpi_errno =
-        MPIR_Allreduce(&hintval_size, &hintval_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
+        MPID_Allreduce(&hintval_size, &hintval_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     hintval_equal = (hintval_size == hintval_size_max);
 
     mpi_errno =
-        MPIR_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
+        MPID_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -688,7 +688,7 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
     hintval_global = (char *) MPL_malloc(strlen(hintval), MPL_MEM_OTHER);
 
     mpi_errno =
-        MPIR_Allreduce(hintval, hintval_global, strlen(hintval), MPI_CHAR,
+        MPID_Allreduce(hintval, hintval_global, strlen(hintval), MPI_CHAR,
                        MPI_MAX, comm_ptr, &errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -696,7 +696,7 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
     hintval_equal = !memcmp(hintval, hintval_global, strlen(hintval));
 
     mpi_errno =
-        MPIR_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
+        MPID_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -165,8 +165,18 @@ int MPI_Finalize(void)
 #endif
 
 #ifdef HAVE_NETLOC
-    if (MPIR_Process.network_attr.u.tree.node_levels != NULL)
-        MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
+    switch (MPIR_Process.network_attr.type) {
+        case MPIR_NETLOC_NETWORK_TYPE__TORUS:
+            if (MPIR_Process.network_attr.u.torus.geometry != NULL)
+                MPL_free(MPIR_Process.network_attr.u.torus.geometry);
+            break;
+        case MPIR_NETLOC_NETWORK_TYPE__FAT_TREE:
+        case MPIR_NETLOC_NETWORK_TYPE__CLOS_NETWORK:
+        default:
+            if (MPIR_Process.network_attr.u.tree.node_levels != NULL)
+                MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
+            break;
+    }
 #endif
 
     /* Note: Only one thread may ever call MPI_Finalize (MPI_Finalize may

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -370,15 +370,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
         mpi_errno =
             netloc_parse_topology(&MPIR_Process.netloc_topology, MPIR_CVAR_NETLOC_NODE_FILE);
         if (mpi_errno == NETLOC_SUCCESS) {
-            mpi_errno =
-                MPIR_Netloc_parse_topology(MPIR_Process.netloc_topology,
-                                           &MPIR_Process.network_attr);
-            if (mpi_errno == MPI_SUCCESS) {
-                MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
-                                                  MPIR_Process.netloc_topology,
-                                                  MPIR_Process.hwloc_topology,
-                                                  &MPIR_Process.network_attr.network_endpoint);
-            }
+            MPIR_Netloc_parse_topology(MPIR_Process.netloc_topology, &MPIR_Process.network_attr);
         }
     }
 #endif

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -10,6 +10,19 @@
 #ifdef HAVE_NETLOC
 #include "netloc_util.h"
 #include "mpl.h"
+#define MAX_DISTANCE 65535
+
+typedef struct semicube_edge {
+    netloc_node_t **src;
+    netloc_node_t **dest;
+} semicube_edge;
+
+typedef struct tree {
+    netloc_node_t ***vertices;
+    int num_nodes;
+    semicube_edge **edges;
+    int num_edges;
+} tree;
 
 #undef FUNCNAME
 #define FUNCNAME get_tree_attributes
@@ -310,6 +323,1161 @@ static int get_tree_attributes(netloc_topology_t topology,
     goto fn_exit;
 }
 
+static unsigned int get_hamming_distance(const unsigned long long src_label,
+                                         const unsigned long long dest_label)
+{
+    unsigned int distance = 0;
+    unsigned long long hamming_distance;
+
+    hamming_distance = (unsigned long long) src_label ^ dest_label;
+    while (hamming_distance) {
+        if (hamming_distance & 1) {
+            distance++;
+        }
+        hamming_distance = hamming_distance >> 1;
+    }
+
+  fn_exit:
+    return distance;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int get_distance(netloc_node_t ** exposed_vertex, netloc_node_t ** root, tree * subtree)
+{
+    int distance = 0;
+    int i;
+    if (exposed_vertex == root) {
+        return distance;
+    }
+
+    for (i = 0; i < subtree->num_edges; i++) {
+        int temp_distance = 0;
+        if (subtree->edges[0]->dest == exposed_vertex) {
+            temp_distance = get_distance(subtree->edges[0]->src, root, subtree);
+            if (temp_distance + 1 > distance) {
+                distance = temp_distance + 1;
+            }
+        }
+    }
+
+  fn_exit:
+    return distance;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static void get_path(netloc_node_t ** src, netloc_node_t ** dest, tree ** forest, int tree_count,
+                     semicube_edge *** path, int *path_length)
+{
+    int i, j;
+    for (i = 0; i < tree_count; i++) {
+        tree *subtree = forest[i];
+        int subtree_edge_count = subtree->num_edges;
+        for (j = 0; j < subtree_edge_count; j++) {
+            int path_size = -1;
+            if (subtree->edges[j]->dest == dest) {
+                semicube_edge edge;
+                edge.src = src;
+                edge.dest = dest;
+                *path[*path_length] = &edge;
+                *path_length = *path_length + 1;
+            } else if (subtree->edges[j]->src == src) {
+                int destination_reached = 0;
+                int current_path_length = *path_length;
+                get_path(subtree->edges[j]->dest, dest, forest, tree_count, path, path_length);
+                if (path_length >= 0) {
+                    semicube_edge *edge = (*path)[path_size - 1];
+                    if (edge->dest == dest) {
+                        destination_reached = 1;
+                        break;
+                    }
+                }
+                if (!destination_reached) {
+                    *path_length = current_path_length;
+                }
+            }
+        }
+    }
+
+  fn_exit:
+    return;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static void get_root_of_tree(tree * subtree, netloc_node_t *** root)
+{
+    int i, j;
+    for (i = 0; i < subtree->num_nodes; i++) {
+        netloc_node_t **vertex = subtree->vertices[i];
+        int rootnode = 1;
+        for (j = 0; j < subtree->num_edges; j++) {
+            if (subtree->edges[j]->dest == vertex) {
+                rootnode = 0;
+                break;
+            }
+        }
+        if (rootnode) {
+            *root = vertex;
+            break;
+        }
+    }
+
+  fn_exit:
+    return;
+
+  fn_fail:
+    goto fn_exit;
+
+}
+
+static void get_blossom(netloc_node_t *** nodes, int num_nodes,
+                        semicube_edge ** edges, int num_edges, netloc_node_t *** unmarked_vertices,
+                        int num_unmarked, netloc_node_t **** blossom_nodes, int *num_blossom_nodes,
+                        int *stem_index)
+{
+    int i, j;
+    netloc_node_t **exposed_vertex;
+    for (j = 0; j < num_unmarked; j++) {
+        if (nodes[i] == unmarked_vertices[j]) {
+            netloc_node_t ***traversed_nodes =
+                (netloc_node_t ***) MPL_calloc(num_nodes, sizeof(netloc_node_t **), MPL_MEM_OTHER);
+            int cycle_index = 0;
+            int odd_cycle_found = 0;
+            exposed_vertex = nodes[i];
+            traversed_nodes[cycle_index++] = exposed_vertex;
+            /* Find an odd cycle starting from the exposed vertex */
+            while (1) {
+                /* Find an edge adjacent to the current node */
+                for (i = 0; i < num_edges; i++) {
+                    if (edges[i]->src == exposed_vertex) {
+                        traversed_nodes[cycle_index++] = edges[i]->dest;
+                        exposed_vertex = edges[i]->dest;
+                        break;
+                    }
+                }
+                for (i = 0; i < cycle_index - 1; i++) {
+                    if (traversed_nodes[i] == exposed_vertex && (cycle_index - 1 - i) & 1) {
+                        odd_cycle_found = 1;
+                        *num_blossom_nodes = cycle_index;
+                        *blossom_nodes = traversed_nodes;
+                        *stem_index = i;
+                        break;
+                    }
+                }
+                if (odd_cycle_found) {
+                    break;
+                }
+            }
+            if (odd_cycle_found) {
+                break;
+            }
+        }
+    }
+  fn_exit:
+    return;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static void find_augmenting_path(netloc_topology_t topology, netloc_node_t *** nodes, int num_nodes,
+                                 semicube_edge ** edges, int num_edges,
+                                 semicube_edge *** augmenting_path, int *augmenting_path_length,
+                                 semicube_edge ** maximum_matching, int num_matching_edges)
+{
+    semicube_edge **current_augmenting_path = NULL;
+    int path_length;
+    int i, j, k, l;
+    int unmarked_vertex_insert, unmarked_edge_insert = 0;
+    netloc_node_t ***unmarked_vertices = NULL;
+    semicube_edge **unmarked_edges = NULL;
+    tree **forest;
+    int forest_insert_index;
+    /* Unmark all vertices and edges in the semicube graph, mark all edges of the matching */
+    unmarked_vertex_insert = 0;
+    unmarked_vertices =
+        (netloc_node_t ***) MPL_calloc(num_nodes, sizeof(netloc_node_t **), MPL_MEM_OTHER);
+    for (i = 0; i < num_nodes; i++) {
+        netloc_node_t **semicube_vertex = nodes[i];
+        int exposed_vertex = 1;
+        for (j = 0; j < num_matching_edges; j++) {
+            semicube_edge *edge = maximum_matching[j];
+            if (edge->src == semicube_vertex || edge->dest == semicube_vertex) {
+                exposed_vertex = 0;
+                break;
+            }
+        }
+        if (exposed_vertex) {
+            unmarked_vertices[unmarked_vertex_insert++] = semicube_vertex;
+        }
+    }
+
+    unmarked_edge_insert = 0;
+    unmarked_edges =
+        (semicube_edge **) MPL_calloc(num_edges, sizeof(semicube_edge *), MPL_MEM_OTHER);
+    /* Unmark all vertices and edges in the semicube graph, mark all edges of the matching */
+    for (i = 0; i < num_edges; i++) {
+        int marked_edge = 0;
+        semicube_edge *edge = edges[i];
+        for (j = 0; j < num_matching_edges; j++) {
+            semicube_edge *local_edge = maximum_matching[j];
+            if (local_edge->src == edge->src && local_edge->dest == edge->dest) {
+                marked_edge = 1;
+                break;
+            }
+        }
+        if (!marked_edge) {
+            unmarked_edges[unmarked_edge_insert++] = edge;
+        }
+    }
+    forest = (tree **) MPL_calloc(unmarked_vertex_insert, sizeof(tree *), MPL_MEM_OTHER);
+    forest_insert_index = 0;
+    /* Create a forest with each exposed vertex as a singleton set */
+    for (i = 0; i < unmarked_vertex_insert; i++) {
+        tree *singleton_tree = (tree *) MPL_malloc(sizeof(tree), MPL_MEM_OTHER);
+        singleton_tree->vertices =
+            (netloc_node_t ***) MPL_malloc(sizeof(netloc_node_t **), MPL_MEM_OTHER);
+        singleton_tree->edges =
+            (semicube_edge **) MPL_malloc(sizeof(semicube_edge *), MPL_MEM_OTHER);
+        singleton_tree->vertices[0] = unmarked_vertices[i];
+        singleton_tree->num_nodes = 1;
+        singleton_tree->num_edges = 0;
+        forest[forest_insert_index++] = singleton_tree;
+    }
+
+    while (1) {
+        int exposed_vertex = 0;
+        netloc_node_t **vertex;
+        netloc_node_t **root;
+        int distance_from_root;
+        int unmarked_vertex_index = -1;
+        int unmarked_edge_index = -1;
+        tree *subtree;
+
+        exposed_vertex = 0;
+        for (i = 0; i < forest_insert_index; i++) {
+            subtree = forest[i];
+            /* Check if the marked vertex is at an even distance from the
+             * root node in its tree */
+            for (j = 0; j < subtree->num_nodes; j++) {
+                vertex = subtree->vertices[j];
+                for (l = 0; l < unmarked_vertex_insert; l++) {
+                    if (unmarked_vertices[l] == vertex) {
+                        exposed_vertex = 1;
+                        unmarked_vertex_index = l;
+                        break;
+                    }
+                }
+                if (exposed_vertex) {
+                    break;
+                }
+            }
+            if (exposed_vertex) {
+                break;
+            }
+        }
+
+        if (!exposed_vertex) {
+            break;
+        }
+        get_root_of_tree(subtree, &root);
+        distance_from_root = get_distance(vertex, root, subtree);
+        if (!(distance_from_root & 1)) {
+            /* Find an unmarked edge from exposed_vertex */
+            int unmarked_edge = 0;
+            semicube_edge *edge;
+            netloc_node_t **dest;
+            for (j = 0; j < unmarked_edge_insert; j++) {
+                if (unmarked_edges[j]->src == vertex || unmarked_edges[j]->dest == vertex) {
+                    unmarked_edge = 1;
+                    unmarked_edge_index = j;
+                    edge = unmarked_edges[j];
+                    dest = unmarked_edges[j]->dest;
+                    break;
+                }
+            }
+            if (unmarked_edge) {
+                /* Check if the destination is not in the forest */
+                int dest_in_forest = 0;
+                tree *dest_subtree;
+                netloc_node_t **dest_root;
+                for (j = 0; j < forest_insert_index; j++) {
+                    tree *tempsubtree = forest[j];
+                    for (k = 0; k < tempsubtree->num_nodes; k++) {
+                        if (tempsubtree->vertices[k] == dest) {
+                            dest_in_forest = 1;
+                            dest_subtree = tempsubtree;
+                            break;
+                        }
+
+                    }
+                    if (dest_in_forest) {
+                        break;
+                    }
+                }
+                get_root_of_tree(dest_subtree, &dest_root);
+
+                if (!dest_in_forest) {
+                    int vertex_insert_position;
+                    int edge_insert_position = 0;
+                    /* The destination node is in matching graph */
+                    semicube_edge *matching_edge = NULL;
+                    for (j = 0; j < num_matching_edges; j++) {
+                        semicube_edge *temp_matching_edge = maximum_matching[j];
+                        if (temp_matching_edge->src == dest || temp_matching_edge->dest == dest) {
+                            matching_edge = temp_matching_edge;
+                            break;
+                        }
+                    }
+                    MPIR_Assert(matching_edge != NULL);
+                    /* Add edge to subtree */
+                    vertex_insert_position = subtree->num_nodes + 1;
+                    subtree->vertices =
+                        (netloc_node_t ***) MPL_realloc(subtree->vertices,
+                                                        (vertex_insert_position + 1) *
+                                                        sizeof(netloc_node_t **), MPL_MEM_OTHER);
+                    subtree->vertices[vertex_insert_position] = dest;
+                    subtree->num_nodes++;
+
+                    subtree->edges =
+                        (semicube_edge **) MPL_realloc(subtree->edges,
+                                                       (edge_insert_position + 3) *
+                                                       sizeof(subtree->edges[0]), MPL_MEM_OTHER);
+
+                    for (j = 0; j < unmarked_edge_index; j++) {
+                        semicube_edge *temp_matching_edge = unmarked_edges[j];
+                        if (temp_matching_edge->src == vertex && temp_matching_edge->dest == dest) {
+                            subtree->edges[edge_insert_position++] = temp_matching_edge;
+                            break;
+                        }
+                    }
+                    subtree->edges[edge_insert_position++] = matching_edge;
+                    subtree->num_edges += 2;
+                } else if (get_distance(dest, dest_root, dest_subtree) & 1) {
+                    /* Do nothing */
+                } else {
+                    if (root != dest_root) {
+                        /* Found an augmenting path */
+                        semicube_edge **first_path, **second_path;
+                        int insert_index = 0;
+                        int first_length = 0, second_length = 0;
+                        get_path(root, vertex, forest, forest_insert_index, &first_path,
+                                 &first_length);
+                        get_path(dest_root, dest, forest, forest_insert_index, &second_path,
+                                 &second_length);
+                        current_augmenting_path =
+                            MPL_calloc(current_augmenting_path, (first_length + second_length + 1) *
+                                       sizeof(semicube_edge *), MPL_MEM_OTHER);
+                        for (j = 0; j < first_length; j++) {
+                            current_augmenting_path[insert_index++] = first_path[j];
+                        }
+                        current_augmenting_path[insert_index++] = edge;
+                        for (j = 0; j < second_length; j++) {
+                            current_augmenting_path[insert_index++] = second_path[j];
+                        }
+                        path_length = first_length + second_length + 1;
+                        goto fn_exit;
+                    } else {
+                        netloc_node_t ***blossom_edges;
+                        int num_blossom_nodes, stem_index, m, n;
+                        get_blossom(nodes, num_nodes, edges, num_edges, unmarked_vertices,
+                                    unmarked_vertex_insert, &blossom_edges,
+                                    &num_blossom_nodes, &stem_index);
+                        /* Contract a blossom in G and look for the path in the contracted graph */
+                        for (j = stem_index + 1; j < num_blossom_nodes; j++) {
+                            netloc_node_t **blossom_node = blossom_edges[j];
+                            for (k = 0; k < num_nodes; k++) {
+                                if (nodes[k] == blossom_node) {
+                                    for (l = k; l < num_nodes - 1; l++) {
+                                        nodes[l] = nodes[l + 1];
+                                    }
+                                    num_nodes--;
+                                    k--;
+                                }
+                            }
+                            if (j < num_blossom_nodes - 1) {
+                                netloc_node_t **adj_blossom_node = blossom_edges[j];
+                                for (k = 0; k < num_edges; k++) {
+                                    if (edges[k]->src == blossom_node &&
+                                        edges[k]->dest == adj_blossom_node) {
+                                        for (l = k; l < num_edges - 1; l++) {
+                                            edges[l] = edges[l + 1];
+                                        }
+                                        num_edges--;
+                                        k--;
+                                    }
+                                }
+                            }
+                        }
+                        find_augmenting_path(topology, nodes, num_nodes, edges, num_edges,
+                                             &current_augmenting_path, &path_length,
+                                             maximum_matching, num_matching_edges);
+                        /* Find the node that connects to the stem */
+                        for (j = 0; j < path_length; j++) {
+                            if (current_augmenting_path[j]->src == blossom_edges[stem_index]) {
+                                break;
+                            }
+                        }
+                        for (k = stem_index + 1; k < num_blossom_nodes; k++) {
+                            if (current_augmenting_path[j]->dest == blossom_edges[k]) {
+                                break;
+                            }
+                        }
+                        current_augmenting_path =
+                            (semicube_edge **) MPL_realloc(current_augmenting_path,
+                                                           sizeof(semicube_edge *) * (k -
+                                                                                      stem_index
+                                                                                      - 1),
+                                                           MPL_MEM_OTHER);
+
+                        current_augmenting_path[j]->dest =
+                            current_augmenting_path[j + 1]->src = blossom_edges[stem_index + 1];
+                        /* Shift edges to make room to lift blossom edges */
+                        for (l = j + 1; l < path_length; l++) {
+                            current_augmenting_path[l] =
+                                current_augmenting_path[l + k - stem_index - 1];
+                        }
+                        for (l = j; l < (j + k - stem_index - 2); l++) {
+                            semicube_edge edge;
+                            edge.src = blossom_edges[l];
+                            edge.dest = blossom_edges[l + 1];
+                            current_augmenting_path[l] = &edge;
+                        }
+                        MPL_free(blossom_edges);
+                        goto fn_exit;
+                    }
+                }
+            }
+            /* Mark edge */
+            if (unmarked_edge) {
+                for (j = unmarked_edge_index; j < unmarked_edge_insert - 1; j++) {
+                    unmarked_edges[j] = unmarked_edges[j + 1];
+                }
+                unmarked_edge_insert--;
+            }
+        }
+        if (exposed_vertex) {
+            /* Mark vertex */
+            for (j = unmarked_vertex_index; j < unmarked_vertex_insert - 1; j++) {
+                unmarked_vertices[j] = unmarked_vertices[j + 1];
+            }
+            unmarked_vertex_insert--;
+        }
+    }
+
+  fn_exit:
+    if (forest != NULL) {
+        MPL_free(forest);
+    }
+    if (unmarked_vertices != NULL) {
+        MPL_free(unmarked_vertices);
+    }
+    if (unmarked_edges != NULL) {
+        MPL_free(unmarked_edges);
+    }
+    *augmenting_path = current_augmenting_path;
+    *augmenting_path_length = path_length;
+    return;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static void find_maximum_matching(netloc_topology_t topology, netloc_node_t *** nodes,
+                                  int num_nodes, semicube_edge ** edges, int num_edges,
+                                  semicube_edge *** maximum_matching, int *num_matching_edges)
+{
+    int i, j;
+    semicube_edge **augmenting_path =
+        (semicube_edge **) MPL_malloc(sizeof(semicube_edge *), MPL_MEM_OTHER);
+    int path_length;
+    int insert_location = 0;
+
+    find_augmenting_path(topology, nodes, num_nodes, edges, num_edges, &augmenting_path,
+                         &path_length, *maximum_matching, *num_matching_edges);
+    if (augmenting_path != NULL && path_length > 0) {
+        semicube_edge **matching =
+            (semicube_edge **) MPL_malloc(sizeof(semicube_edge *), MPL_MEM_OTHER);
+        /* Update the maximum matching */
+        for (i = 0; i < *num_matching_edges; i++) {
+            semicube_edge *edge = (*maximum_matching)[i];
+            int edge_in_both_sets = 0;
+            for (j = 0; j < path_length; j++) {
+                semicube_edge *augmenting_path_edge = augmenting_path[j];
+                if (edge->src == augmenting_path_edge->src &&
+                    edge->dest == augmenting_path_edge->dest) {
+                    edge_in_both_sets = 1;
+                    break;
+                }
+            }
+            if (!edge_in_both_sets) {
+                matching =
+                    (semicube_edge **) MPL_realloc(matching,
+                                                   sizeof(semicube_edge *) * (insert_location + 1),
+                                                   MPL_MEM_OTHER);
+                matching[insert_location++] = edge;
+            }
+        }
+
+        for (i = 0; i < path_length; i++) {
+            semicube_edge *edge = augmenting_path[i];
+            int edge_in_both_sets = 0;
+            for (j = 0; j < *num_matching_edges; j++) {
+                semicube_edge *augmenting_path_edge = (*maximum_matching)[i];
+                if (edge->src == augmenting_path_edge->src &&
+                    edge->dest == augmenting_path_edge->dest) {
+                    edge_in_both_sets = 1;
+                    break;
+                }
+            }
+            if (!edge_in_both_sets) {
+                matching =
+                    (semicube_edge **) MPL_realloc(matching,
+                                                   sizeof(semicube_edge *) * (insert_location + 1),
+                                                   MPL_MEM_OTHER);
+                matching[insert_location++] = edge;
+            }
+        }
+        find_maximum_matching(topology, nodes, num_nodes, edges, num_edges, &matching,
+                              &insert_location);
+        *maximum_matching = matching;
+        *num_matching_edges = insert_location;
+    }
+
+  fn_exit:
+    if (augmenting_path != NULL) {
+        MPL_free(augmenting_path);
+    }
+    return;
+}
+
+static int get_torus_attributes(netloc_topology_t topology,
+                                MPIR_Netloc_network_attributes * network_attr)
+{
+    netloc_dt_lookup_table_t *nodes;
+    struct netloc_dt_lookup_table_iterator *hti = NULL;
+    netloc_node_t *start_node = NULL;
+    int mpi_errno = MPI_SUCCESS;
+    int num_edges = -1;
+
+    if (network_attr->type == MPIR_NETLOC_NETWORK_TYPE__INVALID) {
+        network_attr->type = MPIR_NETLOC_NETWORK_TYPE__TORUS;
+        /* Check necessary condition for a torus i.e., outdegree of each node is the same */
+        int node_count = 0;
+        nodes =
+            (netloc_dt_lookup_table_t *) MPL_malloc(sizeof(netloc_dt_lookup_table_t),
+                                                    MPL_MEM_OTHER);
+        mpi_errno = netloc_get_all_nodes(topology, nodes);
+        hti = netloc_dt_lookup_table_iterator_t_construct(*nodes);
+
+        while (!netloc_lookup_table_iterator_at_end(hti)) {
+            netloc_node_t *node = (netloc_node_t *) netloc_lookup_table_iterator_next_entry(hti);
+            netloc_edge_t **edges;
+            int num_edges_per_node;
+            if (node == NULL) {
+                break;
+            }
+            netloc_get_all_edges(topology, node, &num_edges_per_node, &edges);
+            if (!node_count || num_edges_per_node < num_edges) {
+                num_edges = num_edges_per_node;
+                start_node = node;
+                node_count++;
+            }
+        }
+    }
+    if (start_node != NULL && network_attr->type != MPIR_NETLOC_NETWORK_TYPE__INVALID) {
+        /* Assuming that hypercube dimension size is less than the bit width of long long */
+        unsigned long long *hypercube_labels = NULL;
+        int i, j, k, l;
+        int start_index, end_index;
+        /* Bitmap of non-zero entries in the labels */
+        unsigned long long covered_bits;
+        int covered_bits_count;
+        int index;
+        /* Get rid of the extra bidirectional and cycle edges */
+        netloc_edge_t **ignore_edges = NULL;
+        netloc_node_t **traversal_order = NULL, ***semicube_vertices = NULL;
+        semicube_edge **semicube_edges = NULL;
+        semicube_edge **complementary_edges = NULL;
+        semicube_edge **maximum_matching = NULL;
+        int hypercube_dimension = 0;
+        unsigned int **distance_matrix;
+
+        end_index = 0;
+        start_index = 0;
+        traversal_order =
+            (netloc_node_t **) MPL_malloc(sizeof(netloc_node_t *) * topology->num_nodes,
+                                          MPL_MEM_OTHER);
+        MPIR_Assert(end_index < topology->num_nodes);
+        traversal_order[end_index++] = start_node;
+        /* Compute the depth first order of nodes to associate hamming code */
+        start_index = end_index = 0;
+        traversal_order[end_index++] = start_node;
+        while (start_index < end_index) {
+            netloc_node_t *vertex = traversal_order[start_index++];
+            int num_edges;
+            netloc_edge_t **edges;
+            netloc_get_all_edges(topology, vertex, &num_edges, &edges);
+            for (i = 0; i < num_edges; i++) {
+                int dest_added = 0;
+                int node_added_previously = 0;
+                for (j = 0; j < end_index; j++) {
+                    for (k = 0; k < end_index; k++) {
+                        if (edges[i]->dest_node == traversal_order[k]) {
+                            node_added_previously = 1;
+                            break;
+                        }
+                    }
+                    if (!node_added_previously) {
+                        traversal_order[end_index++] = edges[i]->dest_node;
+                    }
+                }
+            }
+        }
+
+        MPIR_Assert(end_index == topology->num_nodes);
+        distance_matrix =
+            (unsigned int **) MPL_calloc(topology->num_nodes * topology->num_nodes,
+                                         sizeof(unsigned int *), MPL_MEM_OTHER);
+        for (i = 0; i < topology->num_nodes; i++) {
+            netloc_node_t *node = topology->nodes[i];
+            int num_edges;
+            netloc_edge_t **edges;
+            netloc_get_all_edges(topology, node, &num_edges, &edges);
+            distance_matrix[node->__uid__] =
+                (unsigned int *) MPL_calloc(topology->num_nodes, sizeof(unsigned int),
+                                            MPL_MEM_OTHER);
+            for (j = 0; j < topology->num_nodes; j++) {
+                distance_matrix[node->__uid__][topology->nodes[j]->__uid__] = MAX_DISTANCE;
+            }
+            for (j = 0; j < num_edges; j++) {
+                netloc_node_t *neighbor = edges[j]->dest_node;
+                distance_matrix[node->__uid__][neighbor->__uid__] = 1;
+            }
+        }
+
+        /* Compute the transitive closure */
+        for (k = 0; k < topology->num_nodes; k++) {
+            for (i = 0; i < topology->num_nodes; i++) {
+                int first_index = topology->nodes[i]->__uid__;
+                for (j = 0; j < topology->num_nodes; j++) {
+                    int second_index = topology->nodes[j]->__uid__;
+                    int third_index = topology->nodes[k]->__uid__;
+                    if (distance_matrix[first_index][second_index] >
+                        distance_matrix[first_index][third_index] +
+                        distance_matrix[third_index][second_index]) {
+                        distance_matrix[first_index][second_index] =
+                            distance_matrix[first_index][third_index] +
+                            distance_matrix[third_index][second_index];
+                    }
+                }
+            }
+        }
+
+        if (start_index == topology->num_nodes) {
+            int complementary_edge_index;
+            int semicube_vertex_count;
+            int *semicube_vertices_index;
+            int semicube_edge_count;
+            int num_matching_edges;
+            netloc_node_t ****path_graphs;
+            int *path_graph_count;
+            int path_graph_insert;
+            int num_nodes_covered;
+            int **temp_coordinate_map = NULL;
+            long node_index;
+            int *coordinates;
+
+            /* Initialize labels with 0 */
+            hypercube_labels =
+                (unsigned long long *) MPL_calloc(start_index, sizeof(unsigned long long),
+                                                  MPL_MEM_OTHER);
+            covered_bits = 0;
+            covered_bits_count = 0;
+            /* Get the isometric hypercube embedding of the input graph */
+            for (i = 1; i < start_index; i++) {
+                /* Find a neighbor node 1 hop away to the current and try new labels till a feasible label is found */
+                netloc_node_t *neighbor = traversal_order[i];
+                unsigned long long neighbor_label, bit_flip, new_label;
+                netloc_node_t *node;
+                int valid_label;
+                int num_shifts, total_shifts;
+                node = NULL;
+                for (j = 0; j < i; j++) {
+                    int num_edges;
+                    netloc_edge_t **edges;
+                    netloc_get_all_edges(topology, traversal_order[j], &num_edges, &edges);
+                    node = NULL;
+                    for (l = 0; l < num_edges; l++) {
+                        if (edges[l]->dest_node == neighbor) {
+                            node = traversal_order[j];
+                            break;
+                        }
+                    }
+                    if (node != NULL) {
+                        break;
+                    }
+                }
+                MPIR_Assert(node != NULL);
+                /* Generate a new label at hamming distance 1 from neighbor */
+                neighbor_label = hypercube_labels[node->__uid__];
+                bit_flip = 1;
+                num_shifts = 0;
+                valid_label = 0;
+                while (num_shifts++ < (sizeof(unsigned long long) * 8)) {
+                    int current_valid_label = 1;
+                    unsigned long long temp_label = neighbor_label ^ bit_flip;
+                    bit_flip = bit_flip << 1;
+
+                    for (j = 0; j < i; j++) {
+                        netloc_node_t *prev_node = traversal_order[j];
+                        unsigned int distance;
+                        unsigned int hamming_distance;
+                        /* Check if the new label is consistent with previous labels
+                         * with hamming distance */
+                        if (temp_label == hypercube_labels[prev_node->__uid__]) {
+                            current_valid_label = 0;
+                            break;
+                        }
+                        /* Find the distance of `neighbor` to `prev_node` */
+                        distance = distance_matrix[prev_node->__uid__][neighbor->__uid__];
+                        hamming_distance =
+                            get_hamming_distance(hypercube_labels[prev_node->__uid__], temp_label);
+                        if (distance != MAX_DISTANCE && hamming_distance != distance) {
+                            current_valid_label = 0;
+                            break;
+                        }
+                    }
+                    if (current_valid_label) {
+                        valid_label = 1;
+                        /* Check if this covers more bits than before */
+                        int temp_bit_count;
+                        long temp_covered_bits = covered_bits | temp_label;
+                        temp_bit_count = 0;
+                        while (temp_covered_bits) {
+                            if (temp_covered_bits & 1) {
+                                temp_bit_count++;
+                            }
+                            temp_covered_bits = temp_covered_bits / 2;
+                        }
+                        if (covered_bits_count <= temp_bit_count) {
+                            new_label = temp_label;
+                            if (covered_bits_count < temp_bit_count) {
+                                break;
+                            }
+                            covered_bits_count = temp_bit_count;
+                        }
+                    }
+                }
+                if (!valid_label) {
+                    network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
+                    goto cleanup;
+                }
+                hypercube_labels[neighbor->__uid__] = new_label;
+                covered_bits = covered_bits | new_label;
+            }
+
+            MPL_free(distance_matrix);
+            network_attr->type = MPIR_NETLOC_NETWORK_TYPE__TORUS;
+
+            hypercube_dimension = 0;
+            index = 0;
+            while (covered_bits) {
+                int value = covered_bits & 1;
+                if (!value) {
+                    for (i = 0; i < topology->num_nodes; i++) {
+                        unsigned long long label = hypercube_labels[i];
+                        if (!index) {
+                            label =
+                                ((label >> (index + 1)) << index) | (label & ((2 << index) - 1));
+                        }
+                        hypercube_labels[i] = label;
+                    }
+                } else {
+                    hypercube_dimension++;
+                }
+                covered_bits = covered_bits >> 1;
+                index++;
+            }
+
+            semicube_vertices =
+                (netloc_node_t ***) MPL_calloc(2 * hypercube_dimension, sizeof(netloc_node_t **),
+                                               MPL_MEM_OTHER);
+
+            semicube_vertices_index = (int *) MPL_calloc(2 * hypercube_dimension, sizeof(int),
+                                                         MPL_MEM_OTHER);
+            semicube_vertex_count = 0;
+            /* Compute the semicubes of the hypercube embedding */
+            for (j = 0; j < topology->num_nodes; j++) {
+                unsigned long long label = hypercube_labels[topology->nodes[j]->__uid__];
+                for (i = 0; i < hypercube_dimension; i++) {
+                    int semicube_index;
+                    int insert_position;
+                    if (label & (1u << i)) {
+                        semicube_index = 2 * i + 1;
+                    } else {
+                        semicube_index = 2 * i;
+                    }
+                    if (semicube_vertices[semicube_index] == NULL) {
+                        semicube_vertex_count++;
+                        insert_position = 0;
+                        semicube_vertices[semicube_index] =
+                            (netloc_node_t **) MPL_malloc(sizeof(netloc_node_t *), MPL_MEM_OTHER);
+                    } else {
+                        insert_position = semicube_vertices_index[semicube_index] + 1;
+                        semicube_vertices[semicube_index] =
+                            (netloc_node_t **) MPL_realloc(semicube_vertices[semicube_index],
+                                                           (insert_position +
+                                                            1) * sizeof(netloc_node_t *),
+                                                           MPL_MEM_OTHER);
+                    }
+                    semicube_vertices[semicube_index][insert_position] = topology->nodes[j];
+                    semicube_vertices_index[semicube_index] = insert_position;
+                }
+            }
+
+            /* Compute the semicube graph edges from the semicubes of the hypercube embedding */
+            semicube_edges =
+                (semicube_edge **) MPL_malloc(hypercube_dimension * 2 * sizeof(semicube_edge *),
+                                              MPL_MEM_OTHER);
+            MPIR_Assert(semicube_edges != NULL);
+            semicube_edge_count = 0;
+            for (i = 0; i < hypercube_dimension * 2 - 1; i++) {
+                netloc_node_t **first_set = semicube_vertices[i];
+                if (first_set != NULL) {
+                    for (j = i + 1; j < hypercube_dimension * 2; j++) {
+                        netloc_node_t **second_set = semicube_vertices[j];
+                        if (semicube_vertices[j] != NULL) {
+                            int insert_count = 0;
+                            int valid_edge = 0;
+                            netloc_node_t **union_set = (netloc_node_t **)
+                                MPL_malloc((semicube_vertices_index[i] +
+                                            semicube_vertices_index[j] +
+                                            2) * sizeof(netloc_node_t *),
+                                           MPL_MEM_OTHER);
+                            for (k = 0; k <= semicube_vertices_index[i]; k++) {
+                                union_set[insert_count++] = first_set[k];
+                            }
+                            for (k = 0; k <= semicube_vertices_index[j]; k++) {
+                                int added_before = 0;
+                                for (l = 0; l < insert_count; l++) {
+                                    if (union_set[l] == second_set[k]) {
+                                        added_before = 1;
+                                        valid_edge = 1;
+                                        break;
+                                    }
+                                }
+                                if (!added_before) {
+                                    union_set[insert_count++] = second_set[k];
+                                }
+                            }
+                            if (valid_edge && insert_count == topology->num_nodes) {
+                                semicube_edge *edge =
+                                    (semicube_edge *) MPL_malloc(sizeof(semicube_edge *),
+                                                                 MPL_MEM_OTHER);
+                                edge->src = first_set;
+                                edge->dest = second_set;
+                                semicube_edges[semicube_edge_count++] = edge;
+                            }
+                            MPL_free(union_set);
+                        }
+                    }
+                }
+            }
+            num_matching_edges = 0;
+            /* Compute the maximum matching for semicube graph */
+            find_maximum_matching(topology, semicube_vertices, semicube_vertex_count,
+                                  semicube_edges, semicube_edge_count, &maximum_matching,
+                                  &num_matching_edges);
+            complementary_edges =
+                (semicube_edge **) MPL_malloc(hypercube_dimension * 2 * sizeof(semicube_edge *),
+                                              MPL_MEM_OTHER);
+            complementary_edge_index = 0;
+            /* Compute complementary paths in the graph */
+            for (i = 0; i < hypercube_dimension * 2 - 1; i++) {
+                netloc_node_t **first_set = semicube_vertices[i];
+                if (first_set != NULL) {
+                    for (j = i + 1; j < hypercube_dimension * 2; j++) {
+                        netloc_node_t **second_set = semicube_vertices[j];
+                        if (semicube_vertices[j] != NULL) {
+                            int insert_count = 0;
+                            int valid_edge = 1;
+                            netloc_node_t **union_set = (netloc_node_t **)
+                                MPL_malloc(topology->num_nodes * sizeof(netloc_node_t *),
+                                           MPL_MEM_OTHER);
+                            for (k = 0; k <= semicube_vertices_index[i]; k++) {
+                                union_set[insert_count++] = first_set[k];
+                            }
+                            for (k = 0; k <= semicube_vertices_index[j]; k++) {
+                                int added_before = 0;
+                                for (l = 0; l < insert_count; l++) {
+                                    if (union_set[l] == second_set[k]) {
+                                        added_before = 1;
+                                        valid_edge = 0;
+                                        break;
+                                    }
+                                }
+                                if (!added_before) {
+                                    union_set[insert_count++] = second_set[k];
+                                }
+                            }
+                            if (valid_edge && insert_count == topology->num_nodes) {
+                                semicube_edge *edge =
+                                    (semicube_edge *) MPL_malloc(sizeof(semicube_edge *),
+                                                                 MPL_MEM_OTHER);
+                                edge->src = first_set;
+                                edge->dest = second_set;
+                                complementary_edges[complementary_edge_index++] = edge;
+                            }
+                            MPL_free(union_set);
+                        }
+                    }
+                }
+            }
+
+            /* Compute path graphs */
+            path_graphs =
+                (netloc_node_t ****) MPL_malloc((hypercube_dimension - num_matching_edges) *
+                                                sizeof(netloc_node_t ***), MPL_MEM_OTHER);
+            path_graph_count =
+                MPL_calloc((hypercube_dimension - num_matching_edges), sizeof(int), MPL_MEM_OTHER);
+            path_graph_insert = 0;
+            num_nodes_covered = 0;
+            for (i = 0; i < semicube_vertex_count; i++) {
+                netloc_node_t **semicube_vertex = semicube_vertices[i];
+                int vertex_covered = 0;
+                for (j = 0; j < path_graph_insert; j++) {
+                    for (k = 0; k < path_graph_count[j]; k++) {
+                        if (path_graphs[j][k] == semicube_vertex) {
+                            vertex_covered = 1;
+                            break;
+                        }
+                    }
+                    if (vertex_covered) {
+                        break;
+                    }
+                }
+
+                if (!vertex_covered) {
+                    int num_edges = 0;
+                    for (j = 0; j < num_matching_edges; j++) {
+                        if (maximum_matching[j]->src == semicube_vertex ||
+                            maximum_matching[j]->dest == semicube_vertex) {
+                            num_edges++;
+                        }
+                    }
+                    for (j = 0; j < complementary_edge_index; j++) {
+                        if (complementary_edges[j]->src == semicube_vertex ||
+                            complementary_edges[j]->dest == semicube_vertex) {
+                            num_edges++;
+                        }
+                    }
+                    /* Start from a vertex with 1 incoming/outgoing edge */
+                    if (num_edges == 1) {
+                        int num_nodes;
+                        path_graphs[path_graph_insert] =
+                            (netloc_node_t ***) MPL_calloc(semicube_vertex_count,
+                                                           sizeof(netloc_node_t **), MPL_MEM_OTHER);
+                        num_nodes = 0;
+                        path_graphs[path_graph_insert][num_nodes++] = semicube_vertex;
+                        MPIR_Assert(path_graph_insert <=
+                                    (hypercube_dimension - num_matching_edges));
+
+                        while (semicube_vertex) {
+                            netloc_node_t **neighbor = NULL;
+                            for (j = 0; j < num_matching_edges; j++) {
+                                if (maximum_matching[j]->src == semicube_vertex ||
+                                    maximum_matching[j]->dest == semicube_vertex) {
+                                    fflush(stdout);
+                                    netloc_node_t **temp_neighbor = NULL;
+                                    if (maximum_matching[j]->src == semicube_vertex) {
+                                        temp_neighbor = maximum_matching[j]->dest;
+                                    } else {
+                                        temp_neighbor = maximum_matching[j]->src;
+                                    }
+                                    for (k = 0; k < num_nodes; k++) {
+                                        vertex_covered = 0;
+                                        if (path_graphs[path_graph_insert][k] == temp_neighbor) {
+                                            vertex_covered = 1;
+                                            break;
+                                        }
+                                    }
+                                    if (!vertex_covered) {
+                                        neighbor = temp_neighbor;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (!neighbor) {
+                                for (j = 0; j < complementary_edge_index; j++) {
+                                    if (complementary_edges[j]->src == semicube_vertex ||
+                                        complementary_edges[j]->dest == semicube_vertex) {
+                                        netloc_node_t **temp_neighbor = NULL;
+                                        if (complementary_edges[j]->src == semicube_vertex) {
+                                            temp_neighbor = complementary_edges[j]->dest;
+                                        } else {
+                                            temp_neighbor = complementary_edges[j]->src;
+                                        }
+                                        for (k = 0; k < num_nodes; k++) {
+                                            vertex_covered = 0;
+                                            if (path_graphs[path_graph_insert][k] == temp_neighbor) {
+                                                vertex_covered = 1;
+                                                break;
+                                            }
+                                        }
+                                        if (!vertex_covered) {
+                                            neighbor = temp_neighbor;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (neighbor) {
+                                path_graphs[path_graph_insert][num_nodes++] = neighbor;
+                            }
+                            semicube_vertex = neighbor;
+                        }
+                        path_graph_count[path_graph_insert] = num_nodes;
+                        num_nodes_covered += num_nodes;
+                        path_graph_insert++;
+                    }
+                }
+            }
+
+            MPIR_Assert(num_nodes_covered == semicube_vertex_count);
+            network_attr->u.torus.dimension = path_graph_insert;
+            network_attr->u.torus.geometry =
+                (int *) MPL_calloc(path_graph_insert, sizeof(int), MPL_MEM_OTHER);
+            temp_coordinate_map =
+                (int **) MPL_calloc(topology->num_nodes, sizeof(int *), MPL_MEM_OTHER);
+            /* Traverse path graphs to assign coordinates of each node and size of torus along each dimension */
+            for (i = 0; i < topology->num_nodes; i++) {
+                netloc_node_t *vertex = topology->nodes[i];
+                temp_coordinate_map[vertex->__uid__] =
+                    MPL_calloc(path_graph_insert, sizeof(int), MPL_MEM_OTHER);
+                for (j = 0; j < path_graph_insert; j++) {
+                    int current_edge = 0;
+                    /* Required to keep track of the number of complementary edges */
+                    temp_coordinate_map[vertex->__uid__][j] = -1;
+                    while (current_edge < (path_graph_count[j] + 1)) {
+                        int vertex_in_first_set, vertex_in_second_set;
+                        vertex_in_first_set = 0;
+                        if (current_edge == 0) {
+                            vertex_in_first_set = 1;
+                        } else {
+                            netloc_node_t **semicube_node = path_graphs[j][current_edge - 1];
+                            int semicube_node_index = -1;
+                            for (k = 0; k < semicube_vertex_count; k++) {
+                                if (semicube_vertices[k] == semicube_node) {
+                                    semicube_node_index = k;
+                                    break;
+                                }
+                            }
+                            for (k = 0; k <= semicube_vertices_index[semicube_node_index]; k++) {
+                                if (vertex == semicube_node[k]) {
+                                    vertex_in_first_set = 1;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!vertex_in_first_set) {
+                            current_edge++;
+                            continue;
+                        }
+
+                        vertex_in_second_set = 0;
+                        if (current_edge == path_graph_count[j]) {
+                            vertex_in_second_set = 1;
+                        } else {
+                            netloc_node_t **semicube_node = path_graphs[j][current_edge];
+                            int semicube_node_index = -1;
+                            for (k = 0; k < semicube_vertex_count; k++) {
+                                if (semicube_vertices[k] == semicube_node) {
+                                    semicube_node_index = k;
+                                    break;
+                                }
+                            }
+                            for (k = 0; k <= semicube_vertices_index[semicube_node_index]; k++) {
+                                if (vertex == semicube_node[k]) {
+                                    vertex_in_second_set = 1;
+                                    break;
+                                }
+                            }
+                        }
+                        if (vertex_in_second_set) {
+                            /* Current edge counter has to be odd */
+                            MPIR_Assert(current_edge & 1);
+                            temp_coordinate_map[vertex->__uid__][j] = (current_edge + 1) / 2;
+                            if (network_attr->u.torus.geometry[j] <
+                                (temp_coordinate_map[vertex->__uid__][j] + 1)) {
+                                network_attr->u.torus.geometry[j] =
+                                    temp_coordinate_map[vertex->__uid__][j] + 1;
+                            }
+                            break;
+                        }
+                        current_edge++;
+                    }
+                    MPIR_Assert(temp_coordinate_map[vertex->__uid__][j] > -1);
+                }
+            }
+
+            /* Identify the network node corresponding to the current rank's node */
+            errno = MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
+                                                      MPIR_Process.netloc_topology,
+                                                      MPIR_Process.hwloc_topology,
+                                                      &MPIR_Process.network_attr.network_endpoint);
+            if (errno != MPI_SUCCESS) {
+                network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
+            } else {
+                /* Flatten computed coordinates into a long value for the current node */
+                coordinates =
+                    temp_coordinate_map[MPIR_Process.network_attr.network_endpoint->__uid__];
+                node_index = coordinates[0];
+                for (j = 1; j < path_graph_insert; j++) {
+                    node_index = (node_index * network_attr->u.torus.geometry[j]) + coordinates[j];
+                }
+                network_attr->u.torus.node_idx = index;
+            }
+            MPL_free(temp_coordinate_map);
+            MPL_free(path_graph_count);
+            MPL_free(path_graphs);
+        } else {
+            network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
+        }
+
+      cleanup:
+        if (traversal_order != NULL) {
+            MPL_free(traversal_order);
+        }
+        if (hypercube_labels != NULL) {
+            MPL_free(hypercube_labels);
+        }
+        if (semicube_edges != NULL) {
+            MPL_free(semicube_edges);
+        }
+        if (semicube_vertices != NULL) {
+            MPL_free(semicube_vertices);
+        }
+        if (maximum_matching != NULL) {
+            MPL_free(maximum_matching);
+        }
+    } else {
+        network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
+    }
+
+  fn_exit:
+    return mpi_errno;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 #undef FUNCNAME
 #define FUNCNAME MPIR_Netloc_parse_topology
 #undef FCNAME
@@ -321,6 +1489,12 @@ int MPIR_Netloc_parse_topology(netloc_topology_t netloc_topology,
     mpi_errno = get_tree_attributes(MPIR_Process.netloc_topology, network_attr);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
+
+    if (network_attr->type == MPIR_NETLOC_NETWORK_TYPE__INVALID) {
+        mpi_errno = get_torus_attributes(MPIR_Process.netloc_topology, network_attr);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    }
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -148,8 +148,8 @@ static int get_tree_attributes(netloc_topology_t topology,
                 goto fn_exit;
             }
 
-            /*Assign depths to nodes of the graph bottom up, in breadth first order */
-            /* indexed by node id, visited_node_list[i] > -1 indicates that the
+            /* Assign depths to nodes of the graph bottom up, in breadth first order */
+            /* Indexed by node id, visited_node_list[i] > -1 indicates that the
              * node i has been visited */
 
             MPIR_CHKPMEM_MALLOC(network_attr->u.tree.node_levels, int *,
@@ -178,7 +178,7 @@ static int get_tree_attributes(netloc_topology_t topology,
                     for (j = 0; j < num_edges; j++) {
                         if (network_attr->u.tree.node_levels[edges[j]->dest_node->__uid__] < 0) {
                             traversal_order[traversal_end++] = edges[j]->dest_node;
-                            /*Switch levels start from 1 */
+                            /* Switch levels start from 1 */
                             network_attr->u.tree.node_levels[edges[j]->dest_node->__uid__] = 1;
                             max_depth = 1;
                             visited_count++;
@@ -192,7 +192,7 @@ static int get_tree_attributes(netloc_topology_t topology,
                 netloc_edge_t **edges;
                 int depth = network_attr->u.tree.node_levels[traversed_node->__uid__];
 
-                /* find all nodes not visited with an edge from the current node */
+                /* Find all nodes not visited with an edge from the current node */
                 netloc_get_all_edges(topology, traversed_node, &num_edges, &edges);
                 for (j = 0; j < num_edges; j++) {
                     if (edges[j]->dest_node == traversed_node) {
@@ -210,9 +210,9 @@ static int get_tree_attributes(netloc_topology_t topology,
                     }
                 }
             }
-            /*End of depth assignment */
+            /* End of depth assignment */
 
-            /*Count the number of nodes and bandwidth at each level */
+            /* Count the number of nodes and bandwidth at each level */
             for (i = 0; i < max_depth; i++) {
                 int width_at_level = 0;
                 int num_nodes_at_level = 0;
@@ -327,7 +327,7 @@ static int get_physical_address(hwloc_obj_t hwloc_obj, char **device_physical_ad
     int mpi_errno = MPI_SUCCESS;
 
     for (i = 0; i < hwloc_obj->infos_count; i++) {
-        /*Check if node guid matches for infiniband networks */
+        /* Check if node guid matches for infiniband networks */
         if (!strcmp(hwloc_obj->infos[i].name, "NodeGUID")) {
             physical_address =
                 (char *) MPL_malloc(sizeof(hwloc_obj->infos[i].value), MPL_MEM_OTHER);

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -33,6 +33,7 @@ static int get_tree_attributes(netloc_topology_t topology,
     int prev_width = 0;
     int edges_go_across_levels = 0;
     int out_degree_mismatch_at_level = 0;
+    MPIR_CHKPMEM_DECL(3);
 
     network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
 
@@ -40,7 +41,6 @@ static int get_tree_attributes(netloc_topology_t topology,
         (netloc_dt_lookup_table_t *) MPL_malloc(sizeof(netloc_dt_lookup_table_t), MPL_MEM_OTHER);
     mpi_errno = netloc_get_all_host_nodes(topology, host_nodes);
 
-    MPIR_CHKPMEM_DECL(3);
     if (!mpi_errno) {
         int host_node_at_leaf_level;
 

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -280,6 +280,15 @@ static int get_tree_attributes(netloc_topology_t topology,
                 if (!count_at_level_mismatch && !bandwidth_mismatch && !out_degree_mismatch) {
                     network_attr->type = MPIR_NETLOC_NETWORK_TYPE__FAT_TREE;
                 }
+
+                errno = MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
+                                                          MPIR_Process.netloc_topology,
+                                                          MPIR_Process.hwloc_topology,
+                                                          &MPIR_Process.
+                                                          network_attr.network_endpoint);
+                if (errno != MPI_SUCCESS) {
+                    network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
+                }
             } else {
                 network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
             }

--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -22,7 +22,8 @@ static const char *split_topo[] = {
 };
 
 static const char *split_topo_network[] = {
-    "switch_level:2", "subcomm_min_size:2", "min_mem_size:512" /* Minimum memory size in bytes */ , NULL
+    "switch_level:2", "subcomm_min_size:2", "min_mem_size:512" /* Minimum memory size in bytes */ ,
+    "torus_dimension:2", NULL
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR adds support to check if the input network topology file is a torus/mesh graph and computes the relative coordinates of the nodes in the network graph, and adds support for both minimum communicator size and minimum memory size split hints. Known limitation of the type classification algorithm is that torus links must be omitted when generating the input network topology file.  Test graph files are attached in the PR.
[meshgraphs.zip](https://github.com/pmodels/mpich/files/2477651/meshgraphs.zip)
