### PR TITLE
mpi: assert valid pointer at MPIR_type|op_free_impl

### DIFF
--- a/src/mpi/coll/op/op_free.c
+++ b/src/mpi/coll/op/op_free.c
@@ -37,6 +37,7 @@ void MPIR_Op_free_impl(MPI_Op * op)
     int in_use;
 
     MPIR_Op_get_ptr(*op, op_ptr);
+    MPIR_Assert(op_ptr);
 
     MPIR_Op_ptr_release_ref(op_ptr, &in_use);
     if (!in_use) {

--- a/src/mpi/datatype/type_free.c
+++ b/src/mpi/datatype/type_free.c
@@ -34,6 +34,7 @@ void MPIR_Type_free_impl(MPI_Datatype * datatype)
     MPIR_Datatype *datatype_ptr = NULL;
 
     MPIR_Datatype_get_ptr(*datatype, datatype_ptr);
+    MPIR_Assert(datatype_ptr);
     MPIR_Datatype_ptr_release(datatype_ptr);
     *datatype = MPI_DATATYPE_NULL;
 }


### PR DESCRIPTION
In MPIR_type|op_free_impl, we query and release the datatype or op
without checking whether a valid pointer is returned. Although the
MPI_type|op_free routine handles error checking for user code, other
internal routines may also call MPIR_* with an invalid input.

Fixes coverity CID 188696