### PR TITLE
travis: Add matrix builds for ch3/ch4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,22 @@ os:
   - linux
   - osx
 
+env:
+  - DEVICE=ch3:nemesis
+  - DEVICE=ch3:sock
+  - DEVICE=ch4:ofi
+  - DEVICE=ch4:ucx
+
+matrix:
+  exclude:
+    - os: osx
+      env: DEVICE=ch4:ofi
+    - os: osx
+      env: DEVICE=ch4:ucx
+
 addons:
   apt:
-    packages: gfortran
+    packages: gfortran libnuma-dev
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; brew install gcc; fi
@@ -18,5 +31,5 @@ before_script:
 
 script:
   - ./autogen.sh
-  - ./configure --prefix=$PWD/i
+  - ./configure --prefix=$PWD/i --with-device=$DEVICE
   - make -j2 install

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,13 @@ addons:
   apt:
     packages: gfortran libnuma-dev
 
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; brew install gcc; fi
-
 before_script:
   - MPICH_DEPS_PREFIX=$HOME/autotools ./maint/bootstrap.sh
   - export PATH=$HOME/autotools/bin:$PATH
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then MPICH_FORTRAN=--disable-fortran; fi
+
 
 script:
   - ./autogen.sh
-  - ./configure --prefix=$PWD/i --with-device=$DEVICE
+  - ./configure --prefix=$PWD/i --with-device=$DEVICE $MPICH_FORTRAN
   - make -j2 install


### PR DESCRIPTION
Exclude ch4 builds on OSX for now as they take too long. We can add
them back after refactoring.

No reviewer.