### PR TITLE
shm_alloc: fix bug in shm segment allocation

### DIFF
--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -619,6 +619,9 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
     MPIR_CHKPMEM_COMMIT();
   fn_exit:
+    /* reset segment_len to zero */
+    segment_len = 0;
+
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_SHM_SEG_COMMIT);
     return mpi_errno;


### PR DESCRIPTION
The `MPIDU_shm_seg_alloc` and `MPIDU_shm_seg_commit` book memory space
for shared memory and allocate it, respectively. The amount of the total
memory requested is tracked by the alloc function using a static global
variable (i.e., `segmen_len`). When the commit terminates this variable
should be reset to zero but it's not. This does not seem to be a problem
in CH3. However, in CH4 after allocating the first shared memory segment
for intranode communication, the netmods themselves allocate another
segment for business card exchange. Because `segment_len` is never reset
the length of such segment adds to the previous intranode shm segment
length.

This patch fixes the problem by resetting `segment_len` to zero after
every invocation of the commit function.