### PR TITLE
mpir: Add assert to ensure index is within array range

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -208,7 +208,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
         basic_type_ = MPI_DATATYPE_NULL;                            \
  } while (0)
 
-#define MPIR_Datatype_get_ptr(a,ptr)   MPIR_Getb_ptr(Datatype,a,0x000000ff,ptr)
+#define MPIR_Datatype_get_ptr(a,ptr)   MPIR_Getb_ptr(Datatype,DATATYPE,a,0x000000ff,ptr)
 
 /* Note: Probably there is some clever way to build all of these from a macro.
  */

--- a/src/include/mpir_errhandler.h
+++ b/src/include/mpir_errhandler.h
@@ -67,6 +67,7 @@ typedef struct MPIR_Errhandler {
 } MPIR_Errhandler;
 extern MPIR_Object_alloc_t MPIR_Errhandler_mem;
 /* Preallocated errhandler objects */
+#define MPIR_ERRHANDLER_BUILTIN 3
 extern MPIR_Errhandler MPIR_Errhandler_builtin[];
 extern MPIR_Errhandler MPIR_Errhandler_direct[];
 

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -438,7 +438,7 @@ static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 /* TODO examine generated assembly for this construct, it's probably suboptimal
  * on Blue Gene.  An if/else if/else might help the compiler out.  It also lets
  * us hint that one case is likely(), usually the BUILTIN case. */
-#define MPIR_Getb_ptr(kind,a,bmsk,ptr)                                  \
+#define MPIR_Getb_ptr(kind,KIND,a,bmsk,ptr)                             \
     {                                                                   \
         switch (HANDLE_GET_KIND(a)) {                                   \
         case HANDLE_KIND_BUILTIN:                                       \
@@ -480,11 +480,11 @@ static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 
 /* FIXME: the masks should be defined with the handle definitions instead
    of inserted here as literals */
-#define MPIR_Comm_get_ptr(a,ptr)       MPIR_Getb_ptr(Comm,a,0x03ffffff,ptr)
-#define MPIR_Group_get_ptr(a,ptr)      MPIR_Getb_ptr(Group,a,0x03ffffff,ptr)
-#define MPIR_Errhandler_get_ptr(a,ptr) MPIR_Getb_ptr(Errhandler,a,0x3,ptr)
-#define MPIR_Op_get_ptr(a,ptr)         MPIR_Getb_ptr(Op,a,0x000000ff,ptr)
-#define MPIR_Info_get_ptr(a,ptr)       MPIR_Getb_ptr(Info,a,0x03ffffff,ptr)
+#define MPIR_Comm_get_ptr(a,ptr)       MPIR_Getb_ptr(Comm,COMM,a,0x03ffffff,ptr)
+#define MPIR_Group_get_ptr(a,ptr)      MPIR_Getb_ptr(Group,GROUP,a,0x03ffffff,ptr)
+#define MPIR_Errhandler_get_ptr(a,ptr) MPIR_Getb_ptr(Errhandler,ERRHANDLER,a,0x3,ptr)
+#define MPIR_Op_get_ptr(a,ptr)         MPIR_Getb_ptr(Op,OP,a,0x000000ff,ptr)
+#define MPIR_Info_get_ptr(a,ptr)       MPIR_Getb_ptr(Info,INFO,a,0x03ffffff,ptr)
 #define MPIR_Win_get_ptr(a,ptr)        MPIR_Get_ptr(Win,a,ptr)
 #define MPIR_Request_get_ptr(a,ptr)    MPIR_Get_ptr(Request,a,ptr)
 #define MPIR_Grequest_class_get_ptr(a,ptr) MPIR_Get_ptr(Grequest_class,a,ptr)

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -442,6 +442,7 @@ static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
     {                                                                   \
         switch (HANDLE_GET_KIND(a)) {                                   \
         case HANDLE_KIND_BUILTIN:                                       \
+            MPIR_Assert(((a)&(bmsk)) < MPIR_##KIND##_N_BUILTIN);        \
             ptr=MPIR_##kind##_builtin+((a)&(bmsk));                     \
             break;                                                      \
         case HANDLE_KIND_DIRECT:                                        \

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -144,7 +144,7 @@ static int checkForUserErrcode(int);
 #endif
 
 /* Preallocated errorhandler objects */
-MPIR_Errhandler MPIR_Errhandler_builtin[3] = { {0} };
+MPIR_Errhandler MPIR_Errhandler_builtin[MPIR_ERRHANDLER_N_BUILTIN] = { {0} };
 MPIR_Errhandler MPIR_Errhandler_direct[MPIR_ERRHANDLER_PREALLOC] = { {0} };
 
 MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, MPIR_ERRHANDLER,


### PR DESCRIPTION
This should resolves Klocwork issues where it complains
that MPIR_Comm_get_ptr() may use index value beyond the
size of MPIR_Comm_builtin array.