### PR TITLE
mtest: Add MT RMA tests

### DIFF
--- a/test/mpi/threads/rma/Makefile.am
+++ b/test/mpi/threads/rma/Makefile.am
@@ -9,4 +9,43 @@ include $(top_srcdir)/threads/Makefile_threads.mtest
 
 EXTRA_DIST = testlist
 
-noinst_PROGRAMS = multirma multiget multifence
+noinst_PROGRAMS = multirma multiget multifence \
+                  mt_put_huge mt_put_normal mt_get_huge mt_get_normal \
+                  mt_accfence_huge mt_accfence_normal \
+                  mt_getaccfence_huge mt_getaccfence_normal mt_fetchandop mt_compareandswap \
+                  mt_reqops
+
+#MT tests with huge messages
+mt_put_huge_SOURCES = mt_putget.c
+mt_put_huge_CPPFLAGS = -DHUGE_COUNT -DPUT_TEST $(AM_CPPFLAGS)
+
+mt_get_huge_SOURCES = mt_putget.c
+mt_get_huge_CPPFLAGS = -DHUGE_COUNT -DGET_TEST $(AM_CPPFLAGS)
+
+mt_accfence_huge_SOURCES = mt_accfence.c
+mt_accfence_huge_CPPFLAGS = -DHUGE_COUNT $(AM_CPPFLAGS)
+
+mt_getaccfence_huge_SOURCES = mt_getaccfence.c
+mt_getaccfence_huge_CPPFLAGS = -DHUGE_COUNT $(AM_CPPFLAGS)
+
+mt_reqops_SOURCES = mt_reqops.c
+mt_reqops_CPPFLAGS = -DHUGE_COUNT $(AM_CPPFLAGS)
+
+#MT tests with small messages
+mt_put_normal_SOURCES = mt_putget.c
+mt_put_normal_CPPFLAGS = -DPUT_TEST $(AM_CPPFLAGS)
+
+mt_get_normal_SOURCES = mt_putget.c
+mt_get_normal_CPPFLAGS = -DGET_TEST $(AM_CPPFLAGS)
+
+mt_accfence_normal_SOURCES = mt_accfence.c
+mt_accfence_normal_CPPFLAGS = $(AM_CPPFLAGS)
+
+mt_getaccfence_normal_SOURCES = mt_getaccfence.c
+mt_getaccfence_normal_CPPFLAGS = $(AM_CPPFLAGS)
+
+mt_fetchandop_SOURCES = mt_fetchandop.c
+mt_fetchandop_CPPFLAGS = $(AM_CPPFLAGS)
+
+mt_compareandswap_SOURCES = mt_compareandswap.c
+mt_compareandswap_CPPFLAGS = $(AM_CPPFLAGS)

--- a/test/mpi/threads/rma/mt_accfence.c
+++ b/test/mpi/threads/rma/mt_accfence.c
@@ -1,0 +1,108 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Accumulate Test
+ *
+ * This code performs accumulate operations sum two 2D arrays using
+ * multiple threads. The array has dimensions [X, Y] and the transfer is
+ * done by NTHREADS threads concurrently. Both small msg and huge msg transfers
+ * are tested.
+ */
+
+#include "mt_rma_common.h"
+
+#define TEST_ROUNDS 10
+
+int mpi_kernel(enum op_type mpi_op, void *origin_addr, int origin_count,
+               MPI_Datatype origin_datatype, void *result_addr, int result_count,
+               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
+               int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win,
+               MPI_Request * req)
+{
+    MPI_Accumulate(origin_addr, origin_count,
+                   origin_datatype, target_rank, target_disp, target_count,
+                   target_datatype, op, win);
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, j, rank, nranks, bufsize, err, errors = 0;
+    int *win_buf, *local_buf;
+    MPI_Win buf_win;
+    thread_param_t params[NTHREADS];
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    if (nranks != 2) {
+        fprintf(stderr, "Need two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].th_id = i;
+        params[i].rank = rank;
+        params[i].target = rank == 0 ? 1 : 0;
+        params[i].rounds = TEST_ROUNDS;
+        params[i].op = NOREQ;
+    }
+
+    bufsize = XDIM * YDIM * sizeof(int);
+    MPI_Alloc_mem(bufsize, MPI_INFO_NULL, &win_buf);
+    local_buf = (int *) malloc(bufsize);
+    run_init_data(local_buf, nranks);
+    run_reset_data(win_buf);
+
+    MPI_Win_create(win_buf, bufsize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &buf_win);
+    MPI_Win_fence(0, buf_win);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    MPI_Win_fence(0, buf_win);
+
+    if (rank == 1)
+        run_verify(win_buf, &errors, rank, TEST_ROUNDS * nranks);
+
+    MPI_Win_free(&buf_win);
+
+    MPI_Free_mem(win_buf);
+    free(local_buf);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_compareandswap.c
+++ b/test/mpi/threads/rma/mt_compareandswap.c
@@ -1,0 +1,195 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Compare and Swap Test
+ *
+ * This code performs compare_and_swap operations using multiple threads.
+ * Self communication, neighbor communication, contention cases are tested.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <mpi.h>
+#include "mpitest.h"
+#include "mpithreadtest.h"
+#include "squelch.h"
+
+#define NTHREADS 4
+#define ITER 100
+
+typedef struct thread_param {
+    int rank;
+    int target;
+    int target_disp;
+    MPI_Win *win;
+    const int *origin;
+    const int *compare;
+    int *result;
+} thread_param_t;
+
+MTEST_THREAD_RETURN_TYPE run_single_test(void *arg)
+{
+    thread_param_t *p = (thread_param_t *) arg;
+    /* Make sure all threads have launched */
+    MTest_thread_barrier(NTHREADS);
+
+    MPI_Compare_and_swap(p->origin, p->compare, p->result, MPI_INT, p->target, p->target_disp,
+                         *(p->win));
+
+    return (MTEST_THREAD_RETURN_TYPE) NULL;
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, j, rank, nranks, err, errors = 0;
+    MPI_Win win;
+    int val = 0, next, result = -1;
+    thread_param_t params[NTHREADS];
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    if (nranks != 4) {
+        fprintf(stderr, "Need 4 processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Win_create(&val, sizeof(int), sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+
+    /* Test self communication */
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].rank = rank;
+        params[i].target_disp = 0;
+        params[i].win = &win;
+    }
+
+    MPI_Win_fence(0, win);
+
+    for (i = 0; i < ITER; i++) {
+        next = i + 1;
+        for (j = 0; j < NTHREADS; j++) {
+            params[j].target = rank;
+            params[j].origin = &next;
+            params[j].compare = &i;
+            params[j].result = &result;
+            if (j == NTHREADS - 1) {
+                run_single_test(&params[j]);
+            } else {
+                MTest_Start_thread(run_single_test, &params[j]);
+            }
+        }
+        MTest_Join_threads();
+        MPI_Win_fence(0, win);
+
+        if (result != i + 1) {
+            SQUELCH(printf
+                    ("%d->%d [%d] -- SELF: expected result %d, got result %d\n",
+                     rank, rank, i, i + 1, result););
+            errors++;
+        }
+        if (val != i + 1) {
+            SQUELCH(printf
+                    ("%d->%d [%d] -- SELF: expected %d, got %d\n", rank, rank, i, i + 1, val););
+            errors++;
+        }
+    }
+
+    /* Test neighbor communication */
+    val = 0;
+    MPI_Win_fence(0, win);
+
+    for (i = 0; i < ITER; i++) {
+        /* Barrier here to make sure all ranks finish checking. */
+        MPI_Barrier(MPI_COMM_WORLD);
+        next = i + 1;
+        for (j = 0; j < NTHREADS; j++) {
+            params[j].target = (rank + 1) % nranks;
+            params[j].origin = &next;
+            params[j].compare = &i;
+            params[j].result = &result;
+            if (j == NTHREADS - 1) {
+                run_single_test(&params[j]);
+            } else {
+                MTest_Start_thread(run_single_test, &params[j]);
+            }
+        }
+        MTest_Join_threads();
+        MPI_Win_fence(0, win);
+
+        if (result != i + 1) {
+            SQUELCH(printf
+                    ("%d->%d [%d] -- NEIGHBOR: expected result %d, got result %d, val: %d.\n",
+                     rank, (rank + 1) % nranks, i, i + 1, result, val););
+            errors++;
+        }
+        if (val != i + 1) {
+            SQUELCH(printf
+                    ("%d->%d [%d] -- NEIGHBOR: expected %d, got %d, result: %d\n",
+                     rank, (rank + 1) % nranks, i, i + 1, val, result););
+            errors++;
+        }
+    }
+
+    /* Test contention */
+    val = 0;
+    MPI_Win_fence(0, win);
+
+    for (i = 0; i < ITER; i++) {
+        /* Barrier here to make sure rank 0 finishes checking. */
+        MPI_Barrier(MPI_COMM_WORLD);
+        next = i + 1;
+
+        if (rank != 0) {
+            for (j = 0; j < NTHREADS; j++) {
+                params[j].target = 0;
+                params[j].origin = &next;
+                params[j].compare = &i;
+                params[j].result = &result;
+                if (j == NTHREADS - 1) {
+                    run_single_test(&params[j]);
+                } else {
+                    MTest_Start_thread(run_single_test, &params[j]);
+                }
+            }
+            MTest_Join_threads();
+        }
+        MPI_Win_fence(0, win);
+
+        if (rank == 0) {
+            if (val != i + 1) {
+                SQUELCH(printf
+                        ("*->%d [%d] -- CONTENTION: expected %d, got %d\n", 0, i, i + 1, val););
+                errors++;
+            }
+        }
+    }
+
+    MPI_Win_free(&win);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_fetchandop.c
+++ b/test/mpi/threads/rma/mt_fetchandop.c
@@ -1,0 +1,249 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Fetch and Op Test
+ *
+ * This code performs fetch_and_op operations using multiple threads.
+ * Self communication, neighbor communication, contention and all to all
+ * cases are tested.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <mpi.h>
+#include "mpitest.h"
+#include "mpithreadtest.h"
+#include "squelch.h"
+
+#define NTHREADS 4
+#define ITER 100
+#define CMP(x, y) ((x - (double)(y)) > 1.0e-9)
+
+typedef struct thread_param {
+    int rank;
+    int target;
+    int target_disp;
+    MPI_Win *win;
+    const double *origin;
+    double *result;
+} thread_param_t;
+
+void reset_vars(double *val_ptr, double *res_ptr, int nproc)
+{
+    int i;
+
+    for (i = 0; i < nproc; i++) {
+        val_ptr[i] = 0;
+        res_ptr[i] = -1;
+    }
+}
+
+MTEST_THREAD_RETURN_TYPE run_test(void *arg)
+{
+    thread_param_t *p = (thread_param_t *) arg;
+    int i;
+    /* Make sure all threads have launched */
+    MTest_thread_barrier(NTHREADS);
+
+    for (i = 0; i < ITER; i++) {
+        MPI_Fetch_and_op(p->origin, p->result, MPI_DOUBLE, p->target, 0, MPI_SUM, *(p->win));
+    }
+
+    return (MTEST_THREAD_RETURN_TYPE) NULL;
+}
+
+MTEST_THREAD_RETURN_TYPE run_single_test(void *arg)
+{
+    thread_param_t *p = (thread_param_t *) arg;
+    /* Make sure all threads have launched */
+    MTest_thread_barrier(NTHREADS);
+
+    MPI_Fetch_and_op(p->origin, p->result, MPI_DOUBLE, p->target, p->target_disp, MPI_SUM,
+                     *(p->win));
+
+    return (MTEST_THREAD_RETURN_TYPE) NULL;
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, rank, nranks, err, errors = 0;
+    MPI_Win win;
+    double *val_ptr, *res_ptr;
+    thread_param_t params[NTHREADS];
+
+    /* Test self communication */
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    val_ptr = (double *) malloc(sizeof(double) * nranks);
+    res_ptr = (double *) malloc(sizeof(double) * nranks);
+
+    if (nranks != 4) {
+        fprintf(stderr, "Need 4 processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Win_create(val_ptr, nranks * sizeof(double), sizeof(double), MPI_INFO_NULL, MPI_COMM_WORLD,
+                   &win);
+
+    reset_vars(val_ptr, res_ptr, nranks);
+
+    double one = 1, result = -1;
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].rank = rank;
+        params[i].target = rank;
+        params[i].win = &win;
+    }
+
+    MPI_Win_fence(0, win);
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].origin = &one;
+        params[i].result = &result;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+
+    MPI_Win_fence(0, win);
+
+    if (CMP(val_ptr[0], ITER * NTHREADS)) {
+        SQUELCH(printf
+                ("%d->%d -- SELF: expected %f, got %f\n", rank, rank,
+                 (double) (ITER * NTHREADS), val_ptr[0]););
+        errors++;
+    }
+
+    /* Test neighbor communication */
+
+    reset_vars(val_ptr, res_ptr, nranks);
+
+    MPI_Win_fence(0, win);
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].target = (rank + 1) % nranks;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+
+    MPI_Win_fence(0, win);
+
+    if (CMP(val_ptr[0], ITER * NTHREADS)) {
+        SQUELCH(printf
+                ("%d->%d -- SELF: expected %f, got %f\n", rank, rank,
+                 (double) (ITER * NTHREADS), val_ptr[0]););
+        errors++;
+    }
+
+    /* Test contention */
+
+    reset_vars(val_ptr, res_ptr, nranks);
+
+    MPI_Win_fence(0, win);
+
+    if (rank != 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].target = 0;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+    }
+
+    MTest_Join_threads();
+
+    MPI_Win_fence(0, win);
+    if (rank == 0) {
+        if (CMP(val_ptr[0], ITER * NTHREADS * (nranks - 1))) {
+            SQUELCH(printf
+                    ("*->%d - CONTENTION: expected %f, got %f\n", rank,
+                     (double) (NTHREADS * ITER * (nranks - 1)), val_ptr[0]););
+            errors++;
+        }
+    }
+
+    /* Test all-to-all (verify result_addr) */
+    reset_vars(val_ptr, res_ptr, nranks);
+    MPI_Win_fence(0, win);
+
+    double rank_cnv = rank;
+    for (i = 0; i < ITER; i++) {
+        /* Barrier here to make sure all ranks finish checking. */
+        MPI_Barrier(MPI_COMM_WORLD);
+        int j, k;
+
+        for (j = 0; j < nranks; j++) {
+            for (k = 0; k < NTHREADS; k++) {
+                params[k].target = j;
+                params[k].origin = &rank_cnv;
+                params[k].result = &(res_ptr[j]);
+                params[k].target_disp = rank;
+                if (k == NTHREADS - 1) {
+                    run_single_test(&params[k]);
+                } else {
+                    MTest_Start_thread(run_single_test, &params[k]);
+                }
+            }
+            MTest_Join_threads();
+            MPI_Win_fence(0, win);
+        }
+
+        for (j = 0; j < nranks; j++) {
+            if (CMP(res_ptr[j], (i + 1) * rank * NTHREADS - rank)) {
+                SQUELCH(printf
+                        ("%d->%d -- ALL-TO-ALL (FENCE) [%d]: expected result %f, got result %f\n",
+                         rank, j, i, (double) ((i + 1) * rank * NTHREADS - rank), res_ptr[j]););
+                errors++;
+            }
+            if (CMP(val_ptr[j], (i + 1) * j * NTHREADS)) {
+                SQUELCH(printf
+                        ("%d->%d -- ALL-TO-ALL (FENCE) [%d]: expected %f, got %f\n",
+                         rank, j, i, (double) ((i + 1) * j * NTHREADS), val_ptr[j]););
+                errors++;
+            }
+        }
+    }
+
+    MPI_Win_free(&win);
+
+    free(val_ptr);
+    free(res_ptr);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_getaccfence.c
+++ b/test/mpi/threads/rma/mt_getaccfence.c
@@ -1,0 +1,117 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Get_accumulate Test
+ *
+ * This code performs get_accumulate operations to sum two 2D arrays using
+ * multiple threads. The array has dimensions [X, Y] and the transfer is
+ * done by NTHREADS threads concurrently. Both small msg and huge msg transfers
+ * are tested.
+ */
+
+#include "mt_rma_common.h"
+
+#define TEST_ROUNDS 10
+
+int mpi_kernel(enum op_type mpi_op, void *origin_addr, int origin_count,
+               MPI_Datatype origin_datatype, void *result_addr, int result_count,
+               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
+               int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win,
+               MPI_Request * req)
+{
+    return MPI_Get_accumulate(origin_addr, origin_count,
+                              origin_datatype, result_addr, result_count,
+                              result_datatype, target_rank, target_disp,
+                              target_count, target_datatype, op, win);
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, j, rank, nranks, bufsize, err, errors = 0;
+    int *win_buf, *local_buf, *result_buf;
+    MPI_Win buf_win;
+    thread_param_t params[NTHREADS];
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    if (nranks != 2) {
+        fprintf(stderr, "Need two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].th_id = i;
+        params[i].rank = rank;
+        params[i].target = rank == 0 ? 1 : 0;
+        params[i].rounds = TEST_ROUNDS;
+        params[i].op = NOREQ;
+    }
+
+    bufsize = XDIM * YDIM * sizeof(int);
+    MPI_Alloc_mem(bufsize, MPI_INFO_NULL, &win_buf);
+    local_buf = (int *) malloc(bufsize);
+    result_buf = (int *) calloc((XDIM * YDIM), sizeof(int));
+    run_init_data(local_buf, nranks);
+    run_init_data(win_buf, nranks);
+
+    MPI_Win_create(win_buf, bufsize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &buf_win);
+    MPI_Win_fence(0, buf_win);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].result_buf = result_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    MPI_Win_fence(0, buf_win);
+
+    /* Verify target */
+    if (rank == 1)
+        run_verify(win_buf, &errors, rank, (TEST_ROUNDS + 1) * nranks);
+
+    /* Verify result */
+    if (rank == 0)
+        run_verify(result_buf, &errors, rank, (TEST_ROUNDS) * nranks);
+
+    MPI_Win_free(&buf_win);
+
+    MPI_Free_mem(win_buf);
+    free(local_buf);
+    free(result_buf);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_putget.c
+++ b/test/mpi/threads/rma/mt_putget.c
@@ -1,0 +1,282 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Put/Get Test
+ *
+ * This code performs several put/get operations into a 2D array using
+ * multiple threads. The array has dimensions [X, Y] and the transfer is
+ * done by NTHREADS threads concurrently. Both small msg and huge msg transfers
+ * are tested.
+ */
+
+#include "mt_rma_common.h"
+
+#define TEST_ROUNDS 1
+
+#ifdef PUT_TEST
+#define PUT_GET_FUNC MPI_Put
+#else
+#define PUT_GET_FUNC MPI_Get
+#endif /* #ifdef PUT_TEST */
+
+int mpi_kernel(enum op_type mpi_op, void *origin_addr, int origin_count,
+               MPI_Datatype origin_datatype, void *result_addr, int result_count,
+               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
+               int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win,
+               MPI_Request * req)
+{
+    return PUT_GET_FUNC(origin_addr, origin_count, origin_datatype,
+                        target_rank, target_disp, target_count, target_datatype, win);
+}
+
+/* Sync type */
+enum sync_type { FENCE = 0, PSCW, LOCK, LOCK_ALL };
+
+int run_sync(MPI_Win win, MPI_Group group, int rank, int peer, enum sync_type sync, int lock)
+{
+    switch (sync) {
+        case FENCE:
+            MPI_Win_fence(0, win);
+            break;
+        case PSCW:
+            if (rank == 0) {
+                /* rank 0 is origin. */
+                if (lock) {
+                    MPI_Win_start(group, 0, win);
+                } else {
+                    MPI_Win_complete(win);
+                }
+            } else {
+                /* rank 1 is target. */
+                if (lock) {
+                    MPI_Win_post(group, 0, win);
+                } else {
+                    MPI_Win_wait(win);
+                }
+            }
+            break;
+        case LOCK:
+            if (rank == 0) {
+                if (lock) {
+                    MPI_Win_lock(MPI_LOCK_EXCLUSIVE, peer, 0, win);
+                } else {
+                    MPI_Win_unlock(peer, win);
+                }
+            }
+            break;
+        case LOCK_ALL:
+            if (rank == 0) {
+                if (lock) {
+                    MPI_Win_lock_all(0, win);
+                } else {
+                    MPI_Win_unlock_all(win);
+                }
+            }
+            break;
+        default:
+            fprintf(stderr, "Invalid synchronization type.\n");
+            exit(-1);
+    }
+    return MPI_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, j, rank, nranks, peer, bufsize, err, errors = 0;
+    int *win_buf, *local_buf;
+    MPI_Win buf_win;
+    MPI_Group world_group, peer_group;
+    thread_param_t params[NTHREADS];
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    if (nranks != 2) {
+        fprintf(stderr, "Need two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    peer = (rank + 1) % nranks;
+    MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+    MPI_Group_incl(world_group, 1, &peer, &peer_group);
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].th_id = i;
+        params[i].rank = rank;
+        params[i].target = peer;
+        params[i].rounds = TEST_ROUNDS;
+        params[i].op = NOREQ;
+    }
+
+    bufsize = XDIM * YDIM * sizeof(int);
+    MPI_Alloc_mem(bufsize, MPI_INFO_NULL, &win_buf);
+    local_buf = (int *) malloc(bufsize);
+#ifdef PUT_TEST
+    if (rank == 0) {
+        run_init_data(local_buf, nranks);
+        run_reset_data(win_buf);
+    }
+#else
+    if (rank == 1) {
+        run_init_data(win_buf, nranks);
+        run_reset_data(local_buf);
+    }
+#endif /* #ifdef PUT_TEST */
+
+    MPI_Win_create(win_buf, bufsize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &buf_win);
+    MPI_Win_fence(0, buf_win);
+
+    /* a: sync by win_fence */
+    run_sync(buf_win, peer_group, rank, peer, FENCE, 1);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    run_sync(buf_win, peer_group, rank, peer, FENCE, 0);
+
+#ifdef PUT_TEST
+    if (rank == 1)
+        run_verify(win_buf, &errors, rank, nranks);
+#else
+    if (rank == 0)
+        run_verify(local_buf, &errors, rank, nranks);
+#endif /* #ifdef PUT_TEST */
+
+    /* b: sync by PSCW */
+    /* reset data */
+#ifdef PUT_TEST
+    if (rank == 1)
+        run_reset_data(win_buf);
+#else
+    if (rank == 0)
+        run_reset_data(local_buf);
+#endif /* #ifdef PUT_TEST */
+    MPI_Win_fence(0, buf_win);
+    run_sync(buf_win, peer_group, rank, peer, PSCW, 1);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    run_sync(buf_win, peer_group, rank, peer, PSCW, 0);
+
+#ifdef PUT_TEST
+    if (rank == 1)
+        run_verify(win_buf, &errors, rank, nranks);
+#else
+    if (rank == 0)
+        run_verify(local_buf, &errors, rank, nranks);
+#endif /* #ifdef PUT_TEST */
+
+    /* c & d:
+     * Passive target synchronization used for Get only. */
+#ifdef GET_TEST
+    /* c: sync by win_lock */
+    if (rank == 0)
+        run_reset_data(local_buf);
+
+    MPI_Win_fence(0, buf_win);
+
+    run_sync(buf_win, peer_group, rank, peer, LOCK, 1);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    run_sync(buf_win, peer_group, rank, peer, LOCK, 0);
+
+    if (rank == 0)
+        run_verify(local_buf, &errors, rank, nranks);
+
+    /* d: sync by win_lock_all */
+    if (rank == 0)
+        run_reset_data(local_buf);
+
+    MPI_Win_fence(0, buf_win);
+
+    run_sync(buf_win, peer_group, rank, peer, LOCK_ALL, 1);
+
+    if (rank == 0) {
+        for (i = 0; i < NTHREADS; i++) {
+            params[i].origin_buf = local_buf;
+            params[i].win = &buf_win;
+            if (i == NTHREADS - 1) {
+                run_test(&params[i]);
+            } else {
+                MTest_Start_thread(run_test, &params[i]);
+            }
+        }
+
+        MTest_Join_threads();
+    }
+
+    run_sync(buf_win, peer_group, rank, peer, LOCK_ALL, 0);
+
+    if (rank == 0)
+        run_verify(local_buf, &errors, rank, nranks);
+#endif /* #ifdef GET_TEST */
+
+    MPI_Win_free(&buf_win);
+    MPI_Group_free(&peer_group);
+    MPI_Group_free(&world_group);
+
+    MPI_Free_mem(win_buf);
+    free(local_buf);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_reqops.c
+++ b/test/mpi/threads/rma/mt_reqops.c
@@ -1,0 +1,193 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/* Multi-thread One-Sided MPI Request-based RMA Test
+ *
+ * This code performs RPUT, RGET, RACC and RGET_ACC operations into a 2D array using
+ * multiple threads. The array has dimensions [X, Y] and the transfer is
+ * done by NTHREADS threads concurrently.
+ */
+
+#include "mt_rma_common.h"
+
+#define TEST_ROUNDS 10
+
+int mpi_kernel(enum op_type mpi_op, void *origin_addr, int origin_count,
+               MPI_Datatype origin_datatype, void *result_addr, int result_count,
+               MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
+               int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win,
+               MPI_Request * request)
+{
+    switch (mpi_op) {
+        case RPUT:
+            MPI_Rput(origin_addr, origin_count, origin_datatype,
+                     target_rank, target_disp, target_count, target_datatype, win, request);
+            break;
+        case RGET:
+            MPI_Rget(origin_addr, origin_count, origin_datatype,
+                     target_rank, target_disp, target_count, target_datatype, win, request);
+            break;
+        case RACC:
+            MPI_Raccumulate(origin_addr, origin_count, origin_datatype,
+                            target_rank, target_disp, target_count, target_datatype,
+                            op, win, request);
+            break;
+        case RGET_ACC:
+            MPI_Rget_accumulate(origin_addr, origin_count, origin_datatype,
+                                result_addr, result_count, result_datatype,
+                                target_rank, target_disp, target_count, target_datatype,
+                                op, win, request);
+            break;
+        default:
+            fprintf(stderr, "invalid RMA operation.\n");
+            abort();
+    }
+    MPI_Wait(request, MPI_STATUS_IGNORE);
+
+    return MPI_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    int pmode, i, rank, nranks, left_neighbor, right_neighbor, bufsize, err, errors = 0;
+    int *win_buf, *local_buf, *result_buf;
+    MPI_Win buf_win;
+    thread_param_t params[NTHREADS];
+
+    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
+
+    if (pmode != MPI_THREAD_MULTIPLE) {
+        fprintf(stderr, "MPI_THREAD_MULTIPLE not supported by the MPI implementation\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+    err = MTest_thread_barrier_init();
+    if (err) {
+        fprintf(stderr, "Could not create thread barrier\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    right_neighbor = rank == nranks - 1 ? 0 : rank + 1;
+    left_neighbor = rank > 0 ? rank - 1 : nranks - 1;
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].th_id = i;
+        params[i].rank = rank;
+        params[i].target = right_neighbor;
+    }
+
+    bufsize = XDIM * YDIM * sizeof(int);
+    MPI_Alloc_mem(bufsize, MPI_INFO_NULL, &win_buf);
+    local_buf = (int *) malloc(bufsize);
+    result_buf = (int *) malloc(bufsize);
+
+    run_init_data(local_buf, rank);
+
+    MPI_Win_create(win_buf, bufsize, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &buf_win);
+    MPI_Win_fence(0, buf_win);
+
+    /* a: PUT */
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].origin_buf = local_buf;
+        params[i].win = &buf_win;
+        params[i].op = RPUT;
+        params[i].rounds = 1;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    run_verify(win_buf, &errors, rank, left_neighbor);
+
+    /* b: GET */
+    MPI_Win_fence(0, buf_win);
+    run_reset_data(local_buf);
+    run_init_data(win_buf, rank);
+    MPI_Win_fence(0, buf_win);
+
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].target = left_neighbor;
+        params[i].op = RGET;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+    /* No need to have MPI_Barrier() for Get. */
+    run_verify(local_buf, &errors, rank, left_neighbor);
+
+    /* c: ACC */
+    MPI_Win_fence(0, buf_win);
+    run_init_data(local_buf, rank);
+    run_reset_data(win_buf);
+    MPI_Win_fence(0, buf_win);
+
+    /* Need a few repetition for ACC and GET_ACC */
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].target = right_neighbor;
+        params[i].op = RACC;
+        params[i].rounds = TEST_ROUNDS;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+    MPI_Barrier(MPI_COMM_WORLD);
+    run_verify(win_buf, &errors, rank, TEST_ROUNDS * left_neighbor);
+
+    /* d: GET_ACC */
+    MPI_Win_fence(0, buf_win);
+    run_reset_data(result_buf);
+    run_reset_data(win_buf);
+    MPI_Win_fence(0, buf_win);
+
+    /* Need a few repetition for ACC and GET_ACC */
+    for (i = 0; i < NTHREADS; i++) {
+        params[i].result_buf = result_buf;
+        params[i].op = RGET_ACC;
+        if (i == NTHREADS - 1) {
+            run_test(&params[i]);
+        } else {
+            MTest_Start_thread(run_test, &params[i]);
+        }
+    }
+
+    MTest_Join_threads();
+    MPI_Barrier(MPI_COMM_WORLD);
+    run_verify(win_buf, &errors, rank, TEST_ROUNDS * left_neighbor);
+    run_verify(result_buf, &errors, rank, (TEST_ROUNDS - 1) * rank);
+
+    MPI_Win_fence(0, buf_win);
+    MPI_Win_free(&buf_win);
+
+    MPI_Free_mem(win_buf);
+    free(local_buf);
+    free(result_buf);
+
+    MTest_thread_barrier_free();
+    MTest_Finalize(errors);
+
+    return 0;
+}

--- a/test/mpi/threads/rma/mt_rma_common.h
+++ b/test/mpi/threads/rma/mt_rma_common.h
@@ -1,0 +1,133 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+#ifndef MT_RMA_COMMON_H_INCLUDED
+#define MT_RMA_COMMON_H_INCLUDED
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <mpi.h>
+#include "mpitest.h"
+#include "mpithreadtest.h"
+#include "squelch.h"
+
+#define NTHREADS 4
+
+#define XDIM 256
+#define YDIM 256
+
+enum op_type { NOREQ = 0, RPUT, RGET, RACC, RGET_ACC };
+
+typedef struct thread_param {
+    int th_id;                  /* Thread id */
+    int rank;
+    int target;
+    MPI_Win *win;
+    int *origin_buf;
+    int *result_buf;
+    int rounds;                 /* Number of repitition */
+    enum op_type op;
+} thread_param_t;
+
+static void run_init_data(int *buf, int val)
+{
+    int i, j;
+    for (i = 0; i < XDIM; i++) {
+        for (j = 0; j < YDIM; j++) {
+            buf[j * XDIM + i] = val;
+        }
+    }
+}
+
+static void run_reset_data(int *buf)
+{
+    memset(buf, 0, sizeof(int) * XDIM * YDIM);
+}
+
+static void run_verify(int *buf, int *errors, int my_rank, int result)
+{
+    int i, j;
+    for (i = 0; i < XDIM; i++) {
+        for (j = 0; j < YDIM; j++) {
+            if (buf[j * XDIM + i] != result) {
+                SQUELCH(printf
+                        ("rank: %d: Data validation failed at [%d, %d] expected=%d actual=%d\n",
+                         my_rank, j, i, result, buf[j * XDIM + i]););
+                (*errors)++;
+                fflush(stdout);
+            }
+        }
+    }
+}
+
+extern int mpi_kernel(enum op_type mpi_op, void *origin_addr, int origin_count,
+                      MPI_Datatype origin_datatype, void *result_addr, int result_count,
+                      MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp,
+                      int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win,
+                      MPI_Request * request);
+
+static int test_huge(enum op_type mpi_op, int th_id, int rounds,
+                     MPI_Win * win, int target, int *origin, int *result)
+{
+    int row_start, row_end, count, i;
+    MPI_Request req;
+    row_start = th_id * (YDIM / NTHREADS);
+    row_end = (row_start + (YDIM / NTHREADS) - 1);
+    if (row_end > (YDIM - 1))
+        row_end = YDIM - 1;     /* handle the case of out of bound */
+
+    count = (row_end - row_start + 1) * XDIM;
+    for (i = 0; i < rounds; i++) {
+        mpi_kernel(mpi_op, (origin + row_start * XDIM), count, MPI_INT,
+                   (result + row_start * XDIM), count, MPI_INT,
+                   target, (row_start * XDIM * sizeof(int)), count, MPI_INT, MPI_SUM, *win, &req);
+    }
+    return MPI_SUCCESS;
+}
+
+static int test_normal(enum op_type mpi_op, int th_id, int rounds,
+                       MPI_Win * win, int target, int *origin, int *result)
+{
+    int j, row_start, row_end, count, i;
+    MPI_Request req;
+    row_start = th_id * (YDIM / NTHREADS);
+    row_end = (row_start + (YDIM / NTHREADS) - 1);
+    if (row_end > (YDIM - 1))
+        row_end = YDIM - 1;     /* handle the case of out of bound */
+
+    count = (row_end - row_start + 1) * XDIM;
+    for (j = 0; j < count; j++) {
+        for (i = 0; i < rounds; i++) {
+            mpi_kernel(mpi_op, (origin + row_start * XDIM + j), 1, MPI_INT,
+                       (result + row_start * XDIM + j), 1, MPI_INT,
+                       target, ((row_start * XDIM + j) * sizeof(int)), 1, MPI_INT,
+                       MPI_SUM, *win, &req);
+        }
+    }
+    return MPI_SUCCESS;
+}
+
+static MTEST_THREAD_RETURN_TYPE run_test(void *arg)
+{
+    thread_param_t *p = (thread_param_t *) arg;
+
+    /* Make sure all threads have launched */
+    MTest_thread_barrier(NTHREADS);
+#ifdef HUGE_COUNT
+    test_huge(p->op, p->th_id, p->rounds, p->win, p->target, p->origin_buf, p->result_buf);
+#else /* Small data test */
+    test_normal(p->op, p->th_id, p->rounds, p->win, p->target, p->origin_buf, p->result_buf);
+#endif /* #ifdef HUGE_COUNT */
+
+    return (MTEST_THREAD_RETURN_TYPE) NULL;
+}
+
+#endif /* MT_RMA_COMMON_INCLUDED */

--- a/test/mpi/threads/rma/squelch.h
+++ b/test/mpi/threads/rma/squelch.h
@@ -1,0 +1,16 @@
+#ifndef SQUELCH_H_INCLUDED
+#define SQUELCH_H_INCLUDED
+
+static const int SQ_LIMIT = 10;
+static int SQ_COUNT = 0;
+static int SQ_VERBOSE = 0;
+
+#define SQUELCH(X)                              \
+  do {                                          \
+    if (SQ_COUNT < SQ_LIMIT || SQ_VERBOSE) {    \
+      SQ_COUNT++;                               \
+      X                                         \
+    }                                           \
+  } while (0)
+
+#endif /* SQUELCH_H_INCLUDED */

--- a/test/mpi/threads/rma/testlist
+++ b/test/mpi/threads/rma/testlist
@@ -1,3 +1,14 @@
 multirma 2 mpiversion=3.0
 multiget 2 mpiversion=3.0
 multifence 3
+mt_put_huge 2 mpiversion=3.0
+mt_get_huge 2 mpiversion=3.0
+mt_put_normal 2 mpiversion=3.0
+mt_get_normal 2 mpiversion=3.0
+mt_accfence_normal 2 mpiversion=3.0
+mt_accfence_huge 2 mpiversion=3.0
+mt_getaccfence_normal 2 mpiversion=3.0
+mt_getaccfence_huge 2 mpiversion=3.0
+mt_compareandswap 4 mpiversion=3.0
+mt_fetchandop 4 mpiversion=3.0
+mt_reqops 4 mpiversion=3.0


### PR DESCRIPTION
# Summary:
This patch adds multi-threaded RMA test cases,
together with synchronization using fence, lock, lock_all and PSCW.

# Limitation:
All tests pass in `--enable-ch4-direct=netmod` mode.
Currently, we notice that several tests below fail in `--enable-ch4-direct=auto` mode when active message path is involved:
- mt_accfence_normal
- mt_getaccfence_normal 
