### PR TITLE
coll: Fix integer overflow in MPI_Bcast

### DIFF
--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -167,7 +167,7 @@ int MPIR_Bcast_intra_auto(void *buffer,
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     int comm_size;
-    int nbytes = 0;
+    MPI_Aint nbytes = 0;
     MPI_Aint type_size;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_BCAST);
 

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -25,7 +25,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    int nbytes = 0;
+    MPI_Aint nbytes = 0;
     MPI_Aint recvd_size;
     MPI_Status status;
     int is_contig;


### PR DESCRIPTION
Promoted an internal type to MPI_Aint to avoid integer overflow when
verifying number of bytes transferred.

Fixes pmodels/mpich#2257
Fixes pmodels/mpich#2311

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>