### PR TITLE
ROMIO: use MPI_STATUSES_IGNORE in MPI_Waitall and MPI_Testall

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -912,8 +912,12 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
         }
     }
 
+#ifdef MPI_STATUSES_IGNORE
+    statuses = MPI_STATUSES_IGNORE;
+#else
     statuses = (MPI_Status *) ADIOI_Malloc((nprocs_send + nprocs_recv + 1) * sizeof(MPI_Status));
     /* +1 to avoid a 0-size malloc */
+#endif
 
     /* wait on the receives */
     if (nprocs_recv) {
@@ -937,7 +941,9 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     /* wait on the sends */
     MPI_Waitall(nprocs_send, requests + nprocs_recv, statuses + nprocs_recv);
 
+#ifndef MPI_STATUSES_IGNORE
     ADIOI_Free(statuses);
+#endif
     ADIOI_Free(requests);
 
     if (!buftype_is_contig) {

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -1185,6 +1185,9 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
         MPI_Type_free(recv_types + i);
     ADIOI_Free(recv_types);
 
+#ifdef MPI_STATUSES_IGNORE
+    statuses = MPI_STATUSES_IGNORE;
+#else
     if (fd->atomicity) {
         /* bug fix from Wei-keng Liao and Kenin Coloma */
         statuses = (MPI_Status *) ADIOI_Malloc((nprocs_send + 1) * sizeof(MPI_Status));
@@ -1194,6 +1197,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
                                                sizeof(MPI_Status));
         /* +1 to avoid a 0-size malloc */
     }
+#endif
 
 #ifdef NEEDS_MPI_TEST
     i = 0;
@@ -1216,7 +1220,9 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
 #ifdef AGGREGATION_PROFILE
     MPE_Log_event(5033, 0, NULL);
 #endif
+#ifndef MPI_STATUSES_IGNORE
     ADIOI_Free(statuses);
+#endif
     ADIOI_Free(requests);
     if (!buftype_is_contig && nprocs_send) {
         for (i = 0; i < nprocs; i++)

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -899,6 +899,9 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
         MPI_Type_free(recv_types + i);
     ADIOI_Free(recv_types);
 
+#ifdef MPI_STATUSES_IGNORE
+    statuses = MPI_STATUSES_IGNORE;
+#else
     /* bug fix from Wei-keng Liao and Kenin Coloma */
     /* +1 to avoid a 0-size malloc */
     if (fd->atomicity) {
@@ -907,6 +910,7 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
         statuses = (MPI_Status *) ADIOI_Malloc((nprocs_send + nprocs_recv + 1) *
                                                sizeof(MPI_Status));
     }
+#endif
 
 #ifdef NEEDS_MPI_TEST
     i = 0;
@@ -925,7 +929,10 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
     else
         MPI_Waitall(nprocs_send + nprocs_recv, requests, statuses);
 #endif
+
+#ifndef MPI_STATUSES_IGNORE
     ADIOI_Free(statuses);
+#endif
     ADIOI_Free(requests);
     if (!buftype_is_contig && nprocs_send) {
         for (i = 0; i < nprocs; i++)

--- a/src/mpi/romio/adio/common/ad_aggregate.c
+++ b/src/mpi/romio/adio/common/ad_aggregate.c
@@ -433,7 +433,6 @@ void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
     int *count_others_req_per_proc, count_others_req_procs;
     int i, j;
     MPI_Request *requests;
-    MPI_Status *statuses;
     ADIOI_Access *others_req;
 
 /* first find out how much to send/recv and from/to whom */
@@ -485,10 +484,13 @@ void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
     }
 
     if (j) {
-        /* TODO: consider using MPI_STATUSES_IGNORE to avoid malloc */
-        statuses = (MPI_Status *) ADIOI_Malloc(j * sizeof(MPI_Status));
+#ifdef MPI_STATUSES_IGNORE
+        MPI_Waitall(j, requests, MPI_STATUSES_IGNORE);
+#else
+        MPI_Status *statuses = (MPI_Status *) ADIOI_Malloc(j * sizeof(MPI_Status));
         MPI_Waitall(j, requests, statuses);
         ADIOI_Free(statuses);
+#endif
     }
 
     ADIOI_Free(requests);

--- a/src/mpi/romio/adio/common/ad_io_coll.c
+++ b/src/mpi/romio/adio/common/ad_io_coll.c
@@ -364,23 +364,35 @@ void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
                                          &agg_comm_requests, &aggs_client_count);
 
                 if (fd->is_agg && aggs_client_count) {
+#ifdef MPI_STATUSES_IGNORE
+                    agg_comm_statuses = MPI_STATUSES_IGNORE;
+#else
                     agg_comm_statuses = ADIOI_Malloc(aggs_client_count * sizeof(MPI_Status));
+#endif
                     MPI_Waitall(aggs_client_count, agg_comm_requests, agg_comm_statuses);
 #ifdef AGGREGATION_PROFILE
                     MPE_Log_event(5033, 0, NULL);
 #endif
                     ADIOI_Free(agg_comm_requests);
+#ifndef MPI_STATUSES_IGNORE
                     ADIOI_Free(agg_comm_statuses);
+#endif
                 }
 
                 if (clients_agg_count) {
+#ifdef MPI_STATUSES_IGNORE
+                    client_comm_statuses = MPI_STATUSES_IGNORE;
+#else
                     client_comm_statuses = ADIOI_Malloc(clients_agg_count * sizeof(MPI_Status));
+#endif
                     MPI_Waitall(clients_agg_count, client_comm_requests, client_comm_statuses);
 #ifdef AGGREGATION_PROFILE
                     MPE_Log_event(5039, 0, NULL);
 #endif
                     ADIOI_Free(client_comm_requests);
+#ifndef MPI_STATUSES_IGNORE
                     ADIOI_Free(client_comm_statuses);
+#endif
                 }
 #ifdef DEBUG2
                 fprintf(stderr, "buffered_io_size = %lld\n", buffered_io_size);
@@ -427,13 +439,19 @@ void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
 #endif
 
                 if (clients_agg_count) {
+#ifdef MPI_STATUSES_IGNORE
+                    client_comm_statuses = MPI_STATUSES_IGNORE;
+#else
                     client_comm_statuses = ADIOI_Malloc(clients_agg_count * sizeof(MPI_Status));
+#endif
                     MPI_Waitall(clients_agg_count, client_comm_requests, client_comm_statuses);
 #ifdef AGGREGATION_PROFILE
                     MPE_Log_event(5039, 0, NULL);
 #endif
                     ADIOI_Free(client_comm_requests);
+#ifndef MPI_STATUSES_IGNORE
                     ADIOI_Free(client_comm_statuses);
+#endif
                 }
 #ifdef DEBUG2
                 if (bufextent) {
@@ -447,15 +465,21 @@ void ADIOI_IOStridedColl(ADIO_File fd, void *buf, int count, int rdwr,
                 if (fd->is_agg && buffered_io_size) {
                     ADIOI_Assert(aggs_client_count != 0);
                     /* make sure we actually have the data to write out */
+#ifdef MPI_STATUSES_IGNORE
+                    agg_comm_statuses = MPI_STATUSES_IGNORE;
+#else
                     agg_comm_statuses = (MPI_Status *)
                         ADIOI_Malloc(aggs_client_count * sizeof(MPI_Status));
+#endif
 
                     MPI_Waitall(aggs_client_count, agg_comm_requests, agg_comm_statuses);
 #ifdef AGGREGATION_PROFILE
                     MPE_Log_event(5033, 0, NULL);
 #endif
                     ADIOI_Free(agg_comm_requests);
+#ifndef MPI_STATUSES_IGNORE
                     ADIOI_Free(agg_comm_statuses);
+#endif
 #ifdef DEBUG2
                     fprintf(stderr, "cb_buf = [");
                     for (i = 0; i < buffered_io_size; i++)
@@ -917,7 +941,6 @@ static void Exch_data_amounts(ADIO_File fd, int nprocs,
     MPI_Request *recv_requests;
     MPI_Request *send_requests;
     MPI_Status status;
-    MPI_Status *send_statuses;
     /* Aggregators send amounts for data requested to clients */
     if (fd->hints->cb_alltoall != ADIOI_HINT_DISABLE) {
         MPI_Alltoall(client_comm_sz_arr, sizeof(ADIO_Offset), MPI_BYTE,
@@ -984,10 +1007,14 @@ static void Exch_data_amounts(ADIO_File fd, int nprocs,
         ADIOI_Free(recv_requests);
         if (fd->is_agg) {
             /* wait for all sends to complete */
-            send_statuses = ADIOI_Malloc(nprocs * sizeof(MPI_Status));
+#ifdef MPI_STATUSES_IGNORE
+            MPI_Waitall(nprocs, send_requests, MPI_STATUSES_IGNORE);
+#else
+            MPI_Status *send_statuses = ADIOI_Malloc(nprocs * sizeof(MPI_Status));
             MPI_Waitall(nprocs, send_requests, send_statuses);
-            ADIOI_Free(send_requests);
             ADIOI_Free(send_statuses);
+#endif
+            ADIOI_Free(send_requests);
         }
     }
 }

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -878,8 +878,12 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
         }
     }
 
+#ifdef MPI_STATUSES_IGNORE
+    statuses = MPI_STATUSES_IGNORE;
+#else
     statuses = (MPI_Status *) ADIOI_Malloc((nprocs_send + nprocs_recv + 1) * sizeof(MPI_Status));
     /* +1 to avoid a 0-size malloc */
+#endif
 
     /* wait on the receives */
     if (nprocs_recv) {
@@ -901,9 +905,13 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
     }
 
     /* wait on the sends */
+#ifdef MPI_STATUSES_IGNORE
+    MPI_Waitall(nprocs_send, requests + nprocs_recv, MPI_STATUSES_IGNORE);
+#else
     MPI_Waitall(nprocs_send, requests + nprocs_recv, statuses + nprocs_recv);
 
     ADIOI_Free(statuses);
+#endif
     ADIOI_Free(requests);
 
     if (!buftype_is_contig) {

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -745,6 +745,9 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
         MPI_Type_free(recv_types + i);
     ADIOI_Free(recv_types);
 
+#ifdef MPI_STATUSES_IGNORE
+    statuses = MPI_STATUSES_IGNORE;
+#else
     if (fd->atomicity) {
         /* bug fix from Wei-keng Liao and Kenin Coloma */
         statuses = (MPI_Status *) ADIOI_Malloc((nprocs_send + 1) * sizeof(MPI_Status));
@@ -754,6 +757,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
                                                sizeof(MPI_Status));
         /* +1 to avoid a 0-size malloc */
     }
+#endif
 
 #ifdef NEEDS_MPI_TEST
     i = 0;
@@ -776,7 +780,9 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
 #ifdef AGGREGATION_PROFILE
     MPE_Log_event(5033, 0, NULL);
 #endif
+#ifndef MPI_STATUSES_IGNORE
     ADIOI_Free(statuses);
+#endif
     ADIOI_Free(requests);
     if (!buftype_is_contig && nprocs_send) {
         for (i = 0; i < nprocs; i++)


### PR DESCRIPTION
The `statuses` argument used in `MPI_Waitall` and `MPI_Testall` calls has never checked.
This patch replaces it with `MPI_STATUSES_IGNORE` if the constant is defined. Minor performance improvement has been observed.