### PR TITLE
Klocwork Fixes

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -228,6 +228,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
         case HANDLE_KIND_INDIRECT:                                      \
             ptr = ((MPIR_Datatype *)                                    \
              MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem));       \
+            MPIR_Assert(ptr != NULL);                                   \
             size_ = ((MPIR_Datatype *) ptr)->size;                      \
             break;                                                      \
         case HANDLE_KIND_BUILTIN:                                       \
@@ -252,6 +253,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
         case HANDLE_KIND_INDIRECT:                                      \
             ptr = ((MPIR_Datatype *)                                    \
              MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem));       \
+            MPIR_Assert(ptr != NULL);                                   \
             extent_ = ((MPIR_Datatype *) ptr)->extent;                  \
             break;                                                      \
         case HANDLE_KIND_INVALID:                                       \
@@ -272,6 +274,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
         else {                                                                 \
             MPIR_Datatype *dtp_ = NULL;                                        \
             MPIR_Datatype_get_ptr((dtype_), dtp_);                             \
+            MPIR_Assert(dtp_ != NULL);                                         \
             *(is_contig_) = dtp_->is_contig;                                   \
         }                                                                      \
     } while (0)
@@ -467,6 +470,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
     {                                                               \
         MPIR_Datatype *dtp_ = NULL;                                 \
         MPIR_Datatype_get_ptr((datatype_), dtp_);                   \
+        MPIR_Assert(dtp_ != NULL);                                  \
         MPIR_Datatype_ptr_release(dtp_);                            \
     }                                                               \
     } while (0)
@@ -727,6 +731,7 @@ static inline MPI_Aint MPIR_Datatype_size_external32(MPI_Datatype type)
         MPIR_Dataloop *dlp = NULL;
 
         MPIR_Datatype_get_loopptr_macro(type, dlp);
+        MPIR_Assert(dlp != NULL);
 
         return MPIR_Dataloop_stream_size(dlp, MPII_Datatype_get_basic_size_external32);
     }

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -163,6 +163,7 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
         if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {\
             MPIR_Op *op_ptr = NULL;                      \
             MPIR_Op_get_ptr(op, op_ptr);                 \
+            MPIR_Assert(op_ptr != NULL);                 \
             MPIR_Op_ptr_add_ref(op_ptr);                 \
         }                                                \
     } while (0)                                          \
@@ -173,6 +174,7 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
         if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {\
             MPIR_Op *op_ptr = NULL;                      \
             MPIR_Op_get_ptr(op, op_ptr);                 \
+            MPIR_Assert(op_ptr != NULL);                 \
             MPIR_Op_ptr_release(op_ptr);                 \
         }                                                \
     } while (0)                                          \

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -185,8 +185,8 @@ extern MPI_User_function *MPIR_Op_table[];
 typedef int (MPIR_Op_check_dtype_fn) (MPI_Datatype);
 extern MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[];
 
-#define MPIR_OP_HDL_TO_FN(op) MPIR_Op_table[((op)&0xf) - 1]
-#define MPIR_OP_HDL_TO_DTYPE_FN(op) MPIR_Op_check_dtype_table[((op)&0xf) - 1]
+#define MPIR_OP_HDL_TO_FN(op) MPIR_Op_table[((op)&0xf)]
+#define MPIR_OP_HDL_TO_DTYPE_FN(op) MPIR_Op_check_dtype_table[((op)&0xf)]
 
 int MPIR_Op_commutative(MPIR_Op * op_ptr, int *commute);
 

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -118,7 +118,9 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype da
 
 /* The order of entries in this table must match the definitions in
    mpi.h.in */
-MPI_User_function *MPIR_Op_table[] = { MPIR_MAXF, MPIR_MINF, MPIR_SUM,
+MPI_User_function *MPIR_Op_table[] = {
+    NULL, MPIR_MAXF,
+    MPIR_MINF, MPIR_SUM,
     MPIR_PROD, MPIR_LAND,
     MPIR_BAND, MPIR_LOR, MPIR_BOR,
     MPIR_LXOR, MPIR_BXOR,
@@ -127,8 +129,8 @@ MPI_User_function *MPIR_Op_table[] = { MPIR_MAXF, MPIR_MINF, MPIR_SUM,
 };
 
 MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
-    MPIR_MAXF_check_dtype, MPIR_MINF_check_dtype,
-    MPIR_SUM_check_dtype,
+    NULL, MPIR_MAXF_check_dtype,
+    MPIR_MINF_check_dtype, MPIR_SUM_check_dtype,
     MPIR_PROD_check_dtype, MPIR_LAND_check_dtype,
     MPIR_BAND_check_dtype, MPIR_LOR_check_dtype, MPIR_BOR_check_dtype,
     MPIR_LXOR_check_dtype, MPIR_BXOR_check_dtype,

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -175,6 +175,7 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         MPID_END_ERROR_CHECKS;
     }
 #endif /* HAVE_ERROR_CHECKING */
+    MPIR_Assert(datatype_ptr != NULL);
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -213,6 +213,7 @@ int MPIR_Type_indexed(int count,
     new_dtp->is_contig = 0;
     if (old_is_contig) {
         MPI_Aint *blklens = MPL_malloc(count * sizeof(MPI_Aint), MPL_MEM_DATATYPE);
+        MPIR_Assert(blklens != NULL);
         for (i = 0; i < count; i++)
             blklens[i] = blocklength_array[i];
         contig_count = MPIR_Type_indexed_count_contig(count,

--- a/src/mpi/request/greq_start.c
+++ b/src/mpi/request/greq_start.c
@@ -86,7 +86,7 @@ int MPIR_Grequest_start(MPI_Grequest_query_function * query_fn,
     /* MT FIXME this routine is not thread-safe in the non-global case */
 
     *request_ptr = MPIR_Request_create(MPIR_REQUEST_KIND__GREQUEST);
-    MPIR_ERR_CHKANDJUMP1(request_ptr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
+    MPIR_ERR_CHKANDJUMP1(*request_ptr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                          "generalized request");
 
     MPIR_Object_set_ref(*request_ptr, 1);

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -74,6 +74,7 @@ int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status)
     }
 
     MPIR_Request_get_ptr(*request, request_ptr);
+    MPIR_Assert(request_ptr != NULL);
 
     mpi_errno = MPID_Test(request_ptr, flag, status);
     if (mpi_errno)

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -76,6 +76,7 @@ int MPIR_Wait(MPI_Request * request, MPI_Status * status)
     }
 
     MPIR_Request_get_ptr(*request, request_ptr);
+    MPIR_Assert(request_ptr != NULL);
 
     if (!MPIR_Request_is_complete(request_ptr)) {
         /* If this is an anysource request including a communicator with

--- a/src/mpi/topo/dist_gr_create.c
+++ b/src/mpi/topo/dist_gr_create.c
@@ -319,12 +319,16 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
     /* can't use CHKPMEM macros for this b/c we need to realloc */
     in_capacity = 10;   /* arbitrary */
     dist_graph_ptr->in = MPL_malloc(in_capacity * sizeof(int), MPL_MEM_COMM);
-    if (dist_graph_ptr->is_weighted)
+    if (dist_graph_ptr->is_weighted) {
         dist_graph_ptr->in_weights = MPL_malloc(in_capacity * sizeof(int), MPL_MEM_COMM);
+        MPIR_Assert(dist_graph_ptr->in_weights != NULL);
+    }
     out_capacity = 10;  /* arbitrary */
     dist_graph_ptr->out = MPL_malloc(out_capacity * sizeof(int), MPL_MEM_COMM);
-    if (dist_graph_ptr->is_weighted)
+    if (dist_graph_ptr->is_weighted) {
         dist_graph_ptr->out_weights = MPL_malloc(out_capacity * sizeof(int), MPL_MEM_COMM);
+        MPIR_Assert(dist_graph_ptr->out_weights);
+    }
 
     for (i = 0; i < in_out_peers[0]; ++i) {
         MPI_Status status;

--- a/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
@@ -330,6 +330,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Reduce_scatter_select(const void *sen
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
+        MPIR_Assert(op_ptr != NULL);
         if (op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE) {
             is_commutative = 0;
         } else {
@@ -401,6 +402,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Reduce_scatter_block_select(const voi
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
+        MPIR_Assert(op_ptr != NULL);
         if (op_ptr->kind == MPIR_OP_KIND__USER_NONCOMMUTE) {
             is_commutative = 0;
         } else {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -346,6 +346,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
     uint64_t match_bits = 0;
     uint64_t mask_bits = 0;
     MPIR_Context_id_t context_id = 0xF000;
+    MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_CONN_MANAGER_DESTROY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_CONN_MANAGER_DESTROY);
@@ -355,10 +356,13 @@ static inline int MPIDI_OFI_conn_manager_destroy()
 
     if (max_n_conn > 0) {
         /* try wait/close connections */
-        req = (MPIDI_OFI_dynamic_process_request_t *)
-            MPL_malloc(max_n_conn * sizeof(MPIDI_OFI_dynamic_process_request_t), MPL_MEM_BUFFER);
-        conn = (fi_addr_t *) MPL_malloc(max_n_conn * sizeof(fi_addr_t), MPL_MEM_BUFFER);
-        close_msg = (int *) MPL_malloc(max_n_conn * sizeof(int), MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(req, MPIDI_OFI_dynamic_process_request_t *,
+                            max_n_conn * sizeof(MPIDI_OFI_dynamic_process_request_t), mpi_errno,
+                            "req", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(conn, fi_addr_t *, max_n_conn * sizeof(fi_addr_t), mpi_errno, "conn",
+                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(close_msg, int *, max_n_conn * sizeof(int), mpi_errno, "int",
+                            MPL_MEM_BUFFER);
 
         j = 0;
         for (i = 0; i < max_n_conn; ++i) {
@@ -395,9 +399,7 @@ static inline int MPIDI_OFI_conn_manager_destroy()
                             (MPL_DBG_FDEST, "conn_id=%d closed", i));
         }
 
-        MPL_free(req);
-        MPL_free(conn);
-        MPL_free(close_msg);
+        MPIR_CHKLMEM_FREEALL();
     }
 
     MPL_munmap((void *) MPIDI_Global.conn_mgr.conn_list, MPIDI_Global.conn_mgr.mmapped_size,

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -107,6 +107,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count,
     if (countp_huge >= 1 && huge) {
         originv_huge =
             MPL_aligned_alloc(iov_align, sizeof(struct iovec) * countp_huge, MPL_MEM_BUFFER);
+        MPIR_Assert(originv_huge != NULL);
         for (j = 0; j < num_contig; j++) {
             l = 0;
             if (originv[j].iov_len > MPIDI_Global.max_send) {

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -168,6 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     if (countp_huge >= 1 && huge) {
         originv_huge =
             MPL_aligned_alloc(iov_align, sizeof(struct iovec) * countp_huge, MPL_MEM_BUFFER);
+        MPIR_Assert(originv_huge != NULL);
 
         for (j = 0; j < num_contig; j++) {
             l = 0;

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -60,6 +60,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
 
     basic_type = origin_dtp_ptr->basic_type;
     MPIR_Datatype_get_size_macro(basic_type, predefined_dtp_size);
+    MPIR_Assert(predefined_dtp_size > 0);
     predefined_dtp_count = total_len / predefined_dtp_size;
 
 #if defined(HAVE_ERROR_CHECKING)
@@ -660,6 +661,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
     MPIR_Memcpy(result_addr, target_addr, dtype_sz);
 
     if (op != MPI_NO_OP) {
+        /* We need to make sure op is valid here.
+         * 0xf is the mask for op index in MPIR_Op_table,
+         * and op should start from 1. */
+        MPIR_Assert(((op) & 0xf) > 0);
         MPI_User_function *uop = MPIR_OP_HDL_TO_FN(op);
         int one = 1;
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -1117,6 +1117,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_compute_acc_op(void *source_buf, int sou
         last = first + source_count * source_dtp_size;
 
         MPIR_Datatype_get_ptr(target_dtp, dtp);
+        MPIR_Assert(dtp != NULL);
         vec_len = dtp->max_contig_blocks * target_count + 1;
         /* +1 needed because Rob says so */
         dloop_vec = (DLOOP_VECTOR *)

--- a/src/mpl/src/shm/mpl_shm.c
+++ b/src/mpl/src/shm/mpl_shm.c
@@ -79,8 +79,14 @@ int MPL_shm_hnd_deserialize_by_ref(MPL_shm_hnd_t hnd, char **ser_hnd_ptr)
 int MPL_shm_hnd_init(MPL_shm_hnd_t * hnd_ptr)
 {
     int rc = -1;
+
     rc = MPLI_shm_hnd_alloc(hnd_ptr, MPL_MEM_SHM);
+
+    if (MPL_SHM_SUCCESS != rc)
+        return rc;
+
     MPLI_shm_hnd_reset_val(*hnd_ptr);
+
     return rc;
 }
 

--- a/src/pm/hydra/pm/pmiserv/common.c
+++ b/src/pm/hydra/pm/pmiserv/common.c
@@ -31,6 +31,7 @@ HYD_status HYD_pmcd_pmi_parse_pmi_cmd(char *obuf, int pmi_version, char **pmi_cm
 
     /* Make a copy of the original buffer */
     buf = MPL_strdup(obuf);
+    HYDU_ERR_CHKANDJUMP(status, NULL == buf, HYD_INTERNAL_ERROR, "%s", "");
     if (buf[strlen(obuf) - 1] == '\n')
         buf[strlen(obuf) - 1] = '\0';
 
@@ -54,6 +55,7 @@ HYD_status HYD_pmcd_pmi_parse_pmi_cmd(char *obuf, int pmi_version, char **pmi_cm
     /* Search for the PMI command in our table */
     status = HYDU_strsplit(cmd, &str1, pmi_cmd, '=');
     HYDU_ERR_POP(status, "string split returned error\n");
+    HYDU_ERR_CHKANDJUMP(status, NULL == *pmi_cmd, HYD_INTERNAL_ERROR, "%s", "");
 
   fn_exit:
     MPL_free(buf);
@@ -79,6 +81,7 @@ HYD_status HYD_pmcd_pmi_args_to_tokens(char *args[], struct HYD_pmcd_token **tok
 
     for (i = 0; args[i]; i++) {
         arg = MPL_strdup(args[i]);
+        HYDU_ERR_CHKANDJUMP(status, NULL == arg, HYD_INTERNAL_ERROR, "strdup failed\n");
         (*tokens)[i].key = arg;
         for (j = 0; arg[j] && arg[j] != '='; j++);
         if (!arg[j]) {

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v1.c
@@ -458,6 +458,7 @@ static HYD_status fn_put(int fd, char *args[])
     val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "value");
     if (val == NULL)
         val = MPL_strdup("");
+    HYDU_ERR_CHKANDJUMP(status, NULL == val, HYD_INTERNAL_ERROR, "strdup failed\n");
 
     /* add to the cache */
     HYD_STRING_STASH_INIT(stash);
@@ -508,7 +509,9 @@ static HYD_status fn_keyval_cache(int fd, char *args[])
     for (; i < num_elems + token_count; i++) {
         struct cache_elem *elem = cache_get + i;
         elem->key = MPL_strdup(tokens[i - num_elems].key);
+        HYDU_ERR_CHKANDJUMP(status, NULL == elem->key, HYD_INTERNAL_ERROR, "%s", "");
         elem->val = MPL_strdup(tokens[i - num_elems].val);
+        HYDU_ERR_CHKANDJUMP(status, NULL == elem->val, HYD_INTERNAL_ERROR, "%s", "");
         HASH_ADD_STR(hash_get, key, elem, MPL_MEM_PM);
     }
     num_elems += token_count;

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
@@ -114,7 +114,7 @@ static HYD_status poke_progress(char *key)
             req->next = NULL;
         }
 
-        if (key && strcmp(key, req->key)) {
+        if (key && req && strcmp(key, req->key)) {
             /* If the key doesn't match the request, just queue it back */
             if (list_head == NULL) {
                 list_head = req;

--- a/src/pm/hydra/pm/pmiserv/pmip_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_utils.c
@@ -42,6 +42,7 @@ static HYD_status control_port_fn(char *arg, char ***argv)
                         "duplicate control port setting\n");
 
     port = MPL_strdup(**argv);
+    HYDU_ERR_CHKANDJUMP(status, NULL == port, HYD_INTERNAL_ERROR, "port not provided\n");
     name = strtok(port, ":");
     HYD_pmcd_pmip.upstream.server_name = name ? MPL_strdup(name) : NULL;
     HYD_pmcd_pmip.upstream.server_port = strtol(strtok(NULL, ":"), NULL, 10);

--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -358,6 +358,7 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                 /* Search to see if this process is already in the list */
                 included = 0;
                 segment = strtok(current_list, ",");
+                HYDU_ASSERT(segment != NULL, status);
                 do {
                     value = strtol(segment, NULL, 10);
                     if (value == hdr.pid) {

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
@@ -75,7 +75,7 @@ static HYD_status poke_progress(char *key)
             req->next = NULL;
         }
 
-        if (key && strcmp(key, req->key)) {
+        if (key && req && strcmp(key, req->key)) {
             /* If the key doesn't match the request, just queue it back */
             if (list_head == NULL) {
                 list_head = req;
@@ -755,6 +755,7 @@ static HYD_status fn_name_publish(int fd, int pid, int pgid, char *args[])
     if ((val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "name")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: name\n");
     name = MPL_strdup(val);
+    HYDU_ERR_CHKANDJUMP(status, NULL == name, HYD_INTERNAL_ERROR, "%s", "");
 
     if ((val = HYD_pmcd_pmi_find_token_keyval(tokens, token_count, "port")) == NULL)
         HYDU_ERR_POP(status, "cannot find token: port\n");

--- a/src/pm/hydra/tools/bootstrap/external/ll_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/ll_launch.c
@@ -33,6 +33,7 @@ HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list, 
         path = HYDU_find_full_path("poe");
     if (!path)
         path = MPL_strdup("/usr/bin/poe");
+    HYDU_ERR_CHKANDJUMP(status, NULL == path, HYD_INTERNAL_ERROR, "strdup failed\n");
 
     idx = 0;
     targs[idx++] = MPL_strdup(path);

--- a/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
@@ -80,6 +80,8 @@ HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_lis
         path = HYDU_find_full_path("srun");
     if (!path)
         path = MPL_strdup("/usr/bin/srun");
+    if (!path)
+        HYDU_ERR_POP(status, "error allocating memory for strdup\n");
 
     idx = 0;
     targs[idx++] = MPL_strdup(path);

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -375,6 +375,7 @@ static HYD_status extract_tasks_per_node(int nnodes, char *task_list)
     HYDU_MALLOC_OR_JUMP(tmp_core_list, char **, nnodes * sizeof(char *), status);
 
     task_set = strtok(task_list, ",");
+    HYDU_ASSERT(task_set, status);
     i = 0;
     do {
         HYDU_MALLOC_OR_JUMP(tmp_core_list[i], char *, strlen(task_set) + 1, status);

--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -549,7 +549,8 @@ HYD_status HYDT_topo_hwloc_init(const char *binding, const char *mapping, const 
     }
 
     status = handle_bitmap_binding(binding, mapping ? mapping : binding);
-    HYDU_ERR_POP(status, "error binding with bind \"%s\" and map \"%s\"\n", binding, mapping);
+    HYDU_ERR_POP(status, "error binding with bind \"%s\" and map \"%s\"\n", binding,
+                 mapping ? mapping : "NULL");
 
 
     /* Memory binding options */

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -1725,6 +1725,7 @@ HYD_status HYD_uii_mpx_get_parameters(char **t_argv)
 
         /* Check if there's a config file in the hard-coded location */
         conf_file = MPL_strdup(HYDRA_CONF_FILE);
+        HYDU_ERR_CHKANDJUMP(status, NULL == conf_file, HYD_INTERNAL_ERROR, "strdup failed\n");
         ret = open(conf_file, O_RDONLY);
         if (ret < 0) {
             MPL_free(conf_file);
@@ -1754,6 +1755,7 @@ HYD_status HYD_uii_mpx_get_parameters(char **t_argv)
     /* Get the base path */
     /* Find the last '/' in the executable name */
     post = MPL_strdup(progname);
+    HYDU_ERR_CHKANDJUMP(status, NULL == post, HYD_INTERNAL_ERROR, "strdup failed\n");
     loc = strrchr(post, '/');
     if (!loc) { /* If there is no path */
         HYD_server_info.base_path = NULL;

--- a/src/pm/hydra/utils/alloc/alloc.c
+++ b/src/pm/hydra/utils/alloc/alloc.c
@@ -391,7 +391,7 @@ HYD_status HYDU_create_proxy_list(struct HYD_exec *exec_list, struct HYD_node *n
 
         if (pg->proxy_list == NULL)
             pg->proxy_list = proxy;
-        else
+        else if (last_proxy != NULL)
             last_proxy->next = proxy;
         last_proxy = proxy;
 

--- a/src/pm/hydra/utils/args/args.c
+++ b/src/pm/hydra/utils/args/args.c
@@ -34,11 +34,17 @@ static HYD_status get_abs_wd(const char *wd, char **abs_wd)
     }
 
     cwd = HYDU_getcwd();
+    if (NULL == cwd)
+        HYDU_ERR_POP(status, "error calling getcwd\n");
+
     ret = chdir(wd);
     if (ret < 0)
         HYDU_ERR_POP(status, "error calling chdir\n");
 
     *abs_wd = HYDU_getcwd();
+    if (NULL == *abs_wd)
+        HYDU_ERR_POP(status, "error calling getcwd\n");
+
     ret = chdir(cwd);
     if (ret < 0)
         HYDU_ERR_POP(status, "error calling chdir\n");
@@ -64,7 +70,7 @@ HYD_status HYDU_find_in_path(const char *execname, char **path)
     if (user_path) {    /* If the PATH environment exists */
         status = get_abs_wd(strtok(user_path, ";:"), &test_loc);
         HYDU_ERR_POP(status, "error getting absolute working dir\n");
-        do {
+        while (test_loc) {
             tmp[0] = MPL_strdup(test_loc);
             tmp[1] = MPL_strdup("/");
             tmp[2] = MPL_strdup(execname);
@@ -91,7 +97,7 @@ HYD_status HYDU_find_in_path(const char *execname, char **path)
 
             status = get_abs_wd(strtok(NULL, ";:"), &test_loc);
             HYDU_ERR_POP(status, "error getting absolute working dir\n");
-        } while (test_loc);
+        }
     }
 
     /* There is either no PATH environment or we could not find the

--- a/src/pm/hydra/utils/sock/sock.c
+++ b/src/pm/hydra/utils/sock/sock.c
@@ -558,6 +558,7 @@ HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_rang
             HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
 
         ip = MPL_strdup(localhost);
+        HYDU_ERR_CHKANDJUMP(status, NULL == ip, HYD_INTERNAL_ERROR, "%s", "");
     }
 
     sport = HYDU_int_to_str(port);

--- a/src/pm/hydra/utils/sock/sock.c
+++ b/src/pm/hydra/utils/sock/sock.c
@@ -141,7 +141,8 @@ HYD_status HYDU_sock_connect(const char *host, uint16_t port, int *fd, int retri
     ht = gethostbyname(host);
     if (ht == NULL)
         HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
-                            "unable to get host address for %s (%s)\n", host, HYDU_herror(h_errno));
+                            "unable to get host address for %s (%s)\n", host ? host : "NULL",
+                            HYDU_herror(h_errno));
     memcpy(&sa.sin_addr, ht->h_addr_list[0], ht->h_length);
 
     /* Create a socket and set the required options */
@@ -549,6 +550,7 @@ HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_rang
         HYDU_ERR_POP(status, "unable to get network interface IP\n");
     } else if (hostname) {
         ip = MPL_strdup(hostname);
+        HYDU_ERR_CHKANDJUMP(status, NULL == ip, HYD_INTERNAL_ERROR, "%s", "");
     } else {
         char localhost[MAX_HOSTNAME_LEN] = { 0 };
 
@@ -559,6 +561,7 @@ HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_rang
     }
 
     sport = HYDU_int_to_str(port);
+    HYDU_ERR_CHKANDJUMP(status, NULL == sport, HYD_INTERNAL_ERROR, "%s", "");
     HYDU_MALLOC_OR_JUMP(*port_str, char *, strlen(ip) + 1 + strlen(sport) + 1, status);
     MPL_snprintf(*port_str, strlen(ip) + 1 + strlen(sport) + 1, "%s:%s", ip, sport);
     MPL_free(sport);

--- a/src/pm/hydra/utils/string/string.c
+++ b/src/pm/hydra/utils/string/string.c
@@ -92,6 +92,7 @@ HYD_status HYDU_strsplit(char *str, char **str1, char **str2, char sep)
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "%s", "");
 
     *str1 = MPL_strdup(str);
+    HYDU_ERR_CHKANDJUMP(status, NULL == *str1, HYD_INTERNAL_ERROR, "%s", "");
     for (i = 0; (*str1)[i] && ((*str1)[i] != sep); i++);
 
     if ((*str1)[i] == 0)        /* End of the string */


### PR DESCRIPTION
This is a rather large PR (apologies) that fixes a whole bunch of Klocwork issues (Klocwork being the static analysis to that Intel uses, similar to Coverity). The vast majority of fixes here are related to unchecked `NULL` values where we add assertions or other macros (that are turned off in most configurations). There's quite a few other fixes in here too.

On the positive side, now that we have Klocwork running, our PRs should hopefully avoid creating new Coverity issues more often. On the downside, someone has to review this big PR in the meantime.

I squashed this down already from ~65 patches to this svelte 37 so...enjoy. 😄 