### PR TITLE
include: Add assertion in MPIR_Valid_ptr_class

### DIFF
--- a/src/include/mpir_pointers.h
+++ b/src/include/mpir_pointers.h
@@ -18,8 +18,14 @@
 /* This test is lame.  Should eventually include cookie test
    and in-range addresses */
 #define MPIR_Valid_ptr_class(kind,ptr,errclass,err) \
-  {if (!(ptr)) { err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, errclass, \
-                                             "**nullptrtype", "**nullptrtype %s", #kind); } }
+    do {                                                                \
+        if (!(ptr)) {                                                   \
+            err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__, errclass, \
+                                       "**nullptrtype", "**nullptrtype %s", #kind); \
+            /* Explicitly tell Coverity that errclass != MPI_SUCCESS => err != MPI_SUCCESS */ \
+            MPIR_Assert((errclass) == MPI_SUCCESS || ((err) != MPI_SUCCESS)); \
+        }                                                               \
+    } while (0)
 
 #define MPIR_Info_valid_ptr(ptr,err) MPIR_Valid_ptr_class(Info,ptr,MPI_ERR_INFO,err)
 /* Check not only for a null pointer but for an invalid communicator,


### PR DESCRIPTION
Commit b5d7bb6c did not fix CID 171658 and others.
This commit adds a similar assertion as b5d7bb6c did but in a upper
part in the call stack, in order to tell Coverity that the return
value shouldn't be MPI_SUCCESS if `ptr` is NULL.

Trying to fix CID 171658, 171660, 171723, and maybe more.