### PR TITLE
ch4/ofi: save number of context bits in global data structure.

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -612,16 +612,19 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         MPIDI_Global.max_huge_rmas = MPIDI_OFI_MAX_HUGE_RMAS_64;
         MPIDI_Global.context_shift = MPIDI_OFI_CONTEXT_SHIFT_64;
         MPIDI_Global.rma_key_type_bits = MPIDI_OFI_MAX_KEY_TYPE_BITS_64;
+        MPIDI_Global.rma_context_bits = MPIDI_OFI_MAX_CONTEXT_BITS_64;
     } else if (MPIDI_Global.max_mr_key_size >= 4) {
         MPIDI_Global.max_rma_key_bits = MPIDI_OFI_MAX_KEY_BITS_32;
         MPIDI_Global.max_huge_rmas = MPIDI_OFI_MAX_HUGE_RMAS_32;
         MPIDI_Global.context_shift = MPIDI_OFI_CONTEXT_SHIFT_32;
         MPIDI_Global.rma_key_type_bits = MPIDI_OFI_MAX_KEY_TYPE_BITS_32;
+        MPIDI_Global.rma_context_bits = MPIDI_OFI_MAX_CONTEXT_BITS_32;
     } else if (MPIDI_Global.max_mr_key_size >= 2) {
         MPIDI_Global.max_rma_key_bits = MPIDI_OFI_MAX_KEY_BITS_16;
         MPIDI_Global.max_huge_rmas = MPIDI_OFI_MAX_HUGE_RMAS_16;
         MPIDI_Global.context_shift = MPIDI_OFI_CONTEXT_SHIFT_16;
         MPIDI_Global.rma_key_type_bits = MPIDI_OFI_MAX_KEY_TYPE_BITS_16;
+        MPIDI_Global.rma_context_bits = MPIDI_OFI_MAX_CONTEXT_BITS_16;
     } else {
         MPIR_ERR_SETFATALANDJUMP4(mpi_errno,
                                   MPI_ERR_OTHER,

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -367,6 +367,7 @@ typedef struct {
     uint64_t max_rma_key_bits;
     uint64_t max_huge_rmas;
     int rma_key_type_bits;
+    int rma_context_bits;
     int context_shift;
     size_t tx_iov_limit;
     size_t rx_iov_limit;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -527,9 +527,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_init(MPIR_Win * win)
     MPIR_ERR_CHKANDSTMT(window_instance >= MPIDI_Global.max_huge_rmas, mpi_errno,
                         MPI_ERR_OTHER, goto fn_fail, "**ofid_mr_reg");
 
-    assert(MPIDI_Global.max_rma_key_bits > MPIDI_Global.context_shift);
-    max_contexts_allowed =
-        (uint64_t) 1 << (MPIDI_Global.max_rma_key_bits - MPIDI_Global.context_shift);
+    max_contexts_allowed = (uint64_t) 1 << MPIDI_Global.rma_context_bits;
     MPIR_ERR_CHKANDSTMT(MPIR_CONTEXT_READ_FIELD(PREFIX, win->comm_ptr->context_id)
                         >= max_contexts_allowed, mpi_errno, MPI_ERR_OTHER,
                         goto fn_fail, "**ofid_mr_reg");


### PR DESCRIPTION
The number of context bits is useful for checking if the context id can
fit in the MR key during RMA window creation. Saving the size avoid the
negative bit shifting problem due to current MR key fields division.

This is related to the pmodels/mpich#3486, pmodels/mpich#3139 and pmodels/mpich#3477