### PR TITLE
confdb: fix the `--without-*` option.

### DIFF
--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -89,6 +89,8 @@ AC_DEFUN([PAC_CHECK_PREFIX],[
                  :
              elif test "$withval" = "embedded" ; then
                  :
+             elif test "$withval" = "no" ; then
+                 :
              else
                  PAC_APPEND_FLAG([-I${with_$1_prefix}/include],[CPPFLAGS])
                  if test -d "${with_$1_prefix}/lib64" ; then


### PR DESCRIPTION
Fix the handling of the CFLAGS and LDFLAGS when `--without-*` is used
to disable external library.

We can use this to disable hwloc when doing the valgrind test, so that valgrind is chocked by the issues in the hwloc library.