### PR TITLE
ch4/rma: enable fallback for win allocate when shm allocation fails

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_win.h
+++ b/src/mpid/ch4/shm/posix/posix_win.h
@@ -452,12 +452,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_win_allocate_shared_hook(MPIR_Win *
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = NULL;
+    MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
     bool mapfail_flag = false;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_SHARED_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_SHARED_HOOK);
 
-    /* Enable shm RMA only when interprocess mutex is supported */
-    if (!MPL_proc_mutex_enabled())
+    /* Enable shm RMA only when interprocess mutex is supported and
+     * more than 1 processes exist on the node. */
+    if (!shm_comm_ptr || !MPL_proc_mutex_enabled())
         goto fn_exit;
 
     posix_win = &win->dev.shm.posix;

--- a/src/mpid/ch4/shm/posix/posix_win.h
+++ b/src/mpid/ch4/shm/posix/posix_win.h
@@ -409,27 +409,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_win_allocate_hook(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win ATTRIBUTE((unused)) = NULL;
     MPIR_Comm *shm_comm_ptr = win->comm_ptr->node_comm;
+    bool mapfail_flag = false;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_HOOK);
 
     posix_win = &win->dev.shm.posix;
     posix_win->shm_mutex_ptr = NULL;
 
-    /* Enable shm RMA only when interprocess mutex is supported and
-     * more than 1 processes exist on the node. */
-    if (shm_comm_ptr == NULL || !MPL_proc_mutex_enabled())
+    /* Enable shm RMA only when interprocess mutex is supported,
+     * more than 1 processes exist on the node, and shm buffer has been successfully allocated. */
+    if (shm_comm_ptr == NULL || !MPL_proc_mutex_enabled() || !MPIDIG_WIN(win, mmap_addr))
         goto fn_exit;
 
     posix_win = &win->dev.shm.posix;
-    MPIDIG_WIN(win, shm_allocated) = 1;
 
     /* allocate interprocess mutex for RMA atomics over shared memory */
     mpi_errno = MPIDIU_allocate_shm_segment(shm_comm_ptr, sizeof(MPL_proc_mutex_t),
                                             &posix_win->shm_mutex_segment_handle,
-                                            (void **) &posix_win->shm_mutex_ptr);
+                                            (void **) &posix_win->shm_mutex_ptr, &mapfail_flag);
 
-    if (shm_comm_ptr->rank == 0)
-        MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
+    /* disable shm_allocated optimization if mutex allocation fails */
+    if (!mapfail_flag) {
+        if (shm_comm_ptr->rank == 0)
+            MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
+        MPIDIG_WIN(win, shm_allocated) = 1;
+    }
 
     /* No barrier is needed here, because the CH4 generic routine does it */
 
@@ -448,6 +452,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_win_allocate_shared_hook(MPIR_Win *
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = NULL;
+    bool mapfail_flag = false;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_SHARED_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_MPI_WIN_ALLOCATE_SHARED_HOOK);
 
@@ -456,15 +461,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_win_allocate_shared_hook(MPIR_Win *
         goto fn_exit;
 
     posix_win = &win->dev.shm.posix;
-    MPIDIG_WIN(win, shm_allocated) = 1;
 
     /* allocate interprocess mutex for RMA atomics over shared memory */
     mpi_errno = MPIDIU_allocate_shm_segment(win->comm_ptr, sizeof(MPL_proc_mutex_t),
                                             &posix_win->shm_mutex_segment_handle,
-                                            (void **) &posix_win->shm_mutex_ptr);
+                                            (void **) &posix_win->shm_mutex_ptr, &mapfail_flag);
 
-    if (win->comm_ptr->rank == 0)
-        MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
+    /* disable shm_allocated optimization if mutex allocation fails */
+    if (!mapfail_flag) {
+        if (win->comm_ptr->rank == 0)
+            MPIDI_POSIX_RMA_MUTEX_INIT(posix_win->shm_mutex_ptr);
+        MPIDIG_WIN(win, shm_allocated) = 1;
+    }
 
     /* No barrier is needed here, because the CH4 generic routine does it */
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -948,16 +948,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_wait_am_acc(MPIR_Win * win, int target_rank,
 }
 
 /* Collectively allocate shared memory region.
- * MPL_shm routines and MPI collectives are internally used. */
+ * MPL_shm routines and MPI collectives are internally used.
+ * The parameter *mapfail_flag_ptr is set to true and MPI_SUCCESS is returned
+ * if mapping fails (e.g., no memory resource, or opened too many files), thus the
+ * caller can choose fallback if exists. If communication fails it returns an MPI error.*/
 #undef FUNCNAME
 #define FUNCNAME MPIDIU_allocate_shm_segment
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDIU_allocate_shm_segment(MPIR_Comm * shm_comm_ptr, MPI_Aint shm_segment_len,
-                                              MPL_shm_hnd_t * shm_segment_hdl_ptr, void **base_ptr)
+static inline int MPIDIU_allocate_shm_segment(MPIR_Comm * shm_comm_ptr,
+                                              MPI_Aint shm_segment_len,
+                                              MPL_shm_hnd_t * shm_segment_hdl_ptr,
+                                              void **base_ptr, bool * mapfail_flag_ptr)
 {
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
+    bool any_shm_fail_flag = false, shm_fail_flag = false, mapped_flag = false;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_ALLOCATE_SHM_SEGMENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_ALLOCATE_SHM_SEGMENT);
@@ -965,28 +971,48 @@ static inline int MPIDIU_allocate_shm_segment(MPIR_Comm * shm_comm_ptr, MPI_Aint
     mpl_err = MPL_shm_hnd_init(shm_segment_hdl_ptr);
     MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
 
+    *mapfail_flag_ptr = false;
+    *base_ptr = NULL;
     if (shm_comm_ptr->rank == 0) {
         char *serialized_hnd_ptr = NULL;
+        char mpl_err_hnd[MPL_SHM_GHND_SZ] = { 0 };
 
         /* create shared memory region for all processes in win and map */
         mpl_err = MPL_shm_seg_create_and_attach(*shm_segment_hdl_ptr, shm_segment_len, base_ptr, 0);
-        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            shm_fail_flag = true;
+            goto hnd_sync;
+        } else
+            mapped_flag = true;
 
         /* serialize handle and broadcast it to the other processes in win */
         mpl_err = MPL_shm_hnd_get_serialized_by_ref(*shm_segment_hdl_ptr, &serialized_hnd_ptr);
-        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
+        if (mpl_err != MPL_SHM_SUCCESS)
+            shm_fail_flag = true;
 
+      hnd_sync:
+        /* bcast empty hnd as error reporting */
+        if (shm_fail_flag)
+            serialized_hnd_ptr = &mpl_err_hnd[0];
         mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
                                shm_comm_ptr, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-        /* wait for other processes to attach to win */
-        mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
+        if (shm_fail_flag)
+            goto map_fail;
+
+        /* ensure all other processes have mapped successfully */
+        mpi_errno = MPIR_Allreduce(&shm_fail_flag, &any_shm_fail_flag, 1, MPI_C_BOOL,
+                                   MPI_LOR, shm_comm_ptr, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* unlink shared memory region so it gets deleted when all processes exit */
         mpl_err = MPL_shm_seg_remove(*shm_segment_hdl_ptr);
         MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**remove_shar_mem");
+
+        if (any_shm_fail_flag)
+            goto map_fail;
+
     } else {
         char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
 
@@ -995,21 +1021,48 @@ static inline int MPIDIU_allocate_shm_segment(MPIR_Comm * shm_comm_ptr, MPI_Aint
                                shm_comm_ptr, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
+        /* empty handler means root fails */
+        if (strlen(serialized_hnd) == 0)
+            goto map_fail;
+
         mpl_err = MPL_shm_hnd_deserialize(*shm_segment_hdl_ptr, serialized_hnd,
                                           strlen(serialized_hnd));
-        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            shm_fail_flag = true;
+            goto result_sync;
+        }
 
         /* attach to shared memory region created by rank 0 */
         mpl_err = MPL_shm_seg_attach(*shm_segment_hdl_ptr, shm_segment_len, base_ptr, 0);
-        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**attach_shar_mem");
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            shm_fail_flag = true;
+            goto result_sync;
+        } else
+            mapped_flag = true;
 
-        mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
+      result_sync:
+        mpi_errno = MPIR_Allreduce(&shm_fail_flag, &any_shm_fail_flag, 1, MPI_C_BOOL,
+                                   MPI_LOR, shm_comm_ptr, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+
+        if (any_shm_fail_flag)
+            goto map_fail;
     }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_ALLOCATE_SHM_SEGMENT);
     return mpi_errno;
+  map_fail:
+    /* clean up shm mapping resource */
+    if (mapped_flag) {
+        mpl_err = MPL_shm_seg_detach(*shm_segment_hdl_ptr, base_ptr, shm_segment_len);
+        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**detach_shar_mem");
+        *base_ptr = NULL;
+    }
+    mpl_err = MPL_shm_hnd_finalize(shm_segment_hdl_ptr);
+    MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**remove_shar_mem");
+    *mapfail_flag_ptr = true;
+    goto fn_exit;
   fn_fail:
     goto fn_exit;
 }

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -526,12 +526,6 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
                 MPL_munmap(base_ptr, mapsize, MPL_MEM_RMA);
         }
     }
-  fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#endif
 
     if (all_map_result != MPIDIU_SYMSHM_SUCCESS) {
         /* if fail to allocate, return and let the caller choose another method */
@@ -540,8 +534,21 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
         *fail_flag = true;
     }
 
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#else
+
+    /* always fail, return and let the caller choose another method */
+    MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                "WARNING: Win_allocate:  Unable to allocate global symmetric heap\n");
+    *fail_flag = true;
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);
+    return mpi_errno;
+#endif
 }
 
 #endif /* CH4R_SYMHEAP_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -59,6 +59,12 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+enum {
+    MPIDIU_SYMSHM_SUCCESS,
+    MPIDIU_SYMSHM_MAP_FAIL,     /* mapping failure when specified with a fixed start addr */
+    MPIDIU_SYMSHM_OTHER_FAIL    /* other failure reported by MPL shm */
+};
+
 /* Returns aligned size and the page size. The page size parameter must
  * be always initialized to 0 or a previously returned value. If page size
  * is set, we can reuse the value and skip sysconf. */
@@ -196,7 +202,11 @@ static inline void *MPIDIU_generate_random_addr(size_t size)
  * The caller should ensure shm_segment_len is page aligned and base_ptr
  * is a symmetric non-NULL address on all processes.
  *
- * mapfail_flag is set to 1 if it is a mapping failure, otherwise it is 0. */
+ * map_result indicates the mapping result of the node. It can be
+ * MPIDIU_SYMSHM_SUCCESS, MPIDIU_SYMSHM_MAP_FAIL or MPIDIU_SYMSHM_OTHER_FAIL.
+ * If it is MPIDIU_SYMSHM_MAP_FAIL, the caller can try it again with a different
+ * start address; if it is MPIDIU_SYMSHM_OTHER_FAIL, it usually means no more shm
+ * segment can be allocated, thus the caller should stop retrying. */
 #undef FUNCNAME
 #define FUNCNAME MPIDIU_allocate_symshm_segment
 #undef FCNAME
@@ -204,13 +214,17 @@ static inline void *MPIDIU_generate_random_addr(size_t size)
 static inline int MPIDIU_allocate_symshm_segment(MPIR_Comm * shm_comm_ptr,
                                                  MPI_Aint shm_segment_len,
                                                  MPL_shm_hnd_t * shm_segment_hdl_ptr,
-                                                 void **base_ptr, int *mapfail_flag)
+                                                 void **base_ptr, int *map_result_ptr)
 {
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SHM_SUCCESS;
+    bool mapped_flag = false;
+    int all_map_result = MPIDIU_SYMSHM_SUCCESS, map_result = MPIDIU_SYMSHM_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_ALLOCATE_SYMSHM_SEGMENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_ALLOCATE_SYMSHM_SEGMENT);
+
+    *map_result_ptr = MPIDIU_SYMSHM_SUCCESS;
 
     mpl_err = MPL_shm_hnd_init(shm_segment_hdl_ptr);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SHM_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
@@ -222,71 +236,101 @@ static inline int MPIDIU_allocate_symshm_segment(MPIR_Comm * shm_comm_ptr,
         /* try to map with specified symmetric address. */
         mpl_err =
             MPL_shm_fixed_seg_create_and_attach(*shm_segment_hdl_ptr, shm_segment_len, base_ptr, 0);
-        if (mpl_err == MPL_SHM_EINVAL)
-            *mapfail_flag = 1;
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            all_map_result = map_result = (mpl_err == MPL_SHM_EINVAL) ?
+                MPIDIU_SYMSHM_MAP_FAIL : MPIDIU_SYMSHM_OTHER_FAIL;
+            goto root_sync;
+        } else
+            mapped_flag = true;
 
-        /* handle mapping failure separately, caller may retry predefined times before giving up */
-        MPIR_ERR_CHKANDJUMP((mpl_err != MPL_SHM_EINVAL && mpl_err != MPL_SHM_SUCCESS),
-                            mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
+        mpl_err = MPL_shm_hnd_get_serialized_by_ref(*shm_segment_hdl_ptr, &serialized_hnd_ptr);
+        if (mpl_err != MPL_SHM_SUCCESS)
+            all_map_result = map_result = MPIDIU_SYMSHM_OTHER_FAIL;
 
+      root_sync:
         /* broadcast the mapping result on rank 0 */
-        mpi_errno = MPIR_Bcast(mapfail_flag, 1, MPI_INT, 0, shm_comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast(&map_result, 1, MPI_INT, 0, shm_comm_ptr, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-        /* broadcast handle to the others if mapping is successful */
-        if (!*mapfail_flag) {
-            mpl_err = MPL_shm_hnd_get_serialized_by_ref(*shm_segment_hdl_ptr, &serialized_hnd_ptr);
-            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SHM_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                "**alloc_shar_mem");
+        /* broadcast handle to the others if mapping is successful, otherwise stop */
+        if (map_result != MPIDIU_SYMSHM_SUCCESS)
+            goto map_fail;
 
-            mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
-                                   shm_comm_ptr, &errflag);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+        mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
+                               shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-            /* wait for other processes to attach to win */
-            mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
-        }
+        /* ensure all other processes have mapped successfully */
+        mpi_errno = MPIR_Allreduce(&map_result, &all_map_result, 1, MPI_INT,
+                                   MPI_MAX, shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* unlink shared memory region so it gets deleted when all processes exit */
         mpl_err = MPL_shm_seg_remove(*shm_segment_hdl_ptr);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SHM_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                             "**remove_shar_mem");
+
+        if (all_map_result != MPIDIU_SYMSHM_SUCCESS)
+            goto map_fail;
     } else {
+        char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
+
         /* receive the mapping result of rank 0 */
-        mpi_errno = MPIR_Bcast(mapfail_flag, 1, MPI_INT, 0, shm_comm_ptr, &errflag);
+        mpi_errno = MPIR_Bcast(&map_result, 1, MPI_INT, 0, shm_comm_ptr, &errflag);
+        if (map_result != MPIDIU_SYMSHM_SUCCESS) {
+            all_map_result = map_result;
+            goto map_fail;
+        }
 
         /* if rank 0 mapped successfully, others on the node attach shared memory region */
-        if (!*mapfail_flag) {
-            char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
 
-            /* get serialized handle from rank 0 and deserialize it */
-            mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
-                                   shm_comm_ptr, &errflag);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+        /* get serialized handle from rank 0 and deserialize it */
+        mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0,
+                               shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-            mpl_err = MPL_shm_hnd_deserialize(*shm_segment_hdl_ptr, serialized_hnd,
-                                              strlen(serialized_hnd));
-            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SHM_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                "**alloc_shar_mem");
-
-            /* try to attach with specified symmetric address */
-            mpl_err = MPL_shm_fixed_seg_attach(*shm_segment_hdl_ptr, shm_segment_len, base_ptr, 0);
-            if (mpl_err == MPL_SHM_EINVAL)
-                *mapfail_flag = 1;
-
-            /* handle mapping failure separately, caller may retry predefined times before giving up */
-            MPIR_ERR_CHKANDJUMP((mpl_err != MPL_SHM_EINVAL && mpl_err != MPL_SHM_SUCCESS),
-                                mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
-
-            mpi_errno = MPIR_Barrier(shm_comm_ptr, &errflag);
-            MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+        mpl_err = MPL_shm_hnd_deserialize(*shm_segment_hdl_ptr, serialized_hnd,
+                                          strlen(serialized_hnd));
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            map_result = MPIDIU_SYMSHM_OTHER_FAIL;
+            goto result_sync;
         }
+
+        /* try to attach with specified symmetric address */
+        mpl_err = MPL_shm_fixed_seg_attach(*shm_segment_hdl_ptr, shm_segment_len, base_ptr, 0);
+        if (mpl_err != MPL_SHM_SUCCESS) {
+            map_result = (mpl_err == MPL_SHM_EINVAL) ?
+                MPIDIU_SYMSHM_MAP_FAIL : MPIDIU_SYMSHM_OTHER_FAIL;
+            goto result_sync;
+        } else
+            mapped_flag = true;
+
+      result_sync:
+        /* check results of all processes. If any failure happens (max result > 0),
+         * return MPIDIU_SYMSHM_OTHER_FAIL if anyone reports it (max result == 2).
+         * Otherwise return MPIDIU_SYMSHM_MAP_FAIL (max result == 1). */
+        mpi_errno = MPIR_Allreduce(&map_result, &all_map_result, 1, MPI_INT,
+                                   MPI_MAX, shm_comm_ptr, &errflag);
+        MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
+
+        if (all_map_result != MPIDIU_SYMSHM_SUCCESS)
+            goto map_fail;
     }
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_ALLOCATE_SYMSHM_SEGMENT);
     return mpi_errno;
+  map_fail:
+    /* clean up shm mapping resource */
+    if (mapped_flag) {
+        mpl_err = MPL_shm_seg_detach(*shm_segment_hdl_ptr, base_ptr, shm_segment_len);
+        MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**detach_shar_mem");
+        *base_ptr = NULL;
+    }
+    mpl_err = MPL_shm_hnd_finalize(shm_segment_hdl_ptr);
+    MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**remove_shar_mem");
+    *map_result_ptr = all_map_result;
+    goto fn_exit;
   fn_fail:
     goto fn_exit;
 }
@@ -391,7 +435,7 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
                                          MPIR_Comm * comm, MPIR_Win * win, int *fail_flag)
 {
     int mpi_errno = MPI_SUCCESS;
-    unsigned any_mapfail_flag = 1;
+    int all_map_result = MPIDIU_SYMSHM_MAP_FAIL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);
@@ -418,9 +462,11 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
     if (maxsz == 0)
         goto fn_exit;
 
-    while (any_mapfail_flag && iter-- > 0) {
+    /* try symheap multiple times if it is a fixed address mapping failure,
+     * otherwise stop. */
+    while (all_map_result == MPIDIU_SYMSHM_MAP_FAIL && iter-- > 0) {
         void *map_pointer = NULL;
-        unsigned mapfail_flag = 0;
+        int map_result = MPIDIU_SYMSHM_SUCCESS;
 
         /* the leading process in win get a random address */
         if (comm->rank == maxsz_loc)
@@ -447,7 +493,7 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
                 *base_ptr = (void *) ((char *) map_pointer - shm_offsets[shm_comm_ptr->rank]);
                 mpi_errno = MPIDIU_allocate_symshm_segment(shm_comm_ptr, mapsize,
                                                            shm_segment_hdl_ptr, base_ptr,
-                                                           &mapfail_flag);
+                                                           &map_result);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
             } else {
@@ -458,32 +504,26 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
                                          MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0, MPL_MEM_RMA);
                 } else
                     *base_ptr = (void *) MAP_FAILED;
-                mapfail_flag = (*base_ptr == (void *) MAP_FAILED) ? 1 : 0;
+                map_result = (*base_ptr == (void *) MAP_FAILED) ?
+                    MPIDIU_SYMSHM_MAP_FAIL : MPIDIU_SYMSHM_SUCCESS;
             }
         }
 
         /* check if any mapping failure occurs */
-        mpi_errno = MPIR_Allreduce(&mapfail_flag, &any_mapfail_flag, 1, MPI_UNSIGNED,
-                                   MPI_BOR, comm, &errflag);
+        mpi_errno = MPIR_Allreduce(&map_result, &all_map_result, 1, MPI_INT,
+                                   MPI_MAX, comm, &errflag);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
-        /* cleanup local shm segment if mapping failed */
-        if (any_mapfail_flag && mapsize > 0) {
+        /* cleanup local shm segment if mapping failed on other process */
+        if (all_map_result != MPIDIU_SYMSHM_SUCCESS && mapsize > 0 &&
+            map_result == MPIDIU_SYMSHM_SUCCESS) {
             if (shm_comm_ptr != NULL) {
-                if (mapfail_flag) {
-                    /* if locally map failed, only release handle */
-                    int mpl_err = MPL_SHM_SUCCESS;
-                    mpl_err = MPL_shm_hnd_finalize(shm_segment_hdl_ptr);
-                    MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**remove_shar_mem");
-                } else {
-                    /* destroy successful shm segment */
-                    mpi_errno = MPIDIU_destroy_shm_segment(mapsize, shm_segment_hdl_ptr, base_ptr);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
-                }
-            } else if (!mapfail_flag) {
+                /* destroy successful shm segment */
+                mpi_errno = MPIDIU_destroy_shm_segment(mapsize, shm_segment_hdl_ptr, base_ptr);
+                if (mpi_errno)
+                    MPIR_ERR_POP(mpi_errno);
+            } else
                 MPL_munmap(base_ptr, mapsize, MPL_MEM_RMA);
-            }
         }
     }
   fn_exit:
@@ -493,7 +533,7 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
     goto fn_exit;
 #endif
 
-    if (any_mapfail_flag) {
+    if (all_map_result != MPIDIU_SYMSHM_SUCCESS) {
         /* if fail to allocate, return and let the caller choose another method */
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     "WARNING: Win_allocate:  Unable to allocate global symmetric heap\n");

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -432,7 +432,7 @@ static inline int MPIDIU_allreduce_maxloc(size_t mysz, int myloc, MPIR_Comm * co
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offsets,
-                                         MPIR_Comm * comm, MPIR_Win * win, int *fail_flag)
+                                         MPIR_Comm * comm, MPIR_Win * win, bool * fail_flag)
 {
     int mpi_errno = MPI_SUCCESS;
     int all_map_result = MPIDIU_SYMSHM_MAP_FAIL;
@@ -450,7 +450,7 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Comm *shm_comm_ptr = comm->node_comm;
 
-    *fail_flag = 0;
+    *fail_flag = false;
     mapsize = MPIDIU_get_mapsize(shm_size, &page_sz);
 
     /* figure out leading process in win */
@@ -537,7 +537,7 @@ static inline int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offse
         /* if fail to allocate, return and let the caller choose another method */
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     "WARNING: Win_allocate:  Unable to allocate global symmetric heap\n");
-        *fail_flag = 1;
+        *fail_flag = true;
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_SHM_SYMHEAP);

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -732,9 +732,6 @@ case $with_proc_mutex_package in
     AC_CHECK_FUNC([pthread_mutex_init],[],[AC_MSG_ERROR([unable to find pthreads library])])
     # pthread_mutexattr_setpshared is first released in Issue 5
     AC_CHECK_FUNCS(pthread_mutexattr_setpshared)
-    if test "$ac_cv_func_pthread_mutexattr_setpshared" = "no" ; then
-      AC_DEFINE(HAVE_PTHREAD_MUTEXATTR_SETPSHARED,1, [Define if pthread_mutexattr_setpshared is available.])
-    fi
 
     AC_MSG_NOTICE([POSIX will be used for interprocess mutex package.])
     PROC_MUTEX_PACKAGE_NAME=MPL_PROC_MUTEX_PACKAGE_POSIX

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1316,6 +1316,8 @@
 /rma/win_zero
 /rma/wincall
 /rma/window_creation
+/rma/window_allocation
+/rma/window_noncontig_allocation
 /rma/winname
 /rma/wintest
 /rma/wintest_shm

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -81,6 +81,8 @@ noinst_PROGRAMS =          \
     strided_getacc_indexed \
     strided_getacc_indexed_shared \
     window_creation        \
+    window_allocation      \
+    window_noncontig_allocation  \
     win_flavors            \
     win_shared             \
     win_shared_noncontig   \
@@ -214,6 +216,12 @@ strided_getacc_indexed_LDADD    = $(LDADD) -lm
 strided_putget_indexed_LDADD    = $(LDADD) -lm
 strided_getacc_indexed_shared_LDADD = $(LDADD) -lm
 strided_putget_indexed_shared_LDADD = $(LDADD) -lm
+
+window_allocation_SOURCES            = window_creation.c
+window_allocation_CPPFLAGS           = -DUSE_WIN_ALLOCATE $(AM_CPPFLAGS)
+
+window_noncontig_allocation_SOURCES  = window_creation.c
+window_noncontig_allocation_CPPFLAGS = -DUSE_WIN_ALLOCATE_NONCONTIG $(AM_CPPFLAGS)
 
 fetch_and_op_char_CPPFLAGS       = -DFOP_TYPE_CHAR $(AM_CPPFLAGS)
 fetch_and_op_short_CPPFLAGS      = -DFOP_TYPE_SHORT $(AM_CPPFLAGS)

--- a/test/mpi/rma/testlist.def
+++ b/test/mpi/rma/testlist.def
@@ -60,6 +60,8 @@ strided_putget_indexed_shared 4 mpiversion=3.0
 strided_getacc_indexed 4 mpiversion=3.0
 strided_getacc_indexed_shared 4 mpiversion=3.0
 window_creation 2
+window_allocation 4 mpiversion=3.0
+window_noncontig_allocation 4 mpiversion=3.0
 contention_put 4
 contention_putget 4
 put_base 2


### PR DESCRIPTION
<h3>Background</h3>

In CH4 win_allocate, we use the following logic for memory allocation:
1. Check if we can use global symmetric heap with shm allocation (i.e., page aligned size, or noncontig enabled)
2. If *1* is TRUE, try global symmetric heap with shm memory on multi-process node (or mmap on single-process node)
3. If *1* is FALSE or *2* returns a mapping failure (currently we only handles the case that no available starting address after 100 times retry, other failures are handled as mpi error):
   3.a. Use shm memory allocation on the node with multiple processes
   3.b. Use malloc on the node with single process

<h3>Problem</h3>

- For `MPI_Win_allocate`, shm allocation is only a performance optimization in MPICH but not required by standard. Thus, we should provide a fallback routine when both *2* and *3.a* fails, i.e., use malloc.

- For `MPI_Win_allocate_shared`, it requires shared memory as defined in standard, thus we still returns MPI error if shm allocation fails.

<h3>Changes in this PR</h3>

- Change `MPIDI_CH4U_allocate_shm_segment` in order to handle all MPL* shm allocation failing internally.
  + If MPL error is reported by any of the local process, this routine internally cleans up allocated resource and set output parameter `mapfail_flag=true` with `MPI_SUCCESS` as return value;
  + If MPI communication error occurs, still return MPI error.

- Change `MPIDI_CH4I_allocate_symshm_segment` for global symmetric heap allocation. Previously we only handle map failing (i.e., invalid start address passed to `mmap` with `MAP_FIXED` flag) as non-MPI error. This PR changes it as below:
  + Similar to `MPIDI_CH4U_allocate_shm_segment`, handles all MPL shm error as non-MPI error (return `MPI_SUCCESS`) and cleans up allocated resource if such error occurs. The output parameter is `map_result`, with value `SUCCESS|MAP_FAIL|OTHER_FAIL`. `MAP_FAIL` indicates the error caused by *invalid start address*, and `OTHER_FAIL` covers any other failure (e.g., *opened too many files*)
  + In the caller routine `MPIDI_CH4R_get_shm_symheap`, if `MAP_FAIL` returns then retry with another start address; if `OTHER_FAIL` returns, which means that node can no longer allocate shm segments, then it stops retrying and return with `fail_flag=true`.

- Changes in `MPIDI_CH4I_win_shm_alloc_impl`:
  + Allows the caller to pass `bool shm_required` parameter (`false` by `win_allocate`, and `true` by `win_allocate_shared`)
  + When both global symheap and shm allocation fail, if `shm_required==false` then use `malloc`; otherwise generates an MPI error.

- Changes in `MPIDI_POSIX_mpi_win_allocate_hook`:
  + If shm segment is not allocated (i.e., `mmap_addr == NULL`), do not initialize shm mutex and do not set `MPIDI_CH4U_WIN(win, shm_allocated)` (this disables load/store RMA operation)

- Changes in both `MPIDI_POSIX_mpi_win_allocate_hook` and `MPIDI_POSIX_mpi_win_allocate_shared_hook`:
  + If shm mutex allocation fails, do not set `MPIDI_CH4U_WIN(win, shm_allocated)=1` (this disables load/store RMA operation).