### PR TITLE
test/dtpools: Force usage of MPICC

### DIFF
--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -23,6 +23,11 @@ AH_BOTTOM([
 #endif /* !defined(DTPOOLSCONF_H_INCLUDED) */
 ])
 
+# Ensure we have an MPI compiler wrapper
+if test -n "$MPICC" ; then
+  CC=$MPICC
+fi
+
 # Checks for programs.
 AC_PROG_AWK
 AC_PROG_CC


### PR DESCRIPTION
If an environment has both CC and MPICC variables set, the DTPools
configure will use CC in its configuration. This happens regardless of
what the testsuite sets before invoking the DTPools configure, leading
to compilation error when building the DTPools library. Force the
usage of MPICC to fix an issue in the nightly ABI tests in Jenkins.