### PR TITLE
hydra: Use C function instead of MPL in example

### DIFF
--- a/src/pm/hydra/examples/print_process_bind.c
+++ b/src/pm/hydra/examples/print_process_bind.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     MPI_Get_processor_name(processor_name, &namelen);
 
     char shell_cmd[100];
-    MPL_snprintf(shell_cmd, sizeof(shell_cmd), "cat /proc/%d/stat | awk '{print $39}'", getpid());
+    snprintf(shell_cmd, sizeof(shell_cmd), "cat /proc/%d/stat | awk '{print $39}'", getpid());
 
     if (rank == 0) {
         printf("----------------------\n");


### PR DESCRIPTION
MPL functions shall only be used in MPICH and related libraries.
A user-level MPI application example should use C functions instead
of MPL wrappers.