### PR TITLE
ch4/ofi: Move RMA datatype mapping to first window creation

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1009,9 +1009,6 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     OPA_store_int(&MPIDI_Global.am_inflight_inject_emus, 0);
     OPA_store_int(&MPIDI_Global.am_inflight_rma_send_mrs, 0);
 
-    MPIR_Datatype_init_names();
-    MPIDI_OFI_index_datatypes();
-
 #ifndef HAVE_DEBUGGER_SUPPORT
     MPIDI_Global.lw_send_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     if (MPIDI_Global.lw_send_req == NULL) {

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -512,6 +512,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_init(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_INIT);
 
+    MPIR_Datatype_init_names();
+    MPIDI_OFI_index_datatypes();
+
     CH4_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devwin_t) >= sizeof(MPIDI_OFI_win_t));
     CH4_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devdt_t) >= sizeof(MPIDI_OFI_datatype_t));
 

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -526,7 +526,11 @@ static inline void add_index(MPI_Datatype datatype, int *index)
 
 void MPIDI_OFI_index_datatypes()
 {
+    static bool needs_init = true;
     int index = 0;
+
+    if (!needs_init)
+        return;
 
     add_index(MPI_CHAR, &index);
     add_index(MPI_UNSIGNED_CHAR, &index);
@@ -613,4 +617,7 @@ void MPIDI_OFI_index_datatypes()
     /* do not generate map when atomics are not enabled */
     if (MPIDI_OFI_ENABLE_ATOMICS)
         create_dt_map();
+
+    /* only need to do this once */
+    needs_init = false;
 }


### PR DESCRIPTION
[c6b1a1c8c41] broke the way ch4/ofi mapped MPI datatypes to OFI
datatypes for RMA atomic operations. Because we cannot guarantee a
fully-functional datatype system at NM init time, move this mapping to
window creation. A static boolean variable ensures the mapping is done
only once.

Fixes pmodels/mpich#3420
Fixes pmodels/mpich#3421