### PR TITLE
test/datatype: make typename check consistently

### DIFF
--- a/src/mpi/datatype/type_get_name.c
+++ b/src/mpi/datatype/type_get_name.c
@@ -55,10 +55,10 @@ static mpi_names_t mpi_names[] = {
     type_name_entry(MPI_FLOAT),
     type_name_entry(MPI_DOUBLE),
     type_name_entry(MPI_LONG_DOUBLE),
-    /* LONG_LONG_INT is allowed as an alias; we don't make it a separate
+    /* LONG_LONG is a synonym of LONG_LONG_INT; we don't make it a separate
      * type */
-/*    type_name_entry(MPI_LONG_LONG_INT), */
-    type_name_entry(MPI_LONG_LONG),
+/*    type_name_entry(MPI_LONG_LONG), */
+    type_name_entry(MPI_LONG_LONG_INT),
     type_name_entry(MPI_UNSIGNED_LONG_LONG),
     type_name_entry(MPI_PACKED),
     type_name_entry(MPI_LB),

--- a/src/mpi/datatype/type_get_name.c
+++ b/src/mpi/datatype/type_get_name.c
@@ -110,7 +110,10 @@ static mpi_names_t mpi_names[] = {
     type_name_entry(MPI_UINT32_T),
     type_name_entry(MPI_UINT64_T),
     type_name_entry(MPI_C_BOOL),
-    type_name_entry(MPI_C_FLOAT_COMPLEX),
+    /* C_FLOAT_COMPLEX is a synonym of C_COMPLEX; we don't make it a separate
+     * type */
+/*    type_name_entry(MPI_C_FLOAT_COMPLEX), */
+    type_name_entry(MPI_C_COMPLEX),
     type_name_entry(MPI_C_DOUBLE_COMPLEX),
     type_name_entry(MPI_C_LONG_DOUBLE_COMPLEX),
 

--- a/test/mpi/cxx/datatype/typenamex.cxx
+++ b/test/mpi/cxx/datatype/typenamex.cxx
@@ -70,7 +70,10 @@ int main(int argc, char **argv)
             continue;
         name[0] = 0;
         mpi_names[i].dtype.Get_name(name, namelen);
-        if (strncmp(name, mpi_names[i].name, MPI::MAX_OBJECT_NAME)) {
+        if (strncmp(name, mpi_names[i].name, MPI::MAX_OBJECT_NAME) &&
+            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a vaild name */
+            (mpi_names[i].dtype != MPI::LONG_LONG ||
+             strncmp(name, "MPI_LONG_LONG_INT", MPI::MAX_OBJECT_NAME))) {
             errs++;
             cout << "Expected " << mpi_names[i].name << " but got :" << name << ": namelen " <<
                 namelen << "\n";

--- a/test/mpi/cxx/datatype/typenamex.cxx
+++ b/test/mpi/cxx/datatype/typenamex.cxx
@@ -120,7 +120,7 @@ void InitMPINames(void)
         {MPI::FLOAT, "MPI_FLOAT"},
         {MPI::DOUBLE, "MPI_DOUBLE"},
         {MPI::LONG_DOUBLE, "MPI_LONG_DOUBLE"},
-        /*    { MPI::LONG_LONG_INT, "MPI_LONG_LONG_INT" }, */
+        {MPI::LONG_LONG_INT, "MPI_LONG_LONG_INT"},
         {MPI::LONG_LONG, "MPI_LONG_LONG"},
         {MPI::UNSIGNED_LONG_LONG, "MPI_UNSIGNED_LONG_LONG"},
         {MPI::PACKED, "MPI_PACKED"},

--- a/test/mpi/cxx/datatype/typenamex.cxx
+++ b/test/mpi/cxx/datatype/typenamex.cxx
@@ -53,13 +53,13 @@ int main(int argc, char **argv)
     MPI::DOUBLE.Get_name(name, namelen);
     if (strncmp(name, "MPI_DOUBLE", MPI::MAX_OBJECT_NAME)) {
         errs++;
-        cout << "Expected MPI_DOUBLE but got :" << name << ":\n";
+        cout << "Expected MPI_DOUBLE but got :" << name << ": namelen " << namelen << "\n";
     }
 
     MPI::INT.Get_name(name, namelen);
     if (strncmp(name, "MPI_INT", MPI::MAX_OBJECT_NAME)) {
         errs++;
-        cout << "Expected MPI_INT but got :" << name << ":\n";
+        cout << "Expected MPI_INT but got :" << name << ": namelen " << namelen << "\n";
     }
 
     /* Now we try them ALL */
@@ -70,9 +70,10 @@ int main(int argc, char **argv)
             continue;
         name[0] = 0;
         mpi_names[i].dtype.Get_name(name, namelen);
-        if (strncmp(name, mpi_names[i].name, namelen)) {
+        if (strncmp(name, mpi_names[i].name, MPI::MAX_OBJECT_NAME)) {
             errs++;
-            cout << "Expected " << mpi_names[i].name << " but got " << name << "\n";
+            cout << "Expected " << mpi_names[i].name << " but got :" << name << ": namelen " <<
+                namelen << "\n";
         }
     }
 
@@ -82,7 +83,7 @@ int main(int argc, char **argv)
     MPI::INT.Get_name(name, namelen);
     if (strncmp(name, "int", MPI::MAX_OBJECT_NAME)) {
         errs++;
-        cout << "Expected int but got :" << name << ":\n";
+        cout << "Expected int but got :" << name << ": namelen " << namelen << "\n";
     }
 
     delete[]name;

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -79,6 +79,7 @@ static mpi_names_t mpi_names[] = {
     {MPI_UINT32_T, "MPI_UINT32_T"},
     {MPI_UINT64_T, "MPI_UINT64_T"},
     {MPI_C_BOOL, "MPI_C_BOOL"},
+    {MPI_C_COMPLEX, "MPI_C_COMPLEX"},
     {MPI_C_FLOAT_COMPLEX, "MPI_C_FLOAT_COMPLEX"},
     {MPI_C_DOUBLE_COMPLEX, "MPI_C_DOUBLE_COMPLEX"},
     {MPI_AINT, "MPI_AINT"},
@@ -174,6 +175,11 @@ int main(int argc, char **argv)
         /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is a vaild name */
         isSynonymName = (mpi_names[i].dtype == MPI_LONG_LONG &&
                          !strncmp(name, "MPI_LONG_LONG_INT", MPI_MAX_OBJECT_NAME));
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
+        /* C_FLOAT_COMPLEX is a synonym of C_COMPLEX, thus C_COMPLEX is a vaild name */
+        isSynonymName = isSynonymName || (mpi_names[i].dtype == MPI_C_FLOAT_COMPLEX &&
+                                          !strncmp(name, "MPI_C_COMPLEX", MPI_MAX_OBJECT_NAME));
+#endif
 
         if (strncmp(name, mpi_names[i].name, MPI_MAX_OBJECT_NAME) && !isSynonymName) {
             errs++;

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -141,13 +141,13 @@ int main(int argc, char **argv)
     MPI_Type_get_name(MPI_DOUBLE, name, &namelen);
     if (strncmp(name, "MPI_DOUBLE", MPI_MAX_OBJECT_NAME)) {
         errs++;
-        fprintf(stderr, "Expected MPI_DOUBLE but got :%s:\n", name);
+        fprintf(stderr, "Expected MPI_DOUBLE but got :%s:, namelen %d\n", name, namelen);
     }
 
     MPI_Type_get_name(MPI_INT, name, &namelen);
     if (strncmp(name, "MPI_INT", MPI_MAX_OBJECT_NAME)) {
         errs++;
-        fprintf(stderr, "Expected MPI_INT but got :%s:\n", name);
+        fprintf(stderr, "Expected MPI_INT but got :%s:, namelen %d\n", name, namelen);
     }
 
     /* Now we try them ALL */
@@ -169,9 +169,10 @@ int main(int argc, char **argv)
         MTestPrintfMsg(10, "Checking type %s\n", mpi_names[i].name);
         name[0] = 0;
         MPI_Type_get_name(mpi_names[i].dtype, name, &namelen);
-        if (strncmp(name, mpi_names[i].name, namelen)) {
+        if (strncmp(name, mpi_names[i].name, MPI_MAX_OBJECT_NAME)) {
             errs++;
-            fprintf(stderr, "Expected %s but got %s\n", mpi_names[i].name, name);
+            fprintf(stderr, "Expected %s but got :%s:, namelen %d\n", mpi_names[i].name, name,
+                    namelen);
         }
     }
 
@@ -181,7 +182,7 @@ int main(int argc, char **argv)
     MPI_Type_get_name(MPI_INT, name, &namelen);
     if (strncmp(name, "int", MPI_MAX_OBJECT_NAME)) {
         errs++;
-        fprintf(stderr, "Expected int but got :%s:\n", name);
+        fprintf(stderr, "Expected int but got :%s:, namelen %d\n", name, namelen);
     }
 #ifndef HAVE_MPI_INTEGER16
     errs++;

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -130,7 +130,7 @@ static mpi_names_t mpi_names[] = {
 int main(int argc, char **argv)
 {
     char name[MPI_MAX_OBJECT_NAME];
-    int namelen, i, inOptional;
+    int namelen, i, inOptional, isSynonymName;
     int errs = 0;
 
     MTest_Init(&argc, &argv);
@@ -152,6 +152,7 @@ int main(int argc, char **argv)
 
     /* Now we try them ALL */
     inOptional = 0;
+    isSynonymName = 0;
     for (i = 0; mpi_names[i].name != 0; i++) {
         /* Are we in the optional types? */
         if (strcmp(mpi_names[i].name, "MPI_REAL4") == 0)
@@ -169,7 +170,12 @@ int main(int argc, char **argv)
         MTestPrintfMsg(10, "Checking type %s\n", mpi_names[i].name);
         name[0] = 0;
         MPI_Type_get_name(mpi_names[i].dtype, name, &namelen);
-        if (strncmp(name, mpi_names[i].name, MPI_MAX_OBJECT_NAME)) {
+
+        /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is a vaild name */
+        isSynonymName = (mpi_names[i].dtype == MPI_LONG_LONG &&
+                         !strncmp(name, "MPI_LONG_LONG_INT", MPI_MAX_OBJECT_NAME));
+
+        if (strncmp(name, mpi_names[i].name, MPI_MAX_OBJECT_NAME) && !isSynonymName) {
             errs++;
             fprintf(stderr, "Expected %s but got :%s:, namelen %d\n", mpi_names[i].name, name,
                     namelen);

--- a/test/mpi/f77/datatype/allctypesf.f
+++ b/test/mpi/f77/datatype/allctypesf.f
@@ -70,10 +70,9 @@ C
           call checkdtype( MPI_UINT64_T, "MPI_UINT64_T", ierr )
 C other C99 types
           call checkdtype( MPI_C_BOOL, "MPI_C_BOOL", ierr )
-          call checkdtype( MPI_C_FLOAT_COMPLEX, "MPI_C_FLOAT_COMPLEX",
-     *                     ierr)
-          call checkdtype2( MPI_C_COMPLEX, "MPI_C_COMPLEX", 
-     *                      "MPI_C_FLOAT_COMPLEX", ierr )
+          call checkdtype2( MPI_C_FLOAT_COMPLEX, "MPI_C_COMPLEX",
+     *                      "MPI_C_FLOAT_COMPLEX", ierr)
+          call checkdtype( MPI_C_COMPLEX, "MPI_C_COMPLEX", ierr )
           call checkdtype( MPI_C_DOUBLE_COMPLEX, "MPI_C_DOUBLE_COMPLEX", 
      *                     ierr )
           if (MPI_C_LONG_DOUBLE_COMPLEX .ne. MPI_DATATYPE_NULL) then

--- a/test/mpi/f77/ext/ctypesfromc.c
+++ b/test/mpi/f77/ext/ctypesfromc.c
@@ -110,7 +110,9 @@ int f2ctype_(MPI_Fint * fhandle, MPI_Fint * typeidx)
          * corresponding C version of the MPI Datatype bit-for-bit.  But
          * if *must* act like it - e.g., the datatype name must be the same */
         MPI_Type_get_name(ctype, mytypename, &mytypenamelen);
-        if (strcmp(mytypename, mpi_names[*typeidx].name) != 0) {
+        if (strcmp(mytypename, mpi_names[*typeidx].name) != 0 &&
+            /* LONG_LONG is a synonym of LONG_LONG_INT, thus LONG_LONG_INT is also a vaild name */
+            (ctype != MPI_LONG_LONG || strcmp(mytypename, "MPI_LONG_LONG_INT") != 0)) {
             errs++;
             printf("C and Fortran types for %s (c name is %s) do not match f=%d, ctof=%d.\n",
                    mpi_names[*typeidx].name, mytypename, *fhandle, MPI_Type_c2f(ctype));


### PR DESCRIPTION
The datatype/typename.c test compared name with output namelen for some
datatypes. Error cannot be detected if namelen is zero. This patch uses
MPI_MAX_OBJECT_NAME in the name string comparison similar to the
remaining typename check calls. It also prints output namelen when error
occurs.