### PR TITLE
Simplifying and cleaning up the Mrecv paths in CH4

### DIFF
--- a/src/mpid/ch3/src/mpid_mrecv.c
+++ b/src/mpid/ch3/src/mpid_mrecv.c
@@ -11,11 +11,10 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
-               MPIR_Request *message, MPI_Status *status)
+               MPIR_Request *message, MPI_Status *status, MPIR_Request **rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    int active_flag;            /* dummy for MPIR_Request_completion_processing */
-    MPIR_Request *rreq = NULL;
+    *rreq = NULL;
 
     if (message == NULL) {
         /* treat as though MPI_MESSAGE_NO_PROC was passed */
@@ -27,29 +26,8 @@ int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
      * optimization potential in that case.  MPID_Recv exists to prevent
      * creating a request unnecessarily for messages that are already present
      * and eligible for immediate completion. */
-    mpi_errno = MPID_Imrecv(buf, count, datatype, message, &rreq);
+    mpi_errno = MPID_Imrecv(buf, count, datatype, message, rreq);
     if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-
-    if (!MPIR_Request_is_complete(rreq)) {
-        MPID_Progress_state progress_state;
-
-        MPID_Progress_start(&progress_state);
-        while (!MPIR_Request_is_complete(rreq))
-        {
-            mpi_errno = MPID_Progress_wait(&progress_state);
-            if (mpi_errno) {
-                /* --BEGIN ERROR HANDLING-- */
-                MPID_Progress_end(&progress_state);
-                MPIR_ERR_POP(mpi_errno);
-                /* --END ERROR HANDLING-- */
-            }
-        }
-        MPID_Progress_end(&progress_state);
-    }
-    mpi_errno = MPIR_Request_completion_processing(rreq, status, &active_flag);
-    MPIR_Request_free(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
 
 fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -296,12 +296,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMRECV);
 
-    if (message == NULL) {
-        MPIDI_Request_create_null_rreq(rreq, mpi_errno, fn_fail);
-        *rreqp = rreq;
-        goto fn_exit;
-    }
-
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     MPIDI_CH4U_REQUEST(message, req->rreq.mrcv_buffer) = buf;
     MPIDI_CH4U_REQUEST(message, req->rreq.mrcv_count) = count;

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -335,48 +335,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDIG_mrecv
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mrecv(void *buf,
-                                          MPI_Aint count,
-                                          MPI_Datatype datatype,
-                                          MPIR_Request * message, MPI_Status * status)
-{
-    int mpi_errno = MPI_SUCCESS, active_flag;
-    MPID_Progress_state state;
-    MPIR_Request *rreq = NULL;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MRECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MRECV);
-
-    mpi_errno = MPID_Imrecv(buf, count, datatype, message, &rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-    MPID_Progress_start(&state);
-
-    while (!MPIR_Request_is_complete(rreq)) {
-        MPID_Progress_wait(&state);
-    }
-
-    MPID_Progress_end(&state);
-
-    MPIR_Request_extract_status(rreq, status);
-
-    mpi_errno = MPIR_Request_completion_processing(rreq, status, &active_flag);
-    MPIR_Request_free(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MRECV);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-#undef FUNCNAME
 #define FUNCNAME MPIDIG_mpi_irecv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -289,25 +289,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv_init(void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
                                                MPI_Aint count,
                                                MPI_Datatype datatype,
-                                               MPIR_Request * message, MPIR_Request ** rreqp)
+                                               MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMRECV);
 
-    MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     MPIDI_CH4U_REQUEST(message, req->rreq.mrcv_buffer) = buf;
     MPIDI_CH4U_REQUEST(message, req->rreq.mrcv_count) = count;
     MPIDI_CH4U_REQUEST(message, req->rreq.mrcv_datatype) = datatype;
-    *rreqp = message;
 
     /* MPIDI_CS_ENTER(); */
     if (MPIDI_CH4U_REQUEST(message, req->status) & MPIDI_CH4U_REQ_BUSY) {
         MPIDI_CH4U_REQUEST(message, req->status) |= MPIDI_CH4U_REQ_UNEXP_CLAIMED;
     } else if (MPIDI_CH4U_REQUEST(message, req->status) & MPIDI_CH4U_REQ_LONG_RTS) {
         /* Matching receive is now posted, tell the netmod */
-        message->kind = MPIR_REQUEST_KIND__RECV;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDI_CH4U_REQUEST(message, datatype) = datatype;
         MPIDI_CH4U_REQUEST(message, buffer) = (char *) buf;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -42,7 +42,7 @@ MPIDI_CH4I_API(int, Isend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_
                MPIR_Request **);
 MPIDI_CH4I_API(int, Issend, const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                MPIR_Request **);
-MPIDI_CH4I_API(int, Mrecv, void *, MPI_Aint, MPI_Datatype, MPIR_Request *, MPI_Status *);
+MPIDI_CH4I_API(int, Mrecv, void *, MPI_Aint, MPI_Datatype, MPIR_Request *, MPI_Status *, MPIR_Request **);
 MPIDI_CH4I_API(int, Imrecv, void *, MPI_Aint, MPI_Datatype, MPIR_Request *, MPIR_Request **);
 MPIDI_CH4I_API(int, Open_port, MPIR_Info *, char *);
 MPIDI_CH4I_API(int, Close_port, const char *);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -799,8 +799,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_D
                                                 int context_offset, MPIDI_av_entry_t * addr,
                                                 MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                                 MPIR_Request * message,
-                                                 MPIR_Request ** rreqp) MPL_STATIC_INLINE_SUFFIX;
+                                                 MPIR_Request * message) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
     MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -205,7 +205,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         rreq->status.MPI_SOURCE = MPI_UNDEFINED;
     } else if (mode == MPIDI_OFI_USE_EXISTING) {
         rreq = *request;
-        rreq->kind = MPIR_REQUEST_KIND__RECV;
     } else {
         MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**nullptr");
         goto fn_fail;
@@ -357,7 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count,
                                                  MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+                                                 MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -366,13 +365,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_IMRECV);
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message, rreqp);
+        mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
         goto fn_exit;
     }
 
-    MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
-
-    *rreqp = rreq = message;
+    rreq = message;
 
     av = MPIDIU_comm_rank_to_av(rreq->comm, message->status.MPI_SOURCE);
     mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, message->status.MPI_SOURCE,

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -160,7 +160,7 @@ static inline int MPIDI_UCX_recv(void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Aint count,
                                                  MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+                                                 MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t data_sz;
@@ -209,8 +209,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
         MPIDI_UCX_REQ(message).a.ucp_request = ucp_request;
         ucp_request->req = message;
     }
-    message->kind = MPIR_REQUEST_KIND__RECV;
-    *rreqp = message;
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -173,12 +173,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_imrecv(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_IMRECV);
     MPID_THREAD_CS_ENTER(POBJ, MPIDI_POSIX_SHM_MUTEX);
 
-    if (message == NULL) {
-        MPIDI_Request_create_null_rreq(rreq, mpi_errno, goto fn_fail);
-        *rreqp = rreq;
-        goto fn_exit;
-    }
-
     MPIR_Assert(message != NULL);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -182,15 +182,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
 MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
                                         MPI_Aint count,
                                         MPI_Datatype datatype, MPIR_Request * message,
-                                        MPI_Status * status)
+                                        MPI_Status * status, MPIR_Request **rreq)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_MRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_MRECV);
 
-    int active_flag;
-    MPIR_Request *rreq = NULL;
-    MPID_Progress_state state;
+    *rreq = NULL;
 
     if (message == NULL) {
         /* treat as though MPI_MESSAGE_NO_PROC was passed */
@@ -199,33 +197,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
         goto fn_exit;
     }
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, &rreq);
+    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreq);
 #else
     if (MPIDI_CH4I_REQUEST(message, is_local))
-        mpi_errno = MPIDI_SHM_mpi_imrecv(buf, count, datatype, message, &rreq);
+        mpi_errno = MPIDI_SHM_mpi_imrecv(buf, count, datatype, message, rreq);
     else
-        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, &rreq);
+        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreq);
 #endif
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }
-
-    MPID_Progress_start(&state);
-
-    while (!MPIR_Request_is_complete(rreq)) {
-        mpi_errno = MPID_Progress_wait(&state);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-    }
-
-    MPID_Progress_end(&state);
-
-    /* This should probably be moved to MPICH (above device) level */
-    /* Someone neglected to put the blocking at the MPICH level    */
-    mpi_errno = MPIR_Request_completion_processing(rreq, status, &active_flag);
-    MPIR_Request_free(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_MRECV);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -196,13 +196,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
         mpi_errno = MPI_SUCCESS;
         goto fn_exit;
     }
+
+    MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
+    message->kind = MPIR_REQUEST_KIND__RECV;
+    *rreq = message; /* SHM will override this pointer */
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreq);
+    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message);
 #else
     if (MPIDI_CH4I_REQUEST(message, is_local))
         mpi_errno = MPIDI_SHM_mpi_imrecv(buf, count, datatype, message, rreq);
     else
-        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreq);
+        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message);
 #endif
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
@@ -225,6 +230,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
                                          MPIR_Request * message, MPIR_Request ** rreqp)
 {
     int mpi_errno = MPI_SUCCESS;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IMRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IMRECV);
 
@@ -232,13 +238,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf,
         MPIDI_Request_create_null_rreq(*rreqp, mpi_errno, goto fn_fail);
         goto fn_exit;
     }
+
+    MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
+    message->kind = MPIR_REQUEST_KIND__RECV;
+    *rreqp = message; /* SHM will override this pointer */
+
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreqp);
+    mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message);
 #else
     if (MPIDI_CH4I_REQUEST(message, is_local))
         mpi_errno = MPIDI_SHM_mpi_imrecv(buf, count, datatype, message, rreqp);
     else
-        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message, rreqp);
+        mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message);
 #endif
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);


### PR DESCRIPTION
This PR cleans up some redundant code on the `mrecv`/`imrecv` paths.