### PR TITLE
romio: Fix code style problems

### DIFF
--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
@@ -158,7 +158,7 @@ void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
 
     ADIOI_Flatlist_node *flat_buf, *flat_file;
     ADIO_Offset i_offset, new_brd_size, brd_size, size;
-    int i, j, k, err, err_flag=0, st_index = 0;
+    int i, j, k, err, err_flag = 0, st_index = 0;
     MPI_Count num, bufsize;
     int n_etypes_in_filetype;
     ADIO_Offset n_filetypes, etype_in_filetype, st_n_filetypes, size_in_filetype;

--- a/src/mpi/romio/adio/common/ad_iread_fake.c
+++ b/src/mpi/romio/adio/common/ad_iread_fake.c
@@ -18,7 +18,7 @@ void ADIOI_FAKE_IreadContig(ADIO_File fd, void *buf, int count,
     ADIO_Status status;
     MPI_Count typesize;
     MPI_Offset len;
-    int actual_len=0;
+    int actual_len = 0;
 
 
     MPI_Type_size_x(datatype, &typesize);

--- a/src/mpi/romio/adio/common/ad_set_view.c
+++ b/src/mpi/romio/adio/common/ad_set_view.c
@@ -45,7 +45,8 @@ int check_type(ADIOI_Flatlist_node * flat_type,
   err_check:
     *error_code = MPIO_Err_create_code(*error_code,
                                        MPIR_ERR_RECOVERABLE, caller,
-                                       __LINE__, MPI_ERR_IO, "**iobadoverlap", " **iobadoverlap %s", err_msg);
+                                       __LINE__, MPI_ERR_IO, "**iobadoverlap", " **iobadoverlap %s",
+                                       err_msg);
     return 0;
 }
 


### PR DESCRIPTION
It appears that a patch was committed directly instead of going through
GitHub PRs with their style checkers.