### PR TITLE
mtest: Fix bcast test

### DIFF
--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -16,8 +16,8 @@ testing_env="env=MPIR_CVAR_BCAST_DEVICE_COLLECTIVE=0 "
 #test nb algorithms
 testing_env+="env=MPIR_CVAR_BCAST_INTRA_ALGORITHM=nb "
 testing_env+="env=MPIR_CVAR_IBCAST_DEVICE_COLLECTIVE=0 "
-algo_names="tree scatter_recexch_allgather"
-tree_types="kary knomial_1 knomial_2 ring"
+algo_names="tree scatter_recexch_allgather ring"
+tree_types="kary knomial_1 knomial_2"
 kvalues="3"
 
 for algo_name in ${algo_names}; do


### PR DESCRIPTION
By mistake, ring got added as a tree_type when it is
actually an algo type.