### PR TITLE
hydra: Make sure proxy is aware of inherited variables

### DIFF
--- a/src/pm/hydra/pm/pmiserv/pmip_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_utils.c
@@ -342,9 +342,13 @@ static HYD_status global_env_fn(char *arg, char ***argv)
             str[strlen(str) - 1] = 0;
         }
 
-        if (!strcmp(arg, "global-inherited-env"))
+        if (!strcmp(arg, "global-inherited-env")) {
             HYDU_append_env_str_to_list(str, &HYD_pmcd_pmip.user_global.global_env.inherited);
-        else if (!strcmp(arg, "global-system-env"))
+            /* Make sure to let proxy aware of HYDRA related variables */
+            if (!strncmp(str, "HYDRA_", 6)) {
+                MPL_putenv(str);
+            }
+        } else if (!strcmp(arg, "global-system-env"))
             HYDU_append_env_str_to_list(str, &HYD_pmcd_pmip.user_global.global_env.system);
         else if (!strcmp(arg, "global-user-env"))
             HYDU_append_env_str_to_list(str, &HYD_pmcd_pmip.user_global.global_env.user);


### PR DESCRIPTION
This PR fixes Issue https://github.com/pmodels/mpich/issues/3361.

`mpiexec.hydra` invokes proxies passing all the env variables via command line: `--global-inherited-env #count "A=.." "B=.." ...`. These variables are copied into environment of commands when proxy launches them; however, they are not necessary in proxy itself's environment -- especially when the proxy is launched through cobalt or manual mode. 

This patch copies certain variables -- those starts with `HYDRA_` into proxy's environment so debug settings such as `HYDRA_TOPO_DEBUG` will work. We limit to small set of variables to limit its impact. Most inherited variables are global across the launching environment, so they usually don't pose problem any way. 