### PR TITLE
hydra: Remove warnings in alloc macros

### DIFF
--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -620,7 +620,7 @@ HYD_status HYDU_sock_cloexec(int fd);
 #define HYDU_MALLOC_OR_JUMP(p, type, size, status)                      \
     {                                                                   \
         (p) = (type) MPL_malloc((size), MPL_MEM_PM);                 \
-        if ((size) && (p) == NULL)                                      \
+        if ((size) != 0 && (p) == NULL)                                 \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \
@@ -629,7 +629,7 @@ HYD_status HYDU_sock_cloexec(int fd);
 #define HYDU_REALLOC_OR_JUMP(p, type, size, status)                     \
     {                                                                   \
         (p) = (type) MPL_realloc((p),(size), MPL_MEM_PM);            \
-        if ((size) && (p) == NULL)                                      \
+        if ((size) != 0 && (p) == NULL)                                 \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \


### PR DESCRIPTION
The (size) expression in the original code expects a boolean type
but actually an integer type is passed as an argument, to which
some compiler (e.g. GCC 7.2 + --enable-strict) emits warnings.

This patch translates `(size)` to `(size) != 0` to remove these
warnings.

Fixes csr/mpich-ofi#1242