### PR TITLE
ROMIO: combine multiple malloc/calloc

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -250,8 +250,8 @@ void ADIOI_GPFS_Calc_file_domains(ADIO_File fd,
      fd_size = min_fd_size;
      */
     fd_size = (ADIO_Offset *) ADIOI_Malloc(nprocs_for_coll * sizeof(ADIO_Offset));
-    *fd_start_ptr = (ADIO_Offset *) ADIOI_Malloc(nprocs_for_coll * sizeof(ADIO_Offset));
-    *fd_end_ptr = (ADIO_Offset *) ADIOI_Malloc(nprocs_for_coll * sizeof(ADIO_Offset));
+    *fd_start_ptr = (ADIO_Offset *) ADIOI_Malloc(nprocs_for_coll * 2 * sizeof(ADIO_Offset));
+    *fd_end_ptr = *fd_start_ptr + nprocs_for_coll;
     fd_start = *fd_start_ptr;
     fd_end = *fd_end_ptr;
 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -136,34 +136,32 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     nprocs_for_coll = fd->hints->cb_nodes;
     orig_fp = fd->fp_ind;
 
-    GPFSMPIO_T_CIO_SET_GET(w, 1, 0, GPFSMPIO_CIO_T_MPIO_CRW, GPFSMPIO_CIO_LAST)
-        GPFSMPIO_T_CIO_SET_GET(w, 1, 0, GPFSMPIO_CIO_T_LCOMP, GPFSMPIO_CIO_LAST)
+    GPFSMPIO_T_CIO_SET_GET(w, 1, 0, GPFSMPIO_CIO_T_MPIO_CRW, GPFSMPIO_CIO_LAST);
+    GPFSMPIO_T_CIO_SET_GET(w, 1, 0, GPFSMPIO_CIO_T_LCOMP, GPFSMPIO_CIO_LAST);
 
-
-        /* only check for interleaving if cb_write isn't disabled */
-        if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
+    /* only check for interleaving if cb_write isn't disabled */
+    if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
         /* For this process's request, calculate the list of offsets and
-         * lengths in the file and determine the start and end offsets. */
-
-        /* Note: end_offset points to the last byte-offset that will be accessed.
-         * e.g., if start_offset=0 and 100 bytes to be read, end_offset=99 */
-
+         * lengths in the file and determine the start and end offsets.
+         * Note: end_offset points to the last byte-offset to be accessed.
+         * e.g., if start_offset=0 and 100 bytes to be read, end_offset=99
+         */
         ADIOI_Calc_my_off_len(fd, count, datatype, file_ptr_type, offset,
                               &offset_list, &len_list, &start_offset,
                               &end_offset, &contig_access_count);
 
-        GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_GATHER, GPFSMPIO_CIO_T_LCOMP)
+        GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_GATHER, GPFSMPIO_CIO_T_LCOMP);
 
-            /* each process communicates its start and end offsets to other
-             * processes. The result is an array each of start and end offsets stored
-             * in order of process rank. */
-            st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-        end_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
+        /* each process communicates its start and end offsets to other
+         * processes. The result is an array each of start and end offsets stored
+         * in order of process rank. */
+        st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * 2 * sizeof(ADIO_Offset));
+        end_offsets = st_offsets + nprocs;
 
         ADIO_Offset my_count_size = 0;
-        /* One-sided aggregation needs the amount of data per rank as well because
-         * the difference in starting and ending offsets for 1 byte is 0 the same
-         * as 0 bytes so it cannot be distiguished.
+        /* One-sided aggregation needs the amount of data per rank as well
+         * because the difference in starting and ending offsets for 1 byte is
+         * 0 the same as 0 bytes so it cannot be distiguished.
          */
         if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
@@ -173,8 +171,8 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         }
         if (romio_tunegather) {
             if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
-                gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(3 * nprocs * sizeof(ADIO_Offset));
-                gpfs_offsets = (ADIO_Offset *) ADIOI_Malloc(3 * nprocs * sizeof(ADIO_Offset));
+                gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(6 * nprocs * sizeof(ADIO_Offset));
+                gpfs_offsets = gpfs_offsets0 + 3 * nprocs;
                 for (ii = 0; ii < nprocs; ii++) {
                     gpfs_offsets0[ii * 3] = 0;
                     gpfs_offsets0[ii * 3 + 1] = 0;
@@ -209,7 +207,6 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                 }
             }
             ADIOI_Free(gpfs_offsets0);
-            ADIOI_Free(gpfs_offsets);
         } else {
             MPI_Allgather(&start_offset, 1, ADIO_OFFSET, st_offsets, 1, ADIO_OFFSET, fd->comm);
             MPI_Allgather(&end_offset, 1, ADIO_OFFSET, end_offsets, 1, ADIO_OFFSET, fd->comm);
@@ -219,10 +216,10 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
             }
         }
 
-        GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_PATANA, GPFSMPIO_CIO_T_GATHER)
+        GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_PATANA, GPFSMPIO_CIO_T_GATHER);
 
-            /* are the accesses of different processes interleaved? */
-            for (i = 1; i < nprocs; i++)
+        /* are the accesses of different processes interleaved? */
+        for (i = 1; i < nprocs; i++)
             if ((st_offsets[i] < end_offsets[i - 1]) && (st_offsets[i] <= end_offsets[i]))
                 interleave_count++;
         /* This is a rudimentary check for interleaving, but should suffice
@@ -236,16 +233,13 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         /* use independent accesses */
         if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
             ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
         }
 
         fd->fp_ind = orig_fp;
         ADIOI_Datatype_iscontig(fd->filetype, &filetype_is_contig);
 
         if (buftype_is_contig && filetype_is_contig) {
-
             if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
                 off = fd->disp + (ADIO_Offset) (fd->etype_size) * offset;
                 ADIO_WriteContig(fd, buf, count, datatype,
@@ -291,7 +285,6 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                                          nprocs_for_coll, &min_st_offset,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
         } else {
-
             ADIOI_GPFS_Calc_file_domains(fd, st_offsets, end_offsets, nprocs,
                                          nprocs_for_coll, &min_st_offset,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
@@ -339,13 +332,10 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         if (!romio_onesided_no_rmw)
             MPI_Allreduce(&holeFound, &anyHolesFound, 1, MPI_INT, MPI_MAX, fd->comm);
         if (anyHolesFound == 0) {
-            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs)
-                ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
+            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
+            ADIOI_Free(offset_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
             ADIOI_Free(fd_start);
-            ADIOI_Free(fd_end);
             ADIOI_Free(count_sizes);
             goto fn_exit;
         } else {
@@ -368,22 +358,23 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                                            currentValidDataIndex, fd_start, fd_end, &holeFound,
                                            noStripeParms);
             romio_onesided_no_rmw = prev_romio_onesided_no_rmw;
-            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs)
-                ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
+            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
+            ADIOI_Free(offset_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
             ADIOI_Free(fd_start);
-            ADIOI_Free(fd_end);
             ADIOI_Free(count_sizes);
             goto fn_exit;
         }
     }
     if (gpfsmpio_p2pcontig == 1) {
-        /* For some simple yet common(?) workloads, full-on two-phase I/O is overkill.  We can establish sub-groups of processes and their aggregator, and then these sub-groups will carry out a simplified two-phase over that sub-group.
+        /* For some simple yet common(?) workloads, full-on two-phase I/O is
+         * overkill.  We can establish sub-groups of processes and their
+         * aggregator, and then these sub-groups will carry out a simplified
+         * two-phase over that sub-group.
          *
          * First verify that the filetype is contig and the offsets are
-         * increasing in rank order*/
+         * increasing in rank order
+         */
         int inOrderAndNoGaps = 1;
         for (i = 0; i < (nprocs - 1); i++) {
             if (end_offsets[i] != (st_offsets[i + 1] - 1))
@@ -395,15 +386,11 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
             ADIOI_P2PContigWriteAggregation(fd, buf,
                                             error_code, st_offsets, end_offsets, fd_start, fd_end);
             /* NOTE: we are skipping the rest of two-phase in this path */
-            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs)
+            GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
 
-                ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
+            ADIOI_Free(offset_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
             ADIOI_Free(fd_start);
-            ADIOI_Free(fd_end);
-
             goto fn_exit;
         }
     }
@@ -421,15 +408,16 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                           min_st_offset, fd_start, fd_end, fd_size,
                           nprocs, &count_my_req_procs, &count_my_req_per_proc, &my_req, &buf_idx);
 
-    GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_OTHREQ, GPFSMPIO_CIO_T_MYREQ)
+    GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_OTHREQ, GPFSMPIO_CIO_T_MYREQ);
 
-/* based on everyone's my_req, calculate what requests of other
-   processes lie in this process's file domain.
-   count_others_req_procs = number of processes whose requests lie in
-   this process's file domain (including this process itself)
-   count_others_req_per_proc[i] indicates how many separate contiguous
-   requests of proc. i lie in this process's file domain. */
-        if (gpfsmpio_tuneblocking)
+    /* based on everyone's my_req, calculate what requests of other
+     * processes lie in this process's file domain.
+     * count_others_req_procs = number of processes whose requests lie in
+     * this process's file domain (including this process itself)
+     * count_others_req_per_proc[i] indicates how many separate contiguous
+     * requests of proc. i lie in this process's file domain.
+     */
+    if (gpfsmpio_tuneblocking)
         ADIOI_GPFS_Calc_others_req(fd, count_my_req_procs,
                                    count_my_req_per_proc, my_req,
                                    nprocs, myrank, &count_others_req_procs, &others_req);
@@ -438,43 +426,31 @@ void ADIOI_GPFS_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                               count_my_req_per_proc, my_req,
                               nprocs, myrank, &count_others_req_procs, &others_req);
 
-    GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ)
+    GPFSMPIO_T_CIO_SET_GET(w, 1, 1, GPFSMPIO_CIO_T_DEXCH, GPFSMPIO_CIO_T_OTHREQ);
 
-        ADIOI_Free(count_my_req_per_proc);
-    for (i = 0; i < nprocs; i++) {
-        if (my_req[i].count) {
-            ADIOI_Free(my_req[i].offsets);
-        }
-    }
+    ADIOI_Free(count_my_req_per_proc);
+    ADIOI_Free(my_req[0].offsets);
     ADIOI_Free(my_req);
 
-/* exchange data and write in sizes of no more than coll_bufsize. */
+    /* exchange data and write in sizes of no more than coll_bufsize. */
     ADIOI_Exch_and_write(fd, buf, datatype, nprocs, myrank,
                          others_req, offset_list,
                          len_list, contig_access_count, min_st_offset,
                          fd_size, fd_start, fd_end, buf_idx, error_code);
 
-    GPFSMPIO_T_CIO_SET_GET(w, 0, 1, GPFSMPIO_CIO_LAST, GPFSMPIO_CIO_T_DEXCH)
-        GPFSMPIO_T_CIO_SET_GET(w, 0, 1, GPFSMPIO_CIO_LAST, GPFSMPIO_CIO_T_MPIO_CRW)
+    GPFSMPIO_T_CIO_SET_GET(w, 0, 1, GPFSMPIO_CIO_LAST, GPFSMPIO_CIO_T_DEXCH);
+    GPFSMPIO_T_CIO_SET_GET(w, 0, 1, GPFSMPIO_CIO_LAST, GPFSMPIO_CIO_T_MPIO_CRW);
+    GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs);
 
-        GPFSMPIO_T_CIO_REPORT(1, fd, myrank, nprocs)
-
-/* free all memory allocated for collective I/O */
-        for (i = 0; i < nprocs; i++) {
-        if (others_req[i].count) {
-            ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].mem_ptrs);
-        }
-    }
+    /* free all memory allocated for collective I/O */
+    ADIOI_Free(others_req[0].offsets);
+    ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
 
     ADIOI_Free(buf_idx);
     ADIOI_Free(offset_list);
-    ADIOI_Free(len_list);
     ADIOI_Free(st_offsets);
-    ADIOI_Free(end_offsets);
     ADIOI_Free(fd_start);
-    ADIOI_Free(fd_end);
 
   fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
@@ -723,9 +699,9 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
     /* amount of data sent to each proc so far. Used in
      * ADIOI_Fill_send_buffer. initialized to 0 here. */
 
-    send_buf_idx = (int *) ADIOI_Malloc(nprocs * sizeof(int));
-    curr_to_proc = (int *) ADIOI_Malloc(nprocs * sizeof(int));
-    done_to_proc = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    send_buf_idx = (int *) ADIOI_Malloc(nprocs * 3 * sizeof(int));
+    curr_to_proc = send_buf_idx + nprocs;
+    done_to_proc = curr_to_proc + nprocs;
     /* Above three are used in ADIOI_Fill_send_buffer */
 
     start_pos = (int *) ADIOI_Malloc(nprocs * sizeof(int));
@@ -964,8 +940,6 @@ static void ADIOI_Exch_and_write(ADIO_File fd, const void *buf, MPI_Datatype
     ADIOI_Free(sent_to_proc);
     ADIOI_Free(start_pos);
     ADIOI_Free(send_buf_idx);
-    ADIOI_Free(curr_to_proc);
-    ADIOI_Free(done_to_proc);
 
     if (ntimes != 0 && getenv("ROMIO_GPFS_DECLARE_ACCESS") != NULL) {
         gpfs_wr_access_end(fd->fd_sys, st_loc, end_loc - st_loc);
@@ -1153,10 +1127,13 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
             }
     } else if (nprocs_send) {
         /* buftype is not contig */
-        send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
+        size_t msgLen = 0;
         for (i = 0; i < nprocs; i++)
-            if (send_size[i])
-                send_buf[i] = (char *) ADIOI_Malloc(send_size[i]);
+            msgLen += send_size[i];
+        send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
+        send_buf[0] = (char *) ADIOI_Malloc(msgLen * sizeof(char));
+        for (i = 1; i < nprocs; i++)
+            send_buf[i] = send_buf[i - 1] + send_size[i - 1];
 
         ADIOI_Fill_send_buffer(fd, buf, flat_buf, send_buf,
                                offset_list, len_list, send_size,
@@ -1219,9 +1196,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
     ADIOI_Free(statuses);
     ADIOI_Free(requests);
     if (!buftype_is_contig && nprocs_send) {
-        for (i = 0; i < nprocs; i++)
-            if (send_size[i])
-                ADIOI_Free(send_buf[i]);
+        ADIOI_Free(send_buf[0]);
         ADIOI_Free(send_buf);
     }
 }

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.h
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.h
@@ -82,7 +82,7 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code);
 int ADIOI_LUSTRE_Docollect(ADIO_File fd, int contig_access_count,
                            ADIO_Offset * len_list, int nprocs);
 
-void ADIOI_LUSTRE_Get_striping_info(ADIO_File fd, int **striping_info_ptr, int mode);
+void ADIOI_LUSTRE_Get_striping_info(ADIO_File fd, int *striping_info, int mode);
 void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
                               ADIO_Offset * len_list, int contig_access_count,
                               int *striping_info, int nprocs,

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -114,7 +114,7 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     ADIO_Offset orig_fp, start_offset, end_offset, off;
     ADIO_Offset *offset_list = NULL, *st_offsets = NULL, *end_offsets = NULL;
     ADIO_Offset *len_list = NULL;
-    int *striping_info = NULL;
+    int striping_info[3];
     ADIO_Offset **buf_idx = NULL;
     int old_error, tmp_error;
     ADIO_Offset *lustre_offsets0, *lustre_offsets, *count_sizes = NULL;
@@ -127,12 +127,10 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     /* IO patten identification if cb_write isn't disabled */
     if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
         /* For this process's request, calculate the list of offsets and
-         * lengths in the file and determine the start and end offsets. */
-
-        /* Note: end_offset points to the last byte-offset that will be accessed.
+         * lengths in the file and determine the start and end offsets.
+         * Note: end_offset points to the last byte-offset to be accessed.
          * e.g., if start_offset=0 and 100 bytes to be read, end_offset=99
          */
-
         ADIOI_Calc_my_off_len(fd, count, datatype, file_ptr_type, offset,
                               &offset_list, &len_list, &start_offset,
                               &end_offset, &contig_access_count);
@@ -141,12 +139,12 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
          * processes. The result is an array each of start and end offsets
          * stored in order of process rank.
          */
-        st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-        end_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
+        st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * 2 * sizeof(ADIO_Offset));
+        end_offsets = st_offsets + nprocs;
         ADIO_Offset my_count_size = 0;
-        /* One-sided aggregation needs the amount of data per rank as well because
-         * the difference in starting and ending offsets for 1 byte is 0 the same
-         * as 0 bytes so it cannot be distiguished.
+        /* One-sided aggregation needs the amount of data per rank as well
+         * because the difference in starting and ending offsets for 1 byte is
+         * 0 the same as 0 bytes so it cannot be distiguished.
          */
         if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
@@ -156,8 +154,8 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         }
         if (romio_tunegather) {
             if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
-                lustre_offsets0 = (ADIO_Offset *) ADIOI_Malloc(3 * nprocs * sizeof(ADIO_Offset));
-                lustre_offsets = (ADIO_Offset *) ADIOI_Malloc(3 * nprocs * sizeof(ADIO_Offset));
+                lustre_offsets0 = (ADIO_Offset *) ADIOI_Malloc(6 * nprocs * sizeof(ADIO_Offset));
+                lustre_offsets = lustre_offsets0 + 3 * nprocs;
                 for (i = 0; i < nprocs; i++) {
                     lustre_offsets0[i * 3] = 0;
                     lustre_offsets0[i * 3 + 1] = 0;
@@ -174,8 +172,8 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                     count_sizes[i] = lustre_offsets[i * 3 + 2];
                 }
             } else {
-                lustre_offsets0 = (ADIO_Offset *) ADIOI_Malloc(2 * nprocs * sizeof(ADIO_Offset));
-                lustre_offsets = (ADIO_Offset *) ADIOI_Malloc(2 * nprocs * sizeof(ADIO_Offset));
+                lustre_offsets0 = (ADIO_Offset *) ADIOI_Malloc(4 * nprocs * sizeof(ADIO_Offset));
+                lustre_offsets = lustre_offsets0 + 2 * nprocs;
                 for (i = 0; i < nprocs; i++) {
                     lustre_offsets0[i * 2] = 0;
                     lustre_offsets0[i * 2 + 1] = 0;
@@ -192,7 +190,6 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                 }
             }
             ADIOI_Free(lustre_offsets0);
-            ADIOI_Free(lustre_offsets);
         } else {
             MPI_Allgather(&start_offset, 1, ADIO_OFFSET, st_offsets, 1, ADIO_OFFSET, fd->comm);
             MPI_Allgather(&end_offset, 1, ADIO_OFFSET, end_offsets, 1, ADIO_OFFSET, fd->comm);
@@ -227,9 +224,7 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
         /* use independent accesses */
         if (fd->hints->cb_write != ADIOI_HINT_DISABLE) {
             ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
             if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2))
                 ADIOI_Free(count_sizes);
         }
@@ -272,9 +267,9 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     }
 
     /* Get Lustre hints information */
-    ADIOI_LUSTRE_Get_striping_info(fd, &striping_info, 1);
-    /* If the user has specified to use a one-sided aggregation method then do that at
-     * this point instead of the two-phase I/O.
+    ADIOI_LUSTRE_Get_striping_info(fd, striping_info, 1);
+    /* If the user has specified to use a one-sided aggregation method then do
+     * that at this point instead of the two-phase I/O.
      */
     if ((romio_write_aggmethod == 1) || (romio_write_aggmethod == 2)) {
 
@@ -284,14 +279,9 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
                                      firstFileOffset, lastFileOffset, datatype, myrank, error_code);
 
         ADIOI_Free(offset_list);
-        ADIOI_Free(len_list);
         ADIOI_Free(st_offsets);
-        ADIOI_Free(end_offsets);
         ADIOI_Free(count_sizes);
-        ADIOI_Free(striping_info);
-
         goto fn_exit;
-
     }   // onesided aggregation
 
     /* calculate what portions of the access requests of this process are
@@ -351,32 +341,16 @@ void ADIOI_LUSTRE_WriteStridedColl(ADIO_File fd, const void *buf, int count,
     if ((old_error != MPI_SUCCESS) && (old_error != MPI_ERR_IO))
         *error_code = old_error;
 
-
     /* free all memory allocated for collective I/O */
     /* free others_req */
-    for (i = 0; i < nprocs; i++) {
-        if (others_req[i].count) {
-            ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].mem_ptrs);
-        }
-    }
+    ADIOI_Free(others_req[0].offsets);
+    ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
-    /* free my_req here */
-    for (i = 0; i < nprocs; i++) {
-        if (my_req[i].count) {
-            ADIOI_Free(my_req[i].offsets);
-        }
-    }
-    ADIOI_Free(my_req);
-    for (i = 0; i < nprocs; i++) {
-        ADIOI_Free(buf_idx[i]);
-    }
+    ADIOI_Free(buf_idx[0]);     /* also my_req[*].offsets and my_req[*].lens */
     ADIOI_Free(buf_idx);
+    ADIOI_Free(my_req);
     ADIOI_Free(offset_list);
-    ADIOI_Free(len_list);
     ADIOI_Free(st_offsets);
-    ADIOI_Free(end_offsets);
-    ADIOI_Free(striping_info);
 
   fn_exit:
 #ifdef HAVE_STATUS_SET_BYTES
@@ -485,7 +459,10 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
         write_buf = (char *) ADIOI_Malloc(stripe_size);
 
     /* calculate the start offset for each iteration */
-    off_list = (ADIO_Offset *) ADIOI_Malloc(max_ntimes * sizeof(ADIO_Offset));
+    off_list = (ADIO_Offset *) ADIOI_Malloc((max_ntimes + 2 * nprocs) * sizeof(ADIO_Offset));
+    send_buf_idx = off_list + max_ntimes;
+    this_buf_idx = send_buf_idx + nprocs;
+
     for (m = 0; m < max_ntimes; m++)
         off_list[m] = max_end_loc;
     for (i = 0; i < nprocs; i++) {
@@ -496,33 +473,30 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
         }
     }
 
-    recv_curr_offlen_ptr = (int *) ADIOI_Calloc(nprocs, sizeof(int));
-    send_curr_offlen_ptr = (int *) ADIOI_Calloc(nprocs, sizeof(int));
+    recv_curr_offlen_ptr = (int *) ADIOI_Calloc(nprocs * 9, sizeof(int));
+    send_curr_offlen_ptr = recv_curr_offlen_ptr + nprocs;
     /* their use is explained below. calloc initializes to 0. */
 
-    recv_count = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    recv_count = send_curr_offlen_ptr + nprocs;
     /* to store count of how many off-len pairs per proc are satisfied
      * in an iteration. */
 
-    send_size = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    send_size = recv_count + nprocs;
     /* total size of data to be sent to each proc. in an iteration.
      * Of size nprocs so that I can use MPI_Alltoall later. */
 
-    recv_size = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    recv_size = send_size + nprocs;
     /* total size of data to be recd. from each proc. in an iteration. */
 
-    sent_to_proc = (int *) ADIOI_Calloc(nprocs, sizeof(int));
+    sent_to_proc = recv_size + nprocs;
     /* amount of data sent to each proc so far. Used in
      * ADIOI_Fill_send_buffer. initialized to 0 here. */
 
-    send_buf_idx = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-    curr_to_proc = (int *) ADIOI_Malloc(nprocs * sizeof(int));
-    done_to_proc = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    curr_to_proc = sent_to_proc + nprocs;
+    done_to_proc = curr_to_proc + nprocs;
     /* Above three are used in ADIOI_Fill_send_buffer */
 
-    this_buf_idx = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-
-    recv_start_pos = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    recv_start_pos = done_to_proc + nprocs;
     /* used to store the starting value of recv_curr_offlen_ptr[i] in
      * this iteration */
 
@@ -703,16 +677,6 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd, const void *buf,
     if (ntimes)
         ADIOI_Free(write_buf);
     ADIOI_Free(recv_curr_offlen_ptr);
-    ADIOI_Free(send_curr_offlen_ptr);
-    ADIOI_Free(recv_count);
-    ADIOI_Free(send_size);
-    ADIOI_Free(recv_size);
-    ADIOI_Free(sent_to_proc);
-    ADIOI_Free(recv_start_pos);
-    ADIOI_Free(send_buf_idx);
-    ADIOI_Free(curr_to_proc);
-    ADIOI_Free(done_to_proc);
-    ADIOI_Free(this_buf_idx);
     ADIOI_Free(off_list);
 }
 
@@ -740,20 +704,35 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
                                          ADIO_Offset ** srt_off, int **srt_len, int *srt_num,
                                          int *error_code)
 {
-    int i, j, nprocs_recv, nprocs_send, err;
+    int i, j, k, nprocs_recv, nprocs_send, err;
     char **send_buf = NULL;
     MPI_Request *requests, *send_req;
     MPI_Datatype *recv_types;
     MPI_Status *statuses, status;
     int sum_recv;
     int data_sieving = *hole;
+    static size_t malloc_srt_num = 0;
+    size_t send_total_size;
     static char myname[] = "ADIOI_W_EXCHANGE_DATA";
 
     /* create derived datatypes for recv */
+    *srt_num = 0;
+    sum_recv = 0;
     nprocs_recv = 0;
-    for (i = 0; i < nprocs; i++)
+    nprocs_send = 0;
+    send_total_size = 0;
+    for (i = 0; i < nprocs; i++) {
+        *srt_num += count[i];
+        sum_recv += recv_size[i];
         if (recv_size[i])
             nprocs_recv++;
+        if (send_size[i]) {
+            nprocs_send++;
+            send_total_size += send_size[i];
+        }
+    }
+
+    *hole = (size > sum_recv) ? 1 : 0;
 
     recv_types = (MPI_Datatype *) ADIOI_Malloc((nprocs_recv + 1) * sizeof(MPI_Datatype));
     /* +1 to avoid a 0-size malloc */
@@ -776,30 +755,23 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
      * For this, merge the (sorted) offset lists others_req using a heap-merge.
      */
 
-    *srt_num = 0;
-    for (i = 0; i < nprocs; i++)
-        *srt_num += count[i];
-    if (*srt_off)
-        *srt_off = (ADIO_Offset *) ADIOI_Realloc(*srt_off, (*srt_num + 1) * sizeof(ADIO_Offset));
-    else
-        *srt_off = (ADIO_Offset *) ADIOI_Malloc((*srt_num + 1) * sizeof(ADIO_Offset));
-    if (*srt_len)
-        *srt_len = (int *) ADIOI_Realloc(*srt_len, (*srt_num + 1) * sizeof(int));
-    else
-        *srt_len = (int *) ADIOI_Malloc((*srt_num + 1) * sizeof(int));
-    /* +1 to avoid a 0-size malloc */
-
-    ADIOI_Heap_merge(others_req, count, *srt_off, *srt_len, start_pos,
-                     nprocs, nprocs_recv, *srt_num);
-
-    /* check if there are any holes */
-    *hole = 0;
-    for (i = 0; i < *srt_num - 1; i++) {
-        if ((*srt_off)[i] + (*srt_len)[i] < (*srt_off)[i + 1]) {
-            *hole = 1;
-            break;
+    if (*srt_num) {
+        if (*srt_off == NULL || *srt_num > malloc_srt_num) {
+            /* must check srt_off against NULL, as the collective write can be
+             * called more than once */
+            if (*srt_off != NULL) {
+                ADIOI_Free(*srt_off);
+                ADIOI_Free(*srt_len);
+            }
+            *srt_off = (ADIO_Offset *) ADIOI_Malloc(*srt_num * sizeof(ADIO_Offset));
+            *srt_len = (int *) ADIOI_Malloc(*srt_num * sizeof(int));
+            malloc_srt_num = *srt_num;
         }
+
+        ADIOI_Heap_merge(others_req, count, *srt_off, *srt_len, start_pos,
+                         nprocs, nprocs_recv, *srt_num);
     }
+
     /* In some cases (see John Bent ROMIO REQ # 835), an odd interaction
      * between aggregation, nominally contiguous regions, and cb_buffer_size
      * should be handled with a read-modify-write (otherwise we will write out
@@ -807,12 +779,14 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
      * hole detection
      */
     if (*hole == 0) {
-        sum_recv = 0;
-        for (i = 0; i < nprocs; i++)
-            sum_recv += recv_size[i];
-        if (size > sum_recv)
-            *hole = 1;
+        for (i = 0; i < *srt_num - 1; i++) {
+            if ((*srt_off)[i] + (*srt_len)[i] < (*srt_off)[i + 1]) {
+                *hole = 1;
+                break;
+            }
+        }
     }
+
     /* check the hint for data sieving */
     if (data_sieving == ADIOI_HINT_ENABLE && nprocs_recv && *hole) {
         ADIO_ReadContig(fd, write_buf, size, MPI_BYTE, ADIO_EXPLICIT_OFFSET, off, &status, &err);
@@ -826,11 +800,6 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
         }
         // --END ERROR HANDLING--
     }
-
-    nprocs_send = 0;
-    for (i = 0; i < nprocs; i++)
-        if (send_size[i])
-            nprocs_send++;
 
     if (fd->atomicity) {
         /* bug fix from Wei-keng Liao and Kenin Coloma */
@@ -869,9 +838,9 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
     } else if (nprocs_send) {
         /* buftype is not contig */
         send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
-        for (i = 0; i < nprocs; i++)
-            if (send_size[i])
-                send_buf[i] = (char *) ADIOI_Malloc(send_size[i]);
+        send_buf[0] = (char *) ADIOI_Malloc(send_total_size);
+        for (i = 1; i < nprocs; i++)
+            send_buf[i] = send_buf[i - 1] + send_size[i - 1];
 
         ADIOI_LUSTRE_Fill_send_buffer(fd, buf, flat_buf, send_buf, offset_list,
                                       len_list, send_size, send_req,
@@ -928,9 +897,7 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
     ADIOI_Free(statuses);
     ADIOI_Free(requests);
     if (!buftype_is_contig && nprocs_send) {
-        for (i = 0; i < nprocs; i++)
-            if (send_size[i])
-                ADIOI_Free(send_buf[i]);
+        ADIOI_Free(send_buf[0]);
         ADIOI_Free(send_buf);
     }
 }
@@ -1407,7 +1374,6 @@ static void ADIOI_LUSTRE_IterateOneSided(ADIO_File fd, const void *buf, int *str
 
             if (anyHolesFound) {
                 ADIOI_Free(offset_list);
-                ADIOI_Free(len_list);
                 ADIOI_Calc_my_off_len(fd, count, datatype, file_ptr_type, offset,
                                       &offset_list, &len_list, &start_offset,
                                       &end_offset, &contig_access_count);

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -280,8 +280,8 @@ void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, int count,
          * processes. The result is an array each of start and end offsets
          * stored in order of process rank. */
 
-        vars->st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-        vars->end_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
+        vars->st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * 2 * sizeof(ADIO_Offset));
+        vars->end_offsets = vars->st_offsets + nprocs;
 
         *error_code = MPI_Iallgather(&vars->start_offset, 1, ADIO_OFFSET,
                                      vars->st_offsets, 1, ADIO_OFFSET,
@@ -344,9 +344,7 @@ static void ADIOI_GEN_IreadStridedColl_indio(ADIOI_NBC_Request * nbc_req, int *e
         /* don't do aggregation */
         if (fd->hints->cb_read != ADIOI_HINT_DISABLE) {
             ADIOI_Free(vars->offset_list);
-            ADIOI_Free(vars->len_list);
             ADIOI_Free(vars->st_offsets);
-            ADIOI_Free(vars->end_offsets);
         }
 
         fd->fp_ind = vars->orig_fp;
@@ -464,11 +462,7 @@ static void ADIOI_GEN_IreadStridedColl_read(ADIOI_NBC_Request * nbc_req, int *er
      * let's free the memory
      */
     ADIOI_Free(vars->count_my_req_per_proc);
-    for (i = 0; i < nprocs; i++) {
-        if (my_req[i].count) {
-            ADIOI_Free(my_req[i].offsets);
-        }
-    }
+    ADIOI_Free(my_req[0].offsets);
     ADIOI_Free(my_req);
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,
@@ -505,21 +499,14 @@ static void ADIOI_GEN_IreadStridedColl_free(ADIOI_NBC_Request * nbc_req, int *er
 
 
     /* free all memory allocated for collective I/O */
-    for (i = 0; i < nprocs; i++) {
-        if (others_req[i].count) {
-            ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].mem_ptrs);
-        }
-    }
+    ADIOI_Free(others_req[0].offsets);
+    ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
 
     ADIOI_Free(vars->buf_idx);
     ADIOI_Free(vars->offset_list);
-    ADIOI_Free(vars->len_list);
     ADIOI_Free(vars->st_offsets);
-    ADIOI_Free(vars->end_offsets);
     ADIOI_Free(vars->fd_start);
-    ADIOI_Free(vars->fd_end);
 
     fd->fp_sys_posn = -1;       /* set it to null. */
 

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -139,8 +139,8 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
          * processes. The result is an array each of start and end offsets
          * stored in order of process rank. */
 
-        st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
-        end_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
+        st_offsets = (ADIO_Offset *) ADIOI_Malloc(nprocs * 2 * sizeof(ADIO_Offset));
+        end_offsets = st_offsets + nprocs;
 
         MPI_Allgather(&start_offset, 1, ADIO_OFFSET, st_offsets, 1, ADIO_OFFSET, fd->comm);
         MPI_Allgather(&end_offset, 1, ADIO_OFFSET, end_offsets, 1, ADIO_OFFSET, fd->comm);
@@ -160,9 +160,7 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
         /* don't do aggregation */
         if (fd->hints->cb_read != ADIOI_HINT_DISABLE) {
             ADIOI_Free(offset_list);
-            ADIOI_Free(len_list);
             ADIOI_Free(st_offsets);
-            ADIOI_Free(end_offsets);
         }
 
         fd->fp_ind = orig_fp;
@@ -233,13 +231,8 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
      * let's free the memory
      */
     ADIOI_Free(count_my_req_per_proc);
-    for (i = 0; i < nprocs; i++) {
-        if (my_req[i].count) {
-            ADIOI_Free(my_req[i].offsets);
-        }
-    }
+    ADIOI_Free(my_req[0].offsets);
     ADIOI_Free(my_req);
-
 
     /* read data in sizes of no more than ADIOI_Coll_bufsize,
      * communicate, and fill user buf.
@@ -251,21 +244,14 @@ void ADIOI_GEN_ReadStridedColl(ADIO_File fd, void *buf, int count,
 
 
     /* free all memory allocated for collective I/O */
-    for (i = 0; i < nprocs; i++) {
-        if (others_req[i].count) {
-            ADIOI_Free(others_req[i].offsets);
-            ADIOI_Free(others_req[i].mem_ptrs);
-        }
-    }
+    ADIOI_Free(others_req[0].offsets);
+    ADIOI_Free(others_req[0].mem_ptrs);
     ADIOI_Free(others_req);
 
     ADIOI_Free(buf_idx);
     ADIOI_Free(offset_list);
-    ADIOI_Free(len_list);
     ADIOI_Free(st_offsets);
-    ADIOI_Free(end_offsets);
     ADIOI_Free(fd_start);
-    ADIOI_Free(fd_end);
 
 #ifdef HAVE_STATUS_SET_BYTES
     MPI_Type_size_x(datatype, &size);
@@ -319,8 +305,8 @@ void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
 
     if (!filetype_size) {
         *contig_access_count_ptr = 0;
-        *offset_list_ptr = (ADIO_Offset *) ADIOI_Malloc(2 * sizeof(ADIO_Offset));
-        *len_list_ptr = (ADIO_Offset *) ADIOI_Malloc(2 * sizeof(ADIO_Offset));
+        *offset_list_ptr = (ADIO_Offset *) ADIOI_Malloc(4 * sizeof(ADIO_Offset));
+        *len_list_ptr = *offset_list_ptr + 2;
         /* 2 is for consistency. everywhere I malloc one more than needed */
 
         offset_list = *offset_list_ptr;
@@ -336,8 +322,8 @@ void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
 
     if (filetype_is_contig) {
         *contig_access_count_ptr = 1;
-        *offset_list_ptr = (ADIO_Offset *) ADIOI_Malloc(2 * sizeof(ADIO_Offset));
-        *len_list_ptr = (ADIO_Offset *) ADIOI_Malloc(2 * sizeof(ADIO_Offset));
+        *offset_list_ptr = (ADIO_Offset *) ADIOI_Malloc(4 * sizeof(ADIO_Offset));
+        *len_list_ptr = *offset_list_ptr + 2;
         /* 2 is for consistency. everywhere I malloc one more than needed */
 
         offset_list = *offset_list_ptr;
@@ -437,10 +423,9 @@ void ADIOI_Calc_my_off_len(ADIO_File fd, int bufcount, MPI_Datatype
 
         /* allocate space for offset_list and len_list */
 
-        *offset_list_ptr = (ADIO_Offset *)
-            ADIOI_Malloc((contig_access_count + 1) * sizeof(ADIO_Offset));
-        *len_list_ptr =
-            (ADIO_Offset *) ADIOI_Malloc((contig_access_count + 1) * sizeof(ADIO_Offset));
+        *offset_list_ptr =
+            (ADIO_Offset *) ADIOI_Malloc((contig_access_count + 1) * 2 * sizeof(ADIO_Offset));
+        *len_list_ptr = *offset_list_ptr + (contig_access_count + 1);
         /* +1 to avoid a 0-size malloc */
 
         offset_list = *offset_list_ptr;
@@ -574,30 +559,30 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
 
     read_buf = fd->io_buf;      /* Allocated at open time */
 
-    curr_offlen_ptr = (int *) ADIOI_Calloc(nprocs, sizeof(int));
+    curr_offlen_ptr = (int *) ADIOI_Calloc(nprocs * 7, sizeof(int));
     /* its use is explained below. calloc initializes to 0. */
 
-    count = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    count = curr_offlen_ptr + nprocs;
     /* to store count of how many off-len pairs per proc are satisfied
      * in an iteration. */
 
-    partial_send = (int *) ADIOI_Calloc(nprocs, sizeof(int));
+    partial_send = count + nprocs;
     /* if only a portion of the last off-len pair is sent to a process
      * in a particular iteration, the length sent is stored here.
      * calloc initializes to 0. */
 
-    send_size = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    send_size = partial_send + nprocs;
     /* total size of data to be sent to each proc. in an iteration */
 
-    recv_size = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    recv_size = send_size + nprocs;
     /* total size of data to be recd. from each proc. in an iteration.
      * Of size nprocs so that I can use MPI_Alltoall later. */
 
-    recd_from_proc = (int *) ADIOI_Calloc(nprocs, sizeof(int));
+    recd_from_proc = recv_size + nprocs;
     /* amount of data recd. so far from each proc. Used in
      * ADIOI_Fill_user_buffer. initialized to 0 here. */
 
-    start_pos = (int *) ADIOI_Malloc(nprocs * sizeof(int));
+    start_pos = recd_from_proc + nprocs;
     /* used to store the starting value of curr_offlen_ptr[i] in
      * this iteration */
 
@@ -767,12 +752,6 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
                               others_req, m, buftype_extent, buf_idx);
 
     ADIOI_Free(curr_offlen_ptr);
-    ADIOI_Free(count);
-    ADIOI_Free(partial_send);
-    ADIOI_Free(send_size);
-    ADIOI_Free(recv_size);
-    ADIOI_Free(recd_from_proc);
-    ADIOI_Free(start_pos);
 }
 
 static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
@@ -789,6 +768,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
 {
     int i, j, k = 0, tmp = 0, nprocs_recv, nprocs_send;
     char **recv_buf = NULL;
+    size_t memLen;
     MPI_Request *requests;
     MPI_Datatype send_type;
     MPI_Status *statuses;
@@ -799,14 +779,15 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     MPI_Alltoall(send_size, 1, MPI_INT, recv_size, 1, MPI_INT, fd->comm);
 
     nprocs_recv = 0;
-    for (i = 0; i < nprocs; i++)
+    nprocs_send = 0;
+    memLen = 0;
+    for (i = 0; i < nprocs; i++) {
+        memLen += recv_size[i];
         if (recv_size[i])
             nprocs_recv++;
-
-    nprocs_send = 0;
-    for (i = 0; i < nprocs; i++)
         if (send_size[i])
             nprocs_send++;
+    }
 
     requests = (MPI_Request *)
         ADIOI_Malloc((nprocs_send + nprocs_recv + 1) * sizeof(MPI_Request));
@@ -830,13 +811,11 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
             }
         }
     } else {
-/* allocate memory for recv_buf and post receives */
+        /* allocate memory for recv_buf and post receives */
         recv_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
-        for (i = 0; i < nprocs; i++) {
-            if (recv_size[i]) {
-                recv_buf[i] = (char *) ADIOI_Malloc(recv_size[i]);
-            }
-        }
+        recv_buf[0] = (char *) ADIOI_Malloc(memLen);
+        for (i = 1; i < nprocs; i++)
+            recv_buf[i] = recv_buf[i - 1] + recv_size[i - 1];
 
         j = 0;
         for (i = 0; i < nprocs; i++) {
@@ -907,9 +886,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     ADIOI_Free(requests);
 
     if (!buftype_is_contig) {
-        for (i = 0; i < nprocs; i++)
-            if (recv_size[i])
-                ADIOI_Free(recv_buf[i]);
+        ADIOI_Free(recv_buf[0]);
         ADIOI_Free(recv_buf);
     }
 #ifdef AGGREGATION_PROFILE
@@ -995,9 +972,9 @@ void ADIOI_Fill_user_buffer(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                         filled into user buffer in previous iterations
     user_buf_idx = current location in user buffer
     recv_buf_idx[p] = current location in recv_buf of proc. p  */
-    curr_from_proc = (unsigned *) ADIOI_Malloc(nprocs * sizeof(unsigned));
-    done_from_proc = (unsigned *) ADIOI_Malloc(nprocs * sizeof(unsigned));
-    recv_buf_idx = (unsigned *) ADIOI_Malloc(nprocs * sizeof(unsigned));
+    curr_from_proc = (unsigned *) ADIOI_Malloc(nprocs * 3 * sizeof(unsigned));
+    done_from_proc = curr_from_proc + nprocs;
+    recv_buf_idx = done_from_proc + nprocs;
 
     for (i = 0; i < nprocs; i++) {
         recv_buf_idx[i] = curr_from_proc[i] = 0;
@@ -1061,6 +1038,4 @@ void ADIOI_Fill_user_buffer(ADIO_File fd, void *buf, ADIOI_Flatlist_node
             recd_from_proc[i] = curr_from_proc[i];
 
     ADIOI_Free(curr_from_proc);
-    ADIOI_Free(done_from_proc);
-    ADIOI_Free(recv_buf_idx);
 }


### PR DESCRIPTION
There are several places in ROMIO where multiple malloc/calloc calls can be combined. For some I/O patterns, high frequency of calls to malloc and free can be expensive. This patch combines the calls as many as I can find.