### PR TITLE
WIP: Lustre ADIO driver patch for Progressive File Layout feature

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/Makefile.mk
+++ b/src/mpi/romio/adio/ad_lustre/Makefile.mk
@@ -7,7 +7,8 @@
 
 if BUILD_AD_LUSTRE
 
-noinst_HEADERS += adio/ad_lustre/ad_lustre.h
+noinst_HEADERS += adio/ad_lustre/ad_lustre.h	\
+		  adio/ad_lustre/ad_lustre_cyaml.h
 
 romio_other_sources +=                   \
     adio/ad_lustre/ad_lustre.c           \
@@ -16,7 +17,16 @@ romio_other_sources +=                   \
     adio/ad_lustre/ad_lustre_wrcoll.c    \
     adio/ad_lustre/ad_lustre_wrstr.c     \
     adio/ad_lustre/ad_lustre_hints.c     \
-    adio/ad_lustre/ad_lustre_aggregate.c
+    adio/ad_lustre/ad_lustre_aggregate.c \
+    adio/ad_lustre/ad_lustre_layout.c	 \
+    adio/ad_lustre/ad_lustre_cyaml.c
+
+if LUSTRE_YAML
+LUSTRE_YAMLLIB = -lyaml
+else
+LUSTRE_YAMLLIB = -lm
+endif
+external_libs += $(LUSTRE_YAMLLIB)
 
 if LUSTRE_LOCKAHEAD
 romio_other_sources +=                   \

--- a/src/mpi/romio/adio/ad_lustre/README
+++ b/src/mpi/romio/adio/ad_lustre/README
@@ -1,9 +1,14 @@
-Upcoming soon: 
+Upcoming soon:
   o Hierarchical striping as described in the paper from CCGrid2007
     http://ft.ornl.gov/projects/io/pubs/CCGrid-2007-file-joining.pdf
 Further out:
   o To post the code for ParColl (Partitioned collective IO)
  
+-----------------------------------------------------
+V06: 
+-----------------------------------------------------
+  o Composite layout support
+
 -----------------------------------------------------
 V05: 
 -----------------------------------------------------

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.h
@@ -39,6 +39,9 @@
 #include <linux/lustre/lustre_user.h>
 #endif
 
+#ifdef HAVE_LUSTRE_LUSTREAPI_H
+#include <lustre/lustreapi.h>
+#endif
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -54,6 +57,20 @@
 #include <sys/aio.h>
 #endif
 #endif /* End of HAVE_AIO_LITE_H */
+
+#define LDEBUG(format, ...)				\
+do {							\
+    fprintf(stderr, "%s(%d): "format,			\
+	    __func__, __LINE__, ## __VA_ARGS__);	\
+} while (0)
+
+#define DEFAULT_STRIPE_SIZE (1 << 20)
+
+#define GOTO(label, rc)				\
+do {							\
+    ((void)(rc));					\
+    goto label;						\
+} while (0)
 
 void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code);
 void ADIOI_LUSTRE_Close(ADIO_File fd, int *error_code);
@@ -82,7 +99,7 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
 int ADIOI_LUSTRE_Docollect(ADIO_File fd, int contig_access_count,
                            ADIO_Offset * len_list, int nprocs);
 
-void ADIOI_LUSTRE_Get_striping_info(ADIO_File fd, int **striping_info_ptr, int mode);
+void ADIOI_LUSTRE_Get_striping_info(ADIO_File fd, int mode, int **striping_info_ptr);
 void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                               ADIO_Offset * len_list, int contig_access_count,
                               int *striping_info, int nprocs,
@@ -91,5 +108,13 @@ void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                               ADIOI_Access ** my_req_ptr, ADIO_Offset *** buf_idx_ptr);
 
 int ADIOI_LUSTRE_Calc_aggregator(ADIO_File fd, ADIO_Offset off,
-                                 ADIO_Offset * len, int *striping_info);
+                                 int *striping_info, ADIO_Offset * len);
+#ifdef HAVE_LUSTRE_COMP_LAYOUT_SUPPORT
+int ADIOI_LUSTRE_Get_lcm_stripe_count(struct llapi_layout *layout);
+ADIO_Offset ADIOI_LUSTRE_Get_last_stripe_size(struct llapi_layout *layout);
+int ADIOI_LUSTRE_Parse_comp_layout_opt(char *opt, struct llapi_layout **layout_ptr);
+#ifdef HAVE_YAML_SUPPORT
+int ADIOI_LUSTRE_Parse_yaml_temp(char *tempfile, struct llapi_layout **layout_ptr);
+#endif /* HAVE_YAML_SUPPORT */
+#endif /*  HAVE_LUSTRE_COMP_LAYOUT_SUPPORT */
 #endif /* AD_LUSTRE_H_INCLUDED */

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.c
@@ -1,0 +1,593 @@
+/*
+ * LGPL HEADER START
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * LGPL HEADER END
+ *
+ * Copyright (c) 2014, 2015, Intel Corporation.
+ *
+ * Author:
+ *   Amir Shehata <amir.shehata@intel.com>
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <float.h>
+#include <limits.h>
+#include <ctype.h>
+#include "ad_lustre.h"
+
+#ifdef HAVE_YAML_SUPPORT
+#include <yaml.h>
+#include "ad_lustre_cyaml.h"
+
+#define INDENT		4
+#define EXTRA_IND	2
+
+#undef YAML_DEBUG
+
+/*
+ *  cYAML_ll
+ *  Linked list of different trees representing YAML
+ *  documents.
+ */
+struct cYAML_ll {
+    struct list_head list;
+    struct cYAML *obj;
+};
+
+enum cYAML_handler_error {
+    CYAML_ERROR_NONE = 0,
+    CYAML_ERROR_UNEXPECTED_STATE = -1,
+    CYAML_ERROR_NOT_SUPPORTED = -2,
+    CYAML_ERROR_OUT_OF_MEM = -3,
+    CYAML_ERROR_BAD_VALUE = -4,
+    CYAML_ERROR_PARSE = -5,
+};
+
+enum cYAML_tree_state {
+    TREE_STATE_COMPLETE = 0,
+    TREE_STATE_INITED,
+    TREE_STATE_TREE_STARTED,
+    TREE_STATE_BLK_STARTED,
+    TREE_STATE_KEY,
+    TREE_STATE_KEY_FILLED,
+    TREE_STATE_VALUE,
+    TREE_STATE_SEQ_START,
+};
+
+struct cYAML_tree_node {
+    struct cYAML *root;
+    /* cur is the current node we're operating on */
+    struct cYAML *cur;
+    enum cYAML_tree_state state;
+    int from_blk_map_start;
+    /* represents the tree depth */
+    struct list_head ll;
+};
+
+typedef enum cYAML_handler_error (*yaml_token_handler) (yaml_token_t * token,
+                                                        struct cYAML_tree_node *);
+
+static enum cYAML_handler_error yaml_parse_error(yaml_token_t * token,
+                                                 struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_stream_start(yaml_token_t * token,
+                                                  struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_stream_end(yaml_token_t * token, struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_not_supported(yaml_token_t * token,
+                                                   struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_blk_mapping_start(yaml_token_t * token,
+                                                       struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_block_end(yaml_token_t * token, struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_key(yaml_token_t * token, struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_value(yaml_token_t * token, struct cYAML_tree_node *tree);
+static enum cYAML_handler_error yaml_scalar(yaml_token_t * token, struct cYAML_tree_node *tree);
+
+/* dispatch table for token types */
+static yaml_token_handler dispatch_tbl[] = {
+    [YAML_NO_TOKEN] = yaml_parse_error,
+    [YAML_STREAM_START_TOKEN] = yaml_stream_start,
+    [YAML_STREAM_END_TOKEN] = yaml_stream_end,
+    [YAML_BLOCK_MAPPING_START_TOKEN] = yaml_blk_mapping_start,
+    [YAML_BLOCK_END_TOKEN] = yaml_block_end,
+    [YAML_KEY_TOKEN] = yaml_key,
+    [YAML_VALUE_TOKEN] = yaml_value,
+    [YAML_SCALAR_TOKEN] = yaml_scalar,
+};
+
+/* dispatch table */
+static char *token_type_string[] = {
+    [YAML_NO_TOKEN] = "YAML_NO_TOKEN",
+    [YAML_STREAM_START_TOKEN] = "YAML_STREAM_START_TOKEN",
+    [YAML_STREAM_END_TOKEN] = "YAML_STREAM_END_TOKEN",
+    [YAML_BLOCK_MAPPING_START_TOKEN] = "YAML_BLOCK_MAPPING_START_TOKEN",
+    [YAML_BLOCK_END_TOKEN] = "YAML_BLOCK_END_TOKEN",
+    [YAML_KEY_TOKEN] = "YAML_KEY_TOKEN",
+    [YAML_VALUE_TOKEN] = "YAML_VALUE_TOKEN",
+    [YAML_SCALAR_TOKEN] = "YAML_SCALAR_TOKEN",
+};
+
+static void cYAML_ll_free(struct list_head *ll)
+{
+    struct cYAML_ll *node, *tmp;
+
+    list_for_each_entry_safe(node, tmp, ll, list) {
+        free(node);
+    }
+}
+
+static int cYAML_ll_push(struct cYAML *obj, struct list_head *list)
+{
+    struct cYAML_ll *node = calloc(1, sizeof(*node));
+    if (node == NULL)
+        return -1;
+
+    INIT_LIST_HEAD(&node->list);
+    node->obj = obj;
+    list_add(&node->list, list);
+
+    return 0;
+}
+
+static struct cYAML *cYAML_ll_pop(struct list_head *list)
+{
+    struct cYAML_ll *pop;
+    struct cYAML *obj = NULL;
+
+    if (!list_empty(list)) {
+        pop = list_entry(list->next, struct cYAML_ll, list);
+        obj = pop->obj;
+        list_del(&pop->list);
+        free(pop);
+    }
+
+    return obj;
+}
+
+static int cYAML_ll_count(struct list_head *ll)
+{
+    int i = 0;
+    struct list_head *node;
+
+    list_for_each(node, ll)
+        i++;
+
+    return i;
+}
+
+static int cYAML_tree_init(struct cYAML_tree_node *tree)
+{
+    struct cYAML *obj = NULL, *cur = NULL;
+
+    if (tree == NULL)
+        return -1;
+
+    obj = calloc(1, sizeof(*obj));
+    if (obj == NULL)
+        return -1;
+
+    if (tree->root) {
+        /* append the node */
+        cur = tree->root;
+        while (cur->cy_next != NULL)
+            cur = cur->cy_next;
+        cur->cy_next = obj;
+    } else {
+        tree->root = obj;
+    }
+
+    obj->cy_type = CYAML_TYPE_OBJECT;
+
+    tree->cur = obj;
+    tree->state = TREE_STATE_COMPLETE;
+
+    /* free it and start anew */
+    if (!list_empty(&tree->ll))
+        cYAML_ll_free(&tree->ll);
+
+    return 0;
+}
+
+static struct cYAML *create_child(struct cYAML *parent)
+{
+    struct cYAML *obj;
+
+    if (parent == NULL)
+        return NULL;
+
+    obj = calloc(1, sizeof(*obj));
+    if (obj == NULL)
+        return NULL;
+
+    /* set the type to OBJECT and let the value change that */
+    obj->cy_type = CYAML_TYPE_OBJECT;
+
+    parent->cy_child = obj;
+
+    return obj;
+}
+
+static struct cYAML *create_sibling(struct cYAML *sibling)
+{
+    struct cYAML *obj;
+
+    if (sibling == NULL)
+        return NULL;
+
+    obj = calloc(1, sizeof(*obj));
+    if (obj == NULL)
+        return NULL;
+
+    /* set the type to OBJECT and let the value change that */
+    obj->cy_type = CYAML_TYPE_OBJECT;
+
+    sibling->cy_next = obj;
+    obj->cy_prev = sibling;
+
+    return obj;
+}
+
+/* Parse the input text to generate a number,
+ * and populate the result into item. */
+static bool parse_number(struct cYAML *item, const char *input)
+{
+    double n = 0, sign = 1, scale = 0;
+    int subscale = 0, signsubscale = 1;
+    const char *num = input;
+
+    if (*num == '-') {
+        sign = -1;
+        num++;
+    }
+
+    if (*num == '0')
+        num++;
+
+    if (*num >= '1' && *num <= '9') {
+        do {
+            n = (n * 10.0) + (*num++ - '0');
+        } while (*num >= '0' && *num <= '9');
+    }
+
+    if (*num == '.' && num[1] >= '0' && num[1] <= '9') {
+        num++;
+        do {
+            n = (n * 10.0) + (*num++ - '0');
+            scale--;
+        } while (*num >= '0' && *num <= '9');
+    }
+
+    if (*num == 'e' || *num == 'E') {
+        num++;
+        if (*num == '+') {
+            num++;
+        } else if (*num == '-') {
+            signsubscale = -1;
+            num++;
+        }
+        while (*num >= '0' && *num <= '9')
+            subscale = (subscale * 10) + (*num++ - '0');
+    }
+
+    /* check to see if the entire string is consumed.  If not then
+     * that means this is a string with a number in it */
+    if (num != (input + strlen(input)))
+        return false;
+
+    /* number = +/- number.fraction * 10^+/- exponent */
+    n = sign * n * pow(10.0, (scale + subscale * signsubscale));
+
+    item->cy_valuedouble = n;
+    item->cy_valueint = (int) n;
+    item->cy_type = CYAML_TYPE_NUMBER;
+
+    return true;
+}
+
+static int assign_type_value(struct cYAML *obj, const char *value)
+{
+    if (value == NULL)
+        return -1;
+
+    if (strcmp(value, "null") == 0)
+        obj->cy_type = CYAML_TYPE_NULL;
+    else if (strcmp(value, "false") == 0) {
+        obj->cy_type = CYAML_TYPE_FALSE;
+        obj->cy_valueint = 0;
+    } else if (strcmp(value, "true") == 0) {
+        obj->cy_type = CYAML_TYPE_TRUE;
+        obj->cy_valueint = 1;
+    } else if (*value == '-' || (*value >= '0' && *value <= '9')) {
+        if (parse_number(obj, value) == 0) {
+            obj->cy_valuestring = strdup(value);
+            obj->cy_type = CYAML_TYPE_STRING;
+        }
+    } else {
+        obj->cy_valuestring = strdup(value);
+        obj->cy_type = CYAML_TYPE_STRING;
+    }
+
+    return 0;
+}
+
+/*
+ * yaml_handle_token
+ *  Builds the YAML tree rpresentation as the tokens are passed in
+ *
+ *  if token == STREAM_START && tree_state != COMPLETE
+ *    something wrong. fail.
+ *  else tree_state = INITIED
+ *  if token == STREAM_END && tree_state != INITED
+ *    something wrong fail.
+ *  else tree_state = COMPLETED
+ *  if token == YAML_KEY_TOKEN && state != TREE_STARTED
+ *    something wrong, fail.
+ *  if token == YAML_SCALAR_TOKEN && state != KEY || VALUE
+ *    fail.
+ *  else if tree_state == KEY
+ *     create a new sibling under the current head of the ll (if ll is
+ *     empty insert the new node there and it becomes the root.)
+ *    add the scalar value in the "string"
+ *    tree_state = KEY_FILLED
+ *  else if tree_state == VALUE
+ *    try and figure out whether this is a double, int or string and store
+ *    it appropriately
+ *    state = TREE_STARTED
+ * else if token == YAML_BLOCK_MAPPING_START_TOKEN && tree_state != VALUE
+ *   fail
+ * else push the current node on the ll && state = TREE_STARTED
+ * if token == YAML_BLOCK_END_TOKEN && state != TREE_STARTED
+ *   fail.
+ * else pop the current token off the ll and make it the cur
+ * if token == YAML_VALUE_TOKEN && state != KEY_FILLED
+ *   fail.
+ * else state = VALUE
+ *
+ */
+static enum cYAML_handler_error yaml_parse_error(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    return CYAML_ERROR_PARSE;
+}
+
+static enum cYAML_handler_error yaml_stream_start(yaml_token_t * token,
+                                                  struct cYAML_tree_node *tree)
+{
+    enum cYAML_handler_error rc;
+
+    /* with each new stream initialize a new tree */
+    rc = cYAML_tree_init(tree);
+
+    if (rc != CYAML_ERROR_NONE)
+        return rc;
+
+    tree->state = TREE_STATE_INITED;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_stream_end(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    if (tree->state != TREE_STATE_TREE_STARTED && tree->state != TREE_STATE_COMPLETE)
+        return CYAML_ERROR_UNEXPECTED_STATE;
+
+    tree->state = TREE_STATE_INITED;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_key(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    if (tree->state != TREE_STATE_BLK_STARTED && tree->state != TREE_STATE_VALUE)
+        return CYAML_ERROR_UNEXPECTED_STATE;
+
+    if (tree->from_blk_map_start == 0 || tree->state == TREE_STATE_VALUE)
+        tree->cur = create_sibling(tree->cur);
+
+    tree->from_blk_map_start = 0;
+
+    tree->state = TREE_STATE_KEY;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_scalar(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    if (tree->state == TREE_STATE_KEY) {
+        /* assign the scalar value to the key that was created */
+        tree->cur->cy_string = strdup((const char *) token->data.scalar.value);
+
+        tree->state = TREE_STATE_KEY_FILLED;
+    } else if (tree->state == TREE_STATE_VALUE) {
+        if (assign_type_value(tree->cur, (char *) token->data.scalar.value))
+            /* failed to assign a value */
+            return CYAML_ERROR_BAD_VALUE;
+        tree->state = TREE_STATE_BLK_STARTED;
+    } else {
+        return CYAML_ERROR_UNEXPECTED_STATE;
+    }
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_value(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    if (tree->state != TREE_STATE_KEY_FILLED)
+        return CYAML_ERROR_UNEXPECTED_STATE;
+
+    tree->state = TREE_STATE_VALUE;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error
+yaml_blk_mapping_start(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    struct cYAML *obj;
+
+    if (tree->state != TREE_STATE_VALUE &&
+        tree->state != TREE_STATE_INITED &&
+        tree->state != TREE_STATE_SEQ_START && tree->state != TREE_STATE_TREE_STARTED)
+        return CYAML_ERROR_UNEXPECTED_STATE;
+
+    /* block_mapping_start means we're entering another block
+     * indentation, so we need to go one level deeper
+     * create a child of cur */
+    obj = create_child(tree->cur);
+
+    /* push cur on the stack */
+    if (cYAML_ll_push(tree->cur, &tree->ll))
+        return CYAML_ERROR_OUT_OF_MEM;
+
+    /* adding the new child to cur */
+    tree->cur = obj;
+
+    tree->state = TREE_STATE_BLK_STARTED;
+
+    tree->from_blk_map_start = 1;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_block_end(yaml_token_t * token, struct cYAML_tree_node *tree)
+{
+    if (tree->state != TREE_STATE_BLK_STARTED && tree->state != TREE_STATE_VALUE)
+        return CYAML_ERROR_UNEXPECTED_STATE;
+
+    tree->cur = cYAML_ll_pop(&tree->ll);
+
+    /* if you have popped all the way to the top level, then move to
+     * the complete state. */
+    if (cYAML_ll_count(&tree->ll) == 0)
+        tree->state = TREE_STATE_COMPLETE;
+    else if (tree->state == TREE_STATE_VALUE)
+        tree->state = TREE_STATE_BLK_STARTED;
+
+    return CYAML_ERROR_NONE;
+}
+
+static enum cYAML_handler_error yaml_not_supported(yaml_token_t * token,
+                                                   struct cYAML_tree_node *tree)
+{
+    return CYAML_ERROR_NOT_SUPPORTED;
+}
+
+static bool free_node(struct cYAML *node, void *user_data, void **out)
+{
+    if (node->cy_type == CYAML_TYPE_STRING)
+        free(node->cy_valuestring);
+    if (node->cy_string)
+        free(node->cy_string);
+    if (node)
+        free(node);
+
+    return true;
+}
+
+void cYAML_tree_recursive_walk(struct cYAML *node, cYAML_walk_cb cb,
+                               bool cb_first, void *usr_data, void **out)
+{
+    if (node == NULL)
+        return;
+
+    if (cb_first) {
+        if (!cb(node, usr_data, out))
+            return;
+    }
+    if (node->cy_child)
+        cYAML_tree_recursive_walk(node->cy_child, cb, cb_first, usr_data, out);
+    if (node->cy_next)
+        cYAML_tree_recursive_walk(node->cy_next, cb, cb_first, usr_data, out);
+    if (!cb_first) {
+        if (!cb(node, usr_data, out))
+            return;
+    }
+}
+
+void cYAML_free_tree(struct cYAML *node)
+{
+    cYAML_tree_recursive_walk(node, free_node, false, NULL, NULL);
+}
+
+struct cYAML *cYAML_build_tree(char *yaml_file)
+{
+    yaml_parser_t parser;
+    yaml_token_t token;
+    struct cYAML_tree_node tree;
+    enum cYAML_handler_error rc;
+    yaml_token_type_t token_type;
+    char err_str[256];
+    FILE *input = NULL;
+    int done = 0;
+
+    memset(&tree, 0, sizeof(struct cYAML_tree_node));
+
+    INIT_LIST_HEAD(&tree.ll);
+
+    /* Create the Parser object. */
+    yaml_parser_initialize(&parser);
+
+    /* file always takes precedence */
+    if (yaml_file != NULL) {
+        /* Set a file input. */
+        input = fopen(yaml_file, "rb");
+        if (input == NULL) {
+            LDEBUG("Failed to open file: %s\n", yaml_file);
+            return NULL;
+        }
+        yaml_parser_set_input_file(&parser, input);
+    }
+
+    /* Read the event sequence. */
+    while (!done) {
+        /*
+         * Go through the parser and build a cYAML representation
+         * of the passed in YAML text
+         */
+        yaml_parser_scan(&parser, &token);
+#ifdef YAML_DEBUG
+        LDEBUG("token.type = %s: %s: tree.state=%d\n",
+               token_type_string[token.type],
+               (token.type == YAML_SCALAR_TOKEN) ?
+               (char *) token.data.scalar.value : "", tree.state);
+#endif
+        rc = dispatch_tbl[token.type] (&token, &tree);
+
+        /* Are we finished? */
+        done = (rc != CYAML_ERROR_NONE ||
+                token.type == YAML_STREAM_END_TOKEN || token.type == YAML_NO_TOKEN);
+
+        token_type = token.type;
+        yaml_token_delete(&token);
+    }
+
+    /* Destroy the Parser object. */
+    yaml_parser_delete(&parser);
+
+    if (input != NULL)
+        fclose(input);
+
+    if (token_type == YAML_STREAM_END_TOKEN && rc == CYAML_ERROR_NONE)
+        return tree.root;
+    cYAML_free_tree(tree.root);
+
+    return NULL;
+}
+
+#endif /* HAVE_YAML_SUPPORT */

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.c
@@ -18,10 +18,8 @@
  *
  * LGPL HEADER END
  *
- * Copyright (c) 2014, 2015, Intel Corporation.
+ * Copyright (C) 2018 DDN, Lustre Group
  *
- * Author:
- *   Amir Shehata <amir.shehata@intel.com>
  */
 
 #include <stdio.h>
@@ -91,8 +89,6 @@ static enum cYAML_handler_error yaml_parse_error(yaml_token_t * token,
 static enum cYAML_handler_error yaml_stream_start(yaml_token_t * token,
                                                   struct cYAML_tree_node *tree);
 static enum cYAML_handler_error yaml_stream_end(yaml_token_t * token, struct cYAML_tree_node *tree);
-static enum cYAML_handler_error yaml_not_supported(yaml_token_t * token,
-                                                   struct cYAML_tree_node *tree);
 static enum cYAML_handler_error yaml_blk_mapping_start(yaml_token_t * token,
                                                        struct cYAML_tree_node *tree);
 static enum cYAML_handler_error yaml_block_end(yaml_token_t * token, struct cYAML_tree_node *tree);
@@ -113,6 +109,7 @@ static yaml_token_handler dispatch_tbl[] = {
 };
 
 /* dispatch table */
+#ifdef YAML_DEBUG
 static char *token_type_string[] = {
     [YAML_NO_TOKEN] = "YAML_NO_TOKEN",
     [YAML_STREAM_START_TOKEN] = "YAML_STREAM_START_TOKEN",
@@ -123,6 +120,7 @@ static char *token_type_string[] = {
     [YAML_VALUE_TOKEN] = "YAML_VALUE_TOKEN",
     [YAML_SCALAR_TOKEN] = "YAML_SCALAR_TOKEN",
 };
+#endif
 
 static void cYAML_ll_free(struct list_head *ll)
 {
@@ -532,7 +530,6 @@ struct cYAML *cYAML_build_tree(char *yaml_file)
     struct cYAML_tree_node tree;
     enum cYAML_handler_error rc;
     yaml_token_type_t token_type;
-    char err_str[256];
     FILE *input = NULL;
     int done = 0;
 

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.h
@@ -18,10 +18,8 @@
  *
  * LGPL HEADER END
  *
- * Copyright (c) 2014, Intel Corporation.
+ * Copyright (C) 2018 DDN, Lustre group
  *
- * Author:
- *   Amir Shehata <amir.shehata@intel.com>
  */
 
 #ifdef HAVE_YAML_SUPPORT

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_cyaml.h
@@ -1,0 +1,162 @@
+/*
+ * LGPL HEADER START
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * LGPL HEADER END
+ *
+ * Copyright (c) 2014, Intel Corporation.
+ *
+ * Author:
+ *   Amir Shehata <amir.shehata@intel.com>
+ */
+
+#ifdef HAVE_YAML_SUPPORT
+
+#include <stdbool.h>
+
+enum cYAML_object_type {
+    CYAML_TYPE_FALSE = 0,
+    CYAML_TYPE_TRUE,
+    CYAML_TYPE_NULL,
+    CYAML_TYPE_NUMBER,
+    CYAML_TYPE_STRING,
+    CYAML_TYPE_ARRAY,
+    CYAML_TYPE_OBJECT
+};
+
+struct cYAML {
+    /* next/prev allow you to walk array/object chains. */
+    struct cYAML *cy_next, *cy_prev;
+    /* An array or object item will have a child pointer pointing
+     * to a chain of the items in the array/object. */
+    struct cYAML *cy_child;
+    /* The type of the item, as above. */
+    enum cYAML_object_type cy_type;
+
+    /* The item's string, if type==CYAML_TYPE_STRING */
+    char *cy_valuestring;
+    /* The item's number, if type==CYAML_TYPE_NUMBER */
+    int cy_valueint;
+    /* The item's number, if type==CYAML_TYPE_NUMBER */
+    double cy_valuedouble;
+    /* The item's name string, if this item is the child of,
+     * or is in the list of subitems of an object. */
+    char *cy_string;
+    /* user data which might need to be tracked per object */
+    void *cy_user_data;
+};
+
+typedef void (*cYAML_user_data_free_cb) (void *);
+
+/*
+ * cYAML_walk_cb
+ *   Callback called when recursing through the tree
+ *
+ *   cYAML* - pointer to the node currently being visitied
+ *   void* - user data passed to the callback.
+ *   void** - output value from the callback
+ *
+ * Returns true to continue recursing.  false to stop recursing
+ */
+typedef bool(*cYAML_walk_cb) (struct cYAML *, void *, void **);
+
+/*
+ * cYAML_build_tree
+ *   Build a tree representation of the YAML formatted text passed in.
+ */
+struct cYAML *cYAML_build_tree(char *yaml_file);
+
+void cYAML_free_tree(struct cYAML *node);
+
+
+/* list structures and functions */
+#define prefetch(a) ((void)a)
+
+struct list_head {
+    struct list_head *next, *prev;
+};
+
+#define INIT_LIST_HEAD(ptr) do { \
+	(ptr)->next = (ptr); (ptr)->prev = (ptr); \
+} while (0)
+
+/**
+ * Insert an entry at the start of a list.
+ * \param new  new entry to be inserted
+ * \param head list to add it to
+ */
+static inline void list_add(struct list_head *new, struct list_head *entry)
+{
+    new->prev = entry;
+    new->next = entry->next;
+    entry->next = new;
+}
+
+/**
+ * Remove an entry from the list it is currently in.
+ * \param entry the entry to remove
+ */
+static inline void list_del(struct list_head *entry)
+{
+    struct list_head *prev = entry->prev;
+    struct list_head *next = entry->next;
+
+    next->prev = prev;
+    prev->next = next;
+}
+
+/**
+ * Test whether a list is empty
+ * \param head the list to test.
+ */
+static inline int list_empty(struct list_head *head)
+{
+    return head->next == head;
+}
+
+/**
+ * Get the container of a list
+ * \param ptr    the embedded list.
+ * \param type   the type of the struct this is embedded in.
+ * \param member the member name of the list within the struct.
+ */
+#define list_entry(ptr, type, member) \
+	((type *)((char *)(ptr)-(char *)(&((type *)0)->member)))
+
+/**
+ * Iterate over a list
+ * \param pos   the iterator
+ * \param head  the list to iterate over
+ */
+#define list_for_each(pos, head) \
+	for (pos = (head)->next, prefetch(pos->next); pos != (head); \
+		pos = pos->next, prefetch(pos->next))
+
+/**
+ * Iterate over a list of given type safe against removal of list entry
+ * \param pos        the type * to use as a loop counter.
+ * \param n          another type * to use as temporary storage
+ * \param head       the head for your list.
+ * \param member     the name of the list_struct within the struct.
+ */
+#define list_for_each_entry_safe(pos, n, head, member)			 \
+	for (pos = list_entry((head)->next, typeof(*pos), member),	 \
+		n = list_entry(pos->member.next, typeof(*pos), member);  \
+	     &pos->member != (head);					 \
+	     pos = n, n = list_entry(n->member.next, typeof(*n), member))
+
+#endif /* HAVE_YAML_SUPPORT */

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
@@ -6,6 +6,8 @@
  *   Copyright (C) 2007 Oak Ridge National Laboratory
  *
  *   Copyright (C) 2008 Sun Microsystems, Lustre group
+ *
+ *   Copyright (C) 2018 DDN, Lustre group
  */
 
 #include "ad_lustre.h"

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
@@ -179,7 +179,8 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
 
     /* generic hints might step on striping_unit */
     if (users_info != MPI_INFO_NULL) {
-        ADIOI_Info_check_and_install_int(fd, users_info, "striping_unit", NULL, myname, error_code);
+        ADIOI_Info_check_and_install_int(fd, users_info, "striping_unit",
+                                         &(fd->hints->striping_unit), myname, error_code);
     }
 
     if (ADIOI_Direct_read)

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
@@ -124,8 +124,6 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
 #endif
         }
 
-
-
         /* set striping information with ioctl */
         MPI_Comm_rank(fd->comm, &myrank);
         if (myrank == 0) {
@@ -167,6 +165,12 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
                                              &(fd->hints->fs_hints.lustre.ds_in_coll), myname,
                                              error_code);
 
+#ifdef HAVE_LUSTRE_COMP_LAYOUT_SUPPORT
+        /* comp_layout for composite layout feature */
+        ADIOI_Info_check_and_install_str(fd, users_info, "romio_lustre_comp_layout",
+                                         &(fd->hints->fs_hints.lustre.comp_layout), myname,
+                                         error_code);
+#endif
     }
     /* set the values for collective I/O and data sieving parameters */
     ADIOI_GEN_SetInfo(fd, users_info, error_code);

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_layout.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_layout.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
 /*
- *   Copyright (C) 2014, 2015, Intel Corporation
+ *   Copyright (C) 2018, DDN, Lustre group
  */
 
 #include "ad_lustre.h"

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_layout.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_layout.c
@@ -1,0 +1,427 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *   Copyright (C) 2014, 2015, Intel Corporation
+ */
+
+#include "ad_lustre.h"
+#include <unistd.h>
+#include <getopt.h>
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#include <string.h>
+
+#ifdef HAVE_YAML_SUPPORT
+#include "ad_lustre_cyaml.h"
+#endif
+
+#undef LAYOUT_DEBUG
+
+#ifdef HAVE_LUSTRE_COMP_LAYOUT_SUPPORT
+struct layout_setstripe_args {
+    unsigned long long lsa_comp_end;
+    unsigned long long lsa_stripe_size;
+    int lsa_stripe_count;
+    int lsa_stripe_off;
+    __u32 lsa_comp_flags;
+    int lsa_nr_osts;
+    __u32 *lsa_osts;
+    char *lsa_pool_name;
+};
+
+static int comp_args_to_layout(struct llapi_layout **composite, struct layout_setstripe_args *lsa)
+{
+    struct llapi_layout *layout = *composite;
+    uint64_t prev_end = 0;
+    int i = 0, rc;
+
+    if (layout == NULL) {
+        layout = llapi_layout_alloc();
+        if (layout == NULL) {
+            LDEBUG("Alloc llapi_layout failed. %s\n", strerror(errno));
+            return -ENOMEM;
+        }
+        *composite = layout;
+    } else {
+        uint64_t start;
+
+        /* Get current component extent, current component
+         * must be the tail component. */
+        rc = llapi_layout_comp_extent_get(layout, &start, &prev_end);
+        if (rc) {
+            LDEBUG("Get comp extent failed. %s\n", strerror(errno));
+            return rc;
+        }
+
+        rc = llapi_layout_comp_add(layout);
+        if (rc) {
+            LDEBUG("Add component failed. %s\n", strerror(errno));
+            return rc;
+        }
+    }
+
+    rc = llapi_layout_comp_extent_set(layout, prev_end, lsa->lsa_comp_end);
+    if (rc) {
+        LDEBUG("Set extent [%lu, %llu) failed. %s\n", prev_end, lsa->lsa_comp_end, strerror(errno));
+        return rc;
+    }
+
+    if (lsa->lsa_stripe_size != 0) {
+        rc = llapi_layout_stripe_size_set(layout, lsa->lsa_stripe_size);
+        if (rc) {
+            LDEBUG("Set stripe size %llu failed. %s\n", lsa->lsa_stripe_size, strerror(errno));
+            return rc;
+        }
+    }
+
+    if (lsa->lsa_stripe_count != 0) {
+        rc = llapi_layout_stripe_count_set(layout,
+                                           lsa->lsa_stripe_count == -1 ?
+                                           LLAPI_LAYOUT_WIDE : lsa->lsa_stripe_count);
+        if (rc) {
+            LDEBUG("Set stripe count %d failed. %s\n", lsa->lsa_stripe_count, strerror(errno));
+            return rc;
+        }
+    }
+
+    if (lsa->lsa_nr_osts > 0) {
+        if (lsa->lsa_stripe_count > 0 && lsa->lsa_nr_osts != lsa->lsa_stripe_count) {
+            LDEBUG("stripe_count(%d) != nr_osts(%d)\n", lsa->lsa_stripe_count, lsa->lsa_nr_osts);
+            return -EINVAL;
+        }
+        for (i = 0; i < lsa->lsa_nr_osts; i++) {
+            rc = llapi_layout_ost_index_set(layout, i, lsa->lsa_osts[i]);
+            if (rc)
+                break;
+        }
+    } else if (lsa->lsa_stripe_off != -1) {
+        rc = llapi_layout_ost_index_set(layout, 0, lsa->lsa_stripe_off);
+    }
+    if (rc) {
+        LDEBUG("Set ost index %d failed. %s\n", i, strerror(errno));
+        return rc;
+    }
+
+    return 0;
+}
+
+/**
+ * Parse a string containing an OST index list into an array of integers.
+ *
+ * The input string contains a comma delimited list of individual
+ * indices and ranges, for example "1,2-4,7". Add the indices into the
+ * \a osts array and remove duplicates.
+ *
+ * \param[out] osts    array to store indices in
+ * \param[in] size     size of \a osts array
+ * \param[in] offset   starting index in \a osts
+ * \param[in] arg      string containing OST index list
+ *
+ * \retval positive    number of indices in \a osts
+ * \retval -EINVAL     unable to parse \a arg
+ */
+static int parse_targets(__u32 * osts, int size, int offset, char *arg)
+{
+    int rc;
+    int nr = offset;
+    int slots = size - offset;
+    char *ptr = NULL;
+    bool end_of_loop;
+
+    if (arg == NULL)
+        return -EINVAL;
+
+    end_of_loop = false;
+    while (!end_of_loop) {
+        int start_index;
+        int end_index;
+        int i;
+        char *endptr = NULL;
+
+        rc = -EINVAL;
+
+        ptr = strchrnul(arg, ',');
+
+        end_of_loop = *ptr == '\0';
+        *ptr = '\0';
+
+        start_index = strtol(arg, &endptr, 0);
+        if (endptr == arg)      /* no data at all */
+            break;
+        if (*endptr != '-' && *endptr != '\0')  /* has invalid data */
+            break;
+        if (start_index < 0)
+            break;
+
+        end_index = start_index;
+        if (*endptr == '-') {
+            end_index = strtol(endptr + 1, &endptr, 0);
+            if (*endptr != '\0')
+                break;
+            if (end_index < start_index)
+                break;
+        }
+
+        for (i = start_index; i <= end_index && slots > 0; i++) {
+            int j;
+
+            /* remove duplicate */
+            for (j = 0; j < offset; j++) {
+                if (osts[j] == i)
+                    break;
+            }
+            if (j == offset) {  /* no duplicate */
+                osts[nr++] = i;
+                --slots;
+            }
+        }
+        if (slots == 0 && i < end_index)
+            break;
+
+        *ptr = ',';
+        arg = ++ptr;
+        offset = nr;
+        rc = 0;
+    }
+    if (!end_of_loop && ptr != NULL)
+        *ptr = ',';
+
+    return rc < 0 ? rc : nr;
+}
+
+static inline bool arg_is_eof(char *arg)
+{
+    return !strncmp(arg, "-1", strlen("-1")) ||
+        !strncmp(arg, "EOF", strlen("EOF")) || !strncmp(arg, "eof", strlen("eof"));
+}
+
+static inline void setstripe_args_init(struct layout_setstripe_args *lsa)
+{
+    memset(lsa, 0, sizeof(*lsa));
+    lsa->lsa_stripe_off = -1;
+}
+
+int ADIOI_LUSTRE_Parse_comp_layout_opt(char *opt, struct llapi_layout **layout_ptr)
+{
+    int c;
+    struct layout_setstripe_args lsa = { 0 };
+    __u32 osts[LOV_MAX_STRIPE_COUNT] = { 0 };
+    unsigned long long size_units = 1;
+    int start = 0, end = 0, len = 0;
+    int optargc = 1;
+    char *optargv[MPI_MAX_INFO_VAL] = { "comp_layout" };
+    int rc = 0;
+    char *endptr;
+    char *temp = opt;
+    struct option long_opts[] = {
+        {.val = 'c',.name = "stripe-count",.has_arg = required_argument},
+        {.val = 'c',.name = "stripe_count",.has_arg = required_argument},
+        {.val = 'E',.name = "comp-end",.has_arg = required_argument},
+        {.val = 'E',.name = "component-end",
+         .has_arg = required_argument},
+        {.val = 'i',.name = "stripe-index",.has_arg = required_argument},
+        {.val = 'i',.name = "stripe_index",.has_arg = required_argument},
+        {.val = 'o',.name = "ost-list",.has_arg = required_argument},
+        {.val = 'o',.name = "ost_list",.has_arg = required_argument},
+        {.val = 'S',.name = "stripe-size",.has_arg = required_argument},
+        {.val = 'S',.name = "stripe_size",.has_arg = required_argument},
+        {.name = NULL}
+    };
+
+    /* parse the opt string to generate optargc and optargv */
+    if (*opt != '-') {
+        LDEBUG("'%s' is not a valid layout option string.\n", opt);
+        rc = -EINVAL;
+        goto error;
+    }
+    do {
+        end++;
+        if (*(temp + end) == ' ' || *(temp + end) == '\0') {
+            len = end - start;
+            optargv[optargc] = (char *) ADIOI_Malloc(len + 1);
+            memset(optargv[optargc], 0, len + 1);
+            ADIOI_Strncpy(optargv[optargc], temp + start, len);
+#ifdef LAYOUT_DEBUG
+            LDEBUG("argv[%d]=%s\n", optargc, optargv[optargc]);
+#endif
+            optargc++;
+            start = end + 1;
+        }
+    } while (*(temp + end) != '\0');
+
+    optind = 0;
+    while ((c = getopt_long(optargc, optargv, "c:E:i:o:S:", long_opts, NULL)) >= 0) {
+        switch (c) {
+            case 'c':
+                lsa.lsa_stripe_count = strtoul(optarg, &endptr, 0);
+                if (*endptr != '\0') {
+                    LDEBUG("error: bad stripe count '%s'\n", optarg);
+                    goto error;
+                }
+                break;
+            case 'E':
+                if (lsa.lsa_comp_end != 0) {
+                    rc = comp_args_to_layout(layout_ptr, &lsa);
+                    if (rc)
+                        goto error;
+                    setstripe_args_init(&lsa);
+                }
+
+                if (arg_is_eof(optarg)) {
+                    lsa.lsa_comp_end = LUSTRE_EOF;
+                } else {
+                    rc = llapi_parse_size(optarg, &lsa.lsa_comp_end, &size_units, 0);
+                    if (rc) {
+                        LDEBUG("error: bad component end '%s'\n", optarg);
+                        goto error;
+                    }
+                }
+                break;
+            case 'i':
+                if (strcmp(optargv[optind - 1], "--index") == 0)
+                    LDEBUG("warning: '--index' deprecated, " "use '--stripe-index' instead\n");
+                lsa.lsa_stripe_off = strtol(optarg, &endptr, 0);
+                if (*endptr != '\0') {
+                    LDEBUG("error: bad stripe offset '%s'\n", optarg);
+                    goto error;
+                }
+                break;
+            case 'o':
+                lsa.lsa_nr_osts = parse_targets(osts,
+                                                sizeof(osts) / sizeof(__u32),
+                                                lsa.lsa_nr_osts, optarg);
+                if (lsa.lsa_nr_osts < 0) {
+                    LDEBUG("error: bad OST indices '%s'\n", optarg);
+                    goto error;
+                }
+
+                lsa.lsa_osts = osts;
+                if (lsa.lsa_stripe_off == -1)
+                    lsa.lsa_stripe_off = osts[0];
+                break;
+            case 'S':
+                rc = llapi_parse_size(optarg, &lsa.lsa_stripe_size, &size_units, 0);
+                if (rc) {
+                    LDEBUG("error: bad stripe size '%s'\n", optarg);
+                    goto error;
+                }
+                break;
+            default:
+                LDEBUG("option '%s' unrecognized\n", optargv[optind - 1]);
+                rc = -EINVAL;
+                goto error;
+        }
+    }
+
+    if (lsa.lsa_comp_end != 0) {
+        rc = comp_args_to_layout(layout_ptr, &lsa);
+        if (rc)
+            goto error;
+    }
+
+    return 0;
+  error:
+    llapi_layout_free(*layout_ptr);
+    return rc;
+}
+
+#ifdef HAVE_YAML_SUPPORT
+static int build_layout_from_yaml_node(struct cYAML *node,
+                                       struct llapi_layout **layout,
+                                       struct layout_setstripe_args *lsa, __u32 * osts)
+{
+    char *string;
+
+    while (node) {
+        string = node->cy_string;
+        /* skip leading lmm_ if present, to simplify parsing */
+        if (string != NULL && strncmp(string, "lmm_", 4) == 0)
+            string += 4;
+
+        if (node->cy_type == CYAML_TYPE_STRING) {
+            if (!strcmp(string, "lcme_extent.e_end")) {
+                if (!strcmp(node->cy_valuestring, "EOF") || !strcmp(node->cy_valuestring, "eof"))
+                    lsa->lsa_comp_end = LUSTRE_EOF;
+            } else if (!strcmp(string, "pool")) {
+                lsa->lsa_pool_name = node->cy_valuestring;
+            }
+        } else if (node->cy_type == CYAML_TYPE_NUMBER) {
+            if (!strcmp(string, "lcme_extent.e_start")) {
+                if (node->cy_valueint != 0)
+                    /* build a component */
+                    comp_args_to_layout(layout, lsa);
+
+                /* initialize lsa */
+                setstripe_args_init(lsa);
+                lsa->lsa_osts = osts;
+            } else if (!strcmp(string, "lcme_extent.e_end")) {
+                if (node->cy_valueint == -1)
+                    lsa->lsa_comp_end = LUSTRE_EOF;
+                else
+                    lsa->lsa_comp_end = node->cy_valueint;
+            } else if (!strcmp(string, "stripe_count")) {
+                lsa->lsa_stripe_count = node->cy_valueint;
+            } else if (!strcmp(string, "stripe_size")) {
+                lsa->lsa_stripe_size = node->cy_valueint;
+            } else if (!strcmp(string, "stripe_offset")) {
+                lsa->lsa_stripe_off = node->cy_valueint;
+            } else if (!strcmp(string, "l_ost_idx")) {
+                osts[lsa->lsa_nr_osts] = node->cy_valueint;
+                lsa->lsa_nr_osts++;
+            }
+        } else if (node->cy_type == CYAML_TYPE_OBJECT) {
+            /* go deep to sub blocks */
+            build_layout_from_yaml_node(node->cy_child, layout, lsa, osts);
+        }
+        node = node->cy_next;
+    }
+
+    return 0;
+}
+
+static int lfs_comp_create_from_yaml(char *tempfile,
+                                     struct llapi_layout **layout,
+                                     struct layout_setstripe_args *lsa, __u32 * osts)
+{
+    struct cYAML *tree = NULL;
+    int rc = 0;
+
+    tree = cYAML_build_tree(tempfile);
+    if (!tree) {
+        LDEBUG("'%s' is not a valid YAML template file.\n", tempfile);
+        rc = -EINVAL;
+        goto err;
+    }
+
+    /* initialize lsa for plain file */
+    setstripe_args_init(lsa);
+    lsa->lsa_osts = osts;
+
+    rc = build_layout_from_yaml_node(tree, layout, lsa, osts);
+    if (rc) {
+        LDEBUG("Cannot build layout from YAML file %s.\n", tempfile);
+        goto err;
+    } else {
+        comp_args_to_layout(layout, lsa);
+    }
+    /* clean clean lsa */
+    setstripe_args_init(lsa);
+
+  err:
+    if (tree)
+        cYAML_free_tree(tree);
+    return rc;
+}
+
+int ADIOI_LUSTRE_Parse_yaml_temp(char *tempfile, struct llapi_layout **layout_ptr)
+{
+    struct layout_setstripe_args lsa = { 0 };
+    __u32 osts[LOV_MAX_STRIPE_COUNT] = { 0 };
+    int rc;
+
+    /* generate a layout from a YAML template file */
+    return lfs_comp_create_from_yaml(tempfile, layout_ptr, &lsa, osts);
+}
+#endif /* HAVE_YAML_SUPPORT */
+#endif /* HAVE_LUSTRE_COMP_LAYOUT_SUPPORT */

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
@@ -166,7 +166,12 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
     layout = llapi_layout_get_by_fd(fd->fd_sys, 0);
     if (layout != NULL) {
         fd->hints->striping_unit = ADIOI_LUSTRE_Get_last_stripe_size(layout);
+        MPL_snprintf(value, MPI_MAX_INFO_VAL + 1, "%d", fd->hints->striping_unit);
+        ADIOI_Info_set(fd->info, "striping_unit", value);
+
         fd->hints->striping_factor = ADIOI_LUSTRE_Get_lcm_stripe_count(layout);
+        MPL_snprintf(value, MPI_MAX_INFO_VAL + 1, "%d", fd->hints->striping_factor);
+        ADIOI_Info_set(fd->info, "stripoing_factor", value);
     }
 
     if (fd->access_mode & ADIO_APPEND)

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -150,7 +150,7 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
                                   ADIO_Offset offset, ADIO_Status * status,
                                   int io_mode, int *error_code)
 {
-    ssize_t err = -1;
+    ssize_t err = 0;
     size_t rw_count;
     ADIO_Offset bytes_xfered = 0;
     MPI_Count datatype_size, len;

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -120,7 +120,6 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     ADIO_Offset *lustre_offsets0, *lustre_offsets, *count_sizes = NULL;
 
     MPI_Comm_size(fd->comm, &nprocs);
-    fd->hints->cb_nodes = nprocs;
     MPI_Comm_rank(fd->comm, &myrank);
 
     orig_fp = fd->fp_ind;

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -75,6 +75,7 @@ struct ADIOI_Hints_struct {
             int lock_ahead_flags;
             ADIO_Offset lock_ahead_start_extent;
             ADIO_Offset lock_ahead_end_extent;
+            char *comp_layout;
         } lustre;
         struct {
             unsigned read_chunk_sz;     /* chunk size for direct reads */

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -882,7 +882,7 @@ if test -n "$file_system_testfs"; then
     AC_DEFINE(ROMIO_TESTFS,1,[Define for ROMIO with TESTFS])
 fi
 #
-# Verify presence of lustre/lustre_user.h
+# Verify presence of lustre headers
 #
 lustre_lockahead="no"
 if test -n "$file_system_lustre"; then
@@ -905,8 +905,17 @@ if test -n "$file_system_lustre"; then
         ])],
         lustre_lockahead="yes"
 	AC_DEFINE(HAVE_LUSTRE_LOCKAHEAD, 1, [Define if LUSTRE_LOCKAHEAD is enabled.]) )
+    AC_CHECK_HEADERS([lustre/lustreapi.h])
+    # Verify presence of composite layout functions
+    AC_SEARCH_LIBS(llapi_layout_comp_use, lustreapi,
+	[AC_DEFINE(HAVE_LUSTRE_COMP_LAYOUT_SUPPORT, 1, [Lustre composite layout is supported])],
+	[AC_MSG_WARN([Lustre composite layout is not supported])])
+    # Verify presence of yaml.h
+    AC_CHECK_HEADERS(yaml.h,
+	[AC_DEFINE(HAVE_YAML_SUPPORT, 1, [yaml is present])],
+	[AC_MSG_WARN([yaml is not present])])
 fi
-
+AM_CONDITIONAL([LUSTRE_YAML], [test x$ac_cv_header_yaml_h = xyes])
 # Add conditional compilation of Lustre lockahead sources
 AM_CONDITIONAL([LUSTRE_LOCKAHEAD],[test "$lustre_lockahead" = "yes"])
 

--- a/src/mpi/romio/test/noncontig.c
+++ b/src/mpi/romio/test/noncontig.c
@@ -10,6 +10,19 @@
 
 /* tests noncontiguous reads/writes using independent I/O */
 
+static void handle_error(int errcode, char *str)
+{
+    char msg[MPI_MAX_ERROR_STRING];
+    int resultlen;
+    MPI_Error_string(errcode, msg, &resultlen);
+    fprintf(stderr, "%s: %s\n", str, msg);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+}
+
+
+#define CHECK(fn) { int errcode; errcode = (fn); if (errcode != MPI_SUCCESS) handle_error(errcode, #fn); }
+
+
 #define SIZE 5000
 
 #define VERBOSE 0
@@ -93,17 +106,17 @@ int main(int argc, char **argv)
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh);
+    CHECK(MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh));
 
     /* set the file view for each process -- now writes go into the non-
      * overlapping but interleaved region defined by the struct type up above
      */
-    MPI_File_set_view(fh, 0, MPI_INT, newtype, "native", info);
+    CHECK(MPI_File_set_view(fh, 0, MPI_INT, newtype, "native", info));
 
     /* fill our buffer with a pattern and write, using our type again */
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
-    MPI_File_write(fh, buf, 1, newtype, &status);
+    CHECK(MPI_File_write(fh, buf, 1, newtype, &status));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -113,7 +126,7 @@ int main(int argc, char **argv)
      */
     for (i = 0; i < SIZE; i++)
         buf[i] = -1;
-    MPI_File_read_at(fh, 0, buf, 1, newtype, &status);
+    CHECK(MPI_File_read_at(fh, 0, buf, 1, newtype, &status));
 
     /* check that all the values read are correct and also that we didn't
      * overwrite any of the -1 values that we shouldn't have.
@@ -141,7 +154,7 @@ int main(int argc, char **argv)
         }
     }
 
-    MPI_File_close(&fh);
+    CHECK(MPI_File_close(&fh));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -154,7 +167,7 @@ int main(int argc, char **argv)
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh);
+    CHECK(MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh));
 
     /* in this case we write to either the first half or the second half
      * of the file space, so the regions are not interleaved.  this is done
@@ -162,7 +175,7 @@ int main(int argc, char **argv)
      */
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
-    MPI_File_write_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &status);
+    CHECK(MPI_File_write_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &status));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -171,7 +184,7 @@ int main(int argc, char **argv)
      */
     for (i = 0; i < SIZE; i++)
         buf[i] = -1;
-    MPI_File_read_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &status);
+    CHECK(MPI_File_read_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &status));
 
     /* verify that the buffer looks like it should */
     for (i = 0; i < SIZE; i++) {
@@ -197,7 +210,7 @@ int main(int argc, char **argv)
         }
     }
 
-    MPI_File_close(&fh);
+    CHECK(MPI_File_close(&fh));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -210,22 +223,22 @@ int main(int argc, char **argv)
     }
     MPI_Barrier(MPI_COMM_WORLD);
 
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh);
+    CHECK(MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, info, &fh));
 
     /* set the file view so that we have interleaved access again */
-    MPI_File_set_view(fh, 0, MPI_INT, newtype, "native", info);
+    CHECK(MPI_File_set_view(fh, 0, MPI_INT, newtype, "native", info));
 
     /* this time write a contiguous buffer */
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
-    MPI_File_write(fh, buf, SIZE, MPI_INT, &status);
+    CHECK(MPI_File_write(fh, buf, SIZE, MPI_INT, &status));
 
     MPI_Barrier(MPI_COMM_WORLD);
 
     /* fill buffer with -1's; this time they will all be overwritten */
     for (i = 0; i < SIZE; i++)
         buf[i] = -1;
-    MPI_File_read_at(fh, 0, buf, SIZE, MPI_INT, &status);
+    CHECK(MPI_File_read_at(fh, 0, buf, SIZE, MPI_INT, &status));
 
     for (i = 0; i < SIZE; i++) {
         if (!mynod) {
@@ -242,7 +255,7 @@ int main(int argc, char **argv)
         }
     }
 
-    MPI_File_close(&fh);
+    CHECK(MPI_File_close(&fh));
 
     MPI_Allreduce(&errs, &toterrs, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
     if (mynod == 0) {


### PR DESCRIPTION
To make Lustre ADIO driver work with PFL feature correctly, this
patch does the following changes:
- Use llapi_layout_* interfaces to get/set the striping information
  -- use llapi_layout_file_create() instead of ioctl() to set
     striping information when creating a file;
  -- use llapi_layout_xxx_set/get() instead of ioctl() to set/get
     striping information;
  -- since O_LOV_DELAY_CREATE is set with O_CREATE by default
     in llapi_layout_file_open(), the related code to open a file
     in ADIOI_LUSTRE_open() is changed.
- Set composite layout by hint:
  -- add hint "romio_lustre_comp_layout" to specify composite
     layout in the following 3 formats:
     --- YAML template file, e.g. /a/b/layout.yaml
     --- option string, similar to "lfs setstripe" command, e.g.
	 "-E 4M -c 2 -S 512K -E 8M -c 4 -S 1M -E -1 -S 256K"
     --- lustre source file, e.g. /mnt/lustre/compfile, that means
	 creating file with the same layout to this lustre file.
     --- If "romio_lustre_comp_layout" is enabled, hints
         "striping_factor", "striping_unit" and
         "romio_lustre_start_iodevice" will be ignored.
  -- add file ad_lustre_layout.c to parse the composite layout
     options;
  -- add files ad_lustre_cyaml.h and ad_lustre_cyaml.h to parse YAML
     template layout file.
- Improve the following I/O redistribution algorithm with PFL
  feature:
  -- for stripe-contiguous pattern:
     --- use the LCM(lowest common multiple) of different component
	 stripe count to calculate the number of available cb nodes
     --- use the last component stripe size as the common stripe
	 size, because different MPI procs will write different
	 components and it's hard to predict which component will
	 have most impact on performance. (This can be improved.)
  -- for file-contiguous: use the last component stripe size as the
     common stripe size, same as above.
- Fix some issues:
  -- set fn->hints->cb_nodes in ADIOI_LUSTRE_WriteStridedColl(),
     otherwise the final avail_cb_nodes is always 1;
  -- since there is no a mapping/initialization for ranklist[],
     just use #ran directly, otherwise it will get a wrong rank
     number;
  -- add LDEBUG() to print debug information;
  -- remove striping information setting in ADIOI_LUSTRE_SetInfo()
     since these values can be set/gotten easily by
     llapi_layout_xxx_set/get().
  -- add "AC_SEARCH_LIBS(llapi_layout_comp_use, lustreapi,
     [AC_DEFINE(HAVE_LUSTRE_COMP_LAYOUT_SUPPORT, 1,...)], ...)" to
     romio/configure.ac to check if Lustre version installed
     supports PFL feature.
  -- add "AC_CHECK_HEADERS(yaml.h, ...)" to romio/configure.ac to
     check if libyaml and libyaml-devel are installed for YAML
     template file support.