### PR TITLE
Redo the consistency commit

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -339,7 +339,6 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_PUT);
 
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
@@ -476,24 +475,30 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
                                    int target_count, MPI_Datatype target_datatype, MPIR_Win * win,
                                    MPIDI_av_entry_t * addr)
 {
-    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_PUT);
+    int mpi_errno = MPI_SUCCESS;
 
     if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_put(origin_addr, origin_count, origin_datatype,
                                        target_rank, target_disp, target_count,
                                        target_datatype, win);
-    } else {
-        mpi_errno = MPIDI_OFI_do_put(origin_addr,
-                                     origin_count,
-                                     origin_datatype,
-                                     target_rank,
-                                     target_disp, target_count, target_datatype, win, NULL);
+        goto fn_exit;
     }
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+
+    mpi_errno = MPIDI_OFI_do_put(origin_addr,
+                                 origin_count,
+                                 origin_datatype,
+                                 target_rank,
+                                 target_disp, target_count, target_datatype, win, NULL);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_PUT);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 #undef FUNCNAME
@@ -528,7 +533,6 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET);
 
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto null_op_exit;
 
@@ -653,6 +657,7 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
                                    MPIDI_av_entry_t * addr)
 {
     int mpi_errno = MPI_SUCCESS;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_GET);
 
@@ -660,16 +665,22 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
         mpi_errno = MPIDI_CH4U_mpi_get(origin_addr, origin_count, origin_datatype,
                                        target_rank, target_disp, target_count,
                                        target_datatype, win);
-    } else {
-        mpi_errno = MPIDI_OFI_do_get(origin_addr,
-                                     origin_count,
-                                     origin_datatype,
-                                     target_rank,
-                                     target_disp, target_count, target_datatype, win, NULL);
+        goto fn_exit;
     }
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+
+    mpi_errno = MPIDI_OFI_do_get(origin_addr,
+                                 origin_count,
+                                 origin_datatype,
+                                 target_rank,
+                                 target_disp, target_count, target_datatype, win, NULL);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_GET);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 #undef FUNCNAME
@@ -686,24 +697,30 @@ static inline int MPIDI_NM_mpi_rput(const void *origin_addr,
                                     MPIR_Win * win, MPIDI_av_entry_t * addr,
                                     MPIR_Request ** request)
 {
-    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RPUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RPUT);
+    int mpi_errno = MPI_SUCCESS;
 
     if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_rput(origin_addr, origin_count, origin_datatype,
                                         target_rank, target_disp, target_count,
                                         target_datatype, win, request);
-    } else {
-        mpi_errno = MPIDI_OFI_do_put((void *) origin_addr,
-                                     origin_count,
-                                     origin_datatype,
-                                     target_rank,
-                                     target_disp, target_count, target_datatype, win, request);
+        goto fn_exit;
     }
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+
+    mpi_errno = MPIDI_OFI_do_put((void *) origin_addr,
+                                 origin_count,
+                                 origin_datatype,
+                                 target_rank,
+                                 target_disp, target_count, target_datatype, win, request);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RPUT);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 
@@ -1353,24 +1370,30 @@ static inline int MPIDI_NM_mpi_rget(void *origin_addr,
                                     MPIR_Win * win, MPIDI_av_entry_t * addr,
                                     MPIR_Request ** request)
 {
-    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RGET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RGET);
+    int mpi_errno = MPI_SUCCESS;
 
     if (!MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = MPIDI_CH4U_mpi_rget(origin_addr, origin_count, origin_datatype,
                                         target_rank, target_disp, target_count, target_datatype,
                                         win, request);
-    } else {
-        mpi_errno = MPIDI_OFI_do_get(origin_addr,
-                                     origin_count,
-                                     origin_datatype,
-                                     target_rank,
-                                     target_disp, target_count, target_datatype, win, request);
+        goto fn_exit;
     }
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
+
+    mpi_errno = MPIDI_OFI_do_get(origin_addr,
+                                 origin_count,
+                                 origin_datatype,
+                                 target_rank,
+                                 target_disp, target_count, target_datatype, win, request);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RGET);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 
@@ -1405,13 +1428,15 @@ static inline int MPIDI_NM_mpi_get_accumulate(const void *origin_addr,
                                                   result_addr, result_count, result_datatype,
                                                   target_rank, target_disp, target_count,
                                                   target_datatype, op, win);
-    } else {
-        mpi_errno = MPIDI_OFI_do_get_accumulate(origin_addr, origin_count, origin_datatype,
-                                                result_addr, result_count, result_datatype,
-                                                target_rank, target_disp, target_count,
-                                                target_datatype, op, win, NULL);
+        goto fn_exit;
     }
 
+    mpi_errno = MPIDI_OFI_do_get_accumulate(origin_addr, origin_count, origin_datatype,
+                                            result_addr, result_count, result_datatype,
+                                            target_rank, target_disp, target_count,
+                                            target_datatype, op, win, NULL);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
     return mpi_errno;
 }
@@ -1443,15 +1468,16 @@ static inline int MPIDI_NM_mpi_accumulate(const void *origin_addr,
         mpi_errno = MPIDI_CH4U_mpi_accumulate(origin_addr, origin_count, origin_datatype,
                                               target_rank, target_disp, target_count,
                                               target_datatype, op, win);
-    } else {
-        mpi_errno = MPIDI_OFI_do_accumulate(origin_addr,
-                                            origin_count,
-                                            origin_datatype,
-                                            target_rank,
-                                            target_disp, target_count, target_datatype, op, win,
-                                            NULL);
+        goto fn_exit;
     }
 
+    mpi_errno = MPIDI_OFI_do_accumulate(origin_addr,
+                                        origin_count,
+                                        origin_datatype,
+                                        target_rank,
+                                        target_disp, target_count, target_datatype, op, win, NULL);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ACCUMULATE);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -533,7 +533,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET);
 
     MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
+    if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
     MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
@@ -921,7 +921,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
         goto am_fallback;
 
     MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
+    if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
@@ -1069,7 +1069,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         goto am_fallback;
 
     MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
+    if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -339,6 +339,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_PUT);
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
@@ -486,8 +487,6 @@ static inline int MPIDI_NM_mpi_put(const void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
-
     mpi_errno = MPIDI_OFI_do_put(origin_addr,
                                  origin_count,
                                  origin_datatype,
@@ -533,6 +532,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET);
 
+    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
     if (target_rank == MPI_PROC_NULL)
         goto null_op_exit;
 
@@ -668,8 +668,6 @@ static inline int MPIDI_NM_mpi_get(void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
-
     mpi_errno = MPIDI_OFI_do_get(origin_addr,
                                  origin_count,
                                  origin_datatype,
@@ -707,8 +705,6 @@ static inline int MPIDI_NM_mpi_rput(const void *origin_addr,
                                         target_datatype, win, request);
         goto fn_exit;
     }
-
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
 
     mpi_errno = MPIDI_OFI_do_put((void *) origin_addr,
                                  origin_count,
@@ -1380,8 +1376,6 @@ static inline int MPIDI_NM_mpi_rget(void *origin_addr,
                                         win, request);
         goto fn_exit;
     }
-
-    MPIDI_CH4U_RMA_OP_CHECK_SYNC(target_rank, win);
 
     mpi_errno = MPIDI_OFI_do_get(origin_addr,
                                  origin_count,


### PR DESCRIPTION
This PR reverts the last commit in the merged PR https://github.com/pmodels/mpich/pull/3213 because an error was incurred by the branching logic changes in that commit. In addition, some other changes mixes code reformatting and white space changes. In this PR, all changes from the last commit are reverted, and then a new commit for only the `MPIDI_CH4U_RMA_OP_CHECK_SYNC` change is created.

---
Edit:
Added a 3rd commit, which is to add `unlikely` to all `if(target_rank == MPI_PROC_NULL)`