### PR TITLE
coll: Add knomial_2 tree type

### DIFF
--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -60,6 +60,12 @@ int MPII_Treealgo_tree_create(int rank, int nranks, int tree_type, int k, int ro
                 MPIR_ERR_POP(mpi_errno);
             break;
 
+        case TREE_TYPE_KNOMIAL_2:
+            mpi_errno = MPII_Treeutil_tree_knomial_2_init(rank, nranks, k, root, ct);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+            break;
+
         default:
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**treetype", "**treetype %d",
                                  tree_type);

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -48,8 +48,8 @@ int MPII_Treealgo_tree_create(int rank, int nranks, int tree_type, int k, int ro
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPII_TREEALGO_TREE_INIT);
 
     switch (tree_type) {
-        case TREE_TYPE_KNOMIAL:
-            mpi_errno = MPII_Treeutil_tree_knomial_init(rank, nranks, k, root, ct);
+        case TREE_TYPE_KNOMIAL_1:
+            mpi_errno = MPII_Treeutil_tree_knomial_1_init(rank, nranks, k, root, ct);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             break;

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -48,14 +48,14 @@ int MPII_Treealgo_tree_create(int rank, int nranks, int tree_type, int k, int ro
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPII_TREEALGO_TREE_INIT);
 
     switch (tree_type) {
-        case TREE_TYPE_KNOMIAL_1:
-            mpi_errno = MPII_Treeutil_tree_knomial_1_init(rank, nranks, k, root, ct);
+        case TREE_TYPE_KARY:
+            mpi_errno = MPII_Treeutil_tree_kary_init(rank, nranks, k, root, ct);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             break;
 
-        case TREE_TYPE_KARY:
-            mpi_errno = MPII_Treeutil_tree_kary_init(rank, nranks, k, root, ct);
+        case TREE_TYPE_KNOMIAL_1:
+            mpi_errno = MPII_Treeutil_tree_knomial_1_init(rank, nranks, k, root, ct);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             break;

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -73,7 +73,16 @@ int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPII_Tre
     goto fn_exit;
 }
 
-
+/* Some examples of knomial_1 tree */
+/*     4 ranks                8 ranks
+ *       0                      0
+ *     /  \                 /   |   \
+ *    1   3               1     5    7
+ *    |                 /   \   |
+ *    2                2     4  6
+ *                     |
+ *                     3
+ */
 #undef FUNCNAME
 #define FUNCNAME MPII_Treeutil_tree_knomial_1_init
 #undef FCNAME

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -75,11 +75,11 @@ int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPII_Tre
 
 
 #undef FUNCNAME
-#define FUNCNAME MPII_Treeutil_tree_knomial_init
+#define FUNCNAME MPII_Treeutil_tree_knomial_1_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPII_Treeutil_tree_knomial_init(int rank, int nranks, int k, int root,
-                                    MPII_Treealgo_tree_t * ct)
+int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
+                                      MPII_Treealgo_tree_t * ct)
 {
     int lrank, i, j, maxtime, tmp, time, parent, current_rank, running_rank, crank;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/algorithms/treealgo/treeutil.h
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.h
@@ -19,4 +19,8 @@ int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPII_Tre
 int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
                                       MPII_Treealgo_tree_t * ct);
 
+/* Generate knomial_2 tree information for rank 'rank' */
+int MPII_Treeutil_tree_knomial_2_init(int rank, int nranks, int k, int root,
+                                      MPII_Treealgo_tree_t * ct);
+
 #endif /* TREEUTIL_H_INCLUDED */

--- a/src/mpi/coll/algorithms/treealgo/treeutil.h
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.h
@@ -15,8 +15,8 @@
 /* Generate kary tree information for rank 'rank' */
 int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPII_Treealgo_tree_t * ct);
 
-/* Generate knomial tree information for rank 'rank' */
-int MPII_Treeutil_tree_knomial_init(int rank, int nranks, int k, int root,
-                                    MPII_Treealgo_tree_t * ct);
+/* Generate knomial_1 tree information for rank 'rank' */
+int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
+                                      MPII_Treealgo_tree_t * ct);
 
 #endif /* TREEUTIL_H_INCLUDED */

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -31,7 +31,7 @@ cvars:
       description : >-
         Tree type for tree based ibcast
         0 - kary tree type
-        1 - knomial tree type
+        1 - knomial_1 tree type
 
     - name        : MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE
       category    : COLLECTIVE

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -32,6 +32,7 @@ cvars:
         Tree type for tree based ibcast
         0 - kary tree type
         1 - knomial_1 tree type
+        2 - knomial_2 tree type
 
     - name        : MPIR_CVAR_IBCAST_TREE_PIPELINE_CHUNK_SIZE
       category    : COLLECTIVE

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -50,7 +50,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
     if (rank == root)
         is_inplace = (sendbuf == MPI_IN_PLACE); /* For gather, MPI_IN_PLACE is significant only at root */
 
-    tree_type = TREE_TYPE_KNOMIAL;      /* currently only tree_type=TREE_TYPE_KNOMIAL is supported for gather */
+    tree_type = TREE_TYPE_KNOMIAL_1;    /* currently only tree_type=TREE_TYPE_KNOMIAL_1 is supported for gather */
     mpi_errno = MPII_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/include/coll_types.h
+++ b/src/mpi/coll/include/coll_types.h
@@ -26,6 +26,7 @@
 enum {
     TREE_TYPE_KARY = 0,
     TREE_TYPE_KNOMIAL_1,
+    TREE_TYPE_KNOMIAL_2,
 };
 
 /* enumerator for different recexch types */

--- a/src/mpi/coll/include/coll_types.h
+++ b/src/mpi/coll/include/coll_types.h
@@ -25,7 +25,7 @@
 /* enumerator for different tree types */
 enum {
     TREE_TYPE_KARY = 0,
-    TREE_TYPE_KNOMIAL,
+    TREE_TYPE_KNOMIAL_1,
 };
 
 /* enumerator for different recexch types */

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -31,6 +31,7 @@ cvars:
         Tree type for tree based ireduce
         0 - kary tree
         1 - knomial_1 tree
+        2 - knomial_2 tree
 
     - name        : MPIR_CVAR_IREDUCE_TREE_PIPELINE_CHUNK_SIZE
       category    : COLLECTIVE

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -30,7 +30,7 @@ cvars:
       description : >-
         Tree type for tree based ireduce
         0 - kary tree
-        1 - knomial tree
+        1 - knomial_1 tree
 
     - name        : MPIR_CVAR_IREDUCE_TREE_PIPELINE_CHUNK_SIZE
       category    : COLLECTIVE

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -80,7 +80,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
 
     if (!is_commutative) {
         if (k > 1)
-            tree_type = TREE_TYPE_KNOMIAL;      /* Force tree_type to be knomial because kary trees cannot
+            tree_type = TREE_TYPE_KNOMIAL_1;    /* Force tree_type to be knomial_1 because kary trees cannot
                                                  * handle non-commutative operations correctly */
         tree_root = 0;  /* Force the tree root to be rank 0 */
     } else {

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -53,7 +53,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
     if (rank == root)
         is_inplace = (recvbuf == MPI_IN_PLACE); /* For scatter, MPI_IN_PLACE is significant only at root */
 
-    tree_type = TREE_TYPE_KNOMIAL;      /* currently only tree_type=TREE_TYPE_KNOMIAL is supported for scatter */
+    tree_type = TREE_TYPE_KNOMIAL_1;    /* currently only tree_type=TREE_TYPE_KNOMIAL_1 is supported for scatter */
     mpi_errno = MPII_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -17,7 +17,7 @@ testing_env="env=MPIR_CVAR_BCAST_DEVICE_COLLECTIVE=0 "
 testing_env+="env=MPIR_CVAR_BCAST_INTRA_ALGORITHM=nb "
 testing_env+="env=MPIR_CVAR_IBCAST_DEVICE_COLLECTIVE=0 "
 algo_names="tree scatter_recexch_allgather"
-tree_types="0 1"
+tree_types="0 1 2"
 kvalues="3"
 
 for algo_name in ${algo_names}; do
@@ -53,7 +53,7 @@ testing_env="env=MPIR_CVAR_REDUCE_DEVICE_COLLECTIVE=0 "
 testing_env+="env=MPIR_CVAR_REDUCE_INTRA_ALGORITHM=nb "
 testing_env+="env=MPIR_CVAR_IREDUCE_DEVICE_COLLECTIVE=0 "
 algo_names="tree ring"
-tree_types="0 1"
+tree_types="0 1 2"
 kvalues="3"
 
 for algo_name in ${algo_names}; do


### PR DESCRIPTION
This knomial tree is of the same structure as the binomial tree in the old collectives algorithms in MPICH. We noted that this type of tree gives better performance than knomial_1 tree type in some cases, although it is difficult to explain why. We, therefore, want to keep both knomial_1 and knomial_2 tree types and let the collective tuner choose the best for a given configuration. The difference between the two tree types is documented through tree examples in treeutil.c file.

This PR is based on top of PR #3209