### PR TITLE
coll: Fix integer overflow in MPI_Bcast

### DIFF
--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -167,7 +167,7 @@ int MPIR_Bcast_intra_auto(void *buffer,
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int comm_size;
-    int nbytes = 0;
+    MPI_Aint nbytes = 0;
     MPI_Aint type_size;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_BCAST);
 

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -25,7 +25,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    int nbytes = 0;
+    MPI_Aint nbytes = 0;
     MPI_Aint recvd_size;
     MPI_Status status;
     int is_contig;

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -62,6 +62,7 @@
 /coll/bcast_full
 /coll/bcast_min_datatypes
 /coll/bcasttest
+/coll/bcast_intoverflow
 /coll/bcastzerotype
 /coll/coll10
 /coll/coll11

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -33,6 +33,7 @@ noinst_PROGRAMS =      \
     alltoallw2         \
     alltoallw_zeros    \
     bcasttest          \
+    bcast_intoverflow  \
     bcastzerotype      \
     coll2              \
     coll3              \

--- a/test/mpi/coll/bcast_intoverflow.c
+++ b/test/mpi/coll/bcast_intoverflow.c
@@ -1,0 +1,75 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+#include "mpi.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+#include "mpitest.h"
+
+#define GB (size_t)(1<<30)
+#define PAYLOAD (4UL*GB)
+
+int main(int argc, char **argv)
+{
+    int *buffer;
+    int my_rank;                /* rank in world collective */
+    char msg[256];              /* msg sent to test diagnostics */
+    int counts[3];
+    int count;
+    int errs = 0;
+    size_t i;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+
+/* Buffer Allocation */
+    if (!(buffer = (int *) malloc(PAYLOAD))) {
+        fprintf(stderr, "malloc() failed\n");
+        MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    }
+
+/* Initialize buffers */
+    if (my_rank == 0) {
+        for (i = 0; i < (PAYLOAD / sizeof(int)); i++) {
+            buffer[i] = i % INT_MAX;
+        }
+    }
+
+    counts[0] = (1 << 28);
+    counts[1] = (1 << 29);
+    counts[2] = (1 << 30);
+
+    for (i = 0; i < 3; i++) {
+        count = counts[i];
+        if (my_rank != 0)
+            memset(buffer, 0, (count * sizeof(int)));
+
+        MPI_Barrier(MPI_COMM_WORLD);
+#ifdef DEBUG
+        if (my_rank == 0)
+            printf("performing bcast with %d ints\n", count);
+#endif
+        /* Perform Broadcast */
+        MPI_Bcast(buffer, count, MPI_INT, 0, MPI_COMM_WORLD);
+        for (i = 0; i < count; i++) {
+            if (buffer[i] != (i % INT_MAX)) {
+                errs++;
+                if (errs > 0) {
+                    printf("Error: Rank=%d buffer[%zu] = %d, but %d is expected", my_rank, i,
+                           buffer[i], (int) (i % INT_MAX) /*always int */);
+                    fflush(stdout);
+                }
+            }
+        }
+    }
+
+    free(buffer);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -31,6 +31,7 @@ for algo_name in ${algo_names}; do
                 env+="env=MPIR_CVAR_IBCAST_RING_CHUNK_SIZE=4096 "
 
                 coll_algo_tests+="bcasttest 10 ${env}${nl}"
+                coll_algo_tests+="bcast_intoverflow 2 ${env}${nl}"
                 coll_algo_tests+="bcastzerotype 5 ${env}${nl}"
             done
         else

--- a/test/mpi/coll/testlist.def
+++ b/test/mpi/coll/testlist.def
@@ -33,6 +33,7 @@ allgather_struct 10
 bcasttest 4
 bcasttest 8
 bcasttest 10
+@largetest@bcast_intoverflow 2
 bcastzerotype 1
 bcastzerotype 4
 bcastzerotype 5


### PR DESCRIPTION
Promoted an internal type to MPI_Aint to avoid integer overflow when
verifying number of bytes transferred.

Fixes pmodels/mpich#2257
Fixes pmodels/mpich#2311