### PR TITLE
Change MPL SHM for ch4 rma shm win_allocate

### DIFF
--- a/src/mpl/include/mpl_shm_mmap.h
+++ b/src/mpl/include/mpl_shm_mmap.h
@@ -30,7 +30,7 @@ typedef MPLI_shm_lghnd_t *MPL_shm_hnd_t;
 
 #define MPLI_SHM_SEG_ALREADY_EXISTS EEXIST
 
-/* Returns 0 on success, -1 on error */
+/* Returns MPL_SHM_SUCCESS on success, MPL_SHM_EINTERN on error */
 int MPLI_shm_lhnd_close(MPL_shm_hnd_t hnd);
 
 #endif /* MPL_SHM_MMAP_H_INCLUDED */

--- a/src/mpl/include/mpl_shm_win.h
+++ b/src/mpl/include/mpl_shm_win.h
@@ -30,9 +30,9 @@ typedef MPLI_shm_lghnd_t *MPL_shm_hnd_t;
 
 #define MPL_shm_SEG_ALREADY_EXISTS ERROR_ALREADY_EXISTS
 
-/* Returns 0 on success, -1 on error */
+/* Returns MPL_SHM_SUCCESS on success, MPL_SHM_EINTERN on error */
 #define MPLI_shm_lhnd_close(hnd)(\
-    (CloseHandle(MPLI_shm_lhnd_get(hnd)) != 0) ? 0 : -1            \
+    (CloseHandle(MPLI_shm_lhnd_get(hnd)) != 0) ? MPL_SHM_SUCCESS : MPL_SHM_EINTERN  \
 )
 
 #if defined (HAVE_QUERYPERFORMANCECOUNTER)
@@ -48,23 +48,23 @@ static inline int MPL_shm_get_uniq_str(char *str, int strlen)
 }
 #endif
 
-/* Returns 0 on success, -1 on error */
+/* Returns MPL_SHM_SUCCESS on success, MPL_SHM_EINTERN on error */
 static inline int MPLI_shm_ghnd_set_uniq(MPL_shm_hnd_t hnd)
 {
-    if (MPL_shm_hnd_ref_alloc(hnd) == 0) {
+    if (MPL_shm_hnd_ref_alloc(hnd) == MPL_SHM_SUCCESS) {
         if (MPLI_shm_get_uniq_str(hnd->ghnd, MPLI_SHM_GHND_SZ) != 0) {
-            return -1;
+            return MPL_SHM_EINTERN;
         }
     } else {
-        return -1;
+        return MPL_SHM_EINTERN;
     }
-    return 0;
+    return MPL_SHM_SUCCESS;
 }
 
 /* Nothing to be done when removing an SHM segment */
 static inline int MPL_shm_seg_remove(MPL_shm_hnd_t hnd)
 {
-    return MPI_SUCCESS;
+    return MPL_SHM_SUCCESS;
 }
 
 #endif /* MPL_SHM_WIN_H_INCLUDED */

--- a/src/mpl/src/shm/mpl_shm.c
+++ b/src/mpl/src/shm/mpl_shm.c
@@ -31,7 +31,7 @@ int MPL_shm_hnd_serialize(char *str, MPL_shm_hnd_t hnd, int str_len)
  */
 int MPL_shm_hnd_deserialize(MPL_shm_hnd_t hnd, const char *str_hnd, size_t str_hnd_len)
 {
-    int rc = -1;
+    int rc = MPL_SHM_SUCCESS;
     MPLI_shm_hnd_reset_val(hnd);
     rc = MPLI_shm_ghnd_alloc(hnd, MPL_MEM_SHM);
     rc = MPLI_shm_ghnd_set_by_val(hnd, "%s", str_hnd);
@@ -52,7 +52,7 @@ int MPL_shm_hnd_deserialize(MPL_shm_hnd_t hnd, const char *str_hnd, size_t str_h
 int MPL_shm_hnd_get_serialized_by_ref(MPL_shm_hnd_t hnd, char **str_ptr)
 {
     *str_ptr = (char *) MPLI_shm_ghnd_get_by_ref(hnd);
-    return 0;
+    return MPL_SHM_SUCCESS;
 }
 
 /* Deserialize a handle by reference.

--- a/src/mpl/src/shm/mpl_shm_sysv.c
+++ b/src/mpl/src/shm/mpl_shm_sysv.c
@@ -25,7 +25,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t seg_sz,
                                                   void **shm_addr_ptr, int offset, int flag)
 {
-    int rc = -1;
+    int rc = MPL_SHM_SUCCESS;
     int lhnd = -1;
 
     if (flag & MPLI_SHM_FLAG_SHM_CREATE) {
@@ -36,7 +36,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
             goto fn_exit;
         }
         rc = MPLI_shm_ghnd_set_by_val(hnd, "%d", lhnd);
-        if (rc < 0) {
+        if (rc != MPL_SHM_SUCCESS) {
             goto fn_exit;
         }
     } else {
@@ -60,7 +60,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
         /* Attach to shared mem seg */
         *shm_addr_ptr = shmat(MPLI_shm_lhnd_get(hnd), start_addr, 0x0);
         if (*shm_addr_ptr == (void *) -1) {
-            rc = -1;
+            rc = MPL_SHM_EINVAL;
         }
     }
 
@@ -158,7 +158,7 @@ int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, intptr_t seg_sz)
     rc = shmdt(*shm_addr_ptr);
     *shm_addr_ptr = NULL;
 
-    return rc;
+    return (rc == 0) ? MPL_SHM_SUCCESS : MPL_SHM_EINTERN;
 }
 
 /* Remove a shared memory segment
@@ -171,8 +171,11 @@ int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, intptr_t seg_sz)
 int MPL_shm_seg_remove(MPL_shm_hnd_t hnd)
 {
     struct shmid_ds ds;
+    int rc = -1;
 
-    return shmctl(MPLI_shm_lhnd_get(hnd), IPC_RMID, &ds);
+    rc = shmctl(MPLI_shm_lhnd_get(hnd), IPC_RMID, &ds);
+
+    return (rc == 0) ? MPL_SHM_SUCCESS : MPL_SHM_EINTERN;
 }
 
 #endif /* MPL_USE_SYSV_SHM */

--- a/src/mpl/src/shm/mpl_shm_win.c
+++ b/src/mpl/src/shm/mpl_shm_win.c
@@ -25,7 +25,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
                                                   void **shm_addr_ptr, int offset, int flag)
 {
     HANDLE lhnd = INVALID_HANDLE_VALUE;
-    int rc = -1;
+    int rc = MPL_SHM_SUCCESS;
     ULARGE_INTEGER seg_sz_large;
     seg_sz_large.QuadPart = seg_sz;
 
@@ -41,7 +41,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
                                  PAGE_READWRITE, seg_sz_large.HighPart, seg_sz_large.LowPart,
                                  MPLI_shm_ghnd_get_by_ref(hnd));
         if (lhnd == NULL) {
-            rc = -1;
+            rc = MPL_SHM_EINTERN;
             goto fn_exit;
         }
         MPLI_shm_lhnd_set(hnd, lhnd);
@@ -50,7 +50,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
             /* Strangely OpenFileMapping() returns NULL on error! */
             lhnd = OpenFileMapping(FILE_MAP_WRITE, FALSE, MPLI_shm_ghnd_get_by_ref(hnd));
             if (lhnd == NULL) {
-                rc = -1;
+                rc = MPL_SHM_EINTERN;
                 goto fn_exit;
             }
 
@@ -72,7 +72,7 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
             *shm_addr_ptr = MapViewOfFile(MPLI_shm_lhnd_get(hnd), FILE_MAP_WRITE, 0, offset, 0);
         }
         if (*shm_addr_ptr == NULL) {
-            rc = -1;
+            rc = MPL_SHM_EINVAL;
         }
     }
 
@@ -166,7 +166,9 @@ static inline int MPL_shm_seg_detach(MPL_shm_hnd_t hnd, void **shm_addr_ptr, int
     rc = UnmapViewOfFile(*shm_addr_ptr);
     *shm_addr_ptr = NULL;
 
-    return rc;
+    /* If the function succeeds, the return value is nonzero,
+     * otherwise the return value is zero. */
+    return (rc != 0) ? MPL_SHM_SUCCESS : MPL_SHM_EINTERN;
 }
 
 


### PR DESCRIPTION
This PR includes two changes in MPL SHM:
(1) Enable shared memory mapping with fixed start address. New APIs are defined. 
(2) Define return values for MPL SHM in order to allow the caller to handle special errors separately (i.e., in RMA global symmetric heap allocation, we allow mapping failure and retry predefined times; all other errors are treaded as MPI error).

This PR is separated from #3319 