### PR TITLE
coll: Check internal function return code

### DIFF
--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -65,8 +65,17 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         }
 
         /* Get the local intracommunicator */
-        if (!comm_ptr->local_comm)
-            MPII_Setup_intercomm_localcomm(comm_ptr);
+        if (!comm_ptr->local_comm) {
+            mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
+            if (mpi_errno) {
+                /* for communication errors, just record the error but continue */
+                *errflag =
+                    MPIX_ERR_PROC_FAILED ==
+                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+            }
+        }
 
         newcomm_ptr = comm_ptr->local_comm;
 


### PR DESCRIPTION
Now that we're checking the return code of
`MPII_Setup_intercomm_localcomm` in more places, Coverity wants us to do
it everywhere. Adding the check of the return code here fixes that
problem.