### PR TITLE
#Network level hints 3: Minimum memory size comm split type hint for fat tree networks

### DIFF
--- a/test/mpi/comm/cmsplit_type.c
+++ b/test/mpi/comm/cmsplit_type.c
@@ -22,7 +22,7 @@ static const char *split_topo[] = {
 };
 
 static const char *split_topo_network[] = {
-    "switch_level:2", "subcomm_min_size:2", NULL
+    "switch_level:2", "subcomm_min_size:2", "min_mem_size:512" /* Minimum memory size in bytes */ , NULL
 };
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR creates sub communicators for torus networks with a hint indicating the minimum amount of memory to be associated with each subcommunicator. Currently, memory size information is available only for NUMA objects in hwloc, hence this corresponds to minimum numa memory available per subcommunicator.