### PR TITLE
Fix fortran oracle development studio compatibility problem

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -973,6 +973,7 @@ if [ "$do_build_configure" = "yes" ] ; then
             if [ -f $amdir/confdb/libtool.m4 ] ; then
                 # There is no need to patch if we're not going to use Fortran.
                 ifort_patch_requires_rebuild=no
+                oracle_patch_requires_rebuild=no
                 if [ $do_bindings = "yes" ] ; then
                     echo_n "Patching libtool.m4 for compatibility with ifort on OSX... "
                     patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/darwin-ifort.patch
@@ -984,9 +985,19 @@ if [ "$do_build_configure" = "yes" ] ; then
                     else
                         echo "failed"
                     fi
+                    echo_n "Patching libtool.m4 for fort compatibility with Oracle Dev Studio 12.6..."
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/oracle-fort.patch
+                    if [ $? -eq 0 ] ; then
+                        oracle_patch_requires_rebuild=yes
+                        # Remove possible leftovers, which don't imply a failure
+                        rm -f $amdir/confdb/libtool.m4.orig
+                        echo "done"
+                    else
+                        echo "failed"
+                    fi
                 fi
 
-                if [ $ifort_patch_requires_rebuild = "yes" ] ; then
+                if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ]; then
                     # Rebuild configure
                     (cd $amdir && $autoconf -f) || exit 1
                     # Reset libtool.m4 timestamps to avoid confusing make

--- a/maint/patches/optional/confdb/oracle-fort.patch
+++ b/maint/patches/optional/confdb/oracle-fort.patch
@@ -1,0 +1,11 @@
+--- libtool.m4	2018-10-03 15:25:03.000000000 -0500
++++ libtool.m4.fix	2018-10-03 15:30:04.000000000 -0500
+@@ -4746,7 +4746,7 @@
+ 	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+ 	  _LT_TAGVAR(lt_prog_compiler_wl, $1)=''
+ 	  ;;
+-	*Sun\ F* | *Sun*Fortran*)
++	*Sun\ F* | *Sun*Fortran* | *Studio*Fortran*)
+ 	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
+ 	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
+ 	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '


### PR DESCRIPTION
Latest versions of the Oracle Development Studio fortran compiler use a
slightly different format for the version string, thus breaking fortran
compiler detection for oracle in `confdb/libtool.m4` and subsequently in
the configure script. This commit adds a fix to Issue #3350 by patching
`confdb/libtool.m4` at autogen time.