### PR TITLE
Active Message Shared Memory Prereqs

### DIFF
--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -22,7 +22,8 @@ typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 /* for short cases, output arguments are NULL */
 typedef int (*MPIDIG_am_target_msg_cb)
  (int handler_id, void *am_hdr, void **data,    /* data should be iovs if *is_contig is false */
-  size_t * data_sz, int *is_contig, MPIDIG_am_target_cmpl_cb * target_cmpl_cb,  /* completion handler */
+  size_t * data_sz, int is_local,       /* SHM or NM directly specifies locality */
+  int *is_contig, MPIDIG_am_target_cmpl_cb * target_cmpl_cb,    /* completion handler */
   MPIR_Request ** req);         /* if allocated, need pointer to completion function */
 
 typedef struct MPIDIG_global_t {

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -13,7 +13,6 @@
 #define MPIDIG_SEND_H_INCLUDED
 
 #include "ch4_impl.h"
-#include <../mpi/pt2pt/bsendutil.h>
 
 #define MPIDI_NONBLOCKING 0
 #define MPIDI_BLOCKING    1

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -295,7 +295,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_send_init(const void *buf,
                                                   MPI_Datatype datatype,
                                                   int rank,
                                                   int tag, MPIR_Comm * comm, int context_offset,
-                                                  MPIR_Request ** request)
+                                                  MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -318,7 +318,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_ssend_init(const void *buf,
                                                    MPI_Datatype datatype,
                                                    int rank,
                                                    int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -341,7 +341,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_bsend_init(const void *buf,
                                                    MPI_Datatype datatype,
                                                    int rank,
                                                    int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -364,7 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rsend_init(const void *buf,
                                                    MPI_Datatype datatype,
                                                    int rank,
                                                    int tag, MPIR_Comm * comm, int context_offset,
-                                                   MPIR_Request ** request)
+                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -52,6 +52,7 @@ typedef enum {
 #define MPIDI_CH4U_REQ_RCV_NON_CONTIG (0x1 << 5)
 #define MPIDI_CH4U_REQ_MATCHED (0x1 << 6)
 #define MPIDI_CH4U_REQ_LONG_RTS (0x1 << 7)
+#define MPIDI_CH4U_REQ_IN_PROGRESS (0x1 << 8)
 
 #define MPIDI_PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
 #define MPIDI_MAX_KVS_VALUE_LEN  4096
@@ -195,6 +196,7 @@ typedef struct {
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)
 #define MPIDI_CH4I_REQUEST(req,field)       (((req)->dev).field)
 #define MPIDI_CH4U_REQUEST(req,field)       (((req)->dev.ch4.am).field)
+#define MPIDI_CH4U_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req->status & MPIDI_CH4U_REQ_IN_PROGRESS)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
 #define MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(req)  (((req)->dev).anysource_partner_request)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -37,7 +37,7 @@ static inline int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr)
     in_data_sz = data_sz = msg_hdr->data_sz;
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
-                                                       &p_data, &data_sz,
+                                                       &p_data, &data_sz, 0 /* is_local */ ,
                                                        &is_contig, &target_cmpl_cb, &rreq);
 
     if (!rreq)
@@ -106,7 +106,8 @@ static inline int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t * msg_hdr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_SHORT_AM_HDR);
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, NULL, NULL, &target_cmpl_cb, &rreq);
+                                                       NULL, NULL, 0 /* is_local */ ,
+                                                       NULL, &target_cmpl_cb, &rreq);
 
     if (!rreq)
         goto fn_exit;
@@ -206,8 +207,8 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
 
     in_data_sz = data_sz = msg_hdr->data_sz;
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       &p_data, &data_sz, &is_contig,
-                                                       &target_cmpl_cb, &rreq);
+                                                       &p_data, &data_sz, 0 /* is_local */ ,
+                                                       &is_contig, &target_cmpl_cb, &rreq);
 
     if (!rreq)
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -237,7 +237,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
 int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
-                              void **data, size_t * data_sz, int *is_contig,
+                              void **data, size_t * data_sz, int is_local, int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(void);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -567,7 +567,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SEND_INIT);
 
     mpi_errno =
-        MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND_INIT);
     return mpi_errno;
@@ -588,7 +588,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SSEND_INIT);
 
     mpi_errno =
-        MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND_INIT);
     return mpi_errno;
@@ -609,7 +609,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bsend_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BSEND_INIT);
 
     mpi_errno =
-        MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_BSEND_INIT);
     return mpi_errno;
@@ -630,7 +630,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rsend_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RSEND_INIT);
 
     mpi_errno =
-        MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RSEND_INIT);
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -197,6 +197,7 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
                               void **data,
                               size_t * data_sz,
+                              int is_local,
                               int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {

--- a/src/mpid/ch4/netmod/portals4/ptl_progress.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_progress.h
@@ -30,8 +30,8 @@ static inline int MPIDI_PTL_am_handler(ptl_event_t * e)
     int handler_id = e->hdr_data >> 56;
 
     MPIDIG_global.target_msg_cbs[handler_id] (handler_id, e->start,
-                                              &p_data, &data_sz, &is_contig, &target_cmpl_cb,
-                                              &rreq);
+                                              &p_data, &data_sz, 0 /* is_local */ ,
+                                              &is_contig, &target_cmpl_cb, &rreq);
 
     if (!rreq)
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ucx/ucx_am_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_send.h
@@ -43,7 +43,8 @@ static inline int MPIDI_NM_mpi_send_init(const void *buf,
                                          MPIR_Comm * comm, int context_offset,
                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                request);
 }
 
 static inline int MPIDI_NM_mpi_ssend_init(const void *buf,
@@ -54,7 +55,8 @@ static inline int MPIDI_NM_mpi_ssend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 request);
 }
 
 static inline int MPIDI_NM_mpi_bsend_init(const void *buf,
@@ -65,7 +67,8 @@ static inline int MPIDI_NM_mpi_bsend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 request);
 }
 
 static inline int MPIDI_NM_mpi_rsend_init(const void *buf,
@@ -76,7 +79,8 @@ static inline int MPIDI_NM_mpi_rsend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                 request);
 }
 
 static inline int MPIDI_NM_mpi_isend(const void *buf,

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -29,8 +29,8 @@ static inline int MPIDI_UCX_am_handler(void *msg, size_t msg_sz)
     in_data_sz = data_sz = msg_hdr->data_sz;
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
-                                                       &p_data, &data_sz, &is_contig,
-                                                       &target_cmpl_cb, &rreq);
+                                                       &p_data, &data_sz, 0 /* is_local */ ,
+                                                       &is_contig, &target_cmpl_cb, &rreq);
 
     if (!rreq)
         goto fn_exit;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -161,7 +161,8 @@ static inline int MPIDI_NM_mpi_send_init(const void *buf,
                                          MPIR_Comm * comm, int context_offset,
                                          MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_send_init(buf, count, datatype, rank, tag, comm,
+                                context_offset, addr, request);
 }
 
 #undef FUNCNAME
@@ -176,7 +177,8 @@ static inline int MPIDI_NM_mpi_ssend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_ssend_init(buf, count, datatype, rank, tag, comm,
+                                 context_offset, addr, request);
 }
 
 #undef FUNCNAME
@@ -191,7 +193,8 @@ static inline int MPIDI_NM_mpi_bsend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_bsend_init(buf, count, datatype, rank, tag, comm,
+                                 context_offset, addr, request);
 }
 
 #undef FUNCNAME
@@ -206,7 +209,8 @@ static inline int MPIDI_NM_mpi_rsend_init(const void *buf,
                                           MPIR_Comm * comm, int context_offset,
                                           MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
-    return MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    return MPIDIG_mpi_rsend_init(buf, count, datatype, rank, tag, comm,
+                                 context_offset, addr, request);
 }
 
 #undef FUNCNAME

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -75,19 +75,19 @@ typedef int (*MPIDI_SHM_mpi_startall_t) (int count, MPIR_Request * requests[]);
 typedef int (*MPIDI_SHM_mpi_send_init_t) (const void *buf, int count,
                                           MPI_Datatype datatype, int rank, int tag,
                                           MPIR_Comm * comm, int context_offset,
-                                          MPIR_Request ** request);
+                                          MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_ssend_init_t) (const void *buf, int count,
                                            MPI_Datatype datatype, int rank, int tag,
                                            MPIR_Comm * comm, int context_offset,
-                                           MPIR_Request ** request);
+                                           MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_rsend_init_t) (const void *buf, int count,
                                            MPI_Datatype datatype, int rank, int tag,
                                            MPIR_Comm * comm, int context_offset,
-                                           MPIR_Request ** request);
+                                           MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_bsend_init_t) (const void *buf, int count,
                                            MPI_Datatype datatype, int rank, int tag,
                                            MPIR_Comm * comm, int context_offset,
-                                           MPIR_Request ** request);
+                                           MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_SHM_mpi_isend_t) (const void *buf, MPI_Aint count,
                                       MPI_Datatype datatype, int rank, int tag,
                                       MPIR_Comm * comm, int context_offset,
@@ -666,21 +666,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
+                                                     MPIDI_av_entry_t * addr,
                                                      MPIR_Request **
                                                      request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request **
                                                       request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request **
                                                       request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request **
                                                       request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -186,6 +186,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_send_init(const void *buf,
                                                        int rank,
                                                        int tag,
                                                        MPIR_Comm * comm, int context_offset,
+                                                       MPIDI_av_entry_t * addr,
                                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -223,7 +224,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ssend_init(const void *buf,
                                                         int rank,
                                                         int tag,
                                                         MPIR_Comm * comm,
-                                                        int context_offset, MPIR_Request ** request)
+                                                        int context_offset,
+                                                        MPIDI_av_entry_t * addr,
+                                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -257,7 +260,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bsend_init(const void *buf,
                                                         int rank,
                                                         int tag,
                                                         MPIR_Comm * comm,
-                                                        int context_offset, MPIR_Request ** request)
+                                                        int context_offset,
+                                                        MPIDI_av_entry_t * addr,
+                                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
@@ -291,7 +296,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rsend_init(const void *buf,
                                                         int rank,
                                                         int tag,
                                                         MPIR_Comm * comm,
-                                                        int context_offset, MPIR_Request ** request)
+                                                        int context_offset,
+                                                        MPIDI_av_entry_t * addr,
+                                                        MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -398,6 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_startall(int count, MPIR_Request * re
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
+                                                     MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** request)
 {
     int ret;
@@ -406,7 +407,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SEND_INIT);
 
     ret = MPIDI_SHM_native_src_funcs.mpi_send_init(buf, count, datatype, rank, tag, comm,
-                                                   context_offset, request);
+                                                   context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SEND_INIT);
     return ret;
@@ -415,6 +416,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -423,7 +425,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SSEND_INIT);
 
     ret = MPIDI_SHM_native_src_funcs.mpi_ssend_init(buf, count, datatype, rank, tag, comm,
-                                                    context_offset, request);
+                                                    context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SSEND_INIT);
     return ret;
@@ -432,6 +434,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -440,7 +443,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_RSEND_INIT);
 
     ret = MPIDI_SHM_native_src_funcs.mpi_rsend_init(buf, count, datatype, rank, tag, comm,
-                                                    context_offset, request);
+                                                    context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_RSEND_INIT);
     return ret;
@@ -449,6 +452,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -457,7 +461,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_BSEND_INIT);
 
     ret = MPIDI_SHM_native_src_funcs.mpi_bsend_init(buf, count, datatype, rank, tag, comm,
-                                                    context_offset, request);
+                                                    context_offset, addr, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_BSEND_INIT);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -48,6 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend(const void *buf, MPI_Aint count
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
                                                      MPI_Datatype datatype, int rank, int tag,
                                                      MPIR_Comm * comm, int context_offset,
+                                                     MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** request)
 {
     int ret;
@@ -55,7 +56,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_SEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SEND_INIT);
 
-    ret = MPIDI_POSIX_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, request);
+    ret = MPIDI_POSIX_mpi_send_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                    request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SEND_INIT);
     return ret;
@@ -64,6 +66,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_send_init(const void *buf, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -71,8 +74,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_SSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_SSEND_INIT);
 
-    ret = MPIDI_POSIX_mpi_ssend_init(buf, count, datatype, rank, tag, comm,
-                                     context_offset, request);
+    ret = MPIDI_POSIX_mpi_ssend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                     request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_SSEND_INIT);
     return ret;
@@ -81,6 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ssend_init(const void *buf, int count
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -88,8 +92,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_RSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_RSEND_INIT);
 
-    ret = MPIDI_POSIX_mpi_rsend_init(buf, count, datatype, rank, tag, comm,
-                                     context_offset, request);
+    ret = MPIDI_POSIX_mpi_rsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                     request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_RSEND_INIT);
     return ret;
@@ -98,6 +102,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_rsend_init(const void *buf, int count
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int context_offset,
+                                                      MPIDI_av_entry_t * addr,
                                                       MPIR_Request ** request)
 {
     int ret;
@@ -105,8 +110,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bsend_init(const void *buf, int count
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_BSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_BSEND_INIT);
 
-    ret = MPIDI_POSIX_mpi_bsend_init(buf, count, datatype, rank, tag, comm,
-                                     context_offset, request);
+    ret = MPIDI_POSIX_mpi_bsend_init(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                     request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_BSEND_INIT);
     return ret;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -57,14 +57,19 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
             MPIR_ERR_POP(mpi_errno);
         }
 
-        mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                       &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
+        MPIDI_CH4I_REQUEST(*request, is_local) = 1;
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
-        /* cancel the shm request if netmod/am handles the request from unexpected queue. */
-        else if (*request) {
+        if (!MPIR_Request_is_complete(*request) && !MPIDI_CH4U_REQUEST_IN_PROGRESS(*request)) {
+            mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
+                                           av, &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
+
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+
+            MPIDI_CH4I_REQUEST(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
+
+            /* cancel the shm request if netmod/am handles the request from unexpected queue. */
             if (MPIR_Request_is_complete(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request))) {
                 mpi_errno = MPIDI_SHM_mpi_cancel_recv(*request);
                 if (MPIR_STATUS_GET_CANCEL_BIT((*request)->status)) {
@@ -73,12 +78,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
                 MPIR_Request_free(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request));
                 goto fn_exit;
             }
-            MPIDI_CH4I_REQUEST(*request, is_local) = 1;
-            MPIDI_CH4I_REQUEST(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
-        }
 
-        MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
-            *request;
+            MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
+                *request;
+        }
     } else {
         int r;
         if ((r = MPIDI_av_is_local(av)))
@@ -136,19 +139,32 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
             MPIR_ERR_POP(mpi_errno);
         }
 
-        mpi_errno =
-            MPIDI_NM_mpi_recv_init(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                   &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
-
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
-
         MPIDI_CH4I_REQUEST(*request, is_local) = 1;
-        MPIDI_CH4I_REQUEST(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
 
-        MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
-            *request;
+        if (!MPIR_Request_is_complete(*request) && !MPIDI_CH4U_REQUEST_IN_PROGRESS(*request)) {
+            mpi_errno =
+                MPIDI_NM_mpi_recv_init(buf, count, datatype, rank, tag, comm, context_offset, av,
+                                       &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
+
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+
+            MPIDI_CH4I_REQUEST(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
+
+            /* cancel the shm request if netmod/am handles the request from unexpected queue. */
+            if (MPIR_Request_is_complete(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request))) {
+                mpi_errno = MPIDI_SHM_mpi_cancel_recv(*request);
+                if (MPIR_STATUS_GET_CANCEL_BIT((*request)->status)) {
+                    (*request)->status = MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)->status;
+                }
+                MPIR_Request_free(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request));
+                goto fn_exit;
+            }
+
+            MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
+                *request;
+        }
     } else {
         int r;
         if ((r = MPIDI_av_is_local(av)))
@@ -311,18 +327,31 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
             MPIR_ERR_POP(mpi_errno);
         }
 
-        mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                       &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
+        MPIDI_CH4I_REQUEST(*request, is_local) = 1;
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        } else if (*request) {
-            MPIDI_CH4I_REQUEST(*request, is_local) = 1;
+        if (!MPIR_Request_is_complete(*request) && !MPIDI_CH4U_REQUEST_IN_PROGRESS(*request)) {
+            mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
+                                           av, &(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)));
+
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+
             MPIDI_CH4I_REQUEST(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
-        }
 
-        MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
-            *request;
+            /* cancel the shm request if netmod/am handles the request from unexpected queue. */
+            if (MPIR_Request_is_complete(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request))) {
+                mpi_errno = MPIDI_SHM_mpi_cancel_recv(*request);
+                if (MPIR_STATUS_GET_CANCEL_BIT((*request)->status)) {
+                    (*request)->status = MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)->status;
+                }
+                MPIR_Request_free(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request));
+                goto fn_exit;
+            }
+
+            MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(MPIDI_CH4I_REQUEST_ANYSOURCE_PARTNER(*request)) =
+                *request;
+        }
     } else {
         int r;
         if ((r = MPIDI_av_is_local(av)))

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -352,7 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
     int r;
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_send_init(buf, count, datatype, rank, tag,
-                                            comm, context_offset, request);
+                                            comm, context_offset, av, request);
     else
         mpi_errno = MPIDI_NM_mpi_send_init(buf, count, datatype, rank, tag,
                                            comm, context_offset, av, request);
@@ -394,7 +394,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
     int r;
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_ssend_init(buf, count, datatype, rank, tag,
-                                             comm, context_offset, request);
+                                             comm, context_offset, av, request);
     else
         mpi_errno = MPIDI_NM_mpi_ssend_init(buf, count, datatype, rank, tag,
                                             comm, context_offset, av, request);
@@ -437,7 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
     int r;
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_bsend_init(buf, count, datatype, rank, tag,
-                                             comm, context_offset, request);
+                                             comm, context_offset, av, request);
     else
         mpi_errno = MPIDI_NM_mpi_bsend_init(buf, count, datatype, rank, tag,
                                             comm, context_offset, av, request);
@@ -480,7 +480,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
     int r;
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_rsend_init(buf, count, datatype, rank, tag,
-                                             comm, context_offset, request);
+                                             comm, context_offset, av, request);
     else
         mpi_errno = MPIDI_NM_mpi_rsend_init(buf, count, datatype, rank, tag,
                                             comm, context_offset, av, request);

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -499,6 +499,9 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_BUSY;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_UNEXPECTED;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
         /* MPIDI_CS_ENTER(); */
         if (root_comm) {
             MPIR_Comm_add_ref(root_comm);
@@ -608,6 +611,9 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
         MPIDI_CH4U_REQUEST(rreq, tag) = hdr->tag;
         MPIDI_CH4U_REQUEST(rreq, context_id) = hdr->context_id;
         MPIDI_CH4U_REQUEST(rreq, req->status) |= MPIDI_CH4U_REQ_IN_PROGRESS;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
         /* MPIDI_CS_ENTER(); */
         if (root_comm) {

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -434,6 +434,7 @@ static inline int MPIDI_ssend_ack_origin_cb(MPIR_Request * req)
 static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
                                            void **data,
                                            size_t * p_data_sz,
+                                           int is_local,
                                            int *is_contig,
                                            MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                            MPIR_Request ** req)
@@ -542,6 +543,7 @@ static inline int MPIDI_send_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr,
                                                     void **data,
                                                     size_t * p_data_sz,
+                                                    int is_local,
                                                     int *is_contig,
                                                     MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                     MPIR_Request ** req)
@@ -660,6 +662,7 @@ static inline int MPIDI_send_long_req_target_msg_cb(int handler_id, void *am_hdr
 static inline int MPIDI_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr,
                                                     void **data,
                                                     size_t * p_data_sz,
+                                                    int is_local,
                                                     int *is_contig,
                                                     MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                     MPIR_Request ** req)
@@ -688,6 +691,7 @@ static inline int MPIDI_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr
 static inline int MPIDI_ssend_target_msg_cb(int handler_id, void *am_hdr,
                                             void **data,
                                             size_t * p_data_sz,
+                                            int is_local,
                                             int *is_contig,
                                             MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                             MPIR_Request ** req)
@@ -699,8 +703,8 @@ static inline int MPIDI_ssend_target_msg_cb(int handler_id, void *am_hdr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_TARGET_MSG_CB);
 
     mpi_errno =
-        MPIDI_send_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_contig, target_cmpl_cb,
-                                 req);
+        MPIDI_send_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_local, is_contig,
+                                 target_cmpl_cb, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -720,7 +724,7 @@ static inline int MPIDI_ssend_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_ssend_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                 void **data,
-                                                size_t * p_data_sz, int *is_contig,
+                                                size_t * p_data_sz, int is_local, int *is_contig,
                                                 MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                 MPIR_Request ** req)
 {
@@ -748,7 +752,8 @@ static inline int MPIDI_ssend_ack_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_send_long_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                     void **data,
-                                                    size_t * p_data_sz, int *is_contig,
+                                                    size_t * p_data_sz, int is_local,
+                                                    int *is_contig,
                                                     MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                     MPIR_Request ** req)
 {
@@ -819,6 +824,7 @@ static inline int MPIDI_comm_abort_origin_cb(MPIR_Request * sreq)
 static inline int MPIDI_comm_abort_target_msg_cb(int handler_id, void *am_hdr,
                                                  void **data,
                                                  size_t * p_data_sz,
+                                                 int is_local,
                                                  int *is_contig,
                                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                  MPIR_Request ** req)

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -1645,9 +1645,11 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
         MPIR_Assert(dt_iov);
 
         iov = (struct iovec *) ((char *) am_hdr + sizeof(*msg_hdr));
-        for (i = 0; i < msg_hdr->n_iov; i++)
-            iov[i].iov_base = (char *) iov[i].iov_base + base + offset;
-        MPIR_Memcpy(dt_iov, iov, sizeof(struct iovec) * msg_hdr->n_iov);
+        for (i = 0; i < msg_hdr->n_iov; i++) {
+            dt_iov[i].iov_base = (char *) iov[i].iov_base + base + offset;
+            dt_iov[i].iov_len = iov[i].iov_len;
+        }
+
         MPIDI_CH4U_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
         MPIDI_CH4U_REQUEST(rreq, req->preq.n_iov) = msg_hdr->n_iov;
         *is_contig = 0;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -1633,6 +1633,9 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_put_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
     offset = win->disp_unit * msg_hdr->target_disp;
     if (msg_hdr->n_iov) {
@@ -1726,6 +1729,9 @@ static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_put_iov_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
     /* Base adjustment for iov will be done after we get the entire iovs,
      * at MPIDI_CH4U_put_data_target_msg_cb */
@@ -2087,6 +2093,9 @@ static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_cswap_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
     MPIDI_Datatype_check_contig_size(msg_hdr->datatype, 1, dt_contig, data_sz);
     *is_contig = dt_contig;
@@ -2158,6 +2167,9 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_acc_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
     if (is_contig) {
         *is_contig = 1;
@@ -2296,6 +2308,9 @@ static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_acc_iov_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_iov);
@@ -2364,6 +2379,9 @@ static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
     *req = rreq;
     *target_cmpl_cb = MPIDI_get_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(rreq, is_local) = is_local;
+#endif
 
     win = (MPIR_Win *) MPIDI_CH4U_map_lookup(MPIDI_CH4_Global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -2438,6 +2456,9 @@ static inline int MPIDI_get_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     *target_cmpl_cb = MPIDI_get_ack_target_cmpl_cb;
     MPIDI_CH4U_REQUEST(greq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_CH4_Global.nxt_seq_no, 1);
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_CH4I_REQUEST(greq, is_local) = is_local;
+#endif
 
     MPIDI_Datatype_get_info(MPIDI_CH4U_REQUEST(rreq, req->greq.count),
                             MPIDI_CH4U_REQUEST(rreq, req->greq.datatype),

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -1339,7 +1339,7 @@ static inline int MPIDI_cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_put_ack_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
-                                              size_t * p_data_sz, int *is_contig,
+                                              size_t * p_data_sz, int is_local, int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)
 {
@@ -1379,7 +1379,7 @@ static inline int MPIDI_put_ack_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
-                                              size_t * p_data_sz, int *is_contig,
+                                              size_t * p_data_sz, int is_local, int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)
 {
@@ -1420,7 +1420,7 @@ static inline int MPIDI_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                   void **data,
-                                                  size_t * p_data_sz, int *is_contig,
+                                                  size_t * p_data_sz, int is_local, int *is_contig,
                                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                   MPIR_Request ** req)
 {
@@ -1492,7 +1492,7 @@ static inline int MPIDI_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_cswap_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                 void **data,
-                                                size_t * p_data_sz, int *is_contig,
+                                                size_t * p_data_sz, int is_local, int *is_contig,
                                                 MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                 MPIR_Request ** req)
 {
@@ -1527,7 +1527,7 @@ static inline int MPIDI_cswap_ack_target_msg_cb(int handler_id, void *am_hdr,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_win_ctrl_target_msg_cb(int handler_id, void *am_hdr,
                                                void **data,
-                                               size_t * p_data_sz, int *is_contig,
+                                               size_t * p_data_sz, int is_local, int *is_contig,
                                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                MPIR_Request ** req)
 {
@@ -1595,6 +1595,7 @@ static inline int MPIDI_win_ctrl_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
                                           void **data,
                                           size_t * p_data_sz,
+                                          int is_local,
                                           int *is_contig,
                                           MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                           MPIR_Request ** req)
@@ -1696,6 +1697,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
                                               size_t * p_data_sz,
+                                              int is_local,
                                               int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)
@@ -1752,6 +1754,7 @@ static inline int MPIDI_put_iov_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                   void **data,
                                                   size_t * p_data_sz,
+                                                  int is_local,
                                                   int *is_contig,
                                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                   MPIR_Request ** req)
@@ -1818,6 +1821,7 @@ static inline int MPIDI_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                   void **data,
                                                   size_t * p_data_sz,
+                                                  int is_local,
                                                   int *is_contig,
                                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                   MPIR_Request ** req)
@@ -1884,6 +1888,7 @@ static inline int MPIDI_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr,
                                                       void **data,
                                                       size_t * p_data_sz,
+                                                      int is_local,
                                                       int *is_contig,
                                                       MPIDIG_am_target_cmpl_cb *
                                                       target_cmpl_cb, MPIR_Request ** req)
@@ -1950,6 +1955,7 @@ static inline int MPIDI_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_h
 static inline int MPIDI_put_data_target_msg_cb(int handler_id, void *am_hdr,
                                                void **data,
                                                size_t * p_data_sz,
+                                               int is_local,
                                                int *is_contig,
                                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                MPIR_Request ** req)
@@ -1993,6 +1999,7 @@ static inline int MPIDI_put_data_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_acc_data_target_msg_cb(int handler_id, void *am_hdr,
                                                void **data,
                                                size_t * p_data_sz,
+                                               int is_local,
                                                int *is_contig,
                                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                MPIR_Request ** req)
@@ -2023,6 +2030,7 @@ static inline int MPIDI_acc_data_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_acc_data_target_msg_cb(int handler_id, void *am_hdr,
                                                    void **data,
                                                    size_t * p_data_sz,
+                                                   int is_local,
                                                    int *is_contig,
                                                    MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                    MPIR_Request ** req)
@@ -2053,6 +2061,7 @@ static inline int MPIDI_get_acc_data_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
                                             void **data,
                                             size_t * p_data_sz,
+                                            int is_local,
                                             int *is_contig,
                                             MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                             MPIR_Request ** req)
@@ -2117,6 +2126,7 @@ static inline int MPIDI_cswap_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
                                           void **data,
                                           size_t * p_data_sz,
+                                          int is_local,
                                           int *is_contig,
                                           MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                           MPIR_Request ** req)
@@ -2205,6 +2215,7 @@ static inline int MPIDI_acc_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_acc_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
                                               size_t * p_data_sz,
+                                              int is_local,
                                               int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)
@@ -2217,8 +2228,8 @@ static inline int MPIDI_get_acc_target_msg_cb(int handler_id, void *am_hdr,
 
     /* the same handling processing as ACC except the completion handler function. */
     mpi_errno =
-        MPIDI_acc_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_contig, target_cmpl_cb,
-                                req);
+        MPIDI_acc_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_local, is_contig,
+                                target_cmpl_cb, req);
 
     *target_cmpl_cb = MPIDI_get_acc_target_cmpl_cb;
 
@@ -2234,6 +2245,7 @@ static inline int MPIDI_get_acc_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
                                               size_t * p_data_sz,
+                                              int is_local,
                                               int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)
@@ -2300,6 +2312,7 @@ static inline int MPIDI_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
                                                   void **data,
                                                   size_t * p_data_sz,
+                                                  int is_local,
                                                   int *is_contig,
                                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                                   MPIR_Request ** req)
@@ -2312,7 +2325,7 @@ static inline int MPIDI_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 
     /* the same handling processing as ACC except the completion handler function. */
     mpi_errno = MPIDI_acc_iov_target_msg_cb(handler_id, am_hdr, data,
-                                            p_data_sz, is_contig, target_cmpl_cb, req);
+                                            p_data_sz, is_local, is_contig, target_cmpl_cb, req);
 
     *target_cmpl_cb = MPIDI_get_acc_iov_target_cmpl_cb;
 
@@ -2328,6 +2341,7 @@ static inline int MPIDI_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
                                           void **data,
                                           size_t * p_data_sz,
+                                          int is_local,
                                           int *is_contig,
                                           MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                           MPIR_Request ** req)
@@ -2391,6 +2405,7 @@ static inline int MPIDI_get_target_msg_cb(int handler_id, void *am_hdr,
 static inline int MPIDI_get_ack_target_msg_cb(int handler_id, void *am_hdr,
                                               void **data,
                                               size_t * p_data_sz,
+                                              int is_local,
                                               int *is_contig,
                                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                               MPIR_Request ** req)

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -1651,7 +1651,7 @@ static inline int MPIDI_put_target_msg_cb(int handler_id, void *am_hdr,
         MPIDI_CH4U_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
         MPIDI_CH4U_REQUEST(rreq, req->preq.n_iov) = msg_hdr->n_iov;
         *is_contig = 0;
-        *data = iov;
+        *data = dt_iov;
         *p_data_sz = msg_hdr->n_iov;
         goto fn_exit;
     }


### PR DESCRIPTION
This separates out a number of patches from #3199 that can be reviewed and merged independently. These do a variety of things around the active message infrastructure in the `CH4R` code, but largely don't touch the shared memory code itself (with small exceptions).

One of the main features of this patch series is to pass around locality information to reduce the need for redundant lookups on the critical path.