### PR TITLE
mtest: Fix overzealous search/replace

### DIFF
--- a/test/mpi/f08/rma/c2f902cwin.c
+++ b/test/mpi/f08/rma/c2f902cwin.c
@@ -77,7 +77,7 @@ int c2fwin_(int *win)
     MPI_Group_free(&group);
     MPI_Group_free(&wgroup);
 
-    return MTestReturnValue(errs);
+    return 0;
 }
 
 /*


### PR DESCRIPTION
This file is not a standalone test and therefore should have been
omitted from the cleanup in [d740c337e17a]. Fixes compiliation errors
in Jenkins testing with the Fortran 2008 binding enabled.