### PR TITLE
coll:Topology-aware MPIR_Allgather_intra_auto selection logic

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -172,6 +172,10 @@ struct MPIR_Comm {
 
     int revoked;                /* Flag to track whether the communicator
                                  * has been revoked */
+    bool uniform_ranks;         /* Flag to that checks whether there
+                                 * are same number of processes across nodes or not */
+    int max_num_procs;          /* provides processes per node, to be used when processes per
+                                 * node is same across the nodes */
     MPIR_Info *info;            /* Hints to the communicator */
 
 #if defined HAVE_LIBHCOLL

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -176,6 +176,8 @@ struct MPIR_Comm {
                                  * are same number of processes across nodes or not */
     int max_num_procs;          /* provides processes per node, to be used when processes per
                                  * node is same across the nodes */
+    int threshold;              /* provides threshold value to be used to select among the
+                                 * collective algorithms */
     MPIR_Info *info;            /* Hints to the communicator */
 
 #if defined HAVE_LIBHCOLL

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -114,7 +114,7 @@ int MPIR_Allgather_intra_auto(const void *sendbuf,
     int comm_size;
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint tot_bytes;
-    int type_size, max_node_id, threshold = 0;
+    int type_size, threshold = 0;
 
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         return MPI_SUCCESS;
@@ -122,49 +122,28 @@ int MPIR_Allgather_intra_auto(const void *sendbuf,
     comm_size = comm_ptr->local_size;
 
     MPIR_Datatype_get_size_macro(recvtype, type_size);
-    mpi_errno = MPID_Get_max_node_id(comm_ptr, &max_node_id);
 
     tot_bytes = (MPI_Aint) recvcount *comm_size * type_size;
-    if ((!(comm_ptr->uniform_ranks)) && !(comm_size & (comm_size - 1))) {
-        /* Use default selection logic */
-        if ((tot_bytes < MPIR_CVAR_ALLGATHER_LONG_MSG_SIZE) && !(comm_size & (comm_size - 1))) {
-            mpi_errno =
-                MPIR_Allgather_intra_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
-                                                        recvcount, recvtype, comm_ptr, errflag);
-        } else if (tot_bytes < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
-            mpi_errno =
-                MPIR_Allgather_intra_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                            recvtype, comm_ptr, errflag);
-        } else {
-            mpi_errno =
-                MPIR_Allgather_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                          recvtype, comm_ptr, errflag);
-        }
-    } else {
-        /* Threshold Computation for new selection logic */
-        if ((((max_node_id + 1)) > 32) && (comm_ptr->max_num_procs <= (((max_node_id + 1)) / 32))) {
-            threshold = MPIR_CVAR_ALLGATHER_LONG_MSG_SIZE;
-        } else {
-            threshold = (((max_node_id + 1)) * 32768) / comm_ptr->max_num_procs;
-        }
-    }
 
-    /* Use new selection logic */
-    if ((tot_bytes < threshold) || (((max_node_id + 1)) == 1)) {
-        if (!(comm_size & (comm_size - 1))) {
-            mpi_errno =
-                MPIR_Allgather_intra_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
-                                                        recvcount, recvtype, comm_ptr, errflag);
-        } else {
-            mpi_errno =
-                MPIR_Allgather_intra_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                            recvtype, comm_ptr, errflag);
-        }
+    if (strcmp(MPIR_CVAR_ALLGATHER_INTRA_AUTO_TUNE, ""))
+        threshold = comm_ptr->threshold;
+    else
+        threshold = MPIR_CVAR_ALLGATHER_LONG_MSG_SIZE;
+
+    if ((tot_bytes < threshold) && !(comm_size & (comm_size - 1))) {
+        mpi_errno =
+            MPIR_Allgather_intra_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
+                                                    recvcount, recvtype, comm_ptr, errflag);
+    } else if (tot_bytes < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
+        mpi_errno =
+            MPIR_Allgather_intra_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                        recvtype, comm_ptr, errflag);
     } else {
         mpi_errno =
-            MPIR_Allgather_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                      comm_ptr, errflag);
+            MPIR_Allgather_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                      recvtype, comm_ptr, errflag);
     }
+
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -11,6 +11,24 @@
 #include "utlist.h"
 #include "uthash.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_ALLGATHER_INTRA_AUTO_TUNE
+      category    : COLLECTIVE
+      type        : string
+      default     : ""
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        For MPI_Allgather and MPI_Allgatherv, this file provides threshold value
+        through auto-tuned performnce data
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 /* This is the utility file for comm that contains the basic comm items
    and storage management */
 #ifndef MPID_COMM_PREALLOC


### PR DESCRIPTION
The default threshold values in the existing code for selecting MPI_Allgather algorithms causes significant performance loss. The performance study not only revealed the performance loss but also showed that the selection logic dependency on the number of nodes and the number of processes per node. The new selection logic computes threshold based on number of processes per node and number of nodes and selects the suitable algorithm accordingly. More details of this performance tuning study are available at https://anl.box.com/s/6zg2xlizg70t8nlm85photuvsj75r04f