### PR TITLE
hwloc: linking hwloc externally.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1501,9 +1501,7 @@ else
    AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
 
    if test "$have_hwloc" = "yes" ; then
-      hwloclib="-lhwloc"
       if test -d ${with_hwloc_prefix}/lib64 ; then
-         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
          hwloclibdir="-L${with_hwloc_prefix}/lib64"
       else
 	 hwloclibdir="-L${with_hwloc_prefix}/lib"


### PR DESCRIPTION
When an external hwloc library is used, the libdir variable set to
lhwloc results in build failure since it is treated as a make rule.
It only needs to be set when hwloc is used in embedded mode.