### PR TITLE
romio: compiler formatting warnings

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -867,12 +867,13 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     } else {
 /* allocate memory for recv_buf and post receives */
         recv_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
-        for (i = 0; i < nprocs; i++)
+        for (i = 0; i < nprocs; i++) {
             if (recv_size[i])
                 recv_buf[i] = (char *) ADIOI_Malloc(recv_size[i]);
+        }
 
         j = 0;
-        for (i = 0; i < nprocs; i++)
+        for (i = 0; i < nprocs; i++) {
             if (recv_size[i]) {
                 MPI_Irecv(recv_buf[i], recv_size[i], MPI_BYTE, i,
                           myrank + i + 100 * iter, fd->comm, requests + j);
@@ -882,6 +883,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                             myrank, recv_size[i], myrank + i + 100 * iter);
 #endif
             }
+        }
     }
 
 /* create derived datatypes and send data */

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -821,13 +821,14 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
 
     if (buftype_is_contig) {
         j = 0;
-        for (i = 0; i < nprocs; i++)
+        for (i = 0; i < nprocs; i++) {
             if (recv_size[i]) {
                 MPI_Irecv(((char *) buf) + buf_idx[i], recv_size[i],
                           MPI_BYTE, i, myrank + i + 100 * iter, fd->comm, requests + j);
                 j++;
                 buf_idx[i] += recv_size[i];
             }
+        }
     } else {
 /* allocate memory for recv_buf and post receives */
         recv_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));


### PR DESCRIPTION
Michael Raymond's gcc-7.3.1 compiler on SLES15 found a few spots in
ROMIO that gave misleading indentation warnings.  I think most of these
were dealt with in Feburary's whitespace change, but I threw in a few
extra braces just to make sure.