### PR TITLE
test : assert to ensure context shift bits are non zero

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -527,6 +527,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_init(MPIR_Win * win)
     MPIR_ERR_CHKANDSTMT(window_instance >= MPIDI_Global.max_huge_rmas, mpi_errno,
                         MPI_ERR_OTHER, goto fn_fail, "**ofid_mr_reg");
 
+    assert(MPIDI_Global.max_rma_key_bits > MPIDI_Global.context_shift);
     max_contexts_allowed =
         (uint64_t) 1 << (MPIDI_Global.max_rma_key_bits - MPIDI_Global.context_shift);
     MPIR_ERR_CHKANDSTMT(MPIR_CONTEXT_READ_FIELD(PREFIX, win->comm_ptr->context_id)


### PR DESCRIPTION
This is an update to check that rma window creation fails
with ch4 ofi netmod. Window creation should fail because
max_rma_key_bits is set to a value less than context_shift
count, resulting in a negative count for shift value
used to compute the number of maximum allowed contexts.
The bit shift value is computed to be -1 currently, and left
shifting by a negative value behaves differently on each
platform, and cannot be relied on.
This issue was first observed in BGQ (https://github.com/pmodels/mpich/issues/3139 and https://github.com/pmodels/mpich/issues/3477) and was reproduced on JLSE Skylake node.