### PR TITLE
mtest: Add test case for huge Ssend

### DIFF
--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -56,6 +56,7 @@ noinst_PROGRAMS =  \
     huge_underflow \
     huge_anysrc    \
     huge_dupcomm   \
+    huge_ssend     \
     dtype_send		 \
     recv_any		\
     irecv_any   \

--- a/test/mpi/pt2pt/huge_ssend.c
+++ b/test/mpi/pt2pt/huge_ssend.c
@@ -1,0 +1,49 @@
+/*
+ *  (C) 2018 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2018 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ *
+ *  This program checks if MPICH can correctly handle huge synchronous sends
+ *
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "mpitest.h"
+
+#define COUNT (4*1024*1024)
+
+int main(int argc, char *argv[])
+{
+    int *buff;
+    int size, rank;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size != 2) {
+        fprintf(stderr, "Launch with two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    buff = malloc(COUNT * sizeof(int));
+
+    if (rank == 0)
+        MPI_Ssend(buff, COUNT, MPI_INT, 1, 0, MPI_COMM_WORLD);
+    else
+        MPI_Recv(buff, COUNT, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+    free(buff);
+
+    MTest_Finalize(0);
+
+    return 0;
+}

--- a/test/mpi/pt2pt/testlist.def
+++ b/test/mpi/pt2pt/testlist.def
@@ -44,6 +44,7 @@ manylmt 2
 huge_underflow 2
 huge_anysrc 2
 huge_dupcomm 2
+huge_ssend 2
 dtype_send 2
 recv_any 2
 irecv_any 2


### PR DESCRIPTION
This patch adds a test case for MPI_Ssend with a large (16MB)
buffer. At the moment, CH4 shared memory implementation is known
to fail with this case (also mentioned in #3384).

One thing to mention is that in the Argonne Jenkins environment this test may not fail because it is always setting `MPIR_CVAR_ODD_EVEN_CLIQUES=1`, and thus all the communication is going through netmod rather than shmmod.
