### PR TITLE
Fix pipeline chunk calculation 

### DIFF
--- a/src/mpi/coll/algorithms/common/algo_common.h
+++ b/src/mpi/coll/algorithms/common/algo_common.h
@@ -51,7 +51,7 @@ static int MPII_Algo_calculate_pipeline_chunk_info(int maxbytes,
 
     maxelems = maxbytes / type_size;
 
-    if (maxelems == 0 || maxelems >= count) {   /* disable pipelining */
+    if (maxelems <= 0 || maxelems >= count) {   /* disable pipelining */
         *num_segments = 1;
         *segsize_floor = *segsize_ceil = count;
         goto fn_exit;


### PR DESCRIPTION
Since the default value for segment size/maxbytes is -1, when type size is 1 maxelems would be -1. This would still do pipelining instead of disabling it and set chunk_size_floor and chunk_size_ceil as -1 and hence the msgsize for communication is set to -1 as well causing tests to fail.