### PR TITLE
mpl: Fix error handling in mpl related to shm

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -15,6 +15,14 @@
 **nomem %d:Out of memory (unable to allocate %d bytes)
 **nomem2:Unable to allocate memory (probably out of memory)
 **nomem2 %d %s:Unable to allocate %d bytes of memory for %s (probably out of memory)
+**alloc_shar_mem:unable to allocate shared memory
+**alloc_shar_mem %s %s:unable to allocate shared memory - %s %s
+**attach_shar_mem:unable to attach to shared memory
+**attach_shar_mem %s %s:unable to attach to shared memory - %s %s
+**remove_shar_mem:unable to remove shared memory
+**remove_shar_mem %s %s:unable to remove shared memory - %s %s
+**detach_shar_mem:unable to detach shared memory
+**detach_shar_mem %s %s:unable to detach shared memory - %s %s
 **notimpl:Function not implemented
 **notimpl %s:Function %s not implemented
 **nullptr:Null pointer
@@ -717,14 +725,6 @@ is too big (> MPIU_SHMW_GHND_SZ)
 #
 **ioctl:ioctl failed
 **ioctl %d %s:ioctl failed errno=%d - %s
-**alloc_shar_mem:unable to allocate shared memory
-**alloc_shar_mem %s %s:unable to allocate shared memory - %s %s
-**attach_shar_mem:unable to attach to shared memory
-**attach_shar_mem %s %s:unable to attach to shared memory - %s %s
-**remove_shar_mem:unable to remove shared memory
-**remove_shar_mem %s %s:unable to remove shared memory - %s %s
-**detach_shar_mem:unable to detach shared memory
-**detach_shar_mem %s %s:unable to detach shared memory - %s %s
 **read %d %s:read from socket failed - nread=%d %s
 **winput_oob:target pointer for win_put is out of bounds
 **winget_oob:source pointer for win_get is out of bounds

--- a/src/mpl/src/shm/mpl_shm.c
+++ b/src/mpl/src/shm/mpl_shm.c
@@ -18,9 +18,7 @@
  */
 int MPL_shm_hnd_serialize(char *str, MPL_shm_hnd_t hnd, int str_len)
 {
-    int rc = -1;
-    rc = MPLI_shm_ghnd_get_by_val(hnd, str, str_len);
-    return rc;
+    return MPLI_shm_ghnd_get_by_val(hnd, str, str_len);
 }
 
 /* Deserialize a handle.
@@ -53,9 +51,8 @@ int MPL_shm_hnd_deserialize(MPL_shm_hnd_t hnd, const char *str_hnd, size_t str_h
 
 int MPL_shm_hnd_get_serialized_by_ref(MPL_shm_hnd_t hnd, char **str_ptr)
 {
-    int mpi_errno = 0;
     *str_ptr = (char *) MPLI_shm_ghnd_get_by_ref(hnd);
-    return mpi_errno;
+    return 0;
 }
 
 /* Deserialize a handle by reference.
@@ -69,14 +66,10 @@ int MPL_shm_hnd_get_serialized_by_ref(MPL_shm_hnd_t hnd, char **str_ptr)
  */
 int MPL_shm_hnd_deserialize_by_ref(MPL_shm_hnd_t hnd, char **ser_hnd_ptr)
 {
-    int mpi_errno = 0;
-
     MPLI_shm_hnd_reset_val(hnd);
     MPLI_shm_ghnd_set_by_ref(hnd, *ser_hnd_ptr);
 
-    mpi_errno = MPL_shm_seg_open(hnd, 0);
-
-    return mpi_errno;
+    return MPL_shm_seg_open(hnd, 0);
 }
 
 /* Initialize a shared memory handle
@@ -97,8 +90,6 @@ int MPL_shm_hnd_init(MPL_shm_hnd_t * hnd_ptr)
  */
 int MPL_shm_hnd_finalize(MPL_shm_hnd_t * hnd_ptr)
 {
-    int mpi_errno = 0;
-
     /* A finalize can/should be called on an invalid handle
      * Don't assert if we fail here ...
      */
@@ -107,5 +98,5 @@ int MPL_shm_hnd_finalize(MPL_shm_hnd_t * hnd_ptr)
 
     *hnd_ptr = MPL_SHM_HND_INVALID;
 
-    return mpi_errno;
+    return 0;
 }

--- a/src/mpl/src/shm/mpl_shm_mmap.c
+++ b/src/mpl/src/shm/mpl_shm_mmap.c
@@ -143,11 +143,9 @@ int MPL_shm_seg_open(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
                                   void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH,
-                                         MPL_MEM_SHM);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH,
+                                           MPL_MEM_SHM);
 }
 
 /* Attach to an existing SHM segment
@@ -159,10 +157,8 @@ int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
  */
 int MPL_shm_seg_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz, void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_ATTACH, MPL_MEM_SHM);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_ATTACH, MPL_MEM_SHM);
 }
 
 /* Detach from an attached SHM segment */
@@ -187,11 +183,7 @@ int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, intptr_t seg_sz)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPL_shm_seg_remove(MPL_shm_hnd_t hnd)
 {
-    int rc = -1;
-
-    rc = unlink(MPLI_shm_ghnd_get_by_ref(hnd));
-
-    return rc;
+    return unlink(MPLI_shm_ghnd_get_by_ref(hnd));
 }
 
 #endif /* MPL_USE_MMAP_SHM */

--- a/src/mpl/src/shm/mpl_shm_sysv.c
+++ b/src/mpl/src/shm/mpl_shm_sysv.c
@@ -32,7 +32,13 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
         lhnd = shmget(IPC_PRIVATE, seg_sz, IPC_CREAT | S_IRWXU);
         MPLI_shm_lhnd_set(hnd, lhnd);
         rc = MPLI_shm_ghnd_alloc(hnd, MPL_MEM_SHM);
+        if (rc) {
+            goto fn_exit;
+        }
         rc = MPLI_shm_ghnd_set_by_val(hnd, "%d", lhnd);
+        if (rc < 0) {
+            goto fn_exit;
+        }
     } else {
         /* Open an existing shared memory seg */
         if (!MPLI_shm_lhnd_is_valid(hnd)) {
@@ -44,6 +50,9 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
     if (flag & MPLI_SHM_FLAG_SHM_ATTACH) {
         /* Attach to shared mem seg */
         *shm_addr_ptr = shmat(MPLI_shm_lhnd_get(hnd), NULL, 0x0);
+        if (*shm_addr_ptr == (void *) -1) {
+            rc = -1;
+        }
     }
 
   fn_exit:

--- a/src/mpl/src/shm/mpl_shm_sysv.c
+++ b/src/mpl/src/shm/mpl_shm_sysv.c
@@ -57,8 +57,6 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
 
   fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 /* Create new SHM segment
@@ -67,9 +65,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
  */
 int MPL_shm_seg_create(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 {
-    int rc = -1;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_SHM_CREATE);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_SHM_CREATE);
 }
 
 /* Open an existing SHM segment
@@ -79,9 +75,7 @@ int MPL_shm_seg_create(MPL_shm_hnd_t hnd, intptr_t seg_sz)
  */
 int MPL_shm_seg_open(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 {
-    int rc = -1;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_CLR);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_CLR);
 }
 
 /* Create new SHM segment and attach to it
@@ -94,10 +88,8 @@ int MPL_shm_seg_open(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
                                   void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH);
 }
 
 /* Attach to an existing SHM segment
@@ -109,10 +101,8 @@ int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
  */
 int MPL_shm_seg_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz, void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_ATTACH);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_ATTACH);
 }
 
 /* Detach from an attached SHM segment
@@ -131,10 +121,7 @@ int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, intptr_t seg_sz)
     rc = shmdt(*shm_addr_ptr);
     *shm_addr_ptr = NULL;
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 /* Remove a shared memory segment
@@ -147,14 +134,8 @@ int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, intptr_t seg_sz)
 int MPL_shm_seg_remove(MPL_shm_hnd_t hnd)
 {
     struct shmid_ds ds;
-    int rc = -1;
 
-    rc = shmctl(MPLI_shm_lhnd_get(hnd), IPC_RMID, &ds);
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
+    return shmctl(MPLI_shm_lhnd_get(hnd), IPC_RMID, &ds);
 }
 
 #endif /* MPL_USE_SYSV_SHM */

--- a/src/mpl/src/shm/mpl_shm_win.c
+++ b/src/mpl/src/shm/mpl_shm_win.c
@@ -67,8 +67,6 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
 
   fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 /* Create new SHM segment
@@ -77,9 +75,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
  */
 int MPL_shm_seg_create(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 {
-    int rc = -1;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_SHM_CREATE);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_SHM_CREATE);
 }
 
 /* Open an existing SHM segment
@@ -89,9 +85,7 @@ int MPL_shm_seg_create(MPL_shm_hnd_t hnd, intptr_t seg_sz)
  */
 int MPL_shm_seg_open(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 {
-    int rc = -1;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_CLR);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, NULL, 0, MPLI_SHM_FLAG_CLR);
 }
 
 /* Create new SHM segment and attach to it
@@ -104,10 +98,8 @@ int MPL_shm_seg_open(MPL_shm_hnd_t hnd, intptr_t seg_sz)
 int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
                                   void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_CREATE | MPLI_SHM_FLAG_SHM_ATTACH);
 }
 
 /* Attach to an existing SHM segment
@@ -119,10 +111,8 @@ int MPL_shm_seg_create_and_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz,
  */
 int MPL_shm_seg_attach(MPL_shm_hnd_t hnd, intptr_t seg_sz, void **shm_addr_ptr, int offset)
 {
-    int rc = 0;
-    rc = MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
-                                         MPLI_SHM_FLAG_SHM_ATTACH);
-    return rc;
+    return MPL_shm_seg_create_attach_templ(hnd, seg_sz, shm_addr_ptr, offset,
+                                           MPLI_SHM_FLAG_SHM_ATTACH);
 }
 
 /* Detach from an attached SHM segment */
@@ -137,10 +127,7 @@ static inline int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, int
     rc = UnmapViewOfFile(*shm_addr_ptr);
     *shm_addr_ptr = NULL;
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 


### PR DESCRIPTION
Check the return value of POSIX calls like `mmap, open`.
Make sure MPL doesnt return `mpi_errno` and `mpi_errno` is set correctly after MPL_shm calls.