### PR TITLE
test: Initialize info object to MPI_INFO_NULL

### DIFF
--- a/test/mpi/errors/comm/comm_split_type_nullarg.c
+++ b/test/mpi/errors/comm/comm_split_type_nullarg.c
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
     /*test comm_split_type for NULL variable */
+    newinfo = MPI_INFO_NULL;
     mpi_errno = MPI_Comm_split_type(scomm, 2, 4, newinfo, NULL);
     MPI_Error_class(mpi_errno, &errclass);
     if (errclass != MPI_ERR_ARG)


### PR DESCRIPTION
Avoid using uninitialized memory and initailze info object to
`MPI_INFO_NULL`.

Fixes csr/mpich-ofi#1419