### PR TITLE
mtest: Remove redundant statement

### DIFF
--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -182,8 +182,6 @@ for algo_name in ${algo_names}; do
     done
 done
 
-export coll_algo_tests
-
 ######### Add tests for Scatter algorithms ###########
 
 #disable device collectives for scatter to test MPIR algorithms


### PR DESCRIPTION
The export statement should be at the end of the script and that is already there.
This was a redundant and incorrectly placed statement.

Testing not needed.