### PR TITLE
dtpool/configure: requiring the same version of autoconf as MPICH

### DIFF
--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -5,7 +5,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.67])
+AC_PREREQ([2.63])
 AC_INIT([dtpools], [0.0], [discuss@mpich.org])
 AC_CONFIG_SRCDIR([include/dtpools.h])
 


### PR DESCRIPTION
The `configure.ac` requires 2.63, just to be consistent.