### PR TITLE
mpl: Move memory classes out of thread section

### DIFF
--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -106,10 +106,6 @@ static int TR_is_threaded = 0;
 static int is_configured = 0;
 static int classes_initialized = 0;
 
-#if MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE
-
-static MPL_thread_mutex_t memalloc_mutex;
-
 static MPL_memory_allocation_t allocation_classes[MPL_MAX_MEMORY_CLASS];
 
 /* This list should match the enum in mpl_trmem.h */
@@ -134,6 +130,10 @@ static const char *allocation_class_strings[] = {
     "MPL_MEM_USER",
     "MPL_MEM_OTHER"
 };
+
+#if MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE
+
+static MPL_thread_mutex_t memalloc_mutex;
 
 #define TR_THREAD_CS_ENTER                                              \
     do {                                                                \


### PR DESCRIPTION
The allocation classes code was accidentally put inside the threaded
section of MPL. Move it out of that section since it has nothing to do
with it.

Fixes pmodels/mpich#3295