### PR TITLE
ch4/ofi:no segment preparation for contiguous put

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -541,6 +541,8 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count, target_contig,
                                         target_bytes, target_true_lb);
 
+    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
+
     if (unlikely(origin_bytes == 0))
         goto null_op_exit;
 
@@ -554,7 +556,6 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
 
     if (origin_contig && target_contig) {
         offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
-        MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
         MPIDI_OFI_INIT_SIGNAL_REQUEST(win, sigreq, &flags);
         if (!sigreq)
             flags = 0;


### PR DESCRIPTION
The segment preparation steps in `MPIDI_OFI_do_put` might not be needed for put of contiguous buffers. If so, we can skip it and directly conduct `fi_writemsg`, similar to what `MPIDI_NM_mpi_get` does.

---
Edit:
This PR has been extended to incorporate several more things. The main modifications are on the code refactoring of put|get and rput|rget. The original goal which is the contiguous buffer optimization is in the second commit.