### PR TITLE
mpl: disable ATTRIBUTE((used)) when compiler does not support it.

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -118,8 +118,8 @@ MPIR_Thread_sync_list_t sync_wait_list = { NULL };
    If the Fortran binding is supported, these can be initialized to
    their Fortran values (MPI only requires that they be valid between
    MPI_Init and MPI_Finalize) */
-MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUS_IGNORE ATTRIBUTE((used)) = 0;
-MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUSES_IGNORE ATTRIBUTE((used)) = 0;
+MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUS_IGNORE MPL_USED = 0;
+MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUSES_IGNORE MPL_USED = 0;
 
 /* This will help force the load of initinfo.o, which contains data about
    how MPICH was configured. */

--- a/src/mpid/ch3/channels/nemesis/utils/monitor/papi_defs.c
+++ b/src/mpid/ch3/channels/nemesis/utils/monitor/papi_defs.c
@@ -9,7 +9,7 @@
 #include "mpl.h"
 
 /* here to prevent "has no symbols" warnings from ranlib on OS X */
-static int dummy ATTRIBUTE((unused,used)) = 0;
+static int dummy ATTRIBUTE((unused)) MPL_USED = 0;
 
 #ifdef PAPI_MONITOR
 #include <papi.h>

--- a/src/mpid/ch3/channels/nemesis/utils/replacements/mkstemp.c
+++ b/src/mpid/ch3/channels/nemesis/utils/replacements/mkstemp.c
@@ -15,7 +15,7 @@
 #include <unistd.h>
 
 /* here to prevent "has no symbols" warnings from ranlib on OS X */
-static int dummy ATTRIBUTE((unused,used)) = 0;
+static int dummy ATTRIBUTE((unused)) MPL_USED = 0;
 
 #if !defined (HAVE_MKSTEMP) || !HAVE_MKSTEMP
 

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1004,6 +1004,7 @@ AC_CHECK_FUNCS(inet_ntop getifaddrs)
 dnl Check for ATTRIBUTE
 PAC_C_GNU_ATTRIBUTE
 AX_GCC_VAR_ATTRIBUTE(aligned)
+AX_GCC_VAR_ATTRIBUTE(used)
 
 dnl Check for fallthrough attribute
 PAC_PUSH_ALL_FLAGS

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -76,6 +76,12 @@
 #define MPL_ATTR_ALIGNED(x)
 #endif
 
+#ifdef MPL_HAVE_VAR_ATTRIBUTE_USED
+#define MPL_USED ATTRIBUTE((used))
+#else
+#define MPL_USED
+#endif
+
 /* These likely/unlikely macros provide static branch prediction hints to the
  * compiler, if such hints are available.  Simply wrap the relevant expression in
  * the macro, like this:
@@ -124,7 +130,7 @@
  * via the preprocessor).  A semicolon is expected after each invocation
  * of this macro. */
 #define MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING \
-    static int MPL_UNIQUE_SYMBOL_NAME(dummy) ATTRIBUTE((unused,used)) = 0
+    static int MPL_UNIQUE_SYMBOL_NAME(dummy) ATTRIBUTE((unused)) MPL_USED = 0
 
 /* we jump through a couple of extra macro hoops to append the line
  * number to the variable name in order to reduce the chance of a name


### PR DESCRIPTION
IBM XL compiler does not support "used" attribute and throws a warning.