### PR TITLE
ch4/shm: Fix incorrect function signatures

### DIFF
--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -65,11 +65,12 @@ typedef void (*MPIDI_SHM_am_request_init_t) (MPIR_Request * req);
 typedef void (*MPIDI_SHM_am_request_finalize_t) (MPIR_Request * req);
 typedef int (*MPIDI_SHM_mpi_send_t) (const void *buf, MPI_Aint count,
                                      MPI_Datatype datatype, int rank, int tag,
-                                     MPIR_Comm * comm, int context_offset, MPIR_Request ** request);
+                                     MPIR_Comm * comm, int context_offset,
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_ssend_t) (const void *buf, MPI_Aint count,
                                       MPI_Datatype datatype, int rank, int tag,
                                       MPIR_Comm * comm, int context_offset,
-                                      MPIR_Request ** request);
+                                      MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_startall_t) (int count, MPIR_Request * requests[]);
 typedef int (*MPIDI_SHM_mpi_send_init_t) (const void *buf, int count,
                                           MPI_Datatype datatype, int rank, int tag,
@@ -90,11 +91,11 @@ typedef int (*MPIDI_SHM_mpi_bsend_init_t) (const void *buf, int count,
 typedef int (*MPIDI_SHM_mpi_isend_t) (const void *buf, MPI_Aint count,
                                       MPI_Datatype datatype, int rank, int tag,
                                       MPIR_Comm * comm, int context_offset,
-                                      MPIR_Request ** request);
+                                      MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_issend_t) (const void *buf, MPI_Aint count,
                                        MPI_Datatype datatype, int rank, int tag,
                                        MPIR_Comm * comm, int context_offset,
-                                       MPIR_Request ** request);
+                                       MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_cancel_send_t) (MPIR_Request * sreq);
 typedef int (*MPIDI_SHM_mpi_recv_init_t) (void *buf, int count, MPI_Datatype datatype,
                                           int rank, int tag, MPIR_Comm * comm,

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -358,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send(const void *buf, MPI_Aint count,
 
     ret =
         MPIDI_SHM_native_src_funcs.mpi_send(buf, count, datatype, rank, tag, comm, context_offset,
-                                            request);
+                                            addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SEND);
     return ret;
@@ -376,7 +376,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count
 
     ret =
         MPIDI_SHM_native_src_funcs.mpi_ssend(buf, count, datatype, rank, tag, comm, context_offset,
-                                             request);
+                                             addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SSEND);
     return ret;
@@ -475,7 +475,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
 
     ret =
         MPIDI_SHM_native_src_funcs.mpi_isend(buf, count, datatype, rank, tag, comm, context_offset,
-                                             request);
+                                             addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_ISEND);
     return ret;
@@ -493,7 +493,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_issend(const void *buf, MPI_Aint coun
 
     ret =
         MPIDI_SHM_native_src_funcs.mpi_issend(buf, count, datatype, rank, tag, comm, context_offset,
-                                              request);
+                                              addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_ISSEND);
     return ret;


### PR DESCRIPTION
The function signatures for a number of CH4 shared memory functions
don't match correctly and are causing segfaults. Correct this by
matching up the signatures properly.

Fixes csr/mpich-ofi#1291