### PR TITLE
mpl: Fix a missed argument name change.

### DIFF
--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -108,12 +108,12 @@
 #define MPL_static_assert(cond_,msg_) _Static_assert(cond_,msg_)
 #else
 /* A hack:
-    When expr_ is false, result in compile-time duplicated case error.
-    When expr_ is true, compiler should optimize it away.
-    Since it is compile time error, we don't care (much) about how error messgage's look.
+    When cond_ is false, result in compile-time duplicated case error.
+    When cond_ is true, compiler should optimize it away.
+    Since it is compile time error, we don't care (much) about how the error message look.
  */
 #define MPL_static_assert(cond_,msg_) \
-    do { switch(0) { case 0: case (expr_): default: break; } } while (0)
+    do { switch(0) { case 0: case (cond_): default: break; } } while (0)
 #endif
 
 #define MPL_COMPILE_TIME_ASSERT(cond_) MPL_static_assert(cond_, "MPL_COMPILE_TIME_ASSERT failure")


### PR DESCRIPTION
When we marged the macros CH4_COMPILE_TIME_ASSERT with
MPL_static_assert, we forgot to update the former using `expr_` to the
latter that uses `cond_`. This PR fixes it.