### PR TITLE
request: Fix duplicate symbol with profiling library

### DIFF
--- a/src/mpi/coll/op/op_create.c
+++ b/src/mpi/coll/op/op_create.c
@@ -65,7 +65,6 @@ void MPII_Op_set_fc(MPI_Op op)
 }
 #endif
 
-#endif /* MPICH_MPI_FROM_PMPI */
 
 #undef FUNCNAME
 #define FUNCNAME MPIR_Op_create_impl
@@ -103,6 +102,8 @@ int MPIR_Op_create_impl(MPI_User_function * user_fn, int commute, MPI_Op * op)
   fn_fail:
     goto fn_exit;
 }
+
+#endif /* MPICH_MPI_FROM_PMPI */
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Op_create

--- a/src/mpi/coll/op/op_free.c
+++ b/src/mpi/coll/op/op_free.c
@@ -25,7 +25,6 @@ int MPI_Op_free(MPI_Op * op) __attribute__ ((weak, alias("PMPI_Op_free")));
 #undef MPI_Op_free
 #define MPI_Op_free PMPI_Op_free
 
-#endif
 
 #undef FUNCNAME
 #define FUNCNAME MPIR_Op_free_impl
@@ -48,6 +47,8 @@ void MPIR_Op_free_impl(MPI_Op * op)
     }
     *op = MPI_OP_NULL;
 }
+
+#endif
 
 #undef FUNCNAME
 #define FUNCNAME MPI_Op_free

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -11,6 +11,25 @@
 #define MPIR_REQUEST_PTR_ARRAY_SIZE 16
 #endif
 
+/* -- Begin Profiling Symbol Block for routine MPI_Waitany */
+#if defined(HAVE_PRAGMA_WEAK)
+#pragma weak MPI_Waitany = PMPI_Waitany
+#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
+#pragma _HP_SECONDARY_DEF PMPI_Waitany  MPI_Waitany
+#elif defined(HAVE_PRAGMA_CRI_DUP)
+#pragma _CRI duplicate MPI_Waitany as PMPI_Waitany
+#elif defined(HAVE_WEAK_ATTRIBUTE)
+int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Status * status)
+    __attribute__ ((weak, alias("PMPI_Waitany")));
+#endif
+/* -- End Profiling Symbol Block */
+
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPI_Waitany
+#define MPI_Waitany PMPI_Waitany
+
 #undef FUNCNAME
 #define FUNCNAME MPIR_Waitany
 #undef FCNAME
@@ -88,25 +107,6 @@ int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_S
   fn_fail:
     goto fn_exit;
 }
-
-/* -- Begin Profiling Symbol Block for routine MPI_Waitany */
-#if defined(HAVE_PRAGMA_WEAK)
-#pragma weak MPI_Waitany = PMPI_Waitany
-#elif defined(HAVE_PRAGMA_HP_SEC_DEF)
-#pragma _HP_SECONDARY_DEF PMPI_Waitany  MPI_Waitany
-#elif defined(HAVE_PRAGMA_CRI_DUP)
-#pragma _CRI duplicate MPI_Waitany as PMPI_Waitany
-#elif defined(HAVE_WEAK_ATTRIBUTE)
-int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Status * status)
-    __attribute__ ((weak, alias("PMPI_Waitany")));
-#endif
-/* -- End Profiling Symbol Block */
-
-/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
-   the MPI routines */
-#ifndef MPICH_MPI_FROM_PMPI
-#undef MPI_Waitany
-#define MPI_Waitany PMPI_Waitany
 
 #endif
 


### PR DESCRIPTION
Moves profiling macros to the top of waitany.c to be consistent with
other files in src/mpi. The preprocessor guards ensure we only include
MPIR_Waitany_impl in libpmpi. Otherwise the linker may throw an error
when statically building an MPI program. See pmodels/mpich#3449.