### PR TITLE
Patching libtool to support the newer IBM XL Fortran compiler

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -939,6 +939,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 # There is no need to patch if we're not going to use Fortran.
                 ifort_patch_requires_rebuild=no
                 oracle_patch_requires_rebuild=no
+                arm_patch_requires_rebuild=no
                 ibm_patch_requires_rebuild=no
                 if [ $do_bindings = "yes" ] ; then
                     echo_n "Patching libtool.m4 for compatibility with ifort on OSX... "

--- a/autogen.sh
+++ b/autogen.sh
@@ -939,6 +939,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 # There is no need to patch if we're not going to use Fortran.
                 ifort_patch_requires_rebuild=no
                 oracle_patch_requires_rebuild=no
+                ibm_patch_requires_rebuild=no
                 if [ $do_bindings = "yes" ] ; then
                     echo_n "Patching libtool.m4 for compatibility with ifort on OSX... "
                     patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/darwin-ifort.patch
@@ -970,9 +971,20 @@ if [ "$do_build_configure" = "yes" ] ; then
                     else
                         echo "failed"
                     fi
+                    echo_n "Patching libtool.m4 for compatibility with IBM XL Fortran compilers..."
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/ibm-xlf.patch
+                    if [ $? -eq 0 ] ; then
+                        ibm_patch_requires_rebuild=yes
+                        # Remove possible leftovers, which don't imply a failure
+                        rm -f $amdir/confdb/libtool.m4.orig
+                        echo "done"
+                    else
+                        echo "failed"
+                    fi
                 fi
 
-                if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ] || [ $arm_patch_requires_rebuild = "yes" ]; then
+                if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ] \
+                    || [ $arm_patch_requires_rebuild = "yes" ] || [ $ibm_patch_requires_rebuild = "yes" ]; then
                     # Rebuild configure
                     (cd $amdir && $autoconf -f) || exit 1
                     # Reset libtool.m4 timestamps to avoid confusing make

--- a/configure.ac
+++ b/configure.ac
@@ -5598,13 +5598,6 @@ fi
 LT_OUTPUT
 
 if test "X$enable_shared" = "Xyes" ; then
-    # see Github issue pmodels/mpich#3050 for shared object linking issue with
-    # IBM compiler
-    PAC_C_CHECK_COMPILER_OPTION("-qmkshrobj",found_opt=yes,found_opt=no)
-    if test "$found_opt" = "yes" ; then
-        PAC_APPEND_FLAG([-qmkshrobj],[LDFLAGS])
-    fi
-
     # see ticket #1590 for some more background on these Darwin linking issues
     AS_CASE([$host],
         [*-*-darwin*],

--- a/maint/patches/optional/confdb/ibm-xlf.patch
+++ b/maint/patches/optional/confdb/ibm-xlf.patch
@@ -1,0 +1,40 @@
+--- confdb/libtool.m4	2018-10-26 14:37:44.332395000 +0000
++++ /home/yguo/libtool_new.m4	2018-10-25 22:55:38.108314000 +0000
+@@ -5242,16 +5242,27 @@
+ 	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='-rdynamic'
+ 	  ;;
+ 	xlf* | bgf* | bgxlf* | mpixlf*)
+-	  # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
+-	  _LT_TAGVAR(whole_archive_flag_spec, $1)='--whole-archive$convenience --no-whole-archive'
+-	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
+-	  _LT_TAGVAR(archive_cmds, $1)='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
+-	  if test yes = "$supports_anon_versioning"; then
+-	    _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
+-              cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-              echo "local: *; };" >> $output_objdir/$libname.ver~
+-              $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
+-	  fi
++          XLF_VERSION=$($CC -qversion 2>/dev/null | sed 1q | sed -e "s+^.*V++" | sed -e "s+\..*++")
++          if test $XLF_VERSION -ge 13; then
++              _LT_TAGVAR(archive_cmds, $1)='$CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'
++              if test yes = "$supports_anon_versioning"; then
++                _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
++                  cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++                  echo "local: *; };" >> $output_objdir/$libname.ver~
++                  $CC -qmkshrobj $libobjs $deplibs $compiler_flags $wl-soname $wl$soname $wl-version-script $wl$output_objdir/$libname.ver -o $lib'
++              fi
++          else
++              # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
++              _LT_TAGVAR(whole_archive_flag_spec, $1)='--whole-archive$convenience --no-whole-archive'
++              _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='$wl-rpath $wl$libdir'
++              _LT_TAGVAR(archive_cmds, $1)='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
++              if test yes = "$supports_anon_versioning"; then
++                _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
++                  cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++                  echo "local: *; };" >> $output_objdir/$libname.ver~
++                  $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
++              fi
++          fi
+ 	  ;;
+ 	esac
+       else


### PR DESCRIPTION
This is the correct fix for #3050 . The new `xlf` already supports dynamic linking. Libtool need to be patched to pass the correct option.