### PR TITLE
confdb: fix checking for Fortran compiler

### DIFF
--- a/confdb/aclocal_fc.m4
+++ b/confdb/aclocal_fc.m4
@@ -1137,6 +1137,11 @@ int foo_c(CFI_cdesc_t * a_desc, CFI_cdesc_t * b_desc)
 	if (a_desc->dim[1].extent != b_desc->dim[0].extent) { return 3; }
 	return 0;
 }
+
+void test_assumed_rank_async_impl_c(CFI_cdesc_t * a_desc)
+{
+	return;
+}
 ]])],[mv conftest.$OBJEXT conftest1.$OBJEXT],[f08_works=no])
 AC_LANG_POP([C])
 
@@ -1171,9 +1176,11 @@ INTERFACE
     END FUNCTION FOO
 END INTERFACE
 
+
 ! Test assumed-rank + asynchronous
 INTERFACE TEST_ASSUMED_RANK_ASYNC
-    SUBROUTINE TEST_ASSUMED_RANK_ASYNC_IMPL(BUF)
+    SUBROUTINE TEST_ASSUMED_RANK_ASYNC_IMPL(BUF) &
+        BIND(C,name="test_assumed_rank_async_impl_c")
         IMPLICIT NONE
         TYPE(*), DIMENSION(..), ASYNCHRONOUS :: BUF
     END SUBROUTINE TEST_ASSUMED_RANK_ASYNC_IMPL


### PR DESCRIPTION
Cherry-picked from ba35678008a5bd1677fcfc303ffe871e9702b6ff

Original Description:
> The original test for assumed rank is correct but the linking of the
> test fails because `TEST_ASSUMED_RANK_ASYNC_IMPL` is not implemented.
> This fix adds the implementation as a C function
> `test_assumed_rank_async_impl_c` and bind it to the Fortran interface to
> correctly mimic the use case in MPICH.

> Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>