### PR TITLE
Revert "ch4/ofi: Lazy initialization of shared transmit context for RMA"

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -837,6 +837,29 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     }
 
     /* ------------------------------------------------------------------------ */
+    /* Construct:  Shared TX Context for RMA                                    */
+    /* ------------------------------------------------------------------------ */
+    if (MPIDI_OFI_ENABLE_SHARED_CONTEXTS) {
+        int ret;
+        struct fi_tx_attr tx_attr;
+        memset(&tx_attr, 0, sizeof(tx_attr));
+        /* A shared transmit context’s attributes must be a union of all associated
+         * endpoints' transmit capabilities. */
+        tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
+        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+        tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
+        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
+                                             &tx_attr,
+                                             &MPIDI_Global.rma_stx_ctx, NULL /* context */), ret);
+        if (ret < 0) {
+            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        "Failed to create shared TX context for RMA, "
+                        "falling back to global EP/counter scheme");
+            MPIDI_Global.rma_stx_ctx = NULL;
+        }
+    }
+
+    /* ------------------------------------------------------------------------ */
     /* Create a transport level communication endpoint.  To use the endpoint,   */
     /* it must be bound to completion counters or event queues and enabled,     */
     /* and the resources consumed by it, such as address vectors, counters,     */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -289,27 +289,6 @@ static inline int MPIDI_OFI_win_init_stx(MPIR_Win * win)
     finfo = fi_dupinfo(MPIDI_Global.prov_use);
     MPIR_Assert(finfo);
 
-    /* Create shared context only in first call. */
-    if (MPIDI_Global.rma_stx_ctx == NULL) {
-        memset(finfo->tx_attr, 0, sizeof(struct fi_tx_attr));
-        /* A shared transmit context’s attributes must be a union of all associated
-         * endpoints' transmit capabilities. */
-        finfo->tx_attr->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
-        finfo->tx_attr->msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
-        finfo->tx_attr->op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
-        MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_Global.domain,
-                                             finfo->tx_attr,
-                                             &MPIDI_Global.rma_stx_ctx, NULL /* context */), ret);
-        if (ret < 0) {
-            MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        "Failed to create shared TX context for RMA, "
-                        "falling back to global EP/counter scheme");
-            MPIDI_Global.rma_stx_ctx = NULL;
-            mpi_errno = MPIDI_OFI_ENAVAIL;
-            goto fn_fail;
-        }
-    }
-
     /* Set per window transmit attributes. */
     MPIDI_OFI_set_rma_fi_info(win, finfo);
     /* Still need to take out rx capabilities for shared context. */


### PR DESCRIPTION
This reverts commit f16af2e20e78c010048730c67eb0c5282f63c975.

After extensive sifting and testing, I found this commit is causing pt2pt communication performance to drop 50% (comparing to the SC17 paper version or the one commit that precedes this). Testing for correctness here.