### PR TITLE
#Network level hints 2: Cleanup: Netloc utilities and network level comm_split_type hints 

### DIFF
--- a/src/include/netloc_util.h
+++ b/src/include/netloc_util.h
@@ -35,8 +35,7 @@ int MPIR_Netloc_parse_topology(netloc_topology_t topology,
 
 int MPIR_Netloc_get_network_end_point(MPIR_Netloc_network_attributes,
                                       netloc_topology_t netloc_topology,
-                                      hwloc_topology_t hwloc_topology, hwloc_cpuset_t bindset,
-                                      netloc_node_t ** end_point);
+                                      hwloc_topology_t hwloc_topology, netloc_node_t ** end_point);
 
 int MPIR_Netloc_get_switches_at_level(netloc_topology_t netloc_topology,
                                       MPIR_Netloc_network_attributes attributes, int level,

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -376,7 +376,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
             if (mpi_errno == MPI_SUCCESS) {
                 MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
                                                   MPIR_Process.netloc_topology,
-                                                  MPIR_Process.hwloc_topology, MPIR_Process.bindset,
+                                                  MPIR_Process.hwloc_topology,
                                                   &MPIR_Process.network_attr.network_endpoint);
             }
         }

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -350,8 +350,7 @@ static int get_physical_address(hwloc_obj_t hwloc_obj, char **device_physical_ad
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Netloc_get_network_end_point(MPIR_Netloc_network_attributes network_attributes,
                                       netloc_topology_t netloc_topology,
-                                      hwloc_topology_t hwloc_topology, hwloc_cpuset_t bindset,
-                                      netloc_node_t ** end_point)
+                                      hwloc_topology_t hwloc_topology, netloc_node_t ** end_point)
 {
     hwloc_obj_t io_device = NULL;
     int mpi_errno = MPI_SUCCESS;


### PR DESCRIPTION
1. Added asserts after some malloc calls.
2. Removed an unused argument in utility function.