### PR TITLE
coll: nhb_alltoallw

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -1063,6 +1063,13 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                                   void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
                                   const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
                                   MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
+                                                    const MPI_Aint sdispls[],
+                                                    const MPI_Datatype sendtypes[], void *recvbuf,
+                                                    const int recvcounts[],
+                                                    const MPI_Aint rdispls[],
+                                                    const MPI_Datatype recvtypes[],
+                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
 int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -397,6 +397,7 @@ extern MPIR_Ineighbor_alltoallv_inter_algo_t MPIR_Ineighbor_alltoallv_inter_algo
 typedef enum MPIR_Ineighbor_alltoallw_intra_algo_t {
     MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_AUTO,
     MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_LINEAR,
+    MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_GENTRAN_LINEAR,
 } MPIR_Ineighbor_alltoallw_intra_algo_t;
 extern MPIR_Ineighbor_alltoallw_intra_algo_t MPIR_Ineighbor_alltoallw_intra_algo_choice;
 

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -404,6 +404,7 @@ extern MPIR_Ineighbor_alltoallw_intra_algo_t MPIR_Ineighbor_alltoallw_intra_algo
 typedef enum MPIR_Ineighbor_alltoallw_inter_algo_t {
     MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_AUTO,
     MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_LINEAR,
+    MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_GENTRAN_LINEAR,
 } MPIR_Ineighbor_alltoallw_inter_algo_t;
 extern MPIR_Ineighbor_alltoallw_inter_algo_t MPIR_Ineighbor_alltoallw_inter_algo_choice;
 

--- a/src/mpi/coll/ineighbor_alltoallw/Makefile.mk
+++ b/src/mpi/coll/ineighbor_alltoallw/Makefile.mk
@@ -16,4 +16,6 @@ mpi_sources += \
     src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
 
 mpi_core_sources += \
-    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c			\
+    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_gentran_algos.c			\
+    src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_gentran_linear.c

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -148,6 +148,14 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
                                                                   sendtypes, recvbuf, recvcounts,
                                                                   rdispls, recvtypes, comm_ptr, s);
                 break;
+            case MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_GENTRAN_LINEAR:
+                mpi_errno =
+                    MPIR_Ineighbor_alltoallw_sched_allcomm_gentran_linear(sendbuf, sendcounts,
+                                                                          sdispls, sendtypes,
+                                                                          recvbuf, recvcounts,
+                                                                          rdispls, recvtypes,
+                                                                          comm_ptr, s);
+                break;
             case MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_AUTO:
                 MPL_FALLTHROUGH;
             default:
@@ -164,6 +172,14 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
                     MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls,
                                                                   sendtypes, recvbuf, recvcounts,
                                                                   rdispls, recvtypes, comm_ptr, s);
+                break;
+            case MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_GENTRAN_LINEAR:
+                mpi_errno =
+                    MPIR_Ineighbor_alltoallw_sched_allcomm_gentran_linear(sendbuf, sendcounts,
+                                                                          sdispls, sendtypes,
+                                                                          recvbuf, recvcounts,
+                                                                          rdispls, recvtypes,
+                                                                          comm_ptr, s);
                 break;
             case MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_AUTO:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -19,8 +19,9 @@ cvars:
       scope       : MPI_T_SCOPE_ALL_EQ
       description : |-
         Variable to select ineighbor_alltoallw algorithm
-        auto   - Internal algorithm selection
-        linear - Force linear algorithm
+        auto            - Internal algorithm selection
+        linear          - Force linear algorithm
+        gentran_linear  - Force generic transport based linear algorithm
 
     - name        : MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTER_ALGORITHM
       category    : COLLECTIVE

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_gentran_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_gentran_linear.c
@@ -1,0 +1,39 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "mpiimpl.h"
+
+/* generate gentran algo prototypes */
+#include "tsp_gentran.h"
+#include "ineighbor_alltoallw_tsp_linear_algos_prototypes.h"
+#include "tsp_undef.h"
+
+#undef FUNCNAME
+#define FUNCNAME MPIR_Ineighbor_alltoallw_allcomm_gentran_linear
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
+                                                    const MPI_Aint sdispls[],
+                                                    const MPI_Datatype sendtypes[], void *recvbuf,
+                                                    const int recvcounts[],
+                                                    const MPI_Aint rdispls[],
+                                                    const MPI_Datatype recvtypes[],
+                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno =
+        MPII_Gentran_Ineighbor_alltoallw_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
+                                                        recvbuf, recvcounts, rdispls, recvtypes,
+                                                        comm_ptr, request);
+
+    return mpi_errno;
+}

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_gentran_algos.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_gentran_algos.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "mpiimpl.h"
+
+#include "tsp_gentran.h"
+
+/* instantiate alltoallw linear algorithms for the gentran transport */
+#include "ineighbor_alltoallw_tsp_linear_algos_prototypes.h"
+#include "ineighbor_alltoallw_tsp_linear_algos.h"
+#include "ineighbor_alltoallw_tsp_linear_algos_undef.h"
+
+#include "tsp_undef.h"

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -1,0 +1,126 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Header protection (i.e., INEIGHBOR_ALLTOALL_TSP_LINEAR_ALGOS_H_INCLUDED) is
+ * intentionally omitted since this header might get included multiple
+ * times within the same .c file. */
+
+#include "algo_common.h"
+#include "treealgo.h"
+#include "tsp_namespace_def.h"
+
+/* Routine to schedule linear algorithm for neighbor_alltoallw */
+#undef FUNCNAME
+#define FUNCNAME MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                      const MPI_Aint sdispls[],
+                                                      const MPI_Datatype sendtypes[], void *recvbuf,
+                                                      const int recvcounts[],
+                                                      const MPI_Aint rdispls[],
+                                                      const MPI_Datatype recvtypes[],
+                                                      MPIR_Comm * comm_ptr,
+                                                      MPIR_TSP_sched_t * sched)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int indegree, outdegree, weighted;
+    int k, l;
+    int *srcs, *dsts;
+    int tag;
+    MPIR_CHKLMEM_DECL(2);
+
+    mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
+                                    indegree, srcs, MPI_UNWEIGHTED,
+                                    outdegree, dsts, MPI_UNWEIGHTED);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* For correctness, transport based collectives need to get the
+     * tag from the same pool as schedule based collectives */
+    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    for (k = 0; k < outdegree; ++k) {
+        char *sb;
+        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + sdispls[k]);
+
+        sb = ((char *) sendbuf) + sdispls[k];
+        MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
+                             NULL);
+    }
+
+    for (l = 0; l < indegree; ++l) {
+        char *rb;
+        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf + rdispls[l]);
+
+        rb = ((char *) recvbuf) + rdispls[l];
+        MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
+                             NULL);
+    }
+
+  fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+
+/* Non-blocking linear algo based neighbor_alltoallw */
+#undef FUNCNAME
+#define FUNCNAME MPIR_TSP_Ineighbor_alltoallw_allcomm_linear
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                const MPI_Aint sdispls[],
+                                                const MPI_Datatype sendtypes[], void *recvbuf,
+                                                const int recvcounts[], const MPI_Aint rdispls[],
+                                                const MPI_Datatype recvtypes[],
+                                                MPIR_Comm * comm_ptr, MPIR_Request ** req)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_TSP_sched_t *sched;
+    *req = NULL;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALLW_ALLCOMM_LINEAR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALLW_ALLCOMM_LINEAR);
+
+    /* generate the schedule */
+    sched = MPL_malloc(sizeof(MPIR_TSP_sched_t), MPL_MEM_COLL);
+    MPIR_Assert(sched != NULL);
+    MPIR_TSP_sched_create(sched);
+
+    /* schedule linear algo */
+    mpi_errno =
+        MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
+                                                          recvbuf, recvcounts, rdispls, recvtypes,
+                                                          comm_ptr, sched);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* start and register the schedule */
+    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALLW_ALLCOMM_LINEAR);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_prototypes.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_prototypes.h
@@ -1,0 +1,36 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Header protection (i.e., INEIGHBOR_ALLTOALL_TSP_LINEAR_ALGOS_PROTOTYPES_H_INCLUDED) is
+ * intentionally omitted since this header might get included multiple
+ * times within the same .c file. */
+
+#include "tsp_namespace_def.h"
+
+#undef MPIR_TSP_Ineighbor_alltoallw_allcomm_linear
+#define MPIR_TSP_Ineighbor_alltoallw_allcomm_linear        MPIR_TSP_NAMESPACE(Ineighbor_alltoallw_allcomm_linear)
+#undef MPIR_TSP_Ineighor_alltoallw_sched_allcomm_linear
+#define MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear  MPIR_TSP_NAMESPACE(Ineighbor_alltoallw_sched_allcomm_linear)
+
+int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                      const MPI_Aint sdispls[],
+                                                      const MPI_Datatype sendtypes[], void *recvbuf,
+                                                      const int recvcounts[],
+                                                      const MPI_Aint rdispls[],
+                                                      const MPI_Datatype recvtypes[],
+                                                      MPIR_Comm * comm_ptr,
+                                                      MPIR_TSP_sched_t * sched);
+int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int sendcounts[],
+                                                const MPI_Aint sdispls[],
+                                                const MPI_Datatype sendtypes[], void *recvbuf,
+                                                const int recvcounts[], const MPI_Aint rdispls[],
+                                                const MPI_Datatype recvtypes[],
+                                                MPIR_Comm * comm_ptr, MPIR_Request ** req);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_undef.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos_undef.h
@@ -1,0 +1,17 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2006 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2017 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Header protection (i.e., INEIGHBOR_ALLTOALLW_TSP_LINEAR_ALGOS_PROTOTYPES_H_INCLUDED) is
+ * intentionally omitted since this header might get included multiple
+ * times within the same .c file. */
+
+#undef MPIR_TSP_Ineighbor_alltoallw_allcomm_linear
+#undef MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -632,6 +632,9 @@ int MPII_Coll_init(void)
     /* Ineighbor_alltoallw Intra */
     if (0 == strcmp(MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTRA_ALGORITHM, "linear"))
         MPIR_Ineighbor_alltoallw_intra_algo_choice = MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_LINEAR;
+    else if (0 == strcmp(MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTRA_ALGORITHM, "gentran_linear"))
+        MPIR_Ineighbor_alltoallw_intra_algo_choice =
+            MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_GENTRAN_LINEAR;
     else
         MPIR_Ineighbor_alltoallw_intra_algo_choice = MPIR_INEIGHBOR_ALLTOALLW_INTRA_ALGO_AUTO;
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -641,6 +641,9 @@ int MPII_Coll_init(void)
     /* Ineighbor_alltoallw Inter */
     if (0 == strcmp(MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTER_ALGORITHM, "linear"))
         MPIR_Ineighbor_alltoallw_inter_algo_choice = MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_LINEAR;
+    else if (0 == strcmp(MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTRA_ALGORITHM, "gentran_linear"))
+        MPIR_Ineighbor_alltoallw_inter_algo_choice =
+            MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_GENTRAN_LINEAR;
     else
         MPIR_Ineighbor_alltoallw_inter_algo_choice = MPIR_INEIGHBOR_ALLTOALLW_INTER_ALGO_AUTO;
 

--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -294,12 +294,14 @@ testing_env="env=MPIR_CVAR_ALLTOALL_DEVICE_COLLECTIVE=0 "
 #test nb algorithms
 testing_env+="env=MPIR_CVAR_ALLTOALL_INTRA_ALGORITHM=nb "
 testing_env+="env=MPIR_CVAR_IALLTOALL_DEVICE_COLLECTIVE=0 "
+
 algo_names="gentran_ring"
 
 for algo_name in ${algo_names}; do
     env="${testing_env} env=MPIR_CVAR_IALLTOALL_INTRA_ALGORITHM=${algo_name} "
 
     coll_algo_tests+="alltoall1 8 ${env}${nl}"
+done
 
 algo_names="gentran_brucks"
 kvalues="2 3 4"
@@ -312,6 +314,7 @@ for algo_name in ${algo_names}; do
         coll_algo_tests+="alltoall1 8 ${env} env=MPIR_CVAR_IALLTOALL_BRUCKS_BUFFER_PER_NBR=0${nl}"
         coll_algo_tests+="alltoall1 8 ${env} env=MPIR_CVAR_IALLTOALL_BRUCKS_BUFFER_PER_NBR=1${nl}"
     done
+done
 
 ########## Add tests for scan algorithms ############
 
@@ -354,6 +357,23 @@ for algo_name in ${algo_names}; do
             done
         done
     fi
+done
+
+######### add tests for ineighbor_alltoallw algorithms ###########
+
+#disable device collectives for neighnor_alltoallw to test mpir algorithms
+testing_env="env=mpir_cvar_neighbor_alltoallw_device_collective=0 "
+
+#test nb algorithms
+testing_env+="env=mpir_cvar_neighbor_alltoallw_intra_algorithm=nb "
+testing_env+="env=mpir_cvar_ineighbor_alltoallw_device_collective=0 "
+algo_names="gentran_linear"
+
+for algo_name in ${algo_names}; do
+    #set the environment
+    env="${testing_env} env=MPIR_CVAR_INEIGHBOR_ALLTOALLW_INTRA_ALGORITHM=${algo_name} "
+
+    coll_algo_tests+="neighb_alltoallw 4 mpiversion=3.0 ${env}${nl}"
 done
 
 export coll_algo_tests


### PR DESCRIPTION
Implement neighborhood Alltoallw using transport (TSP) API

This is the 2nd PR in the series of the PRs for neighborhood collectives - #3371 (tests), #3372 (alltoallw), #3375 (allgather), #3376 (allgatherv), #3377 (alltoall), #3378 (alltoallv).