### PR TITLE
More Warning Cleanups

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -1155,7 +1155,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
                                                        MPI_Op op, MPIR_Comm * comm_ptr,
                                                        MPIR_Sched_t s);
 int MPIR_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
-                                       int *recvcounts, MPI_Datatype datatype,
+                                       const int *recvcounts, MPI_Datatype datatype,
                                        MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */

--- a/src/mpi/coll/algorithms/common/algo_common.h
+++ b/src/mpi/coll/algorithms/common/algo_common.h
@@ -18,6 +18,8 @@
 #define FUNCNAME MPII_Algo_compare_int
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
+/* Avoid unused function warning in certain configurations */
+static int MPII_Algo_compare_int(const void *a, const void *b) ATTRIBUTE((unused));
 static int MPII_Algo_compare_int(const void *a, const void *b)
 {
     return (*(int *) a - *(int *) b);
@@ -27,6 +29,10 @@ static int MPII_Algo_compare_int(const void *a, const void *b)
 #define FUNCNAME MPII_Algo_calculate_pipeline_chunk_info
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
+/* Avoid unused function warning in certain configurations */
+static int MPII_Algo_calculate_pipeline_chunk_info(int maxbytes, int type_size, int count,
+                                                   int *num_segments, int *segsize_floor,
+                                                   int *segsize_ceil) ATTRIBUTE((unused));
 static int MPII_Algo_calculate_pipeline_chunk_info(int maxbytes,
                                                    int type_size, int count,
                                                    int *num_segments,

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -44,7 +44,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     int *send_id, *reduce_id;
     bool in_step2;
     void *tmp_buf;
-    void **step1_recvbuf;
+    void **step1_recvbuf = NULL;
     void **nbr_buffer;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLREDUCE_SCHED_INTRA_RECEXCH);

--- a/src/mpi/coll/ibcast/ibcast_tsp_ring_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_ring_algos.h
@@ -104,7 +104,6 @@ int MPIR_TSP_Ibcast_intra_ring(void *buffer, int count, MPI_Datatype datatype, i
                                MPIR_Comm * comm, MPIR_Request ** req, int maxbytes)
 {
     int mpi_errno = MPI_SUCCESS;
-    int tag;
     MPIR_TSP_sched_t *sched;
     *req = NULL;
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -29,15 +29,11 @@ int MPIR_TSP_Ibcast_sched_intra_scatter_recexch_allgather(void *buffer, int coun
                                                           MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i;
-    int num_chunks, chunk_size_floor, chunk_size_ceil;
-    int offset = 0;
     size_t extent, type_size;
     MPI_Aint true_lb, true_extent;
     int size, rank;
     int is_contig;
-    int recv_id;
-    int tag;
+    int tag = -1;
     void *tmp_buf = NULL;
     size_t nbytes;
     int scatter_k = MPIR_CVAR_IBCAST_SCATTER_KVAL;
@@ -123,7 +119,6 @@ int MPIR_TSP_Ibcast_intra_scatter_recexch_allgather(void *buffer, int count, MPI
                                                     int root, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
-    int tag;
     MPIR_TSP_sched_t *sched;
     *req = NULL;
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -82,8 +82,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatter_recexch_allgather(void *buffer, int coun
                                            MPI_DATATYPE_NULL, root, comm, scatter_k, sched);
     else
         MPIR_TSP_Iscatter_sched_intra_tree(NULL, 0, MPI_DATATYPE_NULL,
-                                           tmp_buf + rank * bytes_per_rank, bytes_per_rank,
-                                           MPI_BYTE, root, comm, scatter_k, sched);
+                                           ((char *) tmp_buf) + (rank * bytes_per_rank),
+                                           bytes_per_rank, MPI_BYTE, root, comm, scatter_k, sched);
     MPIR_TSP_sched_fence(sched);        /* wait for scatter to complete */
 
     /* Schedule Allgather */

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -36,7 +36,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
     size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
     size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id, *recv_id = NULL;
-    void *tmp_buf = NULL, *data_buf = NULL;
+    void *tmp_buf = NULL;
+    const void *data_buf = NULL;
     int tree_type;
     MPII_Treealgo_tree_t my_tree, parents_tree;
     int next_child, num_children, *child_subtree_size = NULL, *child_data_offset = NULL;

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -33,8 +33,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int size, rank, lrank;
     int i, j, tag, is_inplace = false;
-    size_t sendtype_lb, sendtype_extent, sendtype_size, sendtype_true_extent;
-    size_t recvtype_lb, recvtype_extent, recvtype_size, recvtype_true_extent;
+    size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
+    size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id, *recv_id = NULL;
     void *tmp_buf = NULL, *data_buf = NULL;
     int tree_type;
@@ -69,12 +69,10 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
         recvcount = sendcount;
     }
 
-    MPIR_Datatype_get_size_macro(sendtype, sendtype_size);
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_lb, &sendtype_true_extent);
     sendtype_extent = MPL_MAX(sendtype_extent, sendtype_true_extent);
 
-    MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_lb, &recvtype_true_extent);
     recvtype_extent = MPL_MAX(recvtype_extent, recvtype_true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recexch.c
@@ -21,7 +21,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
-                                       int *recvcounts, MPI_Datatype datatype,
+                                       const int *recvcounts, MPI_Datatype datatype,
                                        MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -28,8 +28,8 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
                                                  MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int is_inplace, is_contig;
-    size_t type_size, extent;
+    int is_inplace;
+    size_t extent;
     MPI_Aint lb, true_extent;
     int is_commutative;
     int step1_sendto = -1, step2_nphases, step1_nrecvs;
@@ -51,7 +51,6 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     nranks = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
 
-    MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -23,7 +23,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                 int *recvcounts, MPI_Datatype datatype,
+                                                 const int *recvcounts, MPI_Datatype datatype,
                                                  MPI_Op op, int tag, MPIR_Comm * comm, int k,
                                                  MPIR_TSP_sched_t * sched)
 {
@@ -229,9 +229,9 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 #define FUNCNAME MPIR_TSP_Ireduce_scatter_intra_recexch
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf, int *recvcounts,
-                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Request ** req, int k)
+int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
+                                           const int *recvcounts, MPI_Datatype datatype, MPI_Op op,
+                                           MPIR_Comm * comm, MPIR_Request ** req, int k)
 {
     int mpi_errno = MPI_SUCCESS;
     int tag;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos_prototypes.h
@@ -21,10 +21,10 @@
 #define MPIR_TSP_Ireduce_scatter_sched_intra_recexch                MPIR_TSP_NAMESPACE(Ireduce_scatter_sched_intra_recexch)
 
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recvbuf,
-                                                 int *recvcounts, MPI_Datatype datatype,
+                                                 const int *recvcounts, MPI_Datatype datatype,
                                                  MPI_Op op, int tag, MPIR_Comm * comm, int k,
                                                  MPIR_TSP_sched_t * sched);
 
-int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf, int *recvcounts,
-                                           MPI_Datatype datatype, MPI_Op op,
+int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
+                                           const int *recvcounts, MPI_Datatype datatype, MPI_Op op,
                                            MPIR_Comm * comm, MPIR_Request ** req, int k);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -28,8 +28,8 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
                                                        MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    int is_inplace, is_contig;
-    size_t type_size, extent;
+    int is_inplace;
+    size_t extent;
     MPI_Aint lb, true_extent;
     int is_commutative;
     int step1_sendto = -1, step2_nphases, step1_nrecvs;
@@ -54,7 +54,6 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     nranks = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
 
-    MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -696,8 +696,6 @@ int MPIR_Comm_split_type_neighborhood(MPIR_Comm * comm_ptr, int split_type, int 
     char hintval[MPI_MAX_INFO_VAL + 1];
     int mpi_errno = MPI_SUCCESS;
     int info_args_are_equal;
-    int hintval_size, hintval_size_max;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     *newcomm_ptr = NULL;
 

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -138,8 +138,8 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
     }
 #else
     {
-        MPIR_Request *sreq;
-        MPIR_Request *rreq;
+        MPIR_Request *sreq = NULL;
+        MPIR_Request *rreq = NULL;
         void *tmpbuf = NULL;
         MPI_Aint tmpbuf_size = 0;
         MPI_Aint tmpbuf_count = 0;

--- a/src/mpid/ch4/generic/mpidig_globals.c
+++ b/src/mpid/ch4/generic/mpidig_globals.c
@@ -26,7 +26,6 @@ int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code)
     int mpi_errno = MPI_SUCCESS;
     int dest;
     int size = 0;
-    int buf = exit_code;
     MPIR_Request *sreq = NULL;
     MPIDI_CH4U_hdr_t am_hdr;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -159,7 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, alloc_iovs, alloc_iov_size;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_PUT_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_PUT_GET);
@@ -208,7 +208,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, alloc_iovs, alloc_iov_size;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_ACCUMULATE);
@@ -264,7 +264,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
 {
     int mpi_errno = MPI_SUCCESS;
     size_t o_size, t_size, r_size, alloc_iovs, alloc_rma_iovs, alloc_iov_size;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_GET_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_GET_ACCUMULATE);
@@ -321,10 +321,10 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
                                    MPIR_Win * win, MPIR_Request ** sigreq)
 {
     int rc, mpi_errno = MPI_SUCCESS;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
     size_t offset, omax, tmax, tout, oout;
     uint64_t flags;
-    struct fid_ep *ep;
+    struct fid_ep *ep = NULL;
     struct fi_msg_rma msg;
     unsigned i;
     struct iovec *originv;
@@ -482,10 +482,10 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
                                    MPIR_Win * win, MPIR_Request ** sigreq)
 {
     int rc, mpi_errno = MPI_SUCCESS;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
     size_t offset, omax, tmax, tout, oout;
     uint64_t flags;
-    struct fid_ep *ep;
+    struct fid_ep *ep = NULL;
     struct fi_msg_rma msg;
     struct iovec *originv;
     struct fi_rma_iov *targetv;
@@ -878,9 +878,9 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
 {
     int rc, acc_check = 0, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
     size_t origin_bytes, offset, max_count, max_size, dt_size, omax, tmax, tout, oout;
-    struct fid_ep *ep;
+    struct fid_ep *ep = NULL;
     MPI_Datatype basic_type;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
@@ -1026,9 +1026,9 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
 {
     int rc, acc_check = 0, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
-    MPIDI_OFI_win_request_t *req;
+    MPIDI_OFI_win_request_t *req = NULL;
     size_t target_bytes, offset, max_count, max_size, dt_size, omax, rmax, tmax, tout, rout, oout;
-    struct fid_ep *ep;
+    struct fid_ep *ep = NULL;
     MPI_Datatype rt, basic_type, basic_type_res;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -856,7 +856,7 @@ static inline int MPIDI_NM_mpi_win_allocate_shared(MPI_Aint size,
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Win *win = NULL;
     ssize_t total_size = 0LL;
-    void *map_ptr;
+    void *map_ptr = NULL;
     MPIDI_CH4U_win_shared_info_t *shared_table = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_ALLOCATE_SHARED);

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -140,7 +140,7 @@ int MPIDI_check_for_failed_procs(void)
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
     int len;
-    char *kvsname;
+    char *kvsname = NULL;
     char *failed_procs_string = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -933,7 +933,7 @@ static inline int MPIDI_CH4R_mpi_win_allocate_shared(MPI_Aint size,
     MPIR_Win *win = NULL;
     ssize_t total_size = 0LL;
     MPIDI_CH4U_win_shared_info_t *shared_table = NULL;
-    void *map_ptr;
+    void *map_ptr = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4R_MPI_WIN_ALLOCATE_SHARED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4R_MPI_WIN_ALLOCATE_SHARED);
 

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -48,7 +48,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
                        void **bc_table, size_t ** bc_indices)
 {
     int mpi_errno = MPI_SUCCESS;
-    int local_rank, local_leader;
+    int local_rank = -1, local_leader = -1;
     int rank = MPIR_Comm_rank(comm), size = MPIR_Comm_size(comm);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
@@ -327,7 +327,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     int start, end, i;
     int key_max, val_max, name_max, out_len, rem;
     char *kvsname = NULL, *key = NULL, *val = NULL, *val_p;
-    int local_rank, local_leader;
+    int local_rank = -1, local_leader = -1;
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &local_rank, &local_leader);
 

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -8,6 +8,7 @@
 #include "mpidimpl.h"
 #include "mpidu_shm.h"
 #include "mpl.h"
+#include "mpidu_bc.h"
 
 static MPIDU_shm_seg_t memory;
 static MPIDU_shm_barrier_t *barrier;

--- a/src/pm/hydra/include/hydra.h
+++ b/src/pm/hydra/include/hydra.h
@@ -620,7 +620,7 @@ HYD_status HYDU_sock_cloexec(int fd);
 #define HYDU_MALLOC_OR_JUMP(p, type, size, status)                      \
     {                                                                   \
         (p) = (type) MPL_malloc((size), MPL_MEM_PM);                 \
-        if ((size) && (p) == NULL)                                      \
+        if ((size != 0) && ((p) == NULL))                               \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \
@@ -629,7 +629,7 @@ HYD_status HYDU_sock_cloexec(int fd);
 #define HYDU_REALLOC_OR_JUMP(p, type, size, status)                     \
     {                                                                   \
         (p) = (type) MPL_realloc((p),(size), MPL_MEM_PM);            \
-        if ((size) && (p) == NULL)                                      \
+        if ((size != 0) && ((p) == NULL))                               \
             HYDU_ERR_SETANDJUMP((status), HYD_NO_MEM,                   \
                                 "failed to allocate %d bytes\n",        \
                                 (int) (size));                          \

--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -602,10 +602,9 @@ static inline void MPIR_NODEMAP_get_local_info(int rank, int size, int *nodemap,
 static inline void MPIR_NODEMAP_get_node_roots(int *nodemap, int size, int **node_roots,
                                                int *num_nodes)
 {
-    int mpi_errno = MPI_SUCCESS;
     int i, max_node_id;
 
-    mpi_errno = MPID_Get_max_node_id(MPIR_Process.comm_world, &max_node_id);
+    MPID_Get_max_node_id(MPIR_Process.comm_world, &max_node_id);
     *num_nodes = max_node_id + 1;
 
     *node_roots = MPL_malloc(sizeof(int) * (*num_nodes), MPL_MEM_ADDRESS);


### PR DESCRIPTION
This PR goes along with #3202 to cleanup warnings all over MPICH.

These warnings show up with GCC 7.2.1 with `--enable-strict`.