### PR TITLE
test/dtpools: Remove visibility flag from Makefile.am

### DIFF
--- a/test/mpi/dtpools/src/Makefile.am
+++ b/test/mpi/dtpools/src/Makefile.am
@@ -4,7 +4,6 @@
 #     See COPYRIGHT in top-level directory.
 #
 AM_CPPFLAGS = $(MPI_H_INCLUDE)
-AM_CPPFLAGS += -fvisibility=default
 AM_CPPFLAGS += -DDTP_MPI_DATATYPE=@DTP_DATATYPES@   # Coma separated list of MPI datatypes
 
 pkglib_LTLIBRARIES = libdtpools.la


### PR DESCRIPTION
Not all compilers support this flag. If we are going to use it, we
need to test for it first.

No reviewer.