### PR TITLE
configure: add shared object option for IBM compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5600,8 +5600,15 @@ fi
 # linking issue on Darwin
 LT_OUTPUT
 
-# see ticket #1590 for some more background on these Darwin linking issues
 if test "X$enable_shared" = "Xyes" ; then
+    # see Github issue pmodels/mpich#3050 for shared object linking issue with
+    # IBM compiler
+    PAC_C_CHECK_COMPILER_OPTION("-qmkshrobj",found_opt=yes,found_opt=no)
+    if test "$found_opt" = "yes" ; then
+        PAC_APPEND_FLAG([-qmkshrobj],[LDFLAGS])
+    fi
+
+    # see ticket #1590 for some more background on these Darwin linking issues
     AS_CASE([$host],
         [*-*-darwin*],
         [


### PR DESCRIPTION
Building shared library with IBM compiler requires `-qmkshrobj` option.

Fix pmodels/mpich#3050

For testing. Will prepare a separate PR for 3.2.x branch.