### PR TITLE
travis: Disable ch4 builds for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ os:
 env:
   - DEVICE=ch3:nemesis
   - DEVICE=ch3:sock
-  - DEVICE=ch4:ofi
-  - DEVICE=ch4:ucx
+#  - DEVICE=ch4:ofi
+#  - DEVICE=ch4:ucx
 
 matrix:
   exclude:


### PR DESCRIPTION
ch4 builds have a tendency to timeout even on Linux machines. Comment
them out until we complete the .h -> .c refactoring.