### PR TITLE
maint: Remove extra style check

### DIFF
--- a/maint/hooks/pre-commit
+++ b/maint/hooks/pre-commit
@@ -88,7 +88,3 @@ if [ $ret != 0 ] ; then
 fi
 
 popd > /dev/null
-
-# If there are whitespace errors, print the offending file names and fail.
-# This will catch adding extra newlines where the above script will not catch that
-exec git diff-index --check --cached $against --


### PR DESCRIPTION
The check using the built-in Git tool seems to no longer be necessary as
GNU indent is correctly checking for whitespace at the end of the file.

Fixes pmodels/mpich#3327