### PR TITLE
doc: remove reference to MPICH_MAKE_xFLAGS

### DIFF
--- a/README.vin
+++ b/README.vin
@@ -290,13 +290,7 @@ MPICHLIB_xFLAGS): Setting these flags would result in the MPICH
 library being compiled with these flags.  However, these flags will
 *not* be used by mpicc and friends.
 
-(c) MPICH_MAKE_CFLAGS: Setting these flags would result in MPICH's
-configure tests to not use these flags, but the makefile's to use
-them. This is a temporary hack for certain cases that advanced
-developers might be interested in, but which break existing configure
-tests (e.g., -Werror). These are NOT recommended for regular users.
-
-(d) MPICH_MPICC_CFLAGS, MPICH_MPICC_CPPFLAGS, MPICH_MPICC_LDFLAGS,
+(c) MPICH_MPICC_CFLAGS, MPICH_MPICC_CPPFLAGS, MPICH_MPICC_LDFLAGS,
 MPICH_MPICC_LIBS, and so on for MPICXX, MPIF77 and MPIFORT
 (abbreviated as MPICH_MPIX_FLAGS): These flags do *not* affect the
 compilation of the MPICH library itself, but will be internally used
@@ -314,10 +308,6 @@ by mpicc and friends.
   +--------------------+----------------------+------------------------+
   |                    |                      |                        |
   |  MPICHLIB_xFLAGS   |         Yes          |           No           |
-  |                    |                      |                        |
-  +--------------------+----------------------+------------------------+
-  |                    |                      |                        |
-  | MPICH_MAKE_xFLAGS  |         Yes          |           No           |
   |                    |                      |                        |
   +--------------------+----------------------+------------------------+
   |                    |                      |                        |
@@ -375,20 +365,6 @@ Example 2:
 
 This will cause the MPICH libraries to be built with -O3, and -O3
 will be included in the mpicc and other MPI wrapper script.
-
-Example 3:
-
-There are certain compiler flags that should not be used with MPICH's
-configure, e.g. gcc's -Werror, which would confuse configure and cause
-certain configure tests to fail to detect the correct system features.
-To use -Werror in building MPICH libraries, you can pass the compiler
-flags during the make step through the Makefile variable
-MPICH_MAKE_CFLAGS as follows:
-
-  make MPICH_MAKE_CFLAGS="-Wall -Werror"
-
-The content of MPICH_MAKE_CFLAGS is appended to the CFLAGS in all
-relevant Makefiles.
 
 -------------------------------------------------------------------------
 

--- a/doc/installguide/install.tex.vin
+++ b/doc/installguide/install.tex.vin
@@ -426,22 +426,6 @@ This will cause the MPICH libraries to be built with \texttt{-O3},
 and \texttt{-O3} will
 not be included in the \texttt{mpicc} and other MPI wrapper script.
 
-There are certain compiler flags that should not be used with MPICH's
-configure, e.g. gcc's \texttt{-Werror} which would confuse configure and cause
-certain configure tests to fail to detect the correct system features.
-To use \texttt{-Werror} in building MPICH libraries, you can pass the compiler
-flags during the make step through the Makefile variable,
-\texttt{MPICH\_MAKE\_CFLAGS} as follows:
-
-\begin{verbatim}
-  make VERBOSE=1 MPICH_MAKE_CFLAGS="-Wall -Werror"
-\end{verbatim}
-
-(assume CC is set to gcc).  The content of \texttt{MPICH\_MAKE\_CFLAGS}
-is appended to the \texttt{CFLAGS} in almost all Makefiles.
-
-
-
 \subsection{Common Non-Default Configuration Options}
 \label{sec:non-default}
 


### PR DESCRIPTION
The flags have been removed many years ago.