### PR TITLE
ROMIO: replace MPI_Isend with MPI_Issend for Lustre collective writes.

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -862,8 +862,8 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
         for (i = 0; i < nprocs; i++)
             if (send_size[i]) {
                 ADIOI_Assert(buf_idx[i] != -1);
-                MPI_Isend(((char *) buf) + buf_idx[i], send_size[i],
-                          MPI_BYTE, i, myrank + i + 100 * iter, fd->comm, send_req + j);
+                MPI_Issend(((char *) buf) + buf_idx[i], send_size[i],
+                           MPI_BYTE, i, myrank + i + 100 * iter, fd->comm, send_req + j);
                 j++;
             }
     } else if (nprocs_send) {
@@ -1058,8 +1058,8 @@ static void ADIOI_LUSTRE_Fill_send_buffer(ADIO_File fd, const void *buf,
                         curr_to_proc[p] += size;
                     ADIOI_BUF_COPY}
                     if (send_buf_idx[p] == send_size[p]) {
-                        MPI_Isend(send_buf[p], send_size[p], MPI_BYTE, p,
-                                  myrank + p + 100 * iter, fd->comm, requests + jj);
+                        MPI_Issend(send_buf[p], send_size[p], MPI_BYTE, p,
+                                   myrank + p + 100 * iter, fd->comm, requests + jj);
                         jj++;
                     }
                 } else {


### PR DESCRIPTION
According to MPI standard, MPI_Isend() is in the standard mode which
means the send-complete call (e.ge. MPI_Wait) may return before a
matching receive is posted, if the message is buffered. In other words,
The send-complete call returns when data has been copied out of the send
buffer (e.g. into system buffers).

MPI_Issend() is in the synchronous mode which means the send can
complete only if a matching receive has started.

The two-phase I/O loop in Lustre driver does not contain any collective
communication, like MPI_Alltoall in other ADIO drivers, which can
prevent pending isend calls posted in one iteration going to the next
iteration and possibly exhausting the system resource like message
queue. Therefore, replacing MPI_Isend with MPI_Issend can effectively
prevent such a problem.

@roblatham00 This patch is what we discussed last week.