### PR TITLE
coll: Fix enum usage

### DIFF
--- a/src/mpi/coll/iallreduce/iallreduce_intra_tree_kary.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_tree_kary.c
@@ -27,7 +27,7 @@ int MPIR_Iallreduce_intra_tree_kary(const void *sendbuf, void *recvbuf, int coun
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPII_Gentran_Iallreduce_intra_tree(sendbuf, recvbuf, count, datatype, op,
-                                                   comm_ptr, request, TREE_TYPE_KARY,
+                                                   comm_ptr, request, MPIR_TREE_TYPE_KARY,
                                                    MPIR_CVAR_IALLREDUCE_TREE_KVAL,
                                                    MPIR_CVAR_IALLREDUCE_TREE_PIPELINE_CHUNK_SIZE);
     return mpi_errno;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_tree_knomial.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_tree_knomial.c
@@ -27,7 +27,7 @@ int MPIR_Iallreduce_intra_tree_knomial(const void *sendbuf, void *recvbuf, int c
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPII_Gentran_Iallreduce_intra_tree(sendbuf, recvbuf, count, datatype, op,
-                                                   comm_ptr, request, TREE_TYPE_KNOMIAL,
+                                                   comm_ptr, request, MPIR_TREE_TYPE_KNOMIAL_1,
                                                    MPIR_CVAR_IALLREDUCE_TREE_KVAL,
                                                    MPIR_CVAR_IALLREDUCE_TREE_PIPELINE_CHUNK_SIZE);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -75,8 +75,8 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
                                              chunk_size_floor, chunk_size_ceil));
 
     if (!is_commutative) {
-        tree_type = TREE_TYPE_KNOMIAL;  /* Force tree_type to be knomial because kary trees cannot
-                                         * handle non-commutative operations correctly */
+        tree_type = MPIR_TREE_TYPE_KNOMIAL_1;   /* Force tree_type to be knomial because kary trees cannot
+                                                 * handle non-commutative operations correctly */
     }
 
     /* initialize the tree */


### PR DESCRIPTION
The names were prefixed with MPIR_ in a recent commit.
This fixes build failures.