### PR TITLE
pm/hydra: Avoid build error with libslurm

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -512,7 +512,7 @@ AC_MSG_RESULT([$available_topolibs])
 #########################################################################
 AC_CHECK_HEADERS(slurm/slurm.h)
 AC_CHECK_LIB([slurm],[slurm_hostlist_create],have_libslurm=yes)
-if test "$have_libslurm" = "yes" ; then
+if test "$have_libslurm" = "yes" -a "$ac_cv_header_slurm_slurm_h" = "yes" ; then
     PAC_PREPEND_FLAG([-lslurm],[LIBS])
     AC_DEFINE(HAVE_LIBSLURM,1,[Define if libslurm is available])
 fi


### PR DESCRIPTION
Ensure both libslurm and slurm/slurm.h are present before enabling
support for libslurm in Hydra.

Signed-off-by: Giuseppe Congiu <gcongiu@anl.gov>