### PR TITLE
Ch4 rma coverity fix

### DIFF
--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -112,7 +112,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_get_info_accu_ops_str(uint32_t val, cha
                                  "bxor,land,lor,lxor,replace,no_op,cswap") + 1);
 
     if (val & (1 << MPIDI_CH4I_ACCU_MAX_SHIFT))
-        c += snprintf(buf + c, maxlen - c, "%smax", (c > 0) ? "," : "");
+        c += snprintf(buf + c, maxlen - c, "max");
     if (val & (1 << MPIDI_CH4I_ACCU_MIN_SHIFT))
         c += snprintf(buf + c, maxlen - c, "%smin", (c > 0) ? "," : "");
     if (val & (1 << MPIDI_CH4I_ACCU_SUM_SHIFT))

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -50,6 +50,9 @@ MPL_STATIC_INLINE_PREFIX uint32_t MPIDI_CH4I_parse_info_accu_ops_str(const char 
     uint32_t ops = 0;
     char *value, *token, *savePtr = NULL;
 
+    /* str can never be NULL. */
+    MPIR_Assert(str);
+
     value = (char *) str;
     token = (char *) strtok_r(value, ",", &savePtr);
     while (token != NULL) {
@@ -212,6 +215,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4I_win_set_info(MPIR_Win * win, MPIR_Info *
                 /* For MPI-3, "none" means no ordering and is not default. */
                 goto next;
             }
+
+            /* value can never be NULL. */
+            MPIR_Assert(curr_ptr->value);
+
             value = curr_ptr->value;
             token = (char *) strtok_r(value, ",", &savePtr);
 


### PR DESCRIPTION
- Fixes some coverity warning caused by recent RMA merge.
- Handles window info setting of `which_accumulate_ops` with empty value (should be ignored)