### PR TITLE
hydra: Sanity check for mpiexec -np 0

### DIFF
--- a/src/pm/hydra/ui/mpich/mpiexec.c
+++ b/src/pm/hydra/ui/mpich/mpiexec.c
@@ -251,9 +251,13 @@ int main(int argc, char **argv)
 
     /* If the number of processes is not given, we allocate all the
      * available nodes to each executable */
+    /* NOTE:
+     *   user may accidently give on command line -np 0, or even -np -1,
+     *   these cases will all be treated as if it is being ignored.
+     */
     HYD_server_info.pg_list.pg_process_count = 0;
     for (exec = HYD_uii_mpx_exec_list; exec; exec = exec->next) {
-        if (exec->proc_count == -1) {
+        if (exec->proc_count <= 0) {
             global_core_count = 0;
             for (node = HYD_server_info.node_list, i = 0; node; node = node->next, i++)
                 global_core_count += node->core_count;


### PR DESCRIPTION
This is corresponding to issue #2306.

The original user reports -np 0 result in mpiexec segfault. The current
code no longer segfaults but reports some cryptic failures during
initializations.

Adding a quick sanity check code to make trivial issues trivial. I used
the error reporting macros in hydra.h. However, -np 0 is not really an
error, so I think simply printf and return should be more approprate.
Request for comment.