### PR TITLE
ch4: Use lightweight complete request from MPIR

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -560,14 +560,14 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* Set the number of tag bits. The device may override this value. */
     MPIR_Process.tag_bits = MPIR_TAG_BITS_DEFAULT;
 
-    mpi_errno = MPID_Init(argc, argv, required, &thread_provided, &has_args, &has_env);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
     /* Create complete request to return in the event of immediately complete
      * operations. Use a SEND request to cover all possible use-cases. */
     MPIR_Process.lw_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_cc_set(&MPIR_Process.lw_req->cc, 0);
+
+    mpi_errno = MPID_Init(argc, argv, required, &thread_provided, &has_args, &has_env);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
     /* Initialize collectives infrastructure */
     mpi_errno = MPII_Coll_init();

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -207,21 +207,6 @@
         MPIR_Request_add_ref((req));                                \
     } while (0)
 
-#ifndef HAVE_DEBUGGER_SUPPORT
-#define MPIDI_OFI_SEND_REQUEST_CREATE_LW(req)                   \
-    do {                                                                \
-        (req) = MPIDI_Global.lw_send_req;                               \
-        MPIR_Request_add_ref((req));                                    \
-    } while (0)
-#else
-#define MPIDI_OFI_SEND_REQUEST_CREATE_LW(req)                   \
-    do {                                                                \
-        (req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);           \
-        MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq"); \
-        MPIR_cc_set(&(req)->cc, 0);                                     \
-    } while (0)
-#endif
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_need_request_creation(const MPIR_Request * req)
 {
     if (MPIDI_CH4_MT_MODEL == MPIDI_CH4_MT_TRYLOCK) {
@@ -274,7 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_lw_request_cc_val(void)
 #define MPIDI_OFI_SEND_REQUEST_CREATE_LW_CONDITIONAL(req)               \
     do {                                                                \
         if (MPIDI_CH4_MT_MODEL == MPIDI_CH4_MT_DIRECT) {                \
-            MPIDI_OFI_SEND_REQUEST_CREATE_LW(req);                      \
+            (req) = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND); \
         } else {                                                        \
             if (MPIDI_OFI_need_request_creation(req)) {                 \
                 MPIR_Assert((req) == NULL);                             \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -911,14 +911,6 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     OPA_store_int(&MPIDI_Global.am_inflight_inject_emus, 0);
     OPA_store_int(&MPIDI_Global.am_inflight_rma_send_mrs, 0);
 
-#ifndef HAVE_DEBUGGER_SUPPORT
-    MPIDI_Global.lw_send_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-    if (MPIDI_Global.lw_send_req == NULL) {
-        MPIR_ERR_SETFATALANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
-    }
-    MPIR_cc_set(&MPIDI_Global.lw_send_req->cc, 0);
-#endif
-
     /* -------------------------------- */
     /* Initialize Dynamic Tasking       */
     /* -------------------------------- */
@@ -1043,10 +1035,6 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_FI_MUTEX, &thr_err);
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_SPAWN_MUTEX, &thr_err);
-
-#ifndef HAVE_DEBUGGER_SUPPORT
-    MPIR_Request_free(MPIDI_Global.lw_send_req);
-#endif
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_FINALIZE);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -498,13 +498,8 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     goto fn_exit;
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
-    if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        MPIR_Request_add_ref(*sigreq);
-        MPIDI_CH4U_request_complete(*sigreq);
-    }
+    if (sigreq)
+        *sigreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
     goto fn_exit;
 }
 
@@ -679,13 +674,8 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     goto fn_exit;
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
-    if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        MPIR_Request_add_ref(*sigreq);
-        MPIDI_CH4U_request_complete(*sigreq);
-    }
+    if (sigreq)
+        *sigreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
     goto fn_exit;
 }
 
@@ -1011,13 +1001,8 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
                                      win);
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
-    if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        MPIR_Request_add_ref(*sigreq);
-        MPIDI_CH4U_request_complete(*sigreq);
-    }
+    if (sigreq)
+        *sigreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
     goto fn_exit;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -420,9 +420,6 @@ typedef struct {
     /* Communication info for dynamic processes */
     MPIDI_OFI_conn_manager_t conn_mgr;
 
-    /* complete request used for lightweight sends */
-    MPIR_Request *lw_send_req;
-
     /* Capability settings */
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS
     MPIDI_OFI_capabilities_t settings;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -105,14 +105,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
 
     MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
 
-#ifndef HAVE_DEBUGGER_SUPPORT
-    MPIDI_UCX_global.lw_send_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-    if (MPIDI_UCX_global.lw_send_req == NULL) {
-        MPIR_ERR_SETFATALANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
-    }
-    MPIR_cc_set(&MPIDI_UCX_global.lw_send_req->cc, 0);
-#endif
-
     *tag_bits = MPIR_TAG_BITS_DEFAULT;
 
   fn_exit:
@@ -205,10 +197,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     MPIR_Comm_release_always(comm);
 
     MPIDIG_finalize();
-
-#ifndef HAVE_DEBUGGER_SUPPORT
-    MPIR_Request_free(MPIDI_UCX_global.lw_send_req);
-#endif
 
   fn_exit:
     MPL_free(pending);

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -103,13 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
     } else if (req != NULL) {
         MPIR_cc_set(&req->cc, 0);
     } else if (have_request) {
-#ifndef HAVE_DEBUGGER_SUPPORT
-        req = MPIDI_UCX_global.lw_send_req;
-        MPIR_Request_add_ref(req);
-#else
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_cc_set(&req->cc, 0);
-#endif
+        req = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
     }
     *request = req;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -36,7 +36,6 @@ typedef struct {
     char kvsname[MPIDI_UCX_KVSAPPSTRLEN];
     char pname[MPI_MAX_PROCESSOR_NAME];
     int max_addr_len;
-    MPIR_Request *lw_send_req;
 } MPIDI_UCX_global_t;
 
 #define MPIDI_UCX_AV(av)     ((av)->netmod.ucx)

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -771,14 +771,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rput(const void *origin_addr,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (sreq == NULL) {
+    if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-        MPIR_Request_add_ref(sreq);
-        MPID_Request_complete(sreq);
-    }
+        sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
 
   fn_exit:
     *request = sreq;
@@ -845,14 +840,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget(void *origin_addr,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (sreq == NULL) {
+    if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-        MPIR_Request_add_ref(sreq);
-        MPID_Request_complete(sreq);
-    }
+        sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
 
   fn_exit:
     *request = sreq;
@@ -888,14 +878,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_raccumulate(const void *origin_addr,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (sreq == NULL) {
+    if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-        MPIR_Request_add_ref(sreq);
-        MPID_Request_complete(sreq);
-    }
+        sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
 
   fn_exit:
     *request = sreq;
@@ -970,14 +955,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_CH4U_mpi_rget_accumulate(const void *origin_a
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (sreq == NULL) {
+    if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-        MPIR_Request_add_ref(sreq);
-        MPID_Request_complete(sreq);
-    }
+        sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
 
   fn_exit:
     *request = sreq;


### PR DESCRIPTION
Remove the private lightweight completed requests in ch4 netmods and
use the one provided in MPIR.