### PR TITLE
ch4:ofi:Move binding of ep and counter after binding of ep and context

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -327,34 +327,33 @@ static inline int MPIDI_OFI_win_init_stx(MPIR_Win * win)
         goto fn_fail;
     }
 
+    MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep, &MPIDI_Global.rma_stx_ctx->fid, 0),
+                          ret);
+    if (ret < 0) {
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    "Failed to bind endpoint to shared transmit contxt.\n");
+        mpi_errno = MPIDI_OFI_EPERROR;
+        goto fn_fail;
+    }
+
+    MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
+                                     &MPIDI_Global.ctx[0].cq->fid,
+                                     FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
+    if (ret < 0) {
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    "Failed to bind endpoint to completion queue.\n");
+        mpi_errno = MPIDI_OFI_EPERROR;
+        goto fn_fail;
+    }
+
+    MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep, &MPIDI_Global.av->fid, 0), ret);
+    if (ret < 0) {
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to bind endpoint to address vector.\n");
+        mpi_errno = MPIDI_OFI_EPERROR;
+        goto fn_fail;
+    }
+
     if (MPIDI_OFI_win_set_per_win_sync(win) == MPI_SUCCESS) {
-        MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep, &MPIDI_Global.rma_stx_ctx->fid, 0),
-                              ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to bind endpoint to shared transmit contxt.\n");
-            mpi_errno = MPIDI_OFI_EPERROR;
-            goto fn_fail;
-        }
-
-        MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                         &MPIDI_Global.ctx[0].cq->fid,
-                                         FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to bind endpoint to completion queue.\n");
-            mpi_errno = MPIDI_OFI_EPERROR;
-            goto fn_fail;
-        }
-
-        MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep, &MPIDI_Global.av->fid, 0), ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to bind endpoint to address vector.\n");
-            mpi_errno = MPIDI_OFI_EPERROR;
-            goto fn_fail;
-        }
-
         MPIDI_OFI_CALL_RETURN(fi_enable(MPIDI_OFI_WIN(win).ep), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "Failed to activate endpoint.\n");


### PR DESCRIPTION
For `MPIDI_OFI_win_init_stx` (shared transmit context), when the binding of endpoint and completion counter is made before the binding of endpoint and context, the counter will have an empty `poll_list`, so it cannot be updated in `fi_cntr_read`, `fi_cntr_wait`, or any functions that check through a counter's `poll_list`. This behavior does not look right. 

`MPIDI_OFI_win_set_per_win_sync` does the binding of ep and counter. I moved it just before `fi_enable`, which is similar to what `MPIDI_OFI_win_init_sep` (scalable endpoint) does.