### PR TITLE
coll: Get tag within the schedule function

### DIFF
--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
@@ -59,7 +59,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *step1_r
 
 int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, int tag, MPIR_Comm * comm,
+                                            MPI_Datatype recvtype, MPIR_Comm * comm,
                                             int is_dist_halving, int k, MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Datatype sendtype,

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -88,8 +88,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatter_recexch_allgather(void *buffer, int coun
 
     /* Schedule Allgather */
     MPIR_TSP_Iallgather_sched_intra_recexch(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, tmp_buf,
-                                            bytes_per_rank, MPI_BYTE, tag, comm, 0, allgather_k,
-                                            sched);
+                                            bytes_per_rank, MPI_BYTE, comm, 0, allgather_k, sched);
     MPIR_TSP_sched_fence(sched);        /* wait for allgather to complete */
 
     if (!is_contig) {


### PR DESCRIPTION
`tag` was not set for call to recursive exchange based allgather from the ibcast algorithm. Change function prototype to set the tag within the function itself instead of having to pass a tag to the function.