### PR TITLE
ch4/ofi: Add manual progress for RMA Put operation

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -267,6 +267,18 @@ cvars:
       description : >-
         Specifies the number of buffers for receiving active messages.
 
+    - name        : MPIR_CVAR_CH4_OFI_RMA_PROGRESS_INTERVAL
+      category    : CH4_OFI
+      type        : int
+      default     : 100
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Specifies the interval for manually flushing RMA operations when automatic progress is not
+        enabled. It the underlying OFI provider supports auto data progress, this value is ignored.
+        If the value is -1, this optimization will be turned off.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -197,6 +197,11 @@ typedef struct {
      * defined in ofi_types.h to allocate the max_count array. The struct
      * size is unknown when we load ofi_pre.h, thus we only set a pointer here. */
     struct MPIDI_OFI_win_acc_hint *acc_hint;
+
+    /* Counter to track whether or not to kick the progress engine when the OFI provider does not
+     * supply automatic progress. This can make a big performance difference when doing
+     * large, non-contiguous RMA operations. */
+    int progress_counter;
 } MPIDI_OFI_win_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -507,6 +507,11 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         msg.rma_iov_count = tout;
         MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
                               fi_writemsg(ep, &msg, flags), rdma_write);
+
+        /* By default, progress is called only during fence, which significantly
+         * slows down the RMA operations for large non-contiguous data. Adding manual
+         * progress helps improve the performance. */
+        MPIDI_OFI_win_trigger_rma_progress(win);
     }
 
     MPIDI_OFI_finalize_seg_state(p);
@@ -680,6 +685,11 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         msg.rma_iov_count = tout;
         MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
                               fi_readmsg(ep, &msg, flags), rdma_write);
+
+        /* By default, progress is called only during fence, which significantly
+         * slows down the RMA operations for large non-contiguous data. Adding manual
+         * progress helps improve the performance. */
+        MPIDI_OFI_win_trigger_rma_progress(win);
     }
 
     MPIDI_OFI_finalize_seg_state(p);
@@ -977,6 +987,11 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.rma_iov_count = tout;
         MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
                               fi_atomicmsg(ep, &msg, flags), rdma_atomicto);
+
+        /* By default, progress is called only during fence, which significantly
+         * slows down the RMA operations for large non-contiguous data. Adding manual
+         * progress helps improve the performance. */
+        MPIDI_OFI_win_trigger_rma_progress(win);
     }
 
     MPIDI_OFI_finalize_seg_state(p);
@@ -1155,6 +1170,10 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
                               fi_fetch_atomicmsg(ep, &msg, resultv,
                                                  NULL, rout, flags), rdma_readfrom);
+        /* By default, progress is called only during fence, which significantly
+         * slows down the RMA operations for large non-contiguous data. Adding manual
+         * progress helps improve the performance. */
+        MPIDI_OFI_win_trigger_rma_progress(win);
     }
 
     if (op != MPI_NO_OP)

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -540,6 +540,7 @@ static int win_init(MPIR_Win * win)
     MPIDIU_map_set(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id, win, MPL_MEM_RMA);
 
     MPIDI_OFI_WIN(win).sep_tx_idx = -1; /* By default, -1 means not using scalable EP. */
+    MPIDI_OFI_WIN(win).progress_counter = 1;
 
     /* First, try to enable scalable EP. */
     if (MPIR_CVAR_CH4_OFI_ENABLE_SCALABLE_ENDPOINTS && MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX > 0) {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -14,7 +14,13 @@
 #include "ofi_impl.h"
 #include <opa_primitives.h>
 
-static inline int MPIDI_OFI_win_progress_fence(MPIR_Win * win)
+/* Blocking progress function to complete outstanding RMA operations on the input window.
+ *
+ * win - Window on which to complete operations
+ * do_free - Flag to indicate whether it is safe to free the operations (whether this progress
+ *           function is being called internally or by the user).
+ */
+static inline int MPIDI_OFI_win_progress_fence_impl(MPIR_Win * win, bool do_free)
 {
     int mpi_errno = MPI_SUCCESS;
     int itercount = 0;
@@ -22,8 +28,8 @@ static inline int MPIDI_OFI_win_progress_fence(MPIR_Win * win)
     uint64_t tcount, donecount;
     MPIDI_OFI_win_request_t *r;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE_IMPL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE_IMPL);
 
     tcount = *MPIDI_OFI_WIN(win).issued_cntr;
     donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
@@ -52,18 +58,37 @@ static inline int MPIDI_OFI_win_progress_fence(MPIR_Win * win)
 
     r = MPIDI_OFI_WIN(win).syncQ;
 
-    while (r) {
-        MPIDI_OFI_win_request_t *next = r->next;
-        MPIDI_OFI_rma_done_event(NULL, (MPIR_Request *) r);
-        r = next;
+    /* Should not free the RMA request when do_free = 0; manual RMA flush could happen in
+     * the middle of issuing one MPI-level RMA op and it could lead to premature freeing of
+     * the request. */
+    if (do_free) {
+        while (r) {
+            MPIDI_OFI_win_request_t *next = r->next;
+            MPIDI_OFI_rma_done_event(NULL, (MPIR_Request *) r);
+            r = next;
+        }
+
+        MPIDI_OFI_WIN(win).syncQ = NULL;
     }
 
-    MPIDI_OFI_WIN(win).syncQ = NULL;
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE_IMPL);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+static inline int MPIDI_OFI_win_progress_fence(MPIR_Win * win)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
+
+    mpi_errno = MPIDI_OFI_win_progress_fence_impl(win, true);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE);
+    return mpi_errno;
 }
 
 static inline int MPIDI_NM_mpi_win_start(MPIR_Group * group, int assert, MPIR_Win * win)


### PR DESCRIPTION
MPI_Put() is very slow for large non-contiguous data, especially
when the origin and target do concurrent Put to each other. Adding
manual progress significantly improves the performance of MPI_Put().