### PR TITLE
hydra2: timeout functionality

### DIFF
--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.c.in
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.c.in
@@ -113,7 +113,7 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
                             struct HYD_int_hash **downstream_stdout_hash,
                             struct HYD_int_hash **downstream_stderr_hash,
                             struct HYD_int_hash **downstream_fd_hash, int **downstream_proxy_id,
-                            int **downstream_pid, int debug, int tree_width)
+                            int **downstream_pid, int debug, int tree_width, int timeout)
 {
     char *targs[HYD_NUM_TMP_STRINGS] = { NULL };
     char *tmp[HYD_NUM_TMP_STRINGS] = { NULL };
@@ -259,6 +259,10 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
             targs[i++] = HYD_str_from_int(tree_width);
             if (debug)
                 targs[i++] = MPL_strdup("--debug");
+            if (timeout > 0) {
+                targs[i++] = MPL_strdup("--timeout");
+                targs[i++] = HYD_str_from_int(timeout);
+            }
             if (pmi_args)
                 for (j = 0; pmi_args[j]; j++)
                     targs[i++] = MPL_strdup(pmi_args[j]);
@@ -313,6 +317,10 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
             targs[i++] = HYD_str_from_int(tree_width);
             if (debug)
                 targs[i++] = MPL_strdup("--debug");
+            if (timeout > 0) {
+                targs[i++] = MPL_strdup("--timeout");
+                targs[i++] = HYD_str_from_int(timeout);
+            }
             if (pmi_args)
                 for (j = 0; pmi_args[j]; j++)
                     targs[i++] = MPL_strdup(pmi_args[j]);
@@ -352,7 +360,12 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
     /* our immediate children have been launched.  wait for them to
      * connect back. */
     while (bstrap_control->current_downstreams < bstrap_control->total_downstreams) {
-        status = HYD_dmx_wait_for_event(-1);
+        status = HYD_dmx_wait_for_event(timeout);
+        if (status == HYD_ERR_TIMED_OUT) {
+            HYD_dmx_deregister_fd(listen_fd);
+            close(listen_fd);
+            goto fn_fail;
+        }
         HYD_ERR_POP(status, "error waiting for event\n");
     }
 

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.h
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.h
@@ -21,7 +21,7 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
                             struct HYD_int_hash **downstream_stderr_hash,
                             struct HYD_int_hash **downstream_control_hash,
                             int **downstream_proxy_id, int **downstream_pid, int debug,
-                            int tree_width);
+                            int tree_width, int timeout);
 
 HYD_status HYD_bstrap_finalize(const char *launcher);
 

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
@@ -38,6 +38,7 @@ static struct HYD_int_hash *downstream_control_hash = NULL;
 static int *downstream_proxy_id = NULL;
 static int *downstream_pid = NULL;
 static int debug = 0;
+static int timeout = -1;
 
 static const char *localhost = NULL;
 
@@ -96,6 +97,10 @@ static HYD_status get_params(int argc, char **argv)
             tree_width = atoi(*argv);
         } else if (!strcmp(*argv, "--debug")) {
             debug = 1;
+        } else if (!strcmp(*argv, "--timeout")) {
+            ++argv;
+            --argc;
+            timeout = atoi(*argv);
         } else {
             int i = 0;
             HYD_MALLOC(proxy_args, char **, (argc + 1) * sizeof(char *), status);
@@ -211,7 +216,7 @@ static HYD_status upstream_cb(int fd, HYD_dmx_event_t events, void *userp)
                                  &num_downstream_proxies, &downstream_stdin,
                                  &downstream_stdout_hash, &downstream_stderr_hash,
                                  &downstream_control_hash, &downstream_proxy_id, &downstream_pid,
-                                 debug, tree_width);
+                                 debug, tree_width, timeout);
             HYD_ERR_POP(status, "error setting up the bstrap proxies\n");
 
             HYD_MALLOC(downstream_control, int *, num_downstream_proxies * sizeof(int), status);

--- a/src/pm/hydra2/mpiexec/mpiexec.h
+++ b/src/pm/hydra2/mpiexec/mpiexec.h
@@ -55,6 +55,7 @@ struct mpiexec_params_s {
     int print_all_exitcodes;
 
     int timeout;
+    int timeout_signal;
 
     enum {
         MPIEXEC_ENVPROP__UNSET = 0,

--- a/src/pm/hydra2/mpiexec/mpiexec_params.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_params.c
@@ -923,6 +923,19 @@ HYD_status mpiexec_get_parameters(char **t_argv)
             mpiexec_params.ppn = atoi(tstr);
     }
 
+    /* check if there's a an environment set for timeout */
+    MPL_env2int("MPIEXEC_TIMEOUT", &mpiexec_params.timeout);
+    MPL_env2int("MPIEXEC_TIMEOUT_SIGNAL", &mpiexec_params.timeout_signal);
+
+    /* check if there's a an environment set for port range */
+    if (MPL_env2str("MPIEXEC_PORTRANGE", (const char **) &mpiexec_params.port_range) ||
+        MPL_env2str("MPIEXEC_PORT_RANGE", (const char **) &mpiexec_params.port_range))
+        mpiexec_params.port_range = MPL_strdup(mpiexec_params.port_range);
+
+    /* check if there's a an environment set for debug */
+    if (mpiexec_params.debug == -1 && MPL_env2bool("HYDRA_DEBUG", &mpiexec_params.debug) == 0)
+        mpiexec_params.debug = 0;
+
 
     /***** AUTO-DETECT/COMPUTE PARAMETERS ****/
 

--- a/src/pm/hydra2/proxy/proxy.c
+++ b/src/pm/hydra2/proxy/proxy.c
@@ -739,7 +739,12 @@ int main(int argc, char **argv)
     /* step 2: wait for MPI process to terminate */
     HASH_ITER(hh, proxy_params.immediate.process.pid_hash, hash, tmp) {
         waitpid(hash->key, &tmp_ret, 0);
-        exitcodes[0][hash->val] = WEXITSTATUS(tmp_ret);
+        if (WIFEXITED(tmp_ret))
+            exitcodes[0][hash->val] = WEXITSTATUS(tmp_ret);
+        else if (WIFSIGNALED(tmp_ret))
+            exitcodes[0][hash->val] = HYD_ERR_TIMED_OUT;
+        else
+            exitcodes[0][hash->val] = HYD_ERR_INTERNAL;
         exitcode_node_ids[0][hash->val] = proxy_params.root.node_id;
         HASH_DEL(proxy_params.immediate.process.pid_hash, hash);
         MPL_free(hash);


### PR DESCRIPTION
1. Set alarm() on timeout
2. Pass SIGKILL on timeout (custom signal accepted as well)
   down the tree
3. Protect from hanging on the bstrap phase by setting wait timeout