### PR TITLE
Allow disabling of dtags while retaining rpath

### DIFF
--- a/confdb/config.rpath
+++ b/confdb/config.rpath
@@ -151,6 +151,8 @@ hardcode_libdir_flag_spec=
 hardcode_libdir_separator=
 hardcode_direct=no
 hardcode_minus_L=no
+enable_dtags_flag=
+disable_dtags_flag=
 
 case "$host_os" in
   cygwin* | mingw* | pw32* | cegcc*)
@@ -223,10 +225,12 @@ if test "$with_gnu_ld" = yes; then
         # use --enable-new-dtags for RUNPATH support, which is required for
         # switching between ABI compatible libraries at runtime.
         if test "$GCC" = yes; then
-          hardcode_libdir_flag_spec="${hardcode_libdir_flag_spec} ${wl}--enable-new-dtags"
+          enable_dtags_flag="${wl}--enable-new-dtags"
+          disable_dtags_flag="${wl}--disable-new-dtags"
         else
           case $cc_basename in ifort*)
-            hardcode_libdir_flag_spec="${hardcode_libdir_flag_spec} ${wl}--enable-new-dtags"
+            enable_dtags_flag="${wl}--enable-new-dtags"
+            disable_dtags_flag="${wl}--disable-new-dtags"
             ;;
           esac
         fi
@@ -691,6 +695,10 @@ library_names_spec="$escaped_library_names_spec"
 # Flag to hardcode \$libdir into a binary during linking.
 # This must work even if \$libdir does not exist.
 hardcode_libdir_flag_spec="$escaped_hardcode_libdir_flag_spec"
+
+# Flag to add dtags to allow using runpath instead of rpath
+enable_dtags_flag="$enable_dtags_flag"
+disable_dtags_flag="$disable_dtags_flag"
 
 # Whether we need a single -rpath flag with a separated argument.
 hardcode_libdir_separator="$hardcode_libdir_separator"

--- a/configure.ac
+++ b/configure.ac
@@ -559,17 +559,20 @@ AC_ARG_ENABLE(multi-aliases,
 		[Multiple aliasing to support multiple fortran compilers (default)]),,
 		enable_multi_aliases=yes)
 
-AC_ARG_ENABLE([wrapper-rpath],
-              [AC_HELP_STRING([--enable-wrapper-rpath],
-                              [Determine whether the rpath is set when programs
-                               are linked by mpicc compiler wrappers.  This only
-                               applies when shared libraries are built.  The
-                               default is yes; use --disable-wrapper-rpath to
-                               turn this feature off.  In that case, shared
-                               libraries will be found according to the rules
-                               for your system (e.g., in LD_LIBRARY_PATH)])],
-              [],[enable_wrapper_rpath=yes])
-AC_SUBST([enable_wrapper_rpath])
+AC_ARG_WITH([wrapper-dl-type],
+            [AC_HELP_STRING([--enable-wrapper-dl-type],
+                            [Dynamic loading model for alternate MPI
+                             libraries, used when programs are linked
+                             by mpicc compiler wrappers.  This only
+                             applies when shared libraries are built.
+                             The default is "runpath"; use
+                             --with-wrapper-dl-type=rpath to force
+                             rpath; use --with-wrapper-dl-type=none to
+                             find shared libraries according to the
+                             rules for your system (e.g., in
+                             LD_LIBRARY_PATH)])],
+              [],[with_wrapper_dl_type=runpath])
+AC_SUBST([with_wrapper_dl_type])
 
 AC_ARG_ENABLE([long-double],
               [AC_HELP_STRING([--disable-long-double],
@@ -643,10 +646,11 @@ LT_INIT()
 # Non-verbose make by default
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
-# Disable rpath in the compiler wrappers if shared libraries are disabled, since
-# rpath makes no sense in the context of static libraries.
+# Disable rpath/runpath-related linkflags in the compiler wrappers if
+# shared libraries are disabled, since rpath/runpath makes no sense in
+# the context of static libraries.
 if test "X$enable_shared" = "Xno" ; then
-    enable_wrapper_rpath=no
+    with_wrapper_dl_type=no
 fi
 
 INTERLIB_DEPS=yes
@@ -2051,18 +2055,26 @@ if test -n "$MPI_DEFAULT_COPTS" ; then
 fi
 
 # ---------------------------------------------------------------------------
-# determine rpath and other shared library flags for CC
+# determine shared library flags for CC
 # src/env may not exist yet in a vpath build
 $MKDIR_P src/env
 cc_shlib_conf=src/env/cc_shlib.conf
 PAC_COMPILER_SHLIB_FLAGS([CC],[$cc_shlib_conf])
 AC_SUBST_FILE([cc_shlib_conf])
 
-# output rpath flags in a usable format for mpich.pc (pkg-config)
-if test "X$enable_wrapper_rpath" = "Xyes"; then
-    eval WRAPPER_RPATH_LDFLAGS=\"$hardcode_libdir_flag_spec\"
+$cc_shlib_conf
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+   eval WRAPPER_C_DYNAMIC_LOADING_FLAGS=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+   eval WRAPPER_C_DYNAMIC_LOADING_FLAGS=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+   WRAPPER_C_DYNAMIC_LOADING_FLAGS=""
 fi
-AC_SUBST(WRAPPER_RPATH_LDFLAGS)
+AC_SUBST(WRAPPER_C_DYNAMIC_LOADING_FLAGS)
 
 # ---------------------------------------------------------------------------
 # Support for MPI_T performance variables
@@ -2357,7 +2369,7 @@ fi
 # Now test for Fortran compiler characteristics
 # ----------------------------------------------------------------------------
 if test "$enable_f77" = "yes" ; then
-    # determine rpath and other shared library flags for F77
+    # determine shared library flags for F77
     f77_shlib_conf=src/env/f77_shlib.conf
     PAC_COMPILER_SHLIB_FLAGS([F77],[$f77_shlib_conf])
     AC_SUBST_FILE([f77_shlib_conf])
@@ -2486,7 +2498,7 @@ MPI_C_INTERFACE_TYPES_NAME=mpi_c_interface_types
 MPI_C_INTERFACE_CDESC_NAME=mpi_c_interface_cdesc
 
 if test "$enable_fc" = "yes" ; then
-    # determine rpath and other shared library flags for FC
+    # determine shared library flags for FC
     fc_shlib_conf=src/env/fc_shlib.conf
     PAC_COMPILER_SHLIB_FLAGS([FC],[$fc_shlib_conf])
     AC_SUBST_FILE([fc_shlib_conf])
@@ -2771,7 +2783,7 @@ int main() {
     AC_SUBST(MPIR_CXX_DOUBLE_COMPLEX)
     AC_SUBST(MPIR_CXX_LONG_DOUBLE_COMPLEX)
 
-    # determine rpath and other shared library flags for CXX
+    # determine shared library flags for CXX
     cxx_shlib_conf=src/env/cxx_shlib.conf
     PAC_COMPILER_SHLIB_FLAGS([CXX],[$cxx_shlib_conf])
     AC_SUBST_FILE([cxx_shlib_conf])

--- a/maint/checkbuilds.in
+++ b/maint/checkbuilds.in
@@ -69,7 +69,6 @@ $hasDemon   = 0;
                   'refcount;lock;lock-free;none',
                   'mutex-timing',
                   'multi-aliases',
-                  'wrapper-rpath',
                   'predefined-refcount',
                   'alloca',
                   'yield;sched_yield;yield;select;usleep;sleep',
@@ -83,6 +82,7 @@ $hasDemon   = 0;
 	       'pm;gforker', #;remshell
 	       'namepublisher;no;file', #;ldap:ldapserver',
 	       'device;ch3;ch3:sock',
+	       'wrapper-dl-type;runpath;rpath;none',
 );
 %chosenWith = ();
 @env_array = (

--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -39,8 +39,19 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 CC="@CC@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @cc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -236,23 +247,12 @@ fi
 # file or an object file.  Instead, we just check for an option that
 # suppressing linking, such as -c or -M.
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -263,7 +263,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -39,8 +39,19 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 CC="@CC@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @cc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -245,23 +256,12 @@ fi
 # file or an object file.  Instead, we just check for an option that
 # suppressing linking, such as -c or -M.
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -272,7 +272,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -36,8 +36,19 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 CXX="@CXX@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @cxx_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -234,23 +245,12 @@ fi
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
       if [ "$static_mpi" = no ] ; then
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
       else
         fabric_dep=""
         if [ "@ofi_embedded@" = yes ] ; then
@@ -261,7 +261,7 @@ if [ "$linking" = yes ] ; then
         else
             fabric_dep=`pkg-config --static --libs libfabric`
         fi
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
       fi
         rc=$?
     fi

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -36,8 +36,19 @@ libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
 CXX="@CXX@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @cxx_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -243,23 +254,12 @@ fi
 # Eventually, we'll want to move this after any non-MPI implementation 
 # libraries
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
       if [ "$static_mpi" = no ] ; then
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs}
       else
         fabric_dep=""
         if [ "@ofi_embedded@" = yes ] ; then
@@ -270,7 +270,7 @@ if [ "$linking" = yes ] ; then
         else
             fabric_dep=`pkg-config --static --libs libfabric`
         fi
-        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
+        $Show $CXX ${final_cppflags} $PROFILE_INCPATHS ${final_cxxflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $cxxlibs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} ${fabric_dep}
       fi
         rc=$?
     fi

--- a/src/env/mpif77.bash.in
+++ b/src/env/mpif77.bash.in
@@ -42,8 +42,19 @@ F77="@F77@"
 F77CPP="@F77CPP@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @f77_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -286,23 +297,12 @@ fi
 # libraries
 #
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
+          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -313,7 +313,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@ ${fabric_dep}
+          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@ ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/env/mpif77.sh.in
+++ b/src/env/mpif77.sh.in
@@ -42,8 +42,19 @@ F77="@F77@"
 F77CPP="@F77CPP@"
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @f77_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead 
@@ -308,23 +319,12 @@ fi
 # libraries
 #
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} $allargs -I$includedir
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
+          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -335,7 +335,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@ ${fabric_dep}
+          $Show $F77 $PROFILE_INCPATHS ${final_fflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $f77libs $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @F77_OTHER_LIBS@ ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -55,8 +55,19 @@ FCEXT="@FCEXT@"
 
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @fc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead
@@ -326,24 +337,12 @@ fi
 # Eventually, we'll want to move this after any non-MPI implementation
 # libraries
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        # prepend the path for the shared libraries to the library list
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}"
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
+          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -354,7 +353,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@ ${fabric_dep}
+          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@ ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -55,8 +55,19 @@ FCEXT="@FCEXT@"
 #
 MPICH_VERSION="@MPICH_VERSION@"
 
-enable_wrapper_rpath="@enable_wrapper_rpath@"
 @fc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
 
 # Internal variables
 # Show is set to echo to cause the compilation command to be echoed instead
@@ -343,23 +354,12 @@ fi
 # Eventually, we'll want to move this after any non-MPI implementation
 # libraries
 if [ "$linking" = yes ] ; then
-    # Attempt to encode rpath info into the executable if the user has not
-    # disabled rpath usage and some flavor of rpath makes sense on this
-    # platform.
-    # TODO configure and config.rpath are computing more sophisticated rpath
-    # schemes than this simple one.  Consider updating this logic accordingly.
-    if test "X$enable_wrapper_rpath" = "Xyes" ; then
-        eval rpath_flags=\"${hardcode_libdir_flag_spec}\"
-    else
-	rpath_flags=""
-    fi
-
     if [ "$nativelinking" = yes ] ; then
         $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} $allargs
         rc=$?
     else
         if [ "$static_mpi" = no ] ; then
-          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
+          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPILIBNAME@ @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@
         else
           fabric_dep=""
           if [ "@ofi_embedded@" = yes ] ; then
@@ -370,7 +370,7 @@ if [ "$linking" = yes ] ; then
           else
               fabric_dep=`pkg-config --static --libs libfabric`
           fi
-          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO $rpath_flags $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@ ${fabric_dep}
+          $Show $FC $PROFILE_INCPATHS ${final_fcflags} ${final_ldflags} "${allargs[@]}" $FCINCDIRS $FCMODDIRS -L$libdir -l@MPIFCLIBNAME@ $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/libmpi.a @LPMPILIBNAME@ $PROFILE_POSTLIB ${final_libs} @FC_OTHER_LIBS@ ${fabric_dep}
         fi
         rc=$?
     fi

--- a/src/packaging/pkgconfig/mpich.pc.in
+++ b/src/packaging/pkgconfig/mpich.pc.in
@@ -9,7 +9,7 @@ Description: High Performance and portable MPI
 Version: @MPICH_VERSION@
 URL: http://www.mcs.anl.gov/research/projects/mpich
 Requires:
-Libs: @WRAPPER_RPATH_LDFLAGS@ @WRAPPER_LDFLAGS@ -L${libdir} -l@MPILIBNAME@ @LPMPILIBNAME@ @WRAPPER_LIBS@
+Libs: @WRAPPER_C_DYNAMIC_LOADING_FLAGS@ @WRAPPER_LDFLAGS@ -L${libdir} -l@MPILIBNAME@ @LPMPILIBNAME@ @WRAPPER_LIBS@
 Cflags: @WRAPPER_CPPFLAGS@ @WRAPPER_CFLAGS@ -I${includedir}
 
 # pkg-config does not understand Cxxflags, etc. So we allow users to


### PR DESCRIPTION
The dtags option distinguishes whether we use rpath or runpath for
executables build with mpicc and friends.  Disabling dtags would allow
users to build their executables with rpath, instead of the default
rpath.