### PR TITLE
refactor: add MPIR_ERR_CHECK macro

### DIFF
--- a/maint/getcoverage.in
+++ b/maint/getcoverage.in
@@ -293,7 +293,7 @@ L:  while (<FD>) {
 	# and nothing else.
 	if ($skipErrExits && 
 	    (/FUNC_EXIT.*STATE/ || /MPIR_Err_return_/ || 
-	     /MPIR_ERR_SET/ || /MPIR_ERR_POP/ || /goto\s+fn_fail/ ||
+	     /MPIR_ERR_SET/ || /MPIR_ERR_POP/ || /MPIR_ERR_CHECK/ || /goto\s+fn_fail/ ||
 	     /MPIR_ERR_ADD/ || /\*errflag\s*=\s*[^;]*;\s*$/ || 
 	     /fn_fail:/ || /MPIR_Err_create_code/)) {
 	    next;
@@ -401,7 +401,7 @@ L2: while (<FD>) {
 	# The format of the line also changed
 	if ($skipErrExits && 
 	    (/FUNC_EXIT.*STATE/ || /MPIR_Err_return_/ || 
-	     /MPIR_ERR_SET/ || /MPIR_ERR_POP/ || /goto\s+fn_fail/ ||
+	     /MPIR_ERR_SET/ || /MPIR_ERR_POP/ || /MPIR_ERR_CHECK/ || /goto\s+fn_fail/ ||
 	     /MPIR_ERR_ADD/ || /\*errflag\s*=\s*[^;]*;\s*$/ || 
             /fn_fail:/ || /MPIR_Err_create_code/)) {
 	    # If requested, skip obvious error checking lines

--- a/src/binding/fortran/use_mpi/create_f90_complex.c
+++ b/src/binding/fortran/use_mpi/create_f90_complex.c
@@ -92,8 +92,7 @@ int MPI_Type_create_f90_complex(int precision, int range, MPI_Datatype * newtype
                                                        f90_real_model[i].digits,
                                                        f90_real_model[i].exponent,
                                                        &f90_real_model[i].dtype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -116,8 +115,7 @@ int MPI_Type_create_f90_complex(int precision, int range, MPI_Datatype * newtype
                                                    MPI_COMBINER_F90_COMPLEX, range, precision,
                                                    newtype);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/binding/fortran/use_mpi/create_f90_real.c
+++ b/src/binding/fortran/use_mpi/create_f90_real.c
@@ -91,8 +91,7 @@ int MPI_Type_create_f90_real(int precision, int range, MPI_Datatype * newtype)
                                                        f90_real_model[i].digits,
                                                        f90_real_model[i].exponent,
                                                        &f90_real_model[i].dtype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -115,8 +114,7 @@ int MPI_Type_create_f90_real(int precision, int range, MPI_Datatype * newtype)
                                                    MPI_COMBINER_F90_REAL, range, precision,
                                                    newtype);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
 
   fn_exit:

--- a/src/binding/fortran/use_mpi/create_f90_util.c
+++ b/src/binding/fortran/use_mpi/create_f90_util.c
@@ -74,8 +74,7 @@ int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
 
     /* Create a contiguous type from one instance of the named type */
     mpi_errno = MPIR_Type_contiguous(1, old, &type->d);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize the contents data */
     {
@@ -99,8 +98,7 @@ int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
 
         MPIR_Datatype_get_ptr(type->d, new_dtp);
         mpi_errno = MPIR_Datatype_set_contents(new_dtp, combiner, nvals, 0, 0, vals, NULL, NULL);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef NDEBUG
         {
@@ -118,8 +116,7 @@ int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
         /* the MPI Standard requires that these types are pre-committed
          * (MPI-2.2, sec 16.2.5, pg 492) */
         mpi_errno = MPIR_Type_commit(&type->d);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *new_ptr = type->d;

--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -76,20 +76,17 @@ int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype)
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
         MPIR_Datatype *datatype_ptr = NULL;
         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
 
         MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_fail:

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -779,11 +779,14 @@ cvars:
     MPIR_ERR_SETFATALANDSTMT(err_,MPI_ERR_OTHER,goto fn_fail,"**fail")
 #define MPIR_ERR_POPFATAL_LABEL(err_, label_)                           \
     MPIR_ERR_SETFATALANDSTMT(err_,MPI_ERR_OTHER,goto label_,"**fail")
+#define MPIR_ERR_CHECK(err_) \
+    if (unlikely(err_)) MPIR_ERR_SETANDSTMT(err_,MPI_ERR_OTHER,goto fn_fail,"**fail")
 #else
 #define MPIR_ERR_POP(err_) goto fn_fail
 #define MPIR_ERR_POP_LABEL(err_, label_) goto label_
 #define MPIR_ERR_POPFATAL(err_) goto fn_fail
 #define MPIR_ERR_POPFATAL_LABEL(err_, label_) goto label_
+#define MPIR_ERR_CHECK(err_) if (unlikely(err_)) goto fn_fail
 #endif
 
 /* If you add any macros to this list, make sure that you update

--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -88,7 +88,7 @@ int MPIR_Sched_barrier(MPIR_Sched_t s);
 #define MPIR_SCHED_BARRIER(sched_)              \
     do {                                        \
         mpi_errno = MPIR_Sched_barrier(sched_); \
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno); \
+        MPIR_ERR_CHECK(mpi_errno);              \
     } while (0)
 
 /* Defers evaluating (*count) until the entry actually begins to execute.  This
@@ -153,7 +153,7 @@ int MPIR_Sched_cb_free_buf(MPIR_Comm * comm, int tag, void *state);
             mpi_errno = MPIR_Sched_cb(&MPIR_Sched_cb_free_buf,                                 \
                                       (mpir_sched_chkpmem_stk_[--mpir_sched_chkpmem_stk_sp_]), \
                                       (sched_));                                               \
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);                                            \
+            MPIR_ERR_CHECK(mpi_errno);                                                         \
         }                                                                                      \
     } while (0)
 

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -46,20 +46,17 @@ int MPIR_Treealgo_tree_create(int rank, int nranks, int tree_type, int k, int ro
     switch (tree_type) {
         case MPIR_TREE_TYPE_KARY:
             mpi_errno = MPII_Treeutil_tree_kary_init(rank, nranks, k, root, ct);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPIR_TREE_TYPE_KNOMIAL_1:
             mpi_errno = MPII_Treeutil_tree_knomial_1_init(rank, nranks, k, root, ct);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         case MPIR_TREE_TYPE_KNOMIAL_2:
             mpi_errno = MPII_Treeutil_tree_knomial_2_init(rank, nranks, k, root, ct);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
 
         default:

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -54,8 +54,7 @@ int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPIR_Tre
 
         val = (val + root) % nranks;
         mpi_errno = tree_add_child(ct, val);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -145,8 +144,7 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
                                 (MPL_DBG_FDEST, "adding child %d to rank %d",
                                  (crank + root) % nranks, rank));
                 mpi_errno = tree_add_child(ct, (crank + root) % nranks);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
             crank += MPL_ipow(k, maxstep - i - 1);
         }

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -133,8 +133,7 @@ int MPIR_Allgather_intra_auto(const void *sendbuf,
             MPIR_Allgather_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                       comm_ptr, errflag);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -223,8 +222,7 @@ int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -18,14 +18,12 @@ int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype s
     mpi_errno =
         MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                         &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -51,15 +51,11 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    tmp_buf, recvcount * recvtype_sz, MPI_BYTE);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Localcopy((char *) recvbuf + rank * recvcount * recvtype_extent,
                                    recvcount, recvtype, tmp_buf, recvcount * recvtype_sz, MPI_BYTE);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* do the first \floor(\lg p) steps */
@@ -115,18 +111,14 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     mpi_errno = MPIR_Localcopy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPI_BYTE,
                                (char *) recvbuf + rank * recvcount * recvtype_extent,
                                (comm_size - rank) * recvcount, recvtype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (rank) {
         mpi_errno = MPIR_Localcopy((char *) tmp_buf +
                                    (comm_size - rank) * recvcount * recvtype_sz,
                                    rank * recvcount * recvtype_sz, MPI_BYTE, recvbuf,
                                    rank * recvcount, recvtype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -56,9 +56,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) recvbuf +
                                     rank * recvcount * recvtype_extent), recvcount, recvtype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     curr_cnt = recvcount;

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -49,9 +49,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) recvbuf +
                                     rank * recvcount * recvtype_extent), recvcount, recvtype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /*

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -120,8 +120,7 @@ int MPIR_Allgatherv_intra_auto(const void *sendbuf,
             MPIR_Allgatherv_intra_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
                                                      recvcounts, displs, recvtype, comm_ptr,
                                                      errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     else if (total_count * recvtype_size < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
@@ -130,8 +129,7 @@ int MPIR_Allgatherv_intra_auto(const void *sendbuf,
         mpi_errno =
             MPIR_Allgatherv_intra_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
                                          recvtype, comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
     } else {
         /* long message or medium-size message and non-power-of-two
@@ -140,8 +138,7 @@ int MPIR_Allgatherv_intra_auto(const void *sendbuf,
         mpi_errno =
             MPIR_Allgatherv_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
                                        recvtype, comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -232,8 +229,7 @@ int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendty
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype 
     mpi_errno =
         MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
                          comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -91,19 +91,16 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, int sen
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Type_indexed_impl(remote_size, recvcounts, displs, recvtype, &newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_commit_impl(&newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Bcast_intra_auto(recvbuf, 1, newtype, 0, newcomm_ptr, errflag);
     if (mpi_errno) {

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -60,15 +60,13 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Localcopy(((char *) recvbuf +
                                     displs[rank] * recvtype_extent),
                                    recvcounts[rank], recvtype, tmp_buf,
                                    recvcounts[rank] * recvtype_sz, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* do the first \floor(\lg p) steps */
@@ -135,8 +133,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                    recvcounts[j] * recvtype_sz, MPI_BYTE,
                                    (char *) recvbuf + displs[j] * recvtype_extent,
                                    recvcounts[j], recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         send_cnt += recvcounts[j];
     }
 
@@ -145,8 +142,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                    recvcounts[i] * recvtype_sz, MPI_BYTE,
                                    (char *) recvbuf + displs[i] * recvtype_extent,
                                    recvcounts[i], recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         send_cnt += recvcounts[i];
     }
 

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -72,8 +72,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) tmp_buf + position *
                                     recvtype_sz), recvcounts[rank] * recvtype_sz, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* if in_place specified, local data is found in recvbuf */
         mpi_errno = MPIR_Localcopy(((char *) recvbuf +
@@ -81,8 +80,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                    recvcounts[rank], recvtype,
                                    ((char *) tmp_buf + position *
                                     recvtype_sz), recvcounts[rank] * recvtype_sz, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     curr_cnt = recvcounts[rank];
@@ -244,8 +242,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                        recvcounts[j] * recvtype_sz, MPI_BYTE,
                                        ((char *) recvbuf + displs[j] * recvtype_extent),
                                        recvcounts[j], recvtype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         position += recvcounts[j];
     }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -63,8 +63,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) recvbuf + displs[rank] * recvtype_extent),
                                    recvcounts[rank], recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     left = (comm_size + rank - 1) % comm_size;

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -277,8 +277,7 @@ int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datat
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -412,8 +411,7 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -15,14 +15,12 @@ int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -51,8 +51,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
@@ -100,8 +99,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -146,18 +144,15 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             if (is_commutative || (dst < rank)) {
                 /* op is commutative OR the order is already right */
                 mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else {
                 /* op is noncommutative and the order is not right */
                 mpi_errno = MPIR_Reduce_local(recvbuf, tmp_buf, count, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* copy result back into recvbuf */
                 mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype, recvbuf, count, datatype);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
             mask <<= 1;
         }

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -71,8 +71,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
@@ -120,8 +119,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -209,8 +207,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIR_Reduce_local(((char *) tmp_buf + disps[recv_idx] * extent),
                                           ((char *) recvbuf + disps[recv_idx] * extent),
                                           recv_cnt, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* update send_idx for next iteration */
             send_idx = recv_idx;

--- a/src/mpi/coll/allreduce/allreduce_intra_smp.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_smp.c
@@ -49,8 +49,7 @@ int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, int count,
         /* only one process on the node. copy sendbuf to recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -12,7 +12,7 @@
     do {                                                                                                      \
         int gr_tmp_ = (gr_);                                                                                  \
         mpi_errno = MPIR_Group_translate_ranks_impl(group_ptr, 1, &(gr_tmp_), comm_ptr->local_group, &(cr_)); \
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);                                                               \
+        MPIR_ERR_CHECK(mpi_errno);                                                                            \
         MPIR_Assert((cr_) != MPI_UNDEFINED);                                                                  \
     } while (0)
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -51,8 +51,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -102,8 +101,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* change the rank */
             newrank = group_rank / 2;
@@ -152,19 +150,16 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
                     if (is_commutative || (dst < group_rank)) {
                         /* op is commutative OR the order is already right */
                         mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     } else {
                         /* op is noncommutative and the order is not right */
                         mpi_errno = MPIR_Reduce_local(recvbuf, tmp_buf, count, datatype, op);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         /* copy result back into recvbuf */
                         mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype,
                                                    recvbuf, count, datatype);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 }
                 mask <<= 1;
@@ -243,8 +238,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
                 mpi_errno = MPIR_Reduce_local(((char *) tmp_buf + disps[recv_idx] * extent),
                                               ((char *) recvbuf + disps[recv_idx] * extent),
                                               recv_cnt, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* update send_idx for next iteration */
                 send_idx = recv_idx;
@@ -355,8 +349,7 @@ int MPII_Allreduce_group(void *sendbuf, void *recvbuf, int count,
 
     mpi_errno = MPII_Allreduce_group_intra(sendbuf, recvbuf, count, datatype,
                                            op, comm_ptr, group_ptr, tag, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoall/alltoall.c
+++ b/src/mpi/coll/alltoall/alltoall.c
@@ -154,8 +154,7 @@ int MPIR_Alltoall_intra_auto(const void *sendbuf,
             MPIR_Alltoall_intra_pairwise(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                          comm_ptr, errflag);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -248,8 +247,7 @@ int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -18,14 +18,12 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype se
     mpi_errno =
         MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                        &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -65,16 +65,12 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
                                rank * sendcount * sendtype_extent,
                                (comm_size - rank) * sendcount, sendtype, recvbuf,
                                (comm_size - rank) * recvcount, recvtype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Localcopy(sendbuf, rank * sendcount, sendtype,
                                (char *) recvbuf +
                                (comm_size - rank) * recvcount * recvtype_extent,
                                rank * recvcount, recvtype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     /* Input data is now stored in recvbuf with datatype recvtype */
 
     /* Now do Phase 2, the communication phase. It takes
@@ -106,17 +102,14 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
 
         mpi_errno = MPIR_Type_create_indexed_block_impl(count, recvcount,
                                                         displs, recvtype, &newtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&newtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         newtype_sz = count * recvcount * recvtype_sz;
         mpi_errno = MPIR_Localcopy(recvbuf, 1, newtype, tmp_buf, newtype_sz, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
@@ -142,16 +135,12 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     mpi_errno = MPIR_Localcopy((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent,
                                (comm_size - rank - 1) * recvcount, recvtype, tmp_buf,
                                (comm_size - rank - 1) * recvcount * recvtype_sz, MPI_BYTE);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Localcopy(recvbuf, (rank + 1) * recvcount, recvtype,
                                (char *) tmp_buf + (comm_size - rank - 1)
                                * recvcount * recvtype_sz,
                                (rank + 1) * recvcount * recvtype_sz, MPI_BYTE);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Blocks are in the reverse order now (comm_size-1 to 0).
      * Reorder them to (0 to comm_size-1) and store them in recvbuf. */
@@ -162,8 +151,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
                                    (char *) recvbuf + (comm_size - i -
                                                        1) * recvcount * recvtype_extent, recvcount,
                                    recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -58,9 +58,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                sendcount, sendtype,
                                ((char *) recvbuf +
                                 rank * recvcount * recvtype_extent), recvcount, recvtype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Is comm_size a power-of-two? */
     i = 1;

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -79,8 +79,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                    dst * recvcount * recvtype_extent,
                                    recvcount, recvtype, dst,
                                    MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i]);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         for (i = 0; i < ss; i++) {
@@ -89,8 +88,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                    dst * sendcount * sendtype_extent,
                                    sendcount, sendtype, dst,
                                    MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss], errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* ... then wait for them to finish: */

--- a/src/mpi/coll/alltoallv/alltoallv.c
+++ b/src/mpi/coll/alltoallv/alltoallv.c
@@ -89,14 +89,12 @@ int MPIR_Alltoallv_intra_auto(const void *sendbuf, const int *sendcounts, const 
             MPIR_Alltoallv_intra_pairwise_sendrecv_replace(sendbuf, sendcounts, sdispls, sendtype,
                                                            recvbuf, recvcounts, rdispls, recvtype,
                                                            comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Alltoallv_intra_scattered(sendbuf, sendcounts, sdispls, sendtype,
                                                    recvbuf, recvcounts, rdispls, recvtype, comm_ptr,
                                                    errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -183,8 +181,7 @@ int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcounts, const int *s
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcounts, const 
     mpi_errno =
         MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
                         recvtype, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallw/alltoallw.c
+++ b/src/mpi/coll/alltoallw/alltoallw.c
@@ -88,14 +88,12 @@ int MPIR_Alltoallw_intra_auto(const void *sendbuf, const int sendcounts[], const
             MPIR_Alltoallw_intra_pairwise_sendrecv_replace(sendbuf, sendcounts, sdispls, sendtypes,
                                                            recvbuf, recvcounts, rdispls, recvtypes,
                                                            comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno =
             MPIR_Alltoallw_intra_scattered(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                            recvcounts, rdispls, recvtypes, comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -180,8 +178,7 @@ int MPIR_Alltoallw_impl(const void *sendbuf, const int sendcounts[], const int s
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[], const
     mpi_errno =
         MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
                         recvtypes, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -74,9 +74,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const int sendcounts[], 
                                            recvcounts[dst], recvtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
                                            &reqarray[outstanding_requests]);
-                    if (mpi_errno) {
-                        MPIR_ERR_POP(mpi_errno);
-                    }
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;
                 }
@@ -92,9 +90,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const int sendcounts[], 
                                            sendcounts[dst], sendtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
                                            &reqarray[outstanding_requests], errflag);
-                    if (mpi_errno) {
-                        MPIR_ERR_POP(mpi_errno);
-                    }
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;
                 }

--- a/src/mpi/coll/barrier/barrier.c
+++ b/src/mpi/coll/barrier/barrier.c
@@ -159,8 +159,7 @@ int MPIR_Barrier_impl(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -251,8 +250,7 @@ int MPI_Barrier(MPI_Comm comm)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Barrier(comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -14,14 +14,12 @@ int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -31,8 +31,7 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;

--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -295,8 +295,7 @@ int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MP
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -411,8 +410,7 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Bcast(buffer, count, datatype, root, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -15,14 +15,12 @@ int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int ro
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -54,8 +54,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -160,8 +159,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
         }
     }

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -85,8 +85,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -275,8 +274,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -71,8 +71,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -146,8 +145,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -69,8 +69,7 @@ int MPIR_Exscan_intra_auto(const void *sendbuf, void *recvbuf, int count, MPI_Da
     mpi_errno =
         MPIR_Exscan_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op, comm_ptr,
                                              errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -104,8 +103,7 @@ int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count,
                 MPIR_Exscan_intra_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
             break;
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -15,14 +15,12 @@ int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Da
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -88,8 +88,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     mpi_errno =
         MPIR_Localcopy((sendbuf == MPI_IN_PLACE ? (const void *) recvbuf : sendbuf), count,
                        datatype, partial_scan, count, datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     flag = 0;
     mask = 0x1;
@@ -112,8 +111,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* On rank 0, recvbuf is not defined.  For sendbuf==MPI_IN_PLACE
                  * recvbuf must not change (per MPI-2.2).
@@ -126,30 +124,25 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                         /* simply copy data recd from rank 0 into recvbuf */
                         mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype,
                                                    recvbuf, count, datatype);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         flag = 1;
                     } else {
                         mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 }
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } else {
                     mpi_errno = MPIR_Reduce_local(partial_scan, tmp_buf, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype,
                                                partial_scan, count, datatype);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }

--- a/src/mpi/coll/gather/gather.c
+++ b/src/mpi/coll/gather/gather.c
@@ -96,8 +96,7 @@ int MPIR_Gather_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype send
     mpi_errno =
         MPIR_Gather_intra_binomial(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
                                    comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -134,8 +133,7 @@ int MPIR_Gather_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype send
         mpi_errno = MPIR_Gather_inter_linear(sendbuf, sendcount, sendtype,
                                              recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -198,8 +196,7 @@ int MPIR_Gather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -18,14 +18,12 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype send
     mpi_errno =
         MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
                      &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -69,8 +69,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcoun
         /* all processes in remote group form new intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         newcomm_ptr = comm_ptr->local_comm;

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -116,16 +116,12 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
             mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                        ((char *) recvbuf + extent * recvcount * rank),
                                        recvcount, recvtype);
-            if (mpi_errno) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
     } else if (tmp_buf_size && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE)) {
         /* copy from sendbuf into tmp_buf */
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype, tmp_buf, nbytes, MPI_BYTE);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     curr_cnt = nbytes;
 
@@ -186,12 +182,10 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
                         displs[1] = 0;
 
                         mpi_errno = MPIR_Type_indexed_impl(2, blocks, displs, recvtype, &tmp_type);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIR_Type_commit_impl(&tmp_type);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
                                               MPIR_GATHER_TAG, comm_ptr, &status, errflag);
@@ -277,12 +271,10 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
                 struct_displs[1] = (MPI_Aint) tmp_buf;
                 mpi_errno =
                     MPIR_Type_create_struct_impl(2, blocks, struct_displs, types, &tmp_type);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIR_Type_commit_impl(&tmp_type);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIC_Send(MPI_BOTTOM, 1, tmp_type, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
@@ -310,14 +302,12 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
                                    nbytes * (comm_size - copy_offset), MPI_BYTE,
                                    ((char *) recvbuf + extent * recvcount * copy_offset),
                                    recvcount * (comm_size - copy_offset), recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Localcopy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
                                    nbytes * (copy_blks - comm_size + copy_offset), MPI_BYTE,
                                    recvbuf,
                                    recvcount * (copy_blks - comm_size + copy_offset), recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -85,8 +85,7 @@ int MPIR_Gatherv_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
     mpi_errno =
         MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
                                     recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -107,8 +106,7 @@ int MPIR_Gatherv_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
     mpi_errno =
         MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
                                     recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -168,8 +166,7 @@ int MPIR_Gatherv_impl(const void *sendbuf, int sendcount,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
   fn_exit:

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -81,15 +81,13 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                                    ((char *) recvbuf + displs[rank] * extent),
                                                    recvcounts[rank], recvtype);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 } else {
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + displs[i] * extent),
                                            recvcounts[i], recvtype, i,
                                            MPIR_GATHERV_TAG, comm_ptr, &reqarray[reqs++]);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sen
     mpi_errno =
         MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
                       comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -64,8 +64,7 @@ int MPIC_Wait(MPIR_Request * request_ptr, MPIR_Errflag_t * errflag)
         request_ptr->status.MPI_TAG = 0;
 
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (request_ptr->kind == MPIR_REQUEST_KIND__RECV)
         MPIR_Process_status(&request_ptr->status, errflag);
@@ -130,12 +129,10 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
 
     mpi_errno = MPID_Send_coll(buf, count, datatype, dest, tag, comm_ptr, context_id,
                                &request_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Request_free(request_ptr);
     }
 
@@ -190,12 +187,10 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
 
     mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr,
                           context_id, status, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr, errflag);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *status = request_ptr->status;
         mpi_errno = status->MPI_ERROR;
@@ -258,12 +253,10 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     }
 
     mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr, context_id, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Request_free(request_ptr);
     }
 
@@ -323,8 +316,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
     } else {
         mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag,
                                comm_ptr, context_id, &recv_req_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* If dest is MPI_PROC_NULL, create a completed request and return. */
@@ -335,13 +327,11 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
     } else {
         mpi_errno = MPID_Isend_coll(sendbuf, sendcount, sendtype, dest, sendtag,
                                     comm_ptr, context_id, &send_req_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIC_Wait(send_req_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIC_Wait(recv_req_ptr, errflag);
     if (mpi_errno)
         MPIR_ERR_POPFATAL(mpi_errno);
@@ -422,8 +412,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
         mpi_errno =
             MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* If source is MPI_PROC_NULL, create a completed request and return. */
@@ -434,8 +423,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
     } else {
         mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag,
                                comm_ptr, context_id_offset, &rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* If dest is MPI_PROC_NULL, create a completed request and return. */
@@ -445,8 +433,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
     } else {
         mpi_errno = MPID_Isend_coll(tmpbuf, actual_pack_bytes, MPI_PACKED, dest,
                                     sendtag, comm_ptr, context_id_offset, &sreq, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */
             /* FIXME: should we cancel the pending (possibly completed) receive
@@ -458,11 +445,9 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
     }
 
     mpi_errno = MPIC_Wait(sreq, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIC_Wait(rreq, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *status = rreq->status;
 
@@ -519,8 +504,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 
     mpi_errno = MPID_Isend_coll(buf, count, datatype, dest, tag, comm_ptr, context_id,
                                 request_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIC_ISEND);
@@ -567,8 +551,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     mpi_errno = MPID_Issend(buf, count, datatype, dest, tag, comm_ptr, context_id, request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIC_ISSEND);
@@ -604,8 +587,7 @@ int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr, context_id, request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIC_IRECV);

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -171,8 +171,7 @@ int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dat
             MPIR_Iallgather_sched_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                              recvtype, comm_ptr, s);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -288,8 +287,7 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
                     MPIR_Iallgather_intra_gentran_recexch_doubling(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcount, recvtype,
                                                                    comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHER_INTRA_ALGORITHM_gentran_recexch_halving:
@@ -297,16 +295,14 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
                     MPIR_Iallgather_intra_gentran_recexch_halving(sendbuf, sendcount, sendtype,
                                                                   recvbuf, recvcount, recvtype,
                                                                   comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHER_INTRA_ALGORITHM_gentran_brucks:
                 mpi_errno =
                     MPIR_Iallgather_intra_gentran_brucks(sendbuf, sendcount, sendtype, recvbuf,
                                                          recvcount, recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHER_INTRA_ALGORITHM_gentran_ring:
@@ -314,8 +310,7 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
                     MPIR_Iallgather_intra_gentran_ring(sendbuf, sendcount, sendtype,
                                                        recvbuf, recvcount, recvtype, comm_ptr,
                                                        request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -325,21 +320,17 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Iallgather_sched(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                               s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -472,8 +463,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
     mpi_errno = MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                 recvtype, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
@@ -49,8 +49,7 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
         mpi_errno = MPIR_Igather_sched(sendbuf, sendcount, sendtype,
                                        tmp_buf, sendcount * sendtype_sz, MPI_BYTE,
                                        0, newcomm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -62,8 +61,7 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_sched(tmp_buf, sendcount * local_size * sendtype_sz,
                                           MPI_BYTE, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* no sched barrier, bcasts are logically concurrent */
@@ -73,8 +71,7 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
             root = 0;
             mpi_errno = MPIR_Ibcast_sched(recvbuf, recvcount * remote_size,
                                           recvtype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
@@ -83,8 +80,7 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
             root = 0;
             mpi_errno = MPIR_Ibcast_sched(recvbuf, recvcount * remote_size,
                                           recvtype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* no sched barrier, bcasts are logically concurrent */
@@ -94,8 +90,7 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_sched(tmp_buf, sendcount * local_size * sendtype_sz,
                                           MPI_BYTE, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iallgather/iallgather_intra_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_brucks.c
@@ -39,15 +39,13 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype, tmp_buf,
                                     recvcount * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else {
         mpi_errno = MPIR_Sched_copy((char *) recvbuf + rank * recvcount * recvtype_extent,
                                     recvcount, recvtype,
                                     tmp_buf, recvcount * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -60,13 +58,11 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
         dst = (rank - pof2 + comm_size) % comm_size;
 
         mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_cnt * recvtype_sz),
                                     curr_cnt * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         curr_cnt *= 2;
@@ -82,13 +78,11 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
 
         mpi_errno =
             MPIR_Sched_send(tmp_buf, rem * recvcount * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv((char *) tmp_buf + curr_cnt * recvtype_sz,
                                     rem * recvcount * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -98,8 +92,7 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
     mpi_errno = MPIR_Sched_copy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPI_BYTE,
                                 ((char *) recvbuf + rank * recvcount * recvtype_extent),
                                 (comm_size - rank) * recvcount, recvtype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     if (rank) {
@@ -107,8 +100,7 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
             MPIR_Sched_copy((char *) tmp_buf + (comm_size - rank) * recvcount * recvtype_sz,
                             rank * recvcount * recvtype_sz, MPI_BYTE,
                             recvbuf, rank * recvcount, recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
@@ -79,8 +79,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     ((char *) recvbuf + rank * recvcount * recvtype_extent),
                                     recvcount, recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -115,19 +114,16 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
         if (dst < comm_size) {
             mpi_errno = MPIR_Sched_send_defer(((char *) recvbuf + send_offset),
                                               &ss->curr_count, recvtype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* send-recv, no sched barrier here */
             mpi_errno = MPIR_Sched_recv_status(((char *) recvbuf + recv_offset),
                                                ((comm_size - dst_tree_root) * recvcount),
                                                recvtype, dst, comm_ptr, &ss->status, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
 
@@ -182,8 +178,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
                     mpi_errno = MPIR_Sched_send_defer(((char *) recvbuf + offset),
                                                       &ss->last_recv_count,
                                                       recvtype, dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
                 /* recv only if this proc. doesn't have data and sender
@@ -199,8 +194,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
                                                        recvtype, dst, comm_ptr, &ss->status, s);
                     MPIR_SCHED_BARRIER(s);
                     mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
 
@@ -216,8 +210,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
 
     if (recv_dtp) {
         mpi_errno = MPIR_Sched_cb(dtp_release_ref, recv_dtp, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/iallgather/iallgather_intra_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_ring.c
@@ -40,8 +40,7 @@ int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Dat
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     ((char *) recvbuf + rank * recvcount * recvtype_extent),
                                     recvcount, recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -55,13 +54,11 @@ int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Dat
     for (i = 1; i < comm_size; i++) {
         mpi_errno = MPIR_Sched_send(((char *) recvbuf + j * recvcount * recvtype_extent),
                                     recvcount, recvtype, right, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* concurrent, no barrier here */
         mpi_errno = MPIR_Sched_recv(((char *) recvbuf + jnext * recvcount * recvtype_extent),
                                     recvcount, recvtype, left, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         j = jnext;

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -47,8 +47,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_BRUCKS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_BRUCKS);
@@ -198,13 +197,11 @@ int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Dat
 
     mpi_errno = MPIR_TSP_Iallgather_sched_intra_brucks(sendbuf, sendcount, sendtype, recvbuf,
                                                        recvcount, recvtype, comm_ptr, sched, k);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHER_INTRA_BRUCKS);

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -229,8 +229,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
     nranks = MPIR_Comm_size(comm);
@@ -328,13 +327,11 @@ int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Da
     mpi_errno =
         MPIR_TSP_Iallgather_sched_intra_recexch(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                                 recvtype, comm, allgather_type, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHER_INTRA_RECEXCH);

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -94,8 +94,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     for (i = 0; i < size - 1; i++) {
         /* Get new tag for each cycle so that the send-recv pairs are matched correctly */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         int vtcs[3], nvtcs;
         if (i == 0) {
@@ -175,13 +174,11 @@ int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datat
     mpi_errno =
         MPIR_TSP_Iallgather_sched_intra_ring(sendbuf, sendcount, sendtype, recvbuf,
                                              recvcount, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHER_INTRA_RING);

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -160,24 +160,21 @@ int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Da
             MPIR_Iallgatherv_sched_intra_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
                                                             recvcounts, displs, recvtype, comm_ptr,
                                                             s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (total_count * recvtype_size < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
         /* Short message and non-power-of-two no. of processes. Use
          * Bruck algorithm (see description above). */
         mpi_errno =
             MPIR_Iallgatherv_sched_intra_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                                 displs, recvtype, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* long message or medium-size message and non-power-of-two
          * no. of processes. Use ring algorithm. */
         mpi_errno =
             MPIR_Iallgatherv_sched_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                               displs, recvtype, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -299,8 +296,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
                     MPIR_Iallgatherv_intra_gentran_recexch_doubling(sendbuf, sendcount, sendtype,
                                                                     recvbuf, recvcounts, displs,
                                                                     recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_gentran_recexch_halving:
@@ -311,8 +307,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
                     MPIR_Iallgatherv_intra_gentran_recexch_halving(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcounts, displs,
                                                                    recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_gentran_ring:
@@ -320,8 +315,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
                     MPIR_Iallgatherv_intra_gentran_ring(sendbuf, sendcount, sendtype,
                                                         recvbuf, recvcounts, displs,
                                                         recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_gentran_brucks:
@@ -329,8 +323,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
                     MPIR_Iallgatherv_intra_gentran_brucks(sendbuf, sendcount, sendtype,
                                                           recvbuf, recvcounts, displs,
                                                           recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -340,21 +333,17 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Iallgatherv_sched(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
                                comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -493,8 +482,7 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
     mpi_errno = MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                  displs, recvtype, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
@@ -39,27 +39,23 @@ int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, 
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Igatherv_sched(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcounts, displs, recvtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* gatherv to right group */
         root = 0;
         mpi_errno = MPIR_Igatherv_sched(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcounts, displs, recvtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* gatherv to left group  */
         root = 0;
         mpi_errno = MPIR_Igatherv_sched(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcounts, displs, recvtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* gatherv from left group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Igatherv_sched(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcounts, displs, recvtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);
@@ -70,23 +66,19 @@ int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, 
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Type_indexed_impl(remote_size, recvcounts, displs, recvtype, &newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_commit_impl(&newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Ibcast_sched(recvbuf, 1, newtype, 0, newcomm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
@@ -39,15 +39,13 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else {
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
                                     recvcounts[rank], recvtype,
                                     tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -72,13 +70,11 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
         }
 
         mpi_errno = MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
                                     incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* we will send everything we had plus what we just got to next round's dst */
@@ -97,14 +93,12 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
             send_cnt += recvcounts[(rank + i) % comm_size];
 
         mpi_errno = MPIR_Sched_send(tmp_buf, send_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
                                     (total_count - curr_count) * recvtype_sz, MPI_BYTE,
                                     src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -118,8 +112,7 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
                                     recvcounts[j] * recvtype_sz, MPI_BYTE,
                                     ((char *) recvbuf + displs[j] * recvtype_extent),
                                     recvcounts[j], recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         send_cnt += recvcounts[j];
     }
 
@@ -128,8 +121,7 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
                                     recvcounts[i] * recvtype_sz, MPI_BYTE,
                                     ((char *) recvbuf + displs[i] * recvtype_extent),
                                     recvcounts[i], recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         send_cnt += recvcounts[i];
     }
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
@@ -52,16 +52,14 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     ((char *) tmp_buf + position * recvtype_sz),
                                     recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* if in_place specified, local data is found in recvbuf */
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
                                     recvcounts[rank], recvtype,
                                     ((char *) tmp_buf + position * recvtype_sz),
                                     recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     curr_count = recvcounts[rank];
@@ -109,13 +107,11 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
 
             mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset * recvtype_sz),
                                         curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + recv_offset * recvtype_sz),
                                         incoming_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             curr_count += incoming_count;
@@ -180,8 +176,7 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                     mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
                                                 incoming_count * recvtype_sz, MPI_BYTE,
                                                 dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
                 /* recv only if this proc. doesn't have data and sender
@@ -203,8 +198,7 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                     mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + offset * recvtype_sz),
                                                 incoming_count * recvtype_sz, MPI_BYTE,
                                                 dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     curr_count += incoming_count;
                 }
@@ -231,8 +225,7 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                                         recvcounts[j] * recvtype_sz, MPI_BYTE,
                                         ((char *) recvbuf + displs[j] * recvtype_extent),
                                         recvcounts[j], recvtype, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         position += recvcounts[j];
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
@@ -38,8 +38,7 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     ((char *) recvbuf + displs[rank] * recvtype_extent),
                                     recvcounts[rank], recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -79,14 +78,12 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
         /* Communicate */
         if (recvnow) {  /* If there's no data to send, just do a recv call */
             mpi_errno = MPIR_Sched_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             torecv -= recvnow;
         }
         if (sendnow) {  /* If there's no data to receive, just do a send call */
             mpi_errno = MPIR_Sched_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             tosend -= sendnow;
         }
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -78,8 +78,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
     rank = MPIR_Comm_rank(comm);
@@ -342,13 +341,11 @@ int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     mpi_errno = MPIR_TSP_Iallgatherv_sched_intra_brucks(sendbuf, sendcount, sendtype, recvbuf,
                                                         recvcounts, displs, recvtype, comm_ptr,
                                                         sched, k);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_BRUCKS);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -254,8 +254,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (nranks == 1) {  /*If only one rank, copy sendbuf to recvbuf and return */
         if (!is_inplace)
@@ -354,13 +353,11 @@ int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_D
     mpi_errno =
         MPIR_TSP_Iallgatherv_sched_intra_recexch(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                                  displs, recvtype, comm, algo_type, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_RECEXCH);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -93,8 +93,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
 
         /* New tag for each send-recv pair. */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         int nvtcs, vtcs[3];
         if (i == 0) {
@@ -174,13 +173,11 @@ int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Data
     mpi_errno =
         MPIR_TSP_Iallgatherv_sched_intra_ring(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                               displs, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLGATHERV_INTRA_RING);

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -166,15 +166,13 @@ int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int cou
         mpi_errno =
             MPIR_Iallreduce_sched_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
                                                            comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* do a reduce-scatter followed by allgather */
         mpi_errno =
             MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(sendbuf, recvbuf, count, datatype,
                                                                  op, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -291,8 +289,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
                     MPIR_Iallreduce_intra_gentran_recexch_single_buffer(sendbuf, recvbuf, count,
                                                                         datatype, op, comm_ptr,
                                                                         request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_gentran_recexch_multiple_buffer:
@@ -300,24 +297,21 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
                     MPIR_Iallreduce_intra_gentran_recexch_multiple_buffer(sendbuf, recvbuf, count,
                                                                           datatype, op, comm_ptr,
                                                                           request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_gentran_tree:
                 mpi_errno =
                     MPIR_Iallreduce_intra_gentran_tree(sendbuf, recvbuf, count, datatype,
                                                        op, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
             case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_gentran_ring:
                 if (is_commutative) {
                     mpi_errno =
                         MPIR_Iallreduce_intra_gentran_ring(sendbuf, recvbuf, count, datatype,
                                                            op, comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -330,8 +324,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
                     mpi_errno =
                         MPIR_Iallreduce_intra_gentran_recexch_reduce_scatter_recexch_allgatherv
                         (sendbuf, recvbuf, count, datatype, op, comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -342,19 +335,15 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Iallreduce_sched(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -478,8 +467,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
+++ b/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
@@ -36,48 +36,41 @@ int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, v
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* no barrier, these reductions can be concurrent */
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* no barrier, these reductions can be concurrent */
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* don't bcast until the reductions have finished */
     mpi_errno = MPIR_Sched_barrier(s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     lcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Ibcast_sched(recvbuf, count, datatype, 0, lcomm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
@@ -19,20 +19,17 @@ int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int co
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
         mpi_errno =
             MPIR_Ireduce_sched_intra_auto(recvbuf, NULL, count, datatype, op, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno =
             MPIR_Ireduce_sched_intra_auto(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);
 
     mpi_errno = MPIR_Ibcast_sched_intra_auto(recvbuf, count, datatype, 0, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
@@ -35,8 +35,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -54,8 +53,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* temporarily set the rank to -1 so that this
@@ -64,16 +62,14 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
             newrank = -1;
         } else {        /* odd */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* change the rank */
@@ -92,12 +88,10 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
             /* Send the most current data, which is in recvbuf. Recv
              * into tmp_buf */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* tmp_buf contains data received in this step.
@@ -106,20 +100,17 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
             if (is_commutative || (dst < rank)) {
                 /* op is commutative OR the order is already right */
                 mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 /* op is noncommutative and the order is not right */
                 mpi_errno = MPIR_Sched_reduce(recvbuf, tmp_buf, count, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into recvbuf */
                 mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
             mask <<= 1;
@@ -132,12 +123,10 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {        /* even */
             mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
@@ -43,8 +43,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -62,8 +61,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* temporarily set the rank to -1 so that this
@@ -72,16 +70,14 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
             newrank = -1;
         } else {        /* odd */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* change the rank */
@@ -138,13 +134,11 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
             /* Send data from recvbuf. Recv into tmp_buf */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + disps[recv_idx] * extent),
                                         recv_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
                                         send_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* tmp_buf contains data received in this step.
@@ -155,8 +149,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
             mpi_errno = MPIR_Sched_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
                                           ((char *) recvbuf + disps[recv_idx] * extent),
                                           recv_cnt, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* update send_idx for next iteration */
@@ -199,13 +192,11 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
 
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + disps[recv_idx] * extent),
                                         recv_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
                                         send_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             if (newrank > newdst)
@@ -221,12 +212,10 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {        /* even */
             mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
@@ -28,8 +28,7 @@ int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int coun
         /* use flat fallback */
         mpi_errno =
             MPIR_Iallreduce_sched_intra_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -42,20 +41,17 @@ int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int coun
             /* IN_PLACE and not root of reduce. Data supplied to this
              * allreduce is in recvbuf. Pass that as the sendbuf to reduce. */
             mpi_errno = MPIR_Ireduce_sched(recvbuf, NULL, count, datatype, op, 0, nc, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, 0, nc, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
         /* only one process on the node. copy sendbuf to recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     }
@@ -63,16 +59,14 @@ int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int coun
     /* now do an IN_PLACE allreduce among the local roots of all nodes */
     if (nrc != NULL) {
         mpi_errno = MPIR_Iallreduce_sched(MPI_IN_PLACE, recvbuf, count, datatype, op, nrc, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
     /* now broadcast the result among local processes */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Ibcast_sched(recvbuf, count, datatype, 0, nc, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -336,13 +336,11 @@ int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int co
     mpi_errno =
         MPIR_TSP_Iallreduce_sched_intra_recexch(sendbuf, recvbuf, count, datatype, op, comm,
                                                 recexch_type, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLREDUCE_INTRA_RECEXCH);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv_algos.h
@@ -68,8 +68,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* if there is only 1 rank, copy data from sendbuf
      * to recvbuf and exit */
@@ -215,13 +214,11 @@ int MPIR_TSP_Iallreduce_intra_recexch_reduce_scatter_recexch_allgatherv(const vo
                                                                                   op, comm, k,
                                                                                   sched);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring_algos.h
@@ -88,8 +88,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, int
 
         /* get a new tag to prevent out of order messages */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         nvtcs = (i == 0) ? 0 : 1;
         vtcs = (i == 0) ? 0 : reduce_id[(i - 1) % 2];
@@ -147,13 +146,11 @@ int MPIR_TSP_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, int count
 
     mpi_errno =
         MPIR_TSP_Iallreduce_sched_intra_ring(sendbuf, recvbuf, count, datatype, op, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLREDUCE_INTRA_RING);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -77,8 +77,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
     /* initialize the tree */
     my_tree.children = NULL;
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     /* Allocate buffers to receive data from children. Any memory required for execution
@@ -127,8 +126,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         for (i = 0; i < num_children; i++) {
             void *recv_address = (char *) child_buffer[i] + offset * extent;
@@ -251,13 +249,11 @@ int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count
     mpi_errno =
         MPIR_TSP_Iallreduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op, comm,
                                              tree_type, k, maxbytes, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLREDUCE_INTRA_TREE);

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -151,8 +151,7 @@ int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Data
             MPIR_Ialltoall_sched_intra_pairwise(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                                 recvtype, comm_ptr, s);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -269,16 +268,14 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
                 mpi_errno =
                     MPIR_Ialltoall_intra_gentran_ring(sendbuf, sendcount, sendtype, recvbuf,
                                                       recvcount, recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLTOALL_INTRA_ALGORITHM_gentran_brucks:
                 mpi_errno =
                     MPIR_Ialltoall_intra_gentran_brucks(sendbuf, sendcount, sendtype, recvbuf,
                                                         recvcount, recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IALLTOALL_INTRA_ALGORITHM_gentran_scattered:
@@ -286,8 +283,7 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
                     MPIR_Ialltoall_intra_gentran_scattered(sendbuf, sendcount,
                                                            sendtype, recvbuf,
                                                            recvcount, recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -302,21 +298,17 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
     *request = NULL;
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Ialltoall_sched(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                              s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -446,8 +438,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     mpi_errno =
         MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
                        &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
@@ -55,11 +55,9 @@ int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendco
         }
 
         mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ialltoall/ialltoall_intra_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_brucks.c
@@ -57,14 +57,12 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     mpi_errno = MPIR_Sched_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
                                 (comm_size - rank) * sendcount, sendtype,
                                 recvbuf, (comm_size - rank) * recvcount, recvtype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_copy(sendbuf, rank * sendcount, sendtype,
                                 ((char *) recvbuf +
                                  (comm_size - rank) * recvcount * recvtype_extent),
                                 rank * recvcount, recvtype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
     /* Input data is now stored in recvbuf with datatype recvtype */
 
@@ -97,27 +95,22 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 
         mpi_errno = MPIR_Type_create_indexed_block_impl(count, recvcount,
                                                         displs, recvtype, &newtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&newtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Datatype_get_size_macro(newtype, newtype_size);
 
         /* we will usually copy much less than nbytes */
         mpi_errno = MPIR_Sched_copy(recvbuf, 1, newtype, tmp_buf, newtype_size, MPI_BYTE, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* now send and recv in parallel */
         mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(recvbuf, 1, newtype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         MPIR_Type_free_impl(&newtype);
@@ -136,14 +129,12 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
                                 (comm_size - rank - 1) * recvcount, recvtype,
                                 tmp_buf, (comm_size - rank - 1) * recvcount * recvtype_sz,
                                 MPI_BYTE, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_copy(recvbuf, (rank + 1) * recvcount, recvtype,
                                 ((char *) tmp_buf +
                                  (comm_size - rank - 1) * recvcount * recvtype_sz),
                                 (rank + 1) * recvcount * recvtype_sz, MPI_BYTE, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     /* Blocks are in the reverse order now (comm_size-1 to 0).
@@ -155,8 +146,7 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
                                     ((char *) recvbuf +
                                      (comm_size - i - 1) * recvcount * recvtype_extent), recvcount,
                                     recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
@@ -60,18 +60,15 @@ int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_D
                 /* pack to tmp_buf */
                 mpi_errno = MPIR_Sched_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, tmp_buf, nbytes, MPI_BYTE, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* now simultaneously send from tmp_buf and recv to recvbuf */
                 mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, peer, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         }

--- a/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
@@ -48,8 +48,7 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
                                 sendcount, sendtype,
                                 ((char *) recvbuf + rank * recvcount * recvtype_extent),
                                 recvcount, recvtype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     is_pof2 = MPL_is_pof2(comm_size, NULL);
 
@@ -65,12 +64,10 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
 
         mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
                                     sendcount, sendtype, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
                                     recvcount, recvtype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
@@ -46,16 +46,14 @@ int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendco
             dst = (rank + i + ii) % comm_size;
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
                                         recvcount, recvtype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
                                         sendcount, sendtype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* force the (2*ss) sends/recvs above to complete before posting additional ops */

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -152,8 +152,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKLMEM_MALLOC(pack_invtcs, int *, sizeof(int) * k, mpi_errno, "pack_invtcs",
                         MPL_MEM_COLL);
@@ -406,13 +405,11 @@ int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Data
     mpi_errno = MPIR_TSP_Ialltoall_sched_intra_brucks(sendbuf, sendcount, sendtype, recvbuf,
                                                       recvcount, recvtype, comm_ptr, sched,
                                                       k, buffer_per_phase);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALL_INTRA_BRUCKS);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -124,8 +124,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         int vtcs[3], nvtcs;
         /* schedule send */
@@ -206,13 +205,11 @@ int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, int sendcount, MPI_Dataty
     mpi_errno =
         MPIR_TSP_Ialltoall_sched_intra_ring(sendbuf, sendcount, sendtype, recvbuf,
                                             recvcount, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALL_INTRA_RING);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered_algos.h
@@ -69,8 +69,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, int sendcount,
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     size = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
@@ -183,13 +182,11 @@ int MPIR_TSP_Ialltoall_intra_scattered(const void *sendbuf, int sendcount,
     mpi_errno =
         MPIR_TSP_Ialltoall_sched_intra_scattered(sendbuf, sendcount, sendtype,
                                                  recvbuf, recvcount, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALL_INTRA_SCATTERED);

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -227,8 +227,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
                                                                 sendtype, recvbuf, recvcounts,
                                                                 rdispls, recvtype, comm_ptr,
                                                                 request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -238,8 +237,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
                         MPIR_Ialltoallv_intra_gentran_blocked(sendbuf, sendcounts, sdispls,
                                                               sendtype, recvbuf, recvcounts,
                                                               rdispls, recvtype, comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -249,8 +247,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
                         MPIR_Ialltoallv_intra_gentran_inplace(sendbuf, sendcounts, sdispls,
                                                               sendtype, recvbuf, recvcounts,
                                                               rdispls, recvtype, comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -266,21 +263,17 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
     *request = NULL;
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Ialltoallv_sched(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
                               recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -416,8 +409,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
     mpi_errno = MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                 recvcounts, rdispls, recvtype, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
@@ -67,14 +67,11 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
             src = MPI_PROC_NULL;
 
         mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
@@ -47,8 +47,7 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (recvcounts[dst] && recvtype_size) {
                 mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst] * recv_extent,
                                             recvcounts[dst], recvtype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
 
@@ -57,8 +56,7 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (sendcounts[dst] && sendtype_size) {
                 mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst] * send_extent,
                                             sendcounts[dst], sendtype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
@@ -60,19 +60,16 @@ int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcount
 
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst] * recvtype_extent),
                                             recvcounts[dst], recvtype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
                                             dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
                                             ((char *) recvbuf + rdispls[dst] * recvtype_extent),
                                             recvcounts[dst], recvtype, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         }

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked_algos.h
@@ -39,8 +39,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendc
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     nranks = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
@@ -114,13 +113,11 @@ int MPIR_TSP_Ialltoallv_intra_blocked(const void *sendbuf, const int sendcounts[
     mpi_errno =
         MPIR_TSP_Ialltoallv_sched_intra_blocked(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                                 recvcounts, rdispls, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALLV_INTRA_BLOCKED);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace_algos.h
@@ -38,8 +38,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendc
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     nranks = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
@@ -109,13 +108,11 @@ int MPIR_TSP_Ialltoallv_intra_inplace(const void *sendbuf, const int sendcounts[
     mpi_errno =
         MPIR_TSP_Ialltoallv_sched_intra_inplace(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                                 recvcounts, rdispls, recvtype, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALLV_INTRA_INPLACE);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -67,8 +67,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
     sendtype_extent = MPL_MAX(sendtype_extent, sendtype_true_extent);
 
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* First, post bblock number of sends/recvs */
     for (i = 0; i < bblock; i++) {
@@ -138,13 +137,11 @@ int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const int sendcount
         MPIR_TSP_Ialltoallv_sched_intra_scattered(sendbuf, sendcounts, sdispls, sendtype,
                                                   recvbuf, recvcounts, rdispls, recvtype, comm,
                                                   sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALLV_INTRA_SCATTERED);

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -203,8 +203,7 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
                                                               sendtypes, recvbuf, recvcounts,
                                                               rdispls, recvtypes, comm_ptr,
                                                               request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -215,8 +214,7 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
                                                               sendtypes, recvbuf, recvcounts,
                                                               rdispls, recvtypes, comm_ptr,
                                                               request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -227,21 +225,17 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Ialltoallw_sched(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
                               recvtypes, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -357,8 +351,7 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
 
     mpi_errno = MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                 recvcounts, rdispls, recvtypes, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
@@ -59,12 +59,10 @@ int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int
         }
 
         mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier here */
         mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
@@ -55,8 +55,7 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
                 if (type_size) {
                     mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst],
                                                 recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }
@@ -68,8 +67,7 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
                 if (type_size) {
                     mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst],
                                                 sendcounts[dst], sendtypes[dst], dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
@@ -71,19 +71,16 @@ int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcount
                 MPIR_Datatype_get_size_macro(recvtypes[i], recvtype_sz);
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
                                             recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
                                             dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
                                             ((char *) recvbuf + rdispls[dst]),
                                             recvcounts[dst], recvtypes[dst], s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         }

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked_algos.h
@@ -44,8 +44,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendc
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* post only bblock isends/irecvs at a time as suggested by Tony Ladd */
     for (i = 0; i < nranks; i += bblock) {
@@ -111,13 +110,11 @@ int MPIR_TSP_Ialltoallw_intra_blocked(const void *sendbuf, const int sendcounts[
     mpi_errno =
         MPIR_TSP_Ialltoallw_sched_intra_blocked(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                                 recvcounts, rdispls, recvtypes, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALLW_INTRA_BLOCKED);

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos.h
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace_algos.h
@@ -43,8 +43,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendc
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     max_size = 0;
     for (i = 0; i < nranks; ++i) {
@@ -115,13 +114,11 @@ int MPIR_TSP_Ialltoallw_intra_inplace(const void *sendbuf, const int sendcounts[
     mpi_errno =
         MPIR_TSP_Ialltoallw_sched_intra_inplace(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                                 recvcounts, rdispls, recvtypes, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IALLTOALLW_INTRA_INPLACE);

--- a/src/mpi/coll/ibarrier/ibarrier.c
+++ b/src/mpi/coll/ibarrier/ibarrier.c
@@ -168,8 +168,7 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
             case MPIR_CVAR_IBARRIER_INTRA_ALGORITHM_gentran_recexch:
                 mpi_errno = MPIR_Ibarrier_intra_gentran_recexch(comm_ptr, request);
 
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -179,19 +178,15 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
     }
     if (comm_ptr->local_size != 1 || comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
         mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_create(&s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Ibarrier_sched(comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -285,8 +280,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request * request)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Ibarrier(comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
+++ b/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
@@ -20,15 +20,13 @@ int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* do a barrier on the local intracommunicator */
     if (comm_ptr->local_size != 1) {
         mpi_errno = MPIR_Ibarrier_sched(comm_ptr->local_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
     /* rank 0 on each group does an intercommunicator broadcast to the
@@ -44,30 +42,26 @@ int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
     if (comm_ptr->is_low_group) {
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ibcast_sched(buf, 1, MPI_BYTE, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* receive bcast from right */
         root = 0;
         mpi_errno = MPIR_Ibcast_sched(buf, 1, MPI_BYTE, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* receive bcast from left */
         root = 0;
         mpi_errno = MPIR_Ibcast_sched(buf, 1, MPI_BYTE, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ibcast_sched(buf, 1, MPI_BYTE, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
@@ -39,16 +39,13 @@ int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
         src = (rank - mask + size) % size;
 
         mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_barrier(s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mask <<= 1;
     }

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -161,8 +161,7 @@ int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype,
     /* simplistic implementation for now */
     if ((nbytes < MPIR_CVAR_BCAST_SHORT_MSG_SIZE) || (comm_size < MPIR_CVAR_BCAST_MIN_PROCS)) {
         mpi_errno = MPIR_Ibcast_sched_intra_binomial(buffer, count, datatype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (nbytes >= MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_size >= MPIR_CVAR_BCAST_MIN_PROCS) */
 
         if ((nbytes < MPIR_CVAR_BCAST_LONG_MSG_SIZE) && (MPL_is_pof2(comm_size, NULL))) {
@@ -170,14 +169,12 @@ int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype,
                 MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(buffer, count,
                                                                              datatype, root,
                                                                              comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno =
                 MPIR_Ibcast_sched_intra_scatter_ring_allgather(buffer, count, datatype, root,
                                                                comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -288,24 +285,21 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
                 mpi_errno =
                     MPIR_Ibcast_intra_gentran_tree(buffer, count, datatype, root, comm_ptr,
                                                    request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_scatterv_recexch_allgatherv:
                 mpi_errno =
                     MPIR_Ibcast_intra_gentran_scatterv_recexch_allgatherv(buffer, count, datatype,
                                                                           root, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IBCAST_INTRA_ALGORITHM_gentran_ring:
                 mpi_errno =
                     MPIR_Ibcast_intra_gentran_ring(buffer, count, datatype, root, comm_ptr,
                                                    request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -317,19 +311,15 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Ibcast_sched(buffer, count, datatype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -434,8 +424,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ibcast/ibcast_inter_flat.c
+++ b/src/mpi/coll/ibcast/ibcast_inter_flat.c
@@ -23,28 +23,24 @@ int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype,
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
         mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* remote group. rank 0 on remote group receives from root */
         if (comm_ptr->rank == 0) {
             mpi_errno = MPIR_Sched_recv(buffer, count, datatype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
 
         if (comm_ptr->local_comm == NULL) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* now do the usual broadcast on this intracommunicator
          * with rank 0 as root. */
         mpi_errno = MPIR_Ibcast_sched(buffer, count, datatype, root, comm_ptr->local_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/ibcast/ibcast_intra_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_binomial.c
@@ -54,8 +54,7 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
             mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }
@@ -99,13 +98,11 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
             else
                 mpi_errno = MPIR_Sched_recv_status(buffer, count, datatype, src,
                                                    comm_ptr, &ibcast_state->status, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_SCHED_BARRIER(s);
             mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             break;
         }
@@ -133,8 +130,7 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
                 mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, s);
             else
                 mpi_errno = MPIR_Sched_send(buffer, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* NOTE: This is departure from MPIR_Bcast_intra_binomial.  A true analog
              * would put an MPIR_Sched_barrier here after every send. */
@@ -146,8 +142,7 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
         if (rank != root) {
             MPIR_SCHED_BARRIER(s);
             mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
@@ -103,16 +103,14 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
 
         if (rank == root) {
             mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }
 
 
     mpi_errno = MPII_Iscatter_for_bcast_sched(tmp_buf, root, comm_ptr, nbytes, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* this is the block size used for the scatter operation */
     scatter_size = (nbytes + comm_size - 1) / comm_size;        /* ceiling division */
@@ -160,18 +158,15 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
 
             mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset),
                                         curr_size, MPI_BYTE, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier */
             mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + recv_offset),
                                                incoming_count,
                                                MPI_BYTE, dst, comm_ptr, &ibcast_state->status, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             curr_size += incoming_count;
@@ -228,8 +223,7 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
                      * sent now. */
                     mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
                                                 incoming_count, MPI_BYTE, dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
                 /* recv only if this proc. doesn't have data and sender
@@ -249,12 +243,10 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
                     mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + offset),
                                                        incoming_count, MPI_BYTE, dst, comm_ptr,
                                                        &ibcast_state->status, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
 
                     curr_size += incoming_count;
@@ -269,13 +261,11 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
         i++;
     }
     mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (!is_contig) {
         if (rank != root) {
             mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
@@ -69,15 +69,13 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
 
         if (rank == root) {
             mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }
 
     mpi_errno = MPII_Iscatter_for_bcast_sched(tmp_buf, root, comm_ptr, nbytes, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* this is the block size used for the scatter operation */
     scatter_size = (nbytes + comm_size - 1) / comm_size;        /* ceiling division */
@@ -113,31 +111,26 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
 
         mpi_errno = MPIR_Sched_send(((char *) tmp_buf + right_disp),
                                     right_count, MPI_BYTE, right, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier here */
         mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + left_disp),
                                            left_count, MPI_BYTE, left, comm_ptr,
                                            &ibcast_state->status, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
         mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }
     mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!is_contig && rank != root) {
         mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ibcast/ibcast_intra_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_smp.c
@@ -56,12 +56,10 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
                                        MPIR_Get_intranode_rank(comm_ptr, root), comm_ptr->node_comm,
                                        &ibcast_state->status, s);
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
         mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -70,8 +68,7 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
         mpi_errno = MPIR_Ibcast_sched(buffer, count, datatype,
                                       MPIR_Get_internode_rank(comm_ptr, root),
                                       comm_ptr->node_roots_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* don't allow the local ops for the intranode phase to start until this has completed */
         MPIR_SCHED_BARRIER(s);
@@ -79,8 +76,7 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
     /* perform the intranode broadcast on all except for the root's node */
     if (comm_ptr->node_comm != NULL) {
         mpi_errno = MPIR_Ibcast_sched(buffer, count, datatype, 0, comm_ptr->node_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv_algos.h
@@ -41,8 +41,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IBCAST_SCHED_INTRA_SCATTERV_ALLGATHERV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IBCAST_SCHED_INTRA_SCATTERV_ALLGATHERV);
@@ -93,8 +92,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
             mpi_errno =
                 MPIR_TSP_sched_localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, sched,
                                          0, NULL);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_TSP_sched_fence(sched);
         }
     }
@@ -102,8 +100,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
     /* knomial scatter for bcast */
     tree_type = MPIR_TREE_TYPE_KNOMIAL_1;       /* currently only tree_type=MPIR_TREE_TYPE_KNOMIAL_1 is supported for scatter */
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, scatterv_k, root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     MPIR_CHKLMEM_MALLOC(child_subtree_size, int *, sizeof(int) * num_children, mpi_errno, "child_subtree_size buffer", MPL_MEM_COLL);   /* to store size of subtree of each child */
@@ -114,8 +111,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
         mpi_errno =
             MPIR_Treealgo_tree_create(my_tree.parent, size, tree_type, scatterv_k, root,
                                       &parents_tree);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {    /* initialize an empty children array */
         parents_tree.num_children = 0;
     }
@@ -179,10 +175,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
     /* Schedule Allgatherv */
     mpi_errno =
         MPIR_TSP_Iallgatherv_sched_intra_recexch(MPI_IN_PLACE, cnts[rank], MPI_BYTE, tmp_buf, cnts,
-                                                 displs, MPI_BYTE, comm, 0, allgatherv_k,
-                                                 sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+                                                 displs, MPI_BYTE, comm, 0, allgatherv_k, sched);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     if (!is_contig) {
@@ -192,8 +186,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, int count,
             mpi_errno =
                 MPIR_TSP_sched_localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, sched,
                                          1, &sink_id);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -228,13 +221,11 @@ int MPIR_TSP_Ibcast_intra_scatterv_allgatherv(void *buffer, int count, MPI_Datat
     mpi_errno =
         MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype, root, comm,
                                                         scatterv_k, allgatherv_k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IBCAST_INTRA_SCATTERV_ALLGATHERV);

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -60,8 +60,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
                                              chunk_size_floor, chunk_size_ceil));
 
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     /* do pipelined tree broadcast */
@@ -74,8 +73,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Receive message from parent */
         if (my_tree.parent != -1) {
@@ -124,13 +122,11 @@ int MPIR_TSP_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, i
     /* schedule pipelined tree algo */
     mpi_errno = MPIR_TSP_Ibcast_sched_intra_tree(buffer, count, datatype, root, comm,
                                                  tree_type, k, maxbytes, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IBCAST_INTRA_TREE);

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -106,8 +106,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
             if (recv_size > 0) {
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + relative_rank * scatter_size),
                                             recv_size, MPI_BYTE, src, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
             break;
@@ -132,8 +131,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
                 mpi_errno =
                     MPIR_Sched_send(((char *) tmp_buf + scatter_size * (relative_rank + mask)),
                                     send_size, MPI_BYTE, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 curr_size -= send_size;
             }

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -68,8 +68,7 @@ int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
     mpi_errno =
         MPIR_Iexscan_sched_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op, comm_ptr,
                                                     s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -126,19 +125,15 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
     *request = NULL;
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Iexscan_sched(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -255,8 +250,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iexscan/iexscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_recursive_doubling.c
@@ -86,8 +86,7 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
     mpi_errno =
         MPIR_Sched_copy((sendbuf == MPI_IN_PLACE ? (const void *) recvbuf : sendbuf), count,
                         datatype, partial_scan, count, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     flag = 0;
     mask = 0x1;
@@ -96,18 +95,15 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
             mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* On rank 0, recvbuf is not defined.  For sendbuf==MPI_IN_PLACE
@@ -121,34 +117,29 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
                         /* simply copy data recd from rank 0 into recvbuf */
                         mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
                                                     recvbuf, count, datatype, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         MPIR_SCHED_BARRIER(s);
 
                         flag = 1;
                     } else {
                         mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         MPIR_SCHED_BARRIER(s);
                     }
                 }
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 } else {
                     mpi_errno = MPIR_Sched_reduce(partial_scan, tmp_buf, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
 
                     mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
                                                 partial_scan, count, datatype, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
             }

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -93,8 +93,7 @@ int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dataty
     mpi_errno =
         MPIR_Igather_sched_intra_binomial(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                           recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -228,8 +227,7 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
                     MPIR_Igather_intra_gentran_tree(sendbuf, sendcount, sendtype,
                                                     recvbuf, recvcount, recvtype, root, comm_ptr,
                                                     request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -239,21 +237,17 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Igather_sched(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
                            comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -433,8 +427,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
     mpi_errno = MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                              root, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/igather/igather_inter_long.c
+++ b/src/mpi/coll/igather/igather_inter_long.c
@@ -31,13 +31,11 @@ int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Dataty
         for (i = 0; i < remote_size; i++) {
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + recvcount * i * extent),
                                         recvcount, recvtype, i, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     } else {
         mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/igather/igather_inter_short.c
+++ b/src/mpi/coll/igather/igather_inter_short.c
@@ -30,8 +30,7 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIR_Sched_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
@@ -54,8 +53,7 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
         /* all processes in remote group form new intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         newcomm_ptr = comm_ptr->local_comm;
@@ -64,14 +62,12 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
         mpi_errno = MPIR_Igather_sched(sendbuf, sendcount, sendtype,
                                        tmp_buf, sendcount * sendtype_sz, MPI_BYTE,
                                        0, newcomm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (rank == 0) {
             mpi_errno = MPIR_Sched_send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
                                         root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/igather/igather_intra_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_binomial.c
@@ -102,14 +102,12 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
             mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                        ((char *) recvbuf + extent * recvcount * rank),
                                        recvcount, recvtype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     } else if (tmp_buf_size && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE)) {
         /* copy from sendbuf into tmp_buf */
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype, tmp_buf, nbytes, MPI_BYTE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     curr_cnt = nbytes;
 
@@ -135,20 +133,16 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                             (char *) recvbuf + (((rank + mask) % comm_size) * recvcount * extent);
                         mpi_errno =
                             MPIR_Sched_recv(rp, (recvblks * recvcount), recvtype, src, comm_ptr, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         mpi_errno = MPIR_Sched_barrier(s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         mpi_errno =
                             MPIR_Sched_recv(tmp_buf, (recvblks * nbytes), MPI_BYTE, src,
                                             comm_ptr, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         mpi_errno = MPIR_Sched_barrier(s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
                     } else {
@@ -158,18 +152,14 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                         displs[1] = 0;
 
                         mpi_errno = MPIR_Type_indexed_impl(2, blocks, displs, recvtype, &tmp_type);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         mpi_errno = MPIR_Type_commit_impl(&tmp_type);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIR_Sched_recv(recvbuf, 1, tmp_type, src, comm_ptr, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         mpi_errno = MPIR_Sched_barrier(s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         /* this "premature" free is safe b/c the sched holds an actual ref to keep it alive */
                         MPIR_Type_free_impl(&tmp_type);
@@ -190,11 +180,9 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                     mpi_errno =
                         MPIR_Sched_recv(((char *) tmp_buf + offset), (recvblks * nbytes),
                                         MPI_BYTE, src, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     mpi_errno = MPIR_Sched_barrier(s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     curr_cnt += (recvblks * nbytes);
                 }
             }
@@ -205,18 +193,14 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
             if (!tmp_buf_size) {
                 /* leaf nodes send directly from sendbuf */
                 mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_barrier(s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                 mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt, MPI_BYTE, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_barrier(s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else {
                 blocks[0] = sendcount;
                 struct_displs[0] = (MPI_Aint) sendbuf;
@@ -233,15 +217,12 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
 
                 mpi_errno =
                     MPIR_Type_create_struct_impl(2, blocks, struct_displs, types, &tmp_type);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Type_commit_impl(&tmp_type);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIR_Sched_send(MPI_BOTTOM, 1, tmp_type, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* this "premature" free is safe b/c the sched holds an actual ref to keep it alive */
@@ -259,14 +240,12 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
         mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes * (comm_size - copy_offset), MPI_BYTE,
                                     ((char *) recvbuf + extent * recvcount * copy_offset),
                                     recvcount * (comm_size - copy_offset), recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_copy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
                                     nbytes * (copy_blks - comm_size + copy_offset), MPI_BYTE,
                                     recvbuf, recvcount * (copy_blks - comm_size + copy_offset),
                                     recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -49,15 +49,13 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
 
     tree_type = MPIR_TREE_TYPE_KNOMIAL_1;       /* currently only tree_type=MPIR_TREE_TYPE_KNOMIAL_1 is supported for gather */
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (rank == root && is_inplace) {
         sendtype = recvtype;
@@ -220,13 +218,11 @@ int MPIR_TSP_Igather_intra_tree(const void *sendbuf, int sendcount,
     mpi_errno = MPIR_TSP_Igather_sched_intra_tree(sendbuf, sendcount, sendtype,
                                                   recvbuf, recvcount, recvtype,
                                                   root, comm, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IGATHER_INTRA_TREE);

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -83,8 +83,7 @@ int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
     mpi_errno =
         MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                            displs, recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -103,8 +102,7 @@ int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
     mpi_errno =
         MPIR_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                                            displs, recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -195,8 +193,7 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
                     MPIR_Igatherv_allcomm_gentran_linear(sendbuf, sendcount, sendtype, recvbuf,
                                                          recvcounts, displs, recvtype, root,
                                                          comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -208,21 +205,17 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Igatherv_sched(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
                             root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -420,8 +413,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
     mpi_errno =
         MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
                       comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
@@ -42,14 +42,12 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
                         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                                     ((char *) recvbuf + displs[rank] * extent),
                                                     recvcounts[rank], recvtype, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 } else {
                     mpi_errno = MPIR_Sched_recv(((char *) recvbuf + displs[i] * extent),
                                                 recvcounts[i], recvtype, i, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }
@@ -71,8 +69,7 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
                 mpi_errno = MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             else
                 mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear_algos.h
@@ -43,8 +43,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
     rank = comm_ptr->rank;
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* If rank == root, then I recv lots, otherwise I send */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
@@ -121,13 +120,11 @@ int MPIR_TSP_Igatherv_allcomm_linear(const void *sendbuf, int sendcount, MPI_Dat
     mpi_errno =
         MPIR_TSP_Igatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype, recvbuf,
                                                recvcounts, displs, recvtype, root, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IGATHERV_ALLCOMM_LINEAR);

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -84,8 +84,7 @@ int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount
     mpi_errno = MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                               recvbuf, recvcount, recvtype,
                                                               comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -104,8 +103,7 @@ int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount
     mpi_errno = MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                               recvbuf, recvcount, recvtype,
                                                               comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -197,8 +195,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_allgather_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                     recvbuf, recvcount, recvtype,
                                                                     comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -213,8 +210,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_allgather_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                     recvbuf, recvcount, recvtype,
                                                                     comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -227,19 +223,15 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
      * sched function. */
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgather_sched(sendbuf, sendcount, sendtype,
                                                recvbuf, recvcount, recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -360,8 +352,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     mpi_errno =
         MPIR_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                  comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
@@ -28,27 +28,23 @@ int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendc
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -39,21 +39,18 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int s
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL);
@@ -95,13 +92,11 @@ int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, int sendcou
     mpi_errno = MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                   recvbuf, recvcount, recvtype,
                                                                   comm_ptr, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLGATHER_INTRA_LINEAR);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -85,8 +85,7 @@ int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcoun
     mpi_errno = MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                recvbuf, recvcounts, displs,
                                                                recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -106,8 +105,7 @@ int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcoun
     mpi_errno = MPIR_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                recvbuf, recvcounts, displs,
                                                                recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -203,8 +201,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                      recvbuf, recvcounts, displs,
                                                                      recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -219,8 +216,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                      recvbuf, recvcounts, displs,
                                                                      recvtype, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -233,19 +229,15 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
      * sched function. */
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgatherv_sched(sendbuf, sendcount, sendtype,
                                                 recvbuf, recvcounts, displs, recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -368,8 +360,7 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     mpi_errno =
         MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
                                   recvtype, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
@@ -29,27 +29,23 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -38,21 +38,18 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL);
@@ -95,13 +92,11 @@ int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, int sendco
     mpi_errno = MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcounts, displs,
                                                                    recvtype, comm_ptr, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLGATHERV_ALLCOMM_LINEAR);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -85,8 +85,7 @@ int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
     mpi_errno = MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                              recvbuf, recvcount, recvtype, comm_ptr,
                                                              s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -105,8 +104,7 @@ int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
     mpi_errno = MPIR_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                              recvbuf, recvcount, recvtype, comm_ptr,
                                                              s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -200,8 +198,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_alltoall_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcount, recvtype,
                                                                    comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -216,8 +213,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
                     MPIR_Ineighbor_alltoall_allcomm_gentran_linear(sendbuf, sendcount, sendtype,
                                                                    recvbuf, recvcount, recvtype,
                                                                    comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -229,19 +225,15 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoall_sched(sendbuf, sendcount, sendtype,
                                               recvbuf, recvcount, recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
   fn_exit:
@@ -363,8 +355,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     mpi_errno =
         MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                 comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
@@ -29,28 +29,24 @@ int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendco
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
         mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -39,21 +39,18 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     for (k = 0; k < outdegree; ++k) {
@@ -97,13 +94,11 @@ int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, int sendcoun
     mpi_errno = MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                  recvbuf, recvcount, recvtype,
                                                                  comm_ptr, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALL_ALLCOMM_LINEAR);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -87,8 +87,7 @@ int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sen
         MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtype,
                                                       recvbuf, recvcounts, rdispls, recvtype,
                                                       comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -109,8 +108,7 @@ int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sen
         MPIR_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtype,
                                                       recvbuf, recvcounts, rdispls, recvtype,
                                                       comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -210,8 +208,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
                                                                     sendtype, recvbuf, recvcounts,
                                                                     rdispls, recvtype, comm_ptr,
                                                                     request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -227,8 +224,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
                                                                     sendtype, recvbuf, recvcounts,
                                                                     rdispls, recvtype, comm_ptr,
                                                                     request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -240,19 +236,15 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallv_sched(sendbuf, sendcounts, sdispls, sendtype,
                                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -376,8 +368,7 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     mpi_errno =
         MPIR_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
                                  rdispls, recvtype, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
@@ -30,28 +30,24 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
         mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
         mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -41,21 +41,18 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
@@ -100,13 +97,11 @@ int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const int s
         MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtype,
                                                           recvbuf, recvcounts, rdispls, recvtype,
                                                           comm_ptr, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALLV_ALLCOMM_LINEAR);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -88,8 +88,7 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
         MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
                                                       recvbuf, recvcounts, rdispls, recvtypes,
                                                       comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -111,8 +110,7 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
         MPIR_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
                                                       recvbuf, recvcounts, rdispls, recvtypes,
                                                       comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -215,8 +213,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                                                                     sendtypes, recvbuf, recvcounts,
                                                                     rdispls, recvtypes, comm_ptr,
                                                                     request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -232,8 +229,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                                                                     sendtypes, recvbuf, recvcounts,
                                                                     rdispls, recvtypes, comm_ptr,
                                                                     request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -246,20 +242,16 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
      * sched function. */
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallw_sched(sendbuf, sendcounts, sdispls, sendtypes,
                                                recvbuf, recvcounts, rdispls, recvtypes,
                                                comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -363,8 +355,7 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
     mpi_errno =
         MPIR_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
                                  rdispls, recvtypes, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
@@ -27,23 +27,20 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
     MPIR_CHKLMEM_DECL(2);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         char *sb;
 
         sb = ((char *) sendbuf) + sdispls[k];
         mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
@@ -51,8 +48,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
 
         rb = ((char *) recvbuf) + rdispls[l];
         mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -39,21 +39,18 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
     MPIR_CHKLMEM_DECL(2);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
     MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
         char *sb;
@@ -105,13 +102,11 @@ int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int s
         MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(sendbuf, sendcounts, sdispls, sendtypes,
                                                           recvbuf, recvcounts, rdispls, recvtypes,
                                                           comm_ptr, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_INEIGHBOR_ALLTOALLW_ALLCOMM_LINEAR);

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -154,15 +154,13 @@ int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
         mpi_errno =
             MPIR_Ireduce_sched_intra_reduce_scatter_gather(sendbuf, recvbuf, count, datatype, op,
                                                            root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* use a binomial tree algorithm */
         mpi_errno =
             MPIR_Ireduce_sched_intra_binomial(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
                                               s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -271,16 +269,14 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
                 mpi_errno =
                     MPIR_Ireduce_intra_gentran_tree(sendbuf, recvbuf, count, datatype, op, root,
                                                     comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             case MPIR_CVAR_IREDUCE_INTRA_ALGORITHM_gentran_ring:
                 mpi_errno =
                     MPIR_Ireduce_intra_gentran_ring(sendbuf, recvbuf, count, datatype, op, root,
                                                     comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -292,19 +288,15 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -438,8 +430,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
@@ -32,11 +32,9 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator reduce, and then sends the data
@@ -55,25 +53,20 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
 
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         mpi_errno =
             MPIR_Ireduce_sched(sendbuf, tmp_buf, count, datatype, op, 0, comm_ptr->local_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (rank == 0) {
             mpi_errno = MPIR_Sched_send(tmp_buf, count, datatype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_barrier(s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/ireduce/ireduce_intra_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_binomial.c
@@ -50,11 +50,9 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
         /* could do this up front as an MPIR_Localcopy instead, but we'll defer
          * it to the progress engine */
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* This code is from MPICH-1. */
@@ -102,44 +100,35 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
             if (source < comm_size) {
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, source, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_barrier(s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* The sender is above us, so the received buffer must be
                  * the second argument (in the noncommutative case). */
                 if (is_commutative) {
                     mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } else {
                     mpi_errno = MPIR_Sched_reduce(recvbuf, tmp_buf, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     mpi_errno = MPIR_Sched_barrier(s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     mpi_errno =
                         MPIR_Sched_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
                 mpi_errno = MPIR_Sched_barrier(s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         } else {
             /* I've received all that I'm going to.  Send my result to
              * my parent */
             source = ((relrank & (~mask)) + lroot) % comm_size;
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, source, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_barrier(s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             break;
         }
@@ -149,18 +138,14 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
     if (!is_commutative && (root != 0)) {
         if (rank == 0) {
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_barrier(s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else if (rank == root) {
             mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_barrier(s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
@@ -86,8 +86,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
 
     if ((rank != root) || (sendbuf != MPI_IN_PLACE)) {
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* In the non-power-of-two case, all odd-numbered
@@ -109,8 +108,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
     if (rank < 2 * rem) {
         if (rank % 2 != 0) {    /* odd */
             mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* temporarily set the rank to -1 so that this
@@ -119,16 +117,14 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             newrank = -1;
         } else {        /* even */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* do the reduction on received data. */
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
             mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* change the rank */
@@ -187,13 +183,11 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             /* Send data from recvbuf. Recv into tmp_buf */
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
                                         send_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + disps[recv_idx] * extent),
                                         recv_cnt, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* tmp_buf contains data received in this step.
@@ -204,8 +198,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             mpi_errno = MPIR_Sched_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
                                           ((char *) recvbuf + disps[recv_idx] * extent),
                                           recv_cnt, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* update send_idx for next iteration */
@@ -239,8 +232,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
                     disps[i] = disps[i - 1] + cnts[i - 1];
 
                 mpi_errno = MPIR_Sched_recv(recvbuf, cnts[0], datatype, 0, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 newrank = 0;
@@ -248,8 +240,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
                 last_idx = 2;
             } else if (newrank == 0) {  /* send */
                 mpi_errno = MPIR_Sched_send(recvbuf, cnts[0], datatype, root, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 newrank = -1;
             }
@@ -313,16 +304,14 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
                 /* Send data from recvbuf. Recv into tmp_buf */
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
                                             send_cnt, datatype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 break;
             } else {
                 /* recv and continue */
                 mpi_errno = MPIR_Sched_recv(((char *) recvbuf + disps[recv_idx] * extent),
                                             recv_cnt, datatype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
 

--- a/src/mpi/coll/ireduce/ireduce_intra_smp.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_smp.c
@@ -29,8 +29,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
     if (!is_commutative) {
         mpi_errno =
             MPIR_Ireduce_sched_intra_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -48,8 +47,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
     /* do the intranode reduce on all nodes other than the root's node */
     if (nc != NULL && MPIR_Get_intranode_rank(comm_ptr, root) == -1) {
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, count, datatype, op, 0, nc, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -61,8 +59,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
             const void *buf = (nc == NULL ? sendbuf : tmp_buf);
             mpi_errno = MPIR_Ireduce_sched(buf, NULL, count, datatype,
                                            op, MPIR_Get_internode_rank(comm_ptr, root), nrc, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm_ptr->rank != root) {
@@ -71,8 +68,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
 
                 mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, count, datatype,
                                                op, MPIR_Get_internode_rank(comm_ptr, root), nrc, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
@@ -82,8 +78,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
 
                 mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype,
                                                op, MPIR_Get_internode_rank(comm_ptr, root), nrc, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
@@ -96,8 +91,7 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
     if (nc != NULL && MPIR_Get_intranode_rank(comm_ptr, root) != -1) {
         mpi_errno = MPIR_Ireduce_sched(sendbuf, recvbuf, count, datatype,
                                        op, MPIR_Get_intranode_rank(comm_ptr, root), nc, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -86,8 +86,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
     /* initialize the tree */
     my_tree.children = NULL;
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, tree_root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     /* identify my locaion in the tree */
@@ -159,8 +158,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         for (i = 0; i < num_children; i++) {
             void *recv_address = (char *) child_buffer[i] + offset * extent;
@@ -275,13 +273,11 @@ int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
     mpi_errno =
         MPIR_TSP_Ireduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op, root, comm,
                                           tree_type, k, maxbytes, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IREDUCE_INTRA_TREE);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -113,14 +113,12 @@ int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
         mpi_errno =
             MPIR_Ireduce_scatter_sched_intra_recursive_halving(sendbuf, recvbuf, recvcounts,
                                                                datatype, op, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (is_commutative && (nbytes >= MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_sched_intra_pairwise(sendbuf, recvbuf, recvcounts, datatype, op,
                                                       comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (!is_commutative) */
 
         int is_block_regular = TRUE;
@@ -136,15 +134,13 @@ int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
             mpi_errno =
                 MPIR_Ireduce_scatter_sched_intra_noncommutative(sendbuf, recvbuf, recvcounts,
                                                                 datatype, op, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* noncommutative and (non-pof2 or block irregular), use recursive doubling. */
             mpi_errno =
                 MPIR_Ireduce_scatter_sched_intra_recursive_doubling(sendbuf, recvbuf, recvcounts,
                                                                     datatype, op, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -268,8 +264,7 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
                     mpi_errno =
                         MPIR_Ireduce_scatter_intra_gentran_recexch(sendbuf, recvbuf, recvcounts,
                                                                    datatype, op, comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -280,19 +275,15 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Ireduce_scatter_sched(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -421,8 +412,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
 
     mpi_errno = MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype,
                                      op, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
@@ -65,8 +65,7 @@ int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *se
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
          * proceed in parallel */
@@ -75,15 +74,13 @@ int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *se
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
          * proceed in parallel */
@@ -92,24 +89,21 @@ int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *se
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_SCHED_BARRIER(s);
 
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Iscatterv_sched(tmp_buf, recvcounts, disps, datatype,
                                      recvbuf, recvcounts[rank], datatype, 0, newcomm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_noncommutative.c
@@ -81,8 +81,7 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
                             ((char *) tmp_buf0 +
                              (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
                               block_size)), block_size, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
     buf0_was_inout = 1;
@@ -107,12 +106,10 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
 
         mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
                                     size, datatype, peer, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
                                     size, datatype, peer, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* always perform the reduction at recv_offset, the data at send_offset
@@ -122,15 +119,13 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
             mpi_errno = MPIR_Sched_reduce((incoming_data + recv_offset * true_extent),
                                           (outgoing_data + recv_offset * true_extent),
                                           size, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
             mpi_errno = MPIR_Sched_reduce((outgoing_data + recv_offset * true_extent),
                                           (incoming_data + recv_offset * true_extent),
                                           size, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
         }
         MPIR_SCHED_BARRIER(s);
@@ -145,8 +140,7 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
     mpi_errno = MPIR_Sched_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
@@ -56,8 +56,7 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
         mpi_errno = MPIR_Sched_copy(((char *) sendbuf + disps[rank] * extent),
                                     recvcounts[rank], datatype,
                                     recvbuf, recvcounts[rank], datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -77,28 +76,23 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
                                         recvcounts[dst], datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
                                         recvcounts[dst], datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcounts[rank], datatype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
                                           recvcounts[rank], datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* We can't store the result at the beginning of
              * recvbuf right here because there is useful data there that
              * other process/processes need.  At the end we will copy back
@@ -113,8 +107,7 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + disps[rank] * extent),
                                     recvcounts[rank], datatype,
                                     recvbuf, recvcounts[rank], datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
@@ -77,8 +77,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
         mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
                                     tmp_results, total_count, datatype, s);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     mask = 0x1;
@@ -114,12 +113,10 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
             dis[1] += recvcounts[j];
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* calculate recvtype */
         blklens[0] = blklens[1] = 0;
@@ -134,12 +131,10 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
             dis[1] += recvcounts[j];
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         received = 0;
         if (dst < comm_size) {
@@ -148,11 +143,9 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
              * tmp_results. accumulation is done later below.   */
 
             mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             received = 1;
         }
@@ -193,8 +186,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
                     mpi_errno = MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
                 /* recv only if this proc. doesn't have data and sender
@@ -203,8 +195,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     received = 1;
                 }
@@ -229,30 +220,25 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
             if (is_commutative || (dst_tree_root < my_tree_root)) {
                 mpi_errno =
                     MPIR_Sched_reduce(tmp_recvbuf, tmp_results, blklens[0], datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + dis[1] * extent),
                                               ((char *) tmp_results + dis[1] * extent),
                                               blklens[1], datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 mpi_errno =
                     MPIR_Sched_reduce(tmp_results, tmp_recvbuf, blklens[0], datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_reduce(((char *) tmp_results + dis[1] * extent),
                                               ((char *) tmp_recvbuf + dis[1] * extent),
                                               blklens[1], datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into tmp_results */
                 mpi_errno = MPIR_Sched_copy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         }
@@ -267,8 +253,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
     /* now copy final results from tmp_results to recvbuf */
     mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
                                 recvcounts[rank], datatype, recvbuf, recvcounts[rank], datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
@@ -95,8 +95,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
     else
         mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
                                     tmp_results, total_count, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     pof2 = comm_ptr->pof2;
@@ -112,8 +111,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* temporarily set the rank to -1 so that this
@@ -122,16 +120,14 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             newrank = -1;
         } else {        /* odd */
             mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* change the rank */
@@ -197,12 +193,10 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
                                             send_cnt, datatype, send_dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                             recv_cnt, datatype, recv_dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
 
@@ -226,8 +220,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
                                         recvcounts[rank], datatype,
                                         recvbuf, recvcounts[rank], datatype, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
 
@@ -241,16 +234,14 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             if (recvcounts[rank - 1]) {
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
                                             recvcounts[rank - 1], datatype, rank - 1, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno =
                     MPIR_Sched_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         }

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -311,13 +311,11 @@ int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
     mpi_errno =
         MPIR_TSP_Ireduce_scatter_sched_intra_recexch(sendbuf, recvbuf, recvcounts, datatype,
                                                      op, comm, k, rs_type, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IREDUCE_SCATTER_INTRA_RECEXCH);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -110,14 +110,12 @@ int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvb
         mpi_errno =
             MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(sendbuf, recvbuf, recvcount,
                                                                      datatype, op, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (is_commutative && (nbytes >= MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_block_sched_intra_pairwise(sendbuf, recvbuf, recvcount, datatype,
                                                             op, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (!is_commutative) */
 
         if (MPL_is_pof2(comm_size, NULL)) {
@@ -125,16 +123,14 @@ int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvb
             mpi_errno =
                 MPIR_Ireduce_scatter_block_sched_intra_noncommutative(sendbuf, recvbuf, recvcount,
                                                                       datatype, op, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* noncommutative and non-pof2, use recursive doubling. */
             mpi_errno =
                 MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(sendbuf, recvbuf,
                                                                           recvcount, datatype, op,
                                                                           comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -266,8 +262,7 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                         MPIR_Ireduce_scatter_block_intra_gentran_recexch(sendbuf, recvbuf,
                                                                          recvcount, datatype, op,
                                                                          comm_ptr, request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     goto fn_exit;
                 }
                 break;
@@ -277,20 +272,16 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
         }
     }
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Ireduce_scatter_block_sched(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -413,8 +404,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
 
     mpi_errno = MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr,
                                            &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
@@ -53,8 +53,7 @@ int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const vo
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
          * proceed in parallel */
@@ -63,15 +62,13 @@ int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const vo
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
          * proceed in parallel */
@@ -80,24 +77,21 @@ int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const vo
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_sched(sendbuf, tmp_buf, total_count,
                                        datatype, op, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_SCHED_BARRIER(s);
 
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Iscatter_sched(tmp_buf, recvcount, datatype,
                                     recvbuf, recvcount, datatype, 0, newcomm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
@@ -67,8 +67,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
                             ((char *) tmp_buf0 +
                              (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
                               block_size)), block_size, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_SCHED_BARRIER(s);
     buf0_was_inout = 1;
@@ -93,12 +92,10 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
 
         mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
                                     size, datatype, peer, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
                                     size, datatype, peer, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* always perform the reduction at recv_offset, the data at send_offset
@@ -108,15 +105,13 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
             mpi_errno = MPIR_Sched_reduce((incoming_data + recv_offset * true_extent),
                                           (outgoing_data + recv_offset * true_extent),
                                           size, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
             mpi_errno = MPIR_Sched_reduce((outgoing_data + recv_offset * true_extent),
                                           (incoming_data + recv_offset * true_extent),
                                           size, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
         }
         MPIR_SCHED_BARRIER(s);
@@ -131,8 +126,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
     mpi_errno = MPIR_Sched_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);
   fn_exit:

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
@@ -50,8 +50,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
         /* copy local data into recvbuf */
         mpi_errno = MPIR_Sched_copy(((char *) sendbuf + disps[rank] * extent),
                                     recvcount, datatype, recvbuf, recvcount, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -70,28 +69,23 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
                                         recvcount, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
                                         recvcount, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, recvbuf, recvcount, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
                                           recvcount, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* We can't store the result at the beginning of
              * recvbuf right here because there is useful data there that
              * other process/processes need.  At the end we will copy back
@@ -105,8 +99,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + disps[rank] * extent),
                                     recvcount, datatype, recvbuf, recvcount, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_halving.c
@@ -69,8 +69,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
     else
         mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
                                     tmp_results, total_count, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     pof2 = 1;
@@ -89,8 +88,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* temporarily set the rank to -1 so that this
@@ -99,16 +97,14 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
             newrank = -1;
         } else {        /* odd */
             mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             /* change the rank */
@@ -174,12 +170,10 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
 
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
                                             send_cnt, datatype, send_dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                             recv_cnt, datatype, recv_dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
 
@@ -189,8 +183,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
                 mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                               ((char *) tmp_results + newdisps[recv_idx] * extent),
                                               recv_cnt, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
 
@@ -203,8 +196,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
         /* copy this process's result from tmp_results to recvbuf */
         mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
                                     recvcount, datatype, recvbuf, recvcount, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
     }
@@ -216,13 +208,11 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
         if (rank % 2) { /* odd */
             mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
                                         recvcount, datatype, rank - 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {        /* even */
             mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, datatype, rank + 1, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -226,13 +226,11 @@ int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recv
     mpi_errno =
         MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(sendbuf, recvbuf, recvcount, datatype,
                                                            op, comm, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_IREDUCE_SCATTER_BLOCK_INTRA_RECEXCH);

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -95,8 +95,7 @@ int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Dat
                 MPIR_Iscan_sched_intra_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
             break;
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -140,8 +139,7 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
                 mpi_errno =
                     MPIR_Iscan_intra_gentran_recursive_doubling(sendbuf, recvbuf, count,
                                                                 datatype, op, comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -151,19 +149,15 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
     }
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Iscan_sched(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -282,8 +276,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
@@ -47,16 +47,14 @@ int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf
      * recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (sendbuf != MPI_IN_PLACE)
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, partial_scan, count, datatype, s);
     else
         mpi_errno = MPIR_Sched_copy(recvbuf, count, datatype, partial_scan, count, datatype, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mask = 0x1;
     while (mask < comm_size) {
@@ -64,38 +62,31 @@ int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
             mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 } else {
                     mpi_errno = MPIR_Sched_reduce(partial_scan, tmp_buf, count, datatype, op, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
 
                     mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
                                                 partial_scan, count, datatype, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
             }

--- a/src/mpi/coll/iscan/iscan_intra_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_smp.c
@@ -59,13 +59,11 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
      * one process, just copy the raw data. */
     if (node_comm != NULL) {
         mpi_errno = MPIR_Iscan_sched(sendbuf, recvbuf, count, datatype, op, node_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
@@ -76,14 +74,12 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
     if (roots_comm != NULL && node_comm != NULL) {
         mpi_errno = MPIR_Sched_recv(localfulldata, count, datatype,
                                     (node_comm->local_size - 1), node_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (roots_comm == NULL && node_comm != NULL &&
                node_comm->rank == node_comm->local_size - 1) {
         mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, 0, node_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (roots_comm != NULL) {
         localfulldata = recvbuf;
@@ -100,21 +96,18 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
 
         mpi_errno =
             MPIR_Iscan_sched(localfulldata, prefulldata, count, datatype, op, roots_comm, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (roots_rank != roots_comm->local_size - 1) {
             mpi_errno =
                 MPIR_Sched_send(prefulldata, count, datatype, (roots_rank + 1), roots_comm, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
         if (roots_rank != 0) {
             mpi_errno = MPIR_Sched_recv(tempbuf, count, datatype, (roots_rank - 1), roots_comm, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
     }
@@ -131,15 +124,13 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
 
         if (node_comm != NULL) {
             mpi_errno = MPIR_Ibcast_sched(tempbuf, count, datatype, 0, node_comm, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
 
         /* do reduce on tempbuf and recvbuf, finish scan. */
         mpi_errno = MPIR_Sched_reduce(tempbuf, recvbuf, count, datatype, op, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -38,8 +38,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (count == 0)
         goto fn_exit;
@@ -149,13 +148,11 @@ int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, 
     mpi_errno =
         MPIR_TSP_Iscan_sched_intra_recursive_doubling(sendbuf, recvbuf, count, datatype,
                                                       op, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_ISCAN_INTRA_RECURSIVE_DOUBLING);

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -103,8 +103,7 @@ int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
     mpi_errno =
         MPIR_Iscatter_sched_intra_binomial(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                            recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
   fn_exit:
@@ -141,8 +140,7 @@ int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
                                                      recvbuf, recvcount, recvtype,
                                                      root, comm_ptr, s);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -241,8 +239,7 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
                     MPIR_Iscatter_intra_gentran_tree(sendbuf, sendcount, sendtype,
                                                      recvbuf, recvcount, recvtype, root, comm_ptr,
                                                      request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -255,21 +252,17 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
      * sched function. */
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Iscatter_sched(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
                             comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -444,8 +437,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
     mpi_errno = MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root,
                               comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iscatter/iscatter_inter_linear.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_linear.c
@@ -36,14 +36,12 @@ int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Dat
             mpi_errno =
                 MPIR_Sched_send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
                                 comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
         mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
@@ -37,8 +37,7 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
     if (root == MPI_ROOT) {
         /* root sends all data to rank 0 on remote group and returns */
         mpi_errno = MPIR_Sched_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
         goto fn_exit;
     } else {
@@ -58,8 +57,7 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
             mpi_errno =
                 MPIR_Sched_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
                                 root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {
             /* silience -Wmaybe-uninitialized due to MPIR_Iscatter_sched by non-zero ranks */
@@ -76,8 +74,7 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
         mpi_errno =
             MPIR_Iscatter_sched(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
                                 recvbuf, recvcount, recvtype, 0, newcomm_ptr, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/iscatter/iscatter_intra_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_binomial.c
@@ -134,14 +134,12 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                                     sendcount * (comm_size - rank - 1), sendtype,
                                     ((char *) tmp_buf + ss->nbytes),
                                     ss->nbytes * (comm_size - rank - 1), MPI_BYTE, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno = MPIR_Sched_copy(sendbuf, sendcount * rank, sendtype,
                                         ((char *) tmp_buf + ss->nbytes * (comm_size - rank)),
                                         ss->nbytes * rank, MPI_BYTE, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_SCHED_BARRIER(s);
             ss->curr_count = ss->nbytes * comm_size;
@@ -163,8 +161,7 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
                 mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, src, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
 
@@ -173,12 +170,10 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                 mpi_errno =
                     MPIR_Sched_recv_status(tmp_buf, tmp_buf_size, MPI_BYTE, src, comm_ptr,
                                            &ss->status, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
             break;
@@ -206,36 +201,31 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                 send_subtree_cnt = curr_cnt - sendcount * mask;
 #endif
                 mpi_errno = MPIR_Sched_cb2(&calc_send_count_root, ss, ((void *) (size_t) mask), s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* mask is also the size of this process's subtree */
                 mpi_errno =
                     MPIR_Sched_send_defer(((char *) sendbuf + extent * sendcount * mask),
                                           &ss->send_subtree_count, sendtype, dst, comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 /* non-zero root and others */
                 mpi_errno =
                     MPIR_Sched_cb2(&calc_send_count_non_root, ss, ((void *) (size_t) mask), s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* mask is also the size of this process's subtree */
                 mpi_errno = MPIR_Sched_send_defer(((char *) tmp_buf + ss->nbytes * mask),
                                                   &ss->send_subtree_count, MPI_BYTE, dst,
                                                   comm_ptr, s);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
             mpi_errno = MPIR_Sched_cb(&calc_curr_count, ss, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
         mask >>= 1;
@@ -244,15 +234,13 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
     if ((rank == root) && (root == 0) && (recvbuf != MPI_IN_PLACE)) {
         /* for root=0, put root's data in recvbuf if not MPI_IN_PLACE */
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (!(relative_rank % 2) && (recvbuf != MPI_IN_PLACE)) {
         /* for non-zero root and non-leaf nodes, copy from tmp_buf
          * into recvbuf */
         mpi_errno = MPIR_Sched_copy(tmp_buf, ss->nbytes, MPI_BYTE, recvbuf, recvcount, recvtype, s);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -51,15 +51,13 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
 
     tree_type = MPIR_TREE_TYPE_KNOMIAL_1;       /* currently only tree_type=MPIR_TREE_TYPE_KNOMIAL_1 is supported for scatter */
     mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, root, &my_tree);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (rank == root && is_inplace) {
         recvtype = sendtype;
@@ -212,13 +210,11 @@ int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, int sendcount,
     mpi_errno = MPIR_TSP_Iscatter_sched_intra_tree(sendbuf, sendcount, sendtype,
                                                    recvbuf, recvcount, recvtype,
                                                    root, comm, k, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_ISCATTER_INTRA_TREE);

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -85,8 +85,7 @@ int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
     mpi_errno =
         MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
                                             recvcount, recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -105,8 +104,7 @@ int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
     mpi_errno =
         MPIR_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
                                             recvcount, recvtype, root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -154,8 +152,7 @@ int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -203,8 +200,7 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
                     MPIR_Iscatterv_allcomm_gentran_linear(sendbuf, sendcounts, displs, sendtype,
                                                           recvbuf, recvcount, recvtype, root,
                                                           comm_ptr, request);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
                 break;
             default:
@@ -216,21 +212,17 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_create(&s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIR_Iscatterv_sched(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype,
                              root, comm_ptr, s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -433,8 +425,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
 
     mpi_errno = MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype,
                                root, comm_ptr, &request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a complete request, if needed */
     if (!request_ptr)

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
@@ -45,14 +45,12 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
                         mpi_errno = MPIR_Sched_copy(((char *) sendbuf + displs[rank] * extent),
                                                     sendcounts[rank], sendtype,
                                                     recvbuf, recvcount, recvtype, s);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 } else {
                     mpi_errno = MPIR_Sched_send(((char *) sendbuf + displs[i] * extent),
                                                 sendcounts[i], sendtype, i, comm_ptr, s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }
@@ -62,8 +60,7 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear_algos.h
@@ -37,8 +37,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendc
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
@@ -109,13 +108,11 @@ int MPIR_TSP_Iscatterv_allcomm_linear(const void *sendbuf, const int sendcounts[
     mpi_errno =
         MPIR_TSP_Iscatterv_sched_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
                                                 recvcount, recvtype, root, comm, sched);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* start and register the schedule */
     mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_TSP_ISCATTERV_ALLCOMM_LINEAR);

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
@@ -82,8 +82,7 @@ int MPIR_Neighbor_allgather_intra_auto(const void *sendbuf, int sendcount, MPI_D
     mpi_errno =
         MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                            recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -100,8 +99,7 @@ int MPIR_Neighbor_allgather_inter_auto(const void *sendbuf, int sendcount, MPI_D
     mpi_errno =
         MPIR_Neighbor_allgather_allcomm_nb(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                                            recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -146,8 +144,7 @@ int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -258,8 +255,7 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
 
     mpi_errno = MPIR_Neighbor_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcount, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather_allcomm_nb.c
@@ -18,14 +18,12 @@ int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_D
     mpi_errno =
         MPIR_Ineighbor_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                                  comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -83,8 +83,7 @@ int MPIR_Neighbor_allgatherv_intra_auto(const void *sendbuf, int sendcount, MPI_
     mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
                                                     recvbuf, recvcounts, displs, recvtype,
                                                     comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -102,8 +101,7 @@ int MPIR_Neighbor_allgatherv_inter_auto(const void *sendbuf, int sendcount, MPI_
     mpi_errno = MPIR_Neighbor_allgatherv_allcomm_nb(sendbuf, sendcount, sendtype,
                                                     recvbuf, recvcounts, displs, recvtype,
                                                     comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -150,8 +148,7 @@ int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -261,8 +258,7 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
 
     mpi_errno = MPIR_Neighbor_allgatherv(sendbuf, sendcount, sendtype, recvbuf,
                                          recvcounts, displs, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_
     mpi_errno = MPIR_Ineighbor_allgatherv(sendbuf, sendcount, sendtype,
                                           recvbuf, recvcounts, displs, recvtype,
                                           comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
@@ -81,8 +81,7 @@ int MPIR_Neighbor_alltoall_intra_auto(const void *sendbuf, int sendcount, MPI_Da
 
     mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
                                                   recvbuf, recvcount, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -99,8 +98,7 @@ int MPIR_Neighbor_alltoall_inter_auto(const void *sendbuf, int sendcount, MPI_Da
 
     mpi_errno = MPIR_Neighbor_alltoall_allcomm_nb(sendbuf, sendcount, sendtype,
                                                   recvbuf, recvcount, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -146,8 +144,7 @@ int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -260,8 +257,7 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
 
     mpi_errno = MPIR_Neighbor_alltoall(sendbuf, sendcount, sendtype, recvbuf,
                                        recvcount, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall_allcomm_nb.c
@@ -17,14 +17,12 @@ int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Da
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ineighbor_alltoall(sendbuf, sendcount, sendtype,
                                         recvbuf, recvcount, recvtype, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
@@ -84,8 +84,7 @@ int MPIR_Neighbor_alltoallv_intra_auto(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                            recvcounts, rdispls, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -104,8 +103,7 @@ int MPIR_Neighbor_alltoallv_inter_auto(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Neighbor_alltoallv_allcomm_nb(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                            recvcounts, rdispls, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -156,8 +154,7 @@ int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -271,8 +268,7 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
 
     mpi_errno = MPIR_Neighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype,
                                         recvbuf, recvcounts, rdispls, recvtype, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Ineighbor_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts,
                                  rdispls, recvtype, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw.c
@@ -85,8 +85,7 @@ int MPIR_Neighbor_alltoallw_intra_auto(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                            recvcounts, rdispls, recvtypes, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -106,8 +105,7 @@ int MPIR_Neighbor_alltoallw_inter_auto(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Neighbor_alltoallw_allcomm_nb(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                            recvcounts, rdispls, recvtypes, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -160,8 +158,7 @@ int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -261,8 +258,7 @@ int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MP
     mpi_errno = MPIR_Neighbor_alltoallw_impl(sendbuf, sendcounts, sdispls,
                                              sendtypes, recvbuf, recvcounts,
                                              rdispls, recvtypes, comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/neighbor_alltoallw/neighbor_alltoallw_allcomm_nb.c
@@ -20,14 +20,12 @@ int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts
     mpi_errno =
         MPIR_Ineighbor_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts,
                                  rdispls, recvtypes, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/op/op_commutative.c
+++ b/src/mpi/coll/op/op_commutative.c
@@ -104,8 +104,7 @@ int MPI_Op_commutative(MPI_Op op, int *commute)
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/coll/op/opreplace.c
+++ b/src/mpi/coll/op/opreplace.c
@@ -13,9 +13,7 @@ void MPIR_REPLACE(void *invec, void *inoutvec, int *Len, MPI_Datatype * type)
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Localcopy(invec, *Len, *type, inoutvec, *Len, *type);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return;

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -300,8 +300,7 @@ int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -485,8 +484,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -15,14 +15,12 @@ int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Da
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -68,8 +68,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
         /* Get the local intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         newcomm_ptr = comm_ptr->local_comm;

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -55,9 +55,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
 
     if ((rank != root) || (sendbuf != MPI_IN_PLACE)) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -121,17 +119,13 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                  * the second argument (in the noncommutative case). */
                 if (is_commutative) {
                     mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } else {
                     mpi_errno = MPIR_Reduce_local(recvbuf, tmp_buf, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype, recvbuf, count, datatype);
-                    if (mpi_errno) {
-                        MPIR_ERR_POP(mpi_errno);
-                    }
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         } else {

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -77,9 +77,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
     if ((rank != root) || (sendbuf != MPI_IN_PLACE)) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -144,8 +142,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
             mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* change the rank */
             newrank = rank / 2;
         }
@@ -228,8 +225,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             mpi_errno = MPIR_Reduce_local((char *) tmp_buf + disps[recv_idx] * extent,
                                           (char *) recvbuf + disps[recv_idx] * extent,
                                           recv_cnt, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* update send_idx for next iteration */
             send_idx = recv_idx;
             mask <<= 1;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -169,8 +169,7 @@ int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype 
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Reduce_local(inbuf, inoutbuf, count, datatype, op);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -140,8 +140,7 @@ int MPIR_Reduce_scatter_intra_auto(const void *sendbuf, void *recvbuf, const int
         mpi_errno =
             MPIR_Reduce_scatter_intra_recursive_halving(sendbuf, recvbuf, recvcounts, datatype, op,
                                                         comm_ptr, errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (is_commutative && (nbytes >= MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
@@ -151,8 +150,7 @@ int MPIR_Reduce_scatter_intra_auto(const void *sendbuf, void *recvbuf, const int
         mpi_errno =
             MPIR_Reduce_scatter_intra_pairwise(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr,
                                                errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
     }
 
@@ -279,8 +277,7 @@ int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -17,14 +17,12 @@ int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -117,8 +117,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
     /* Get the local intracommunicator */
     if (!comm_ptr->local_comm) {
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     newcomm_ptr = comm_ptr->local_comm;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -84,8 +84,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                            (char *) tmp_buf0 +
                            (MPL_mirror_permutation(i, log2_comm_size) * true_extent * block_size),
                            block_size, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     buf0_was_inout = 1;
 
@@ -127,14 +126,12 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
             mpi_errno = MPIR_Reduce_local(incoming_data + recv_offset * true_extent,
                                           outgoing_data + recv_offset * true_extent,
                                           size, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
             MPIR_Reduce_local(outgoing_data + recv_offset * true_extent,
                               incoming_data + recv_offset * true_extent, size, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
         }
 
@@ -148,8 +145,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
     mpi_errno = MPIR_Localcopy(result_ptr, size, datatype, recvbuf, size, datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -62,8 +62,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
         /* copy local data into recvbuf */
         mpi_errno = MPIR_Localcopy(((char *) sendbuf + disps[rank] * extent),
                                    recvcounts[rank], datatype, recvbuf, recvcounts[rank], datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* allocate temporary buffer to store incoming data */
@@ -113,8 +112,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
              * end, we will copy back the result to the
              * beginning of recvbuf. */
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* if MPI_IN_PLACE, move output data to the beginning of
@@ -123,8 +121,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
         mpi_errno = MPIR_Localcopy(((char *) recvbuf +
                                     disps[rank] * extent),
                                    recvcounts[rank], datatype, recvbuf, recvcounts[rank], datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -83,8 +83,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
         mpi_errno = MPIR_Localcopy(recvbuf, total_count, datatype,
                                    tmp_results, total_count, datatype);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mask = 0x1;
     i = 0;
@@ -119,12 +118,10 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
             dis[1] += recvcounts[j];
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* calculate recvtype */
         blklens[0] = blklens[1] = 0;
@@ -139,12 +136,10 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
             dis[1] += recvcounts[j];
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         received = 0;
         if (dst < comm_size) {
@@ -250,32 +245,27 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                 {
                     mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, blklens[0],
                                                   datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     mpi_errno = MPIR_Reduce_local(((char *) tmp_recvbuf + dis[1] * extent),
                                                   ((char *) tmp_results + dis[1] * extent),
                                                   blklens[1], datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             } else {
                 {
                     mpi_errno = MPIR_Reduce_local(tmp_results, tmp_recvbuf, blklens[0],
                                                   datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     mpi_errno = MPIR_Reduce_local(((char *) tmp_results + dis[1] * extent),
                                                   ((char *) tmp_recvbuf + dis[1] * extent),
                                                   blklens[1], datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
                 /* copy result back into tmp_results */
                 mpi_errno = MPIR_Localcopy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
 
@@ -289,8 +279,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     /* now copy final results from tmp_results to recvbuf */
     mpi_errno = MPIR_Localcopy(((char *) tmp_results + disps[rank] * extent),
                                recvcounts[rank], datatype, recvbuf, recvcounts[rank], datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -102,8 +102,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         mpi_errno = MPIR_Localcopy(recvbuf, total_count, datatype,
                                    tmp_results, total_count, datatype);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     pof2 = comm_ptr->pof2;
 
@@ -149,8 +148,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, total_count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -249,8 +247,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIR_Reduce_local((char *) tmp_recvbuf + newdisps[recv_idx] * extent,
                                               (char *) tmp_results + newdisps[recv_idx] * extent,
                                               recv_cnt, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
             /* update send_idx for next iteration */
@@ -265,8 +262,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                        disps[rank] * extent,
                                        recvcounts[rank], datatype, recvbuf,
                                        recvcounts[rank], datatype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
     }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -245,8 +245,7 @@ int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -17,14 +17,12 @@ int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -82,8 +82,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                            (char *) tmp_buf0 +
                            (MPL_mirror_permutation(i, log2_comm_size) * true_extent * block_size),
                            block_size, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     buf0_was_inout = 1;
 
@@ -125,15 +124,13 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
             mpi_errno = MPIR_Reduce_local(incoming_data + recv_offset * true_extent,
                                           outgoing_data + recv_offset * true_extent,
                                           size, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
             mpi_errno = MPIR_Reduce_local(outgoing_data + recv_offset * true_extent,
                                           incoming_data + recv_offset * true_extent,
                                           size, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
         }
 
@@ -147,8 +144,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
     mpi_errno = MPIR_Localcopy(result_ptr, size, datatype, recvbuf, size, datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -69,8 +69,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
         /* copy local data into recvbuf */
         mpi_errno = MPIR_Localcopy(((char *) sendbuf + disps[rank] * extent),
                                    recvcount, datatype, recvbuf, recvcount, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* allocate temporary buffer to store incoming data */
@@ -120,8 +119,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
              * end, we will copy back the result to the
              * beginning of recvbuf. */
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* if MPI_IN_PLACE, move output data to the beginning of
@@ -130,8 +128,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(((char *) recvbuf +
                                     disps[rank] * extent),
                                    recvcount, datatype, recvbuf, recvcount, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -83,8 +83,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(recvbuf, total_count, datatype,
                                    tmp_results, total_count, datatype);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mask = 0x1;
     i = 0;
@@ -119,12 +118,10 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
             dis[1] += recvcount;
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&sendtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* calculate recvtype */
         blklens[0] = blklens[1] = 0;
@@ -139,12 +136,10 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
             dis[1] += recvcount;
 
         mpi_errno = MPIR_Type_indexed_impl(2, blklens, dis, datatype, &recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Type_commit_impl(&recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         received = 0;
         if (dst < comm_size) {
@@ -248,29 +243,24 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
         if (received) {
             if (is_commutative || (dst_tree_root < my_tree_root)) {
                 mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, blklens[0], datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIR_Reduce_local(((char *) tmp_recvbuf + dis[1] * extent),
                                               ((char *) tmp_results + dis[1] * extent),
                                               blklens[1], datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else {
                 mpi_errno = MPIR_Reduce_local(tmp_results, tmp_recvbuf, blklens[0], datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIR_Reduce_local(((char *) tmp_results + dis[1] * extent),
                                               ((char *) tmp_recvbuf + dis[1] * extent),
                                               blklens[1], datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* copy result back into tmp_results */
                 mpi_errno = MPIR_Localcopy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
 
@@ -284,8 +274,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     /* now copy final results from tmp_results to recvbuf */
     mpi_errno = MPIR_Localcopy(((char *) tmp_results + disps[rank] * extent),
                                recvcount, datatype, recvbuf, recvcount, datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -105,8 +105,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         mpi_errno = MPIR_Localcopy(recvbuf, total_count, datatype,
                                    tmp_results, total_count, datatype);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     pof2 = comm_ptr->pof2;
 
@@ -154,8 +153,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, tmp_results, total_count, datatype, op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* change the rank */
             newrank = rank / 2;
@@ -255,8 +253,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                 mpi_errno = MPIR_Reduce_local((char *) tmp_recvbuf + newdisps[recv_idx] * extent,
                                               (char *) tmp_results + newdisps[recv_idx] * extent,
                                               recv_cnt, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
             /* update send_idx for next iteration */
@@ -269,8 +266,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         mpi_errno = MPIR_Localcopy((char *) tmp_results +
                                    disps[rank] * extent,
                                    recvcount, datatype, recvbuf, recvcount, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* In the non-power-of-two case, all odd-numbered

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -80,8 +80,7 @@ int MPIR_Scan_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                                errflag);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -114,8 +113,7 @@ int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count,
                 MPIR_Scan_intra_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
             break;
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -15,14 +15,12 @@ int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Data
 
     /* just call the nonblocking version and wait on it */
     mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -86,16 +86,14 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
      * recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (sendbuf != MPI_IN_PLACE)
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, partial_scan, count, datatype);
     else
         mpi_errno = MPIR_Localcopy(recvbuf, count, datatype, partial_scan, count, datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mask = 0x1;
     while (mask < comm_size) {
@@ -117,24 +115,19 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Reduce_local(tmp_buf, recvbuf, count, datatype, op);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } else {
                     mpi_errno = MPIR_Reduce_local(partial_scan, tmp_buf, count, datatype, op);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     mpi_errno = MPIR_Localcopy(tmp_buf, count, datatype,
                                                partial_scan, count, datatype);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -57,8 +57,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count,
         }
     } else if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* get result from local node's last processor which

--- a/src/mpi/coll/scatter/scatter.c
+++ b/src/mpi/coll/scatter/scatter.c
@@ -94,8 +94,7 @@ int MPIR_Scatter_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
 
     mpi_errno = MPIR_Scatter_intra_binomial(sendbuf, sendcount, sendtype,
                                             recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -134,8 +133,7 @@ int MPIR_Scatter_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sen
                                               recvcount, recvtype, root, comm_ptr, errflag);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -200,8 +198,7 @@ int MPIR_Scatter_impl(const void *sendbuf, int sendcount,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -18,14 +18,12 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sen
     mpi_errno =
         MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
                       &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -95,14 +95,12 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype
                                            sendcount * (comm_size - rank - 1),
                                            sendtype, (char *) tmp_buf + nbytes,
                                            nbytes * (comm_size - rank - 1), MPI_BYTE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno = MPIR_Localcopy(sendbuf, sendcount * rank, sendtype,
                                        ((char *) tmp_buf + nbytes * (comm_size - rank)),
                                        nbytes * rank, MPI_BYTE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             curr_cnt = nbytes * comm_size;
         } else
@@ -196,14 +194,12 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype
     if ((rank == root) && (root == 0) && (recvbuf != MPI_IN_PLACE)) {
         /* for root=0, put root's data in recvbuf if not MPI_IN_PLACE */
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (!(relative_rank % 2) && (recvbuf != MPI_IN_PLACE)) {
         /* for non-zero root and non-leaf nodes, copy from tmp_buf
          * into recvbuf */
         mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, recvbuf, recvcount, recvtype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -85,8 +85,7 @@ int MPIR_Scatterv_intra_auto(const void *sendbuf, const int *sendcounts, const i
     mpi_errno =
         MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
                                      recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -107,8 +106,7 @@ int MPIR_Scatterv_inter_auto(const void *sendbuf, const int *sendcounts, const i
     mpi_errno =
         MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
                                      recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)
@@ -167,8 +165,7 @@ int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcounts,
                 break;
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (*errflag != MPIR_ERR_NONE)

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -57,15 +57,13 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, con
                         mpi_errno = MPIR_Localcopy(((char *) sendbuf + displs[rank] * extent),
                                                    sendcounts[rank], sendtype,
                                                    recvbuf, recvcount, recvtype);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 } else {
                     mpi_errno = MPIC_Isend(((char *) sendbuf + displs[i] * extent),
                                            sendcounts[i], sendtype, i,
                                            MPIR_SCATTERV_TAG, comm_ptr, &reqarray[reqs++], errflag);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -19,14 +19,12 @@ int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcounts, const i
     mpi_errno =
         MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
                        comm_ptr, &req_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (req_ptr)
         req = req_ptr->handle;
 
     mpi_errno = MPIR_Wait(&req, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -72,27 +72,21 @@ int MPII_Coll_init(void)
 
     /* register non blocking collectives progress hook */
     mpi_errno = MPID_Progress_register_hook(MPIDU_Sched_progress, &MPIR_Nbc_progress_hook_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* initialize transports */
     mpi_errno = MPII_Stubtran_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Gentran_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* initialize algorithms */
     mpi_errno = MPII_Stubalgo_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Treealgo_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Recexchalgo_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -108,11 +102,9 @@ int MPII_Coll_finalize(void)
     MPID_Progress_deregister_hook(MPIR_Nbc_progress_hook_id);
 
     mpi_errno = MPII_Gentran_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Stubtran_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -134,20 +126,16 @@ int MPIR_Coll_comm_init(MPIR_Comm * comm)
 
     /* initialize any stub algo related data structures */
     mpi_errno = MPII_Stubalgo_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* initialize any tree algo related data structures */
     mpi_errno = MPII_Treealgo_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* initialize any transport data structures */
     mpi_errno = MPII_Stubtran_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Gentran_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -162,19 +150,15 @@ int MPII_Coll_comm_cleanup(MPIR_Comm * comm)
 
     /* cleanup all collective communicators */
     mpi_errno = MPII_Stubalgo_comm_cleanup(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Treealgo_comm_cleanup(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* cleanup transport data */
     mpi_errno = MPII_Stubtran_comm_cleanup(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Gentran_comm_cleanup(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/transports/gentran/gentran_impl.c
+++ b/src/mpi/coll/transports/gentran/gentran_impl.c
@@ -42,8 +42,7 @@ int MPII_Gentran_init(void)
 
     mpi_errno =
         MPID_Progress_register_hook(MPII_Genutil_progress_hook, &MPII_Genutil_progress_hook_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/comm/comm_agree.c
+++ b/src/mpi/comm/comm_agree.c
@@ -41,8 +41,7 @@ int MPIR_Comm_agree(MPIR_Comm * comm_ptr, int *flag)
 
     /* Get the locally known (not acknowledged) group of failed procs */
     mpi_errno = MPID_Comm_failure_get_acked(comm_ptr, &failed_grp);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* First decide on the group of failed procs. */
     mpi_errno = MPID_Comm_get_all_failed_procs(comm_ptr, &global_failed, MPIR_AGREE_TAG);
@@ -50,13 +49,11 @@ int MPIR_Comm_agree(MPIR_Comm * comm_ptr, int *flag)
         errflag = MPIR_ERR_PROC_FAILED;
 
     mpi_errno = MPIR_Group_compare_impl(failed_grp, global_failed, &result);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Create a subgroup without the failed procs */
     mpi_errno = MPIR_Group_difference_impl(comm_grp, global_failed, &new_group_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* If that group isn't the same as what we think is failed locally, then
      * mark it as such. */
@@ -164,8 +161,7 @@ int MPIX_Comm_agree(MPI_Comm comm, int *flag)
 
     /* ... body of routine ... */
     mpi_errno = MPIR_Comm_agree(comm_ptr, flag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/comm/comm_compare.c
+++ b/src/mpi/comm/comm_compare.c
@@ -119,24 +119,19 @@ int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
         MPIR_Group *group_ptr1, *group_ptr2;
 
         mpi_errno = MPIR_Comm_group_impl(comm_ptr1, &group_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Comm_group_impl(comm_ptr2, &group_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_compare_impl(group_ptr1, group_ptr2, result);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* If the groups are the same but the contexts are different, then
          * the communicators are congruent */
         if (*result == MPI_IDENT)
             *result = MPI_CONGRUENT;
         mpi_errno = MPIR_Group_free_impl(group_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_free_impl(group_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* INTER_COMM */
         int lresult, rresult;
@@ -145,24 +140,18 @@ int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
 
         /* Get the groups and see what their relationship is */
         mpi_errno = MPIR_Comm_group_impl(comm_ptr1, &group_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Comm_group_impl(comm_ptr2, &group_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_compare_impl(group_ptr1, group_ptr2, &lresult);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Comm_remote_group_impl(comm_ptr1, &rgroup_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Comm_remote_group_impl(comm_ptr2, &rgroup_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_compare_impl(rgroup_ptr1, rgroup_ptr2, &rresult);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Choose the result that is "least" strong. This works
          * due to the ordering of result types in mpi.h */
@@ -175,17 +164,13 @@ int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result)
 
         /* Free the groups */
         mpi_errno = MPIR_Group_free_impl(group_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_free_impl(group_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_free_impl(rgroup_ptr1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Group_free_impl(rgroup_ptr2);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     /* ... end of body of routine ... */
 

--- a/src/mpi/comm/comm_create_group.c
+++ b/src/mpi/comm/comm_create_group.c
@@ -58,20 +58,17 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
          *group*, so processes not in the group do not participate. */
 
         mpi_errno = MPIR_Get_contextid_sparse_group(comm_ptr, group_ptr, tag, &new_context_id, 0);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(new_context_id != 0);
 
         mpi_errno = MPII_Comm_create_calculate_mapping(group_ptr, comm_ptr,
                                                        &mapping, &mapping_comm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Get the new communicator structure and context id */
 
         mpi_errno = MPIR_Comm_create(newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         (*newcomm_ptr)->recvcontext_id = new_context_id;
         (*newcomm_ptr)->rank = group_ptr->rank;
@@ -91,12 +88,10 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
         /* Setup the communicator's vc table.  This is for the remote group,
          * which is the same as the local group for intracommunicators */
         mpi_errno = MPII_Comm_create_map(n, 0, mapping, NULL, mapping_comm, *newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* This process is not in the group */
         new_context_id = 0;
@@ -205,8 +200,7 @@ int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm * ne
 
     /* ... body of routine ...  */
     mpi_errno = MPIR_Comm_create_group(comm_ptr, group_ptr, tag, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (newcomm_ptr)
         MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);

--- a/src/mpi/comm/comm_dup.c
+++ b/src/mpi/comm/comm_dup.c
@@ -39,8 +39,7 @@ int MPIR_Comm_dup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
      */
     if (MPIR_Process.attr_dup) {
         mpi_errno = MPIR_Process.attr_dup(comm_ptr->handle, comm_ptr->attributes, &new_attributes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
 
@@ -49,8 +48,7 @@ int MPIR_Comm_dup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
      * rank of the process in the communicator.  For intercomms,
      * this must be the local size */
     mpi_errno = MPII_Comm_copy(comm_ptr, comm_ptr->local_size, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*newcomm_ptr)->attributes = new_attributes;
 
@@ -152,8 +150,7 @@ int MPI_Comm_dup(MPI_Comm comm, MPI_Comm * newcomm)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Comm_dup_impl(comm_ptr, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);
     /* ... end of body of routine ... */

--- a/src/mpi/comm/comm_dup_with_info.c
+++ b/src/mpi/comm/comm_dup_with_info.c
@@ -35,8 +35,7 @@ int MPIR_Comm_dup_with_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr,
     /* FIXME: We just ignore the info argument for now and just call
      * Comm_dup */
     mpi_errno = MPIR_Comm_dup_impl(comm_ptr, newcomm_p_p);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -123,8 +122,7 @@ int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm * newcomm)
 
     /* ... body of routine ...  */
     mpi_errno = MPIR_Comm_dup_with_info_impl(comm_ptr, info_ptr, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);
     /* ... end of body of routine ... */

--- a/src/mpi/comm/comm_group.c
+++ b/src/mpi/comm/comm_group.c
@@ -40,8 +40,7 @@ int MPIR_Comm_group_impl(MPIR_Comm * comm_ptr, MPIR_Group ** group_ptr)
     if (!comm_ptr->local_group) {
         n = comm_ptr->local_size;
         mpi_errno = MPIR_Group_create(n, group_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         (*group_ptr)->is_local_dense_monotonic = TRUE;
         for (i = 0; i < n; i++) {

--- a/src/mpi/comm/comm_idup.c
+++ b/src/mpi/comm/comm_idup.c
@@ -40,13 +40,11 @@ int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcommp, MPIR_Reques
      */
     if (MPIR_Process.attr_dup) {
         mpi_errno = MPIR_Process.attr_dup(comm_ptr->handle, comm_ptr->attributes, &new_attributes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPII_Comm_copy_data(comm_ptr, newcommp);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*newcommp)->attributes = new_attributes;
 
@@ -54,12 +52,10 @@ int MPIR_Comm_idup_impl(MPIR_Comm * comm_ptr, MPIR_Comm ** newcommp, MPIR_Reques
      * allocating a context ID to use for actual communication */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
         mpi_errno = MPIR_Get_intercomm_contextid_nonblock(comm_ptr, *newcommp, reqp);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Get_contextid_nonblock(comm_ptr, *newcommp, reqp);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -133,8 +129,7 @@ int MPI_Comm_idup(MPI_Comm comm, MPI_Comm * newcomm, MPI_Request * request)
     *newcomm = MPI_COMM_NULL;
 
     mpi_errno = MPIR_Comm_idup_impl(comm_ptr, &newcomm_ptr, &dreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: this is a publication for most of the comm, but the context ID
      * won't be valid yet, so we must "republish" relative to the request

--- a/src/mpi/comm/comm_remote_group.c
+++ b/src/mpi/comm/comm_remote_group.c
@@ -38,8 +38,7 @@ int MPIR_Comm_remote_group_impl(MPIR_Comm * comm_ptr, MPIR_Group ** group_ptr)
     if (!comm_ptr->remote_group) {
         n = comm_ptr->remote_size;
         mpi_errno = MPIR_Group_create(n, group_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         for (i = 0; i < n; i++) {
             (void) MPID_Comm_get_lpid(comm_ptr, i, &lpid, TRUE);
@@ -139,8 +138,7 @@ int MPI_Comm_remote_group(MPI_Comm comm, MPI_Group * group)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Comm_remote_group_impl(comm_ptr, &group_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *group = group_ptr->handle;
 

--- a/src/mpi/comm/comm_revoke.c
+++ b/src/mpi/comm/comm_revoke.c
@@ -88,8 +88,7 @@ int MPIX_Comm_revoke(MPI_Comm comm)
     /* ... body of routine ... */
 
     mpi_errno = MPID_Comm_revoke(comm_ptr, 0);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/comm/comm_set_info.c
+++ b/src/mpi/comm/comm_set_info.c
@@ -56,8 +56,7 @@ int MPIR_Comm_set_info_impl(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
             continue;
 
         mpi_errno = MPIR_Info_set_impl(comm_ptr->info, curr_info->key, curr_info->value);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/comm/comm_shrink.c
+++ b/src/mpi/comm/comm_shrink.c
@@ -64,8 +64,7 @@ int MPIR_Comm_shrink(MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr)
          * with failed procs */
 
         mpi_errno = MPIR_Group_difference_impl(comm_grp, global_failed, &new_group_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (MPIR_Group_empty != global_failed)
             MPIR_Group_release(global_failed);
 
@@ -172,8 +171,7 @@ int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm * newcomm)
 
     /* ... body of routine ... */
     mpi_errno = MPIR_Comm_shrink(comm_ptr, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (newcomm_ptr)
         MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -159,8 +159,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
     /* Gather information on the local group of processes */
     mpi_errno =
         MPIR_Allgather(MPI_IN_PLACE, 2, MPI_INT, table, 2, MPI_INT, local_comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     /* Step 2: How many processes have our same color? */
@@ -208,8 +207,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
         mypair.key = key;
         mpi_errno = MPIR_Allgather(&mypair, 2, MPI_INT, remotetable, 2, MPI_INT,
                                    comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* Each process can now match its color with the entries in the table */
@@ -245,8 +243,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
      * calling routine already holds the single criticial section */
     mpi_errno = MPIR_Get_contextid_sparse(local_comm_ptr, &new_context_id, !in_newcomm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(new_context_id != 0);
 
     /* In the intercomm case, we need to exchange the context ids */
@@ -255,22 +252,18 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
             mpi_errno = MPIC_Sendrecv(&new_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, 0,
                                       &remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE,
                                       0, 0, comm_ptr, MPI_STATUS_IGNORE, &errflag);
-            if (mpi_errno) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno =
                 MPIR_Bcast(&remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, local_comm_ptr,
                            &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         } else {
             /* Broadcast to the other members of the local group */
             mpi_errno =
                 MPIR_Bcast(&remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, local_comm_ptr,
                            &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         }
     }
@@ -380,8 +373,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
         MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(comm_ptr));
 
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -477,8 +469,7 @@ int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm * newcomm)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (newcomm_ptr)
         MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);
     else

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -45,8 +45,7 @@ int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key
     /* split out the undefined processes */
     mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
                                      key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (split_type == MPI_UNDEFINED) {
         *newcomm_ptr = NULL;
@@ -56,8 +55,7 @@ int MPIR_Comm_split_type_self(MPIR_Comm * user_comm_ptr, int split_type, int key
     MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
     mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, newcomm_ptr);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (comm_ptr)
@@ -78,8 +76,7 @@ int MPIR_Comm_split_type_node(MPIR_Comm * user_comm_ptr, int split_type, int key
     /* split out the undefined processes */
     mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
                                      key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (split_type == MPI_UNDEFINED) {
         *newcomm_ptr = NULL;
@@ -87,12 +84,10 @@ int MPIR_Comm_split_type_node(MPIR_Comm * user_comm_ptr, int split_type, int key
     }
 
     mpi_errno = MPID_Get_node_id(comm_ptr, comm_ptr->rank, &color);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (comm_ptr)
@@ -192,8 +187,7 @@ static int node_split_processor(MPIR_Comm * comm_ptr, int key, const char *hintv
 
   split_id:
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -233,8 +227,7 @@ static int node_split_pci_device(MPIR_Comm * comm_ptr, int key,
         color = MPI_UNDEFINED;
 
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -308,8 +301,7 @@ static int node_split_network_device(MPIR_Comm * comm_ptr, int key,
     }
 
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -349,8 +341,7 @@ static int node_split_gpu_device(MPIR_Comm * comm_ptr, int key,
     }
 
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -422,8 +413,7 @@ static int network_split_switch_level(MPIR_Comm * comm_ptr, int key,
         color = MPI_UNDEFINED;
     }
     mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -495,8 +485,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
                                                        MPIR_Process.netloc_topology, network_node,
                                                        &node_index, &num_nodes);
 
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             num_processes_at_node = (int *) MPL_calloc(1, sizeof(int) * num_nodes, MPL_MEM_OTHER);
             num_processes_at_node[node_index] = 1;
@@ -595,8 +584,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
         }
 
         mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* There are more processes in the subset than requested within the node.
          * Split further inside each node */
@@ -679,8 +667,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
                                                  num_hwloc_objs_at_depth, subcomm_min_size);
 
                 mpi_errno = MPIR_Comm_split_impl(node_comm, color, key, newcomm_ptr);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPL_free(processes_cpuset);
                 MPL_free(parent_idx);
                 MPL_free(obj_idx_at_depth);
@@ -797,16 +784,14 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
      * comparison is successful on all processes. */
     mpi_errno =
         MPID_Allreduce(&hintval_size, &hintval_size_max, 1, MPI_INT, MPI_MAX, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     hintval_equal = (hintval_size == hintval_size_max);
 
     mpi_errno =
         MPID_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!hintval_equal_global)
         goto fn_exit;
@@ -819,16 +804,14 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
     mpi_errno =
         MPID_Allreduce(hintval, hintval_global, strlen(hintval), MPI_CHAR,
                        MPI_MAX, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     hintval_equal = !memcmp(hintval, hintval_global, strlen(hintval));
 
     mpi_errno =
         MPID_Allreduce(&hintval_equal, &hintval_equal_global, 1, MPI_INT, MPI_LAND,
                        comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPL_free(hintval_global);
@@ -851,8 +834,7 @@ int MPIR_Comm_split_type_node_topo(MPIR_Comm * user_comm_ptr, int split_type, in
     *newcomm_ptr = NULL;
 
     mpi_errno = MPIR_Comm_split_type_node(user_comm_ptr, split_type, key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (comm_ptr == NULL) {
         MPIR_Assert(split_type == MPI_UNDEFINED);
@@ -870,8 +852,7 @@ int MPIR_Comm_split_type_node_topo(MPIR_Comm * user_comm_ptr, int split_type, in
 
     mpi_errno = compare_info_hint(hintval, comm_ptr, &info_args_are_equal);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* if all processes do not have the same hintval, skip
      * topology-aware comm split */
@@ -899,8 +880,7 @@ int MPIR_Comm_split_type_node_topo(MPIR_Comm * user_comm_ptr, int split_type, in
         else
             mpi_errno = node_split_processor(comm_ptr, key, hintval, newcomm_ptr);
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Comm_free_impl(comm_ptr);
 
@@ -954,8 +934,7 @@ int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
     /* split out the undefined processes */
     mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
                                      key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (split_type == MPI_UNDEFINED) {
         *newcomm_ptr = NULL;
@@ -964,13 +943,11 @@ int MPIR_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key,
 
     if (split_type == MPI_COMM_TYPE_SHARED) {
         mpi_errno = MPIR_Comm_split_type_self(comm_ptr, split_type, key, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (split_type == MPIX_COMM_TYPE_NEIGHBORHOOD) {
         mpi_errno =
             MPIR_Comm_split_type_neighborhood(comm_ptr, split_type, key, info_ptr, newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_ARG, "**arg");
     }
@@ -993,8 +970,7 @@ int MPIR_Comm_split_type_nbhd_common_dir(MPIR_Comm * user_comm_ptr, int key, con
     MPIR_Comm *dummycomm_ptr;
 
     mpi_errno = MPIR_Comm_split_filesystem(user_comm_ptr->handle, key, hintval, &dummycomm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Comm_get_ptr(dummycomm, dummycomm_ptr);
     *newcomm_ptr = dummycomm_ptr;
@@ -1028,8 +1004,7 @@ int MPIR_Comm_split_type_neighborhood(MPIR_Comm * comm_ptr, int split_type, int 
     *newcomm_ptr = NULL;
     mpi_errno = compare_info_hint(hintval, comm_ptr, &info_args_are_equal);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (info_args_are_equal && flag) {
         MPIR_Comm_split_type_nbhd_common_dir(comm_ptr, key, hintval, newcomm_ptr);
@@ -1045,8 +1020,7 @@ int MPIR_Comm_split_type_neighborhood(MPIR_Comm * comm_ptr, int split_type, int 
 
         mpi_errno = compare_info_hint(hintval, comm_ptr, &info_args_are_equal);
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* if all processes have the same hintval, perform
          * topology-aware comm split */
@@ -1077,8 +1051,7 @@ int MPIR_Comm_split_type_impl(MPIR_Comm * comm_ptr, int split_type, int key,
     } else {
         mpi_errno = MPIR_Comm_split_type(comm_ptr, split_type, key, info_ptr, newcomm_ptr);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1162,8 +1135,7 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Comm_split_type_impl(comm_ptr, split_type, key, info_ptr, &newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (newcomm_ptr)
         MPIR_OBJ_PUBLISH_HANDLE(*newcomm, newcomm_ptr->handle);
     else

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -135,8 +135,7 @@ int MPIR_Comm_create(MPIR_Comm ** newcomm_ptr)
     *newcomm_ptr = newptr;
 
     mpi_errno = MPII_Comm_init(newptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Insert this new communicator into the list of known communicators.
      * Make this conditional on debugger support to match the test in
@@ -165,8 +164,7 @@ int MPII_Setup_intercomm_localcomm(MPIR_Comm * intercomm_ptr)
 
     /* get sensible default values for most fields (usually zeros) */
     mpi_errno = MPII_Comm_init(localcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* use the parent intercomm's recv ctx as the basis for our ctx */
     localcomm_ptr->recvcontext_id =
@@ -198,8 +196,7 @@ int MPII_Setup_intercomm_localcomm(MPIR_Comm * intercomm_ptr)
 
     /* sets up the SMP-aware sub-communicators and tables */
     mpi_errno = MPIR_Comm_commit(localcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_SETUP_INTERCOMM_LOCALCOMM);
@@ -327,16 +324,14 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
     /* Notify device of communicator creation */
     if (comm != MPIR_Process.comm_world) {
         mpi_errno = MPID_Comm_create_hook(comm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Comm_map_free(comm);
     }
 
     /* Create collectives-specific infrastructure */
     mpi_errno = MPIR_Coll_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Comm_map_free(comm);
 
@@ -394,8 +389,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         /* we don't need a local comm if this process is the only one on this node */
         if (num_local > 1) {
             mpi_errno = MPIR_Comm_create(&comm->node_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             comm->node_comm->context_id = comm->context_id + MPIR_CONTEXT_INTRANODE_OFFSET;
             comm->node_comm->recvcontext_id = comm->node_comm->context_id;
@@ -414,14 +408,12 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
 
             /* Notify device of communicator creation */
             mpi_errno = MPID_Comm_create_hook(comm->node_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* don't call MPIR_Comm_commit here */
 
             /* Create collectives-specific infrastructure */
             mpi_errno = MPIR_Coll_comm_init(comm->node_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_Comm_map_free(comm->node_comm);
         }
@@ -430,8 +422,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         /* this process may not be a member of the node_roots_comm */
         if (local_rank == 0) {
             mpi_errno = MPIR_Comm_create(&comm->node_roots_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             comm->node_roots_comm->context_id = comm->context_id + MPIR_CONTEXT_INTERNODE_OFFSET;
             comm->node_roots_comm->recvcontext_id = comm->node_roots_comm->context_id;
@@ -451,14 +442,12 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
 
             /* Notify device of communicator creation */
             mpi_errno = MPID_Comm_create_hook(comm->node_roots_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             /* don't call MPIR_Comm_commit here */
 
             /* Create collectives-specific infrastructure */
             mpi_errno = MPIR_Coll_comm_init(comm->node_roots_comm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_Comm_map_free(comm->node_roots_comm);
         }
@@ -469,8 +458,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
   fn_exit:
     if (comm == MPIR_Process.comm_world) {
         mpi_errno = MPID_Comm_create_hook(comm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Comm_map_free(comm);
     }
@@ -542,13 +530,11 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Comm ** outcomm_ptr)
      * of intercomms here */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
         mpi_errno = MPIR_Get_intercomm_contextid(comm_ptr, &new_context_id, &new_recvcontext_id);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Get_contextid_sparse(comm_ptr, &new_context_id, FALSE);
         new_recvcontext_id = new_context_id;
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(new_context_id != 0);
     }
 
@@ -627,19 +613,16 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Comm ** outcomm_ptr)
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(comm_ptr));
 
     mpi_errno = MPIR_Comm_commit(newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Start with no attributes on this communicator */
     newcomm_ptr->attributes = 0;
 
     /* Copy over the info hints from the original communicator. */
     mpi_errno = MPIR_Info_dup_impl(comm_ptr->info, &(newcomm_ptr->info));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPII_Comm_apply_hints(newcomm_ptr, newcomm_ptr->info);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *outcomm_ptr = newcomm_ptr;
 
@@ -754,14 +737,12 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
 
         /* Cleanup collectives-specific infrastructure */
         mpi_errno = MPII_Coll_comm_cleanup(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Notify the device that the communicator is about to be
          * destroyed */
         mpi_errno = MPID_Comm_free_hook(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Free info hints */
         if (comm_ptr->info != NULL) {
@@ -851,8 +832,7 @@ int MPIR_Comm_release_always(MPIR_Comm * comm_ptr)
     MPIR_Object_release_ref_always(comm_ptr, &in_use);
     if (!in_use) {
         mpi_errno = MPIR_Comm_delete_internal(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -886,8 +866,7 @@ int MPII_Comm_apply_hints(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr)
         /* Skip hints that MPICH doesn't recognize. */
         if (hint_fn) {
             mpi_errno = hint_fn->fn(comm_ptr, hint, hint_fn->state);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -48,8 +48,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     mpi_errno = MPID_Intercomm_exchange_map(local_comm_ptr, local_leader,
                                             peer_comm_ptr, remote_leader,
                                             &remote_size, &remote_lpids, &is_low_group);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /*
      * Create the contexts.  Each group will have a context for sending
@@ -64,8 +63,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
      * calling routine already holds the single criticial section */
     /* TODO: Make sure this is tag-safe */
     mpi_errno = MPIR_Get_contextid_sparse(local_comm_ptr, &recvcontext_id, FALSE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(recvcontext_id != 0);
     MPL_DBG_MSG_FMT(MPIR_DBG_COMM, VERBOSE, (MPL_DBG_FDEST, "Got contextid=%d", recvcontext_id));
 
@@ -78,8 +76,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
             MPIC_Sendrecv(&recvcontext_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, tag,
                           &remote_context_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, tag,
                           peer_comm_ptr, MPI_STATUS_IGNORE, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         final_context_id = remote_context_id;
 
@@ -88,8 +85,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
         comm_info[0] = final_context_id;
         MPL_DBG_MSG(MPIR_DBG_COMM, VERBOSE, "About to bcast on local_comm");
         mpi_errno = MPIR_Bcast(comm_info, 1, MPI_INT, local_leader, local_comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "end of bcast on local_comm of size %d",
                       local_comm_ptr->local_size);
@@ -97,8 +93,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
         /* we're the other processes */
         MPL_DBG_MSG(MPIR_DBG_COMM, VERBOSE, "About to receive bcast on local_comm");
         mpi_errno = MPIR_Bcast(comm_info, 1, MPI_INT, local_leader, local_comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* Extract the context and group sign informatin */
@@ -139,8 +134,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_COMM_MUTEX(local_comm_ptr));
 
     mpi_errno = MPIR_Comm_commit(*new_intercomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
   fn_exit:

--- a/src/mpi/comm/intercomm_merge.c
+++ b/src/mpi/comm/intercomm_merge.c
@@ -73,8 +73,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     if (!comm_ptr->local_comm) {
         /* Manufacture the local communicator */
         mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* Find the "high" value of the other group of processes.  This
@@ -87,8 +86,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
         mpi_errno = MPIC_Sendrecv(&local_high, 1, MPI_INT, 0, 0,
                                   &remote_high, 1, MPI_INT, 0, 0, comm_ptr,
                                   MPI_STATUS_IGNORE, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* If local_high and remote_high are the same, then order is arbitrary.
          * we use the is_low_group in the intercomm in this case. */
@@ -106,8 +104,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
      * of processes had the same value for high
      */
     mpi_errno = MPIR_Bcast(&local_high, 1, MPI_INT, 0, comm_ptr->local_comm, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     /*
@@ -125,8 +122,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     new_size = comm_ptr->local_size + comm_ptr->remote_size;
 
     mpi_errno = MPIR_Comm_create(new_intracomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (local_high) {
         (*new_intracomm_ptr)->context_id =
@@ -143,8 +139,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     /* Now we know which group comes first.  Build the new mapping
      * from the existing comm */
     mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* We've setup a temporary context id, based on the context id
      * used by the intercomm.  This allows us to perform the allreduce
@@ -152,28 +147,24 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
      * have a valid (almost - see comm_create_hook) communicator.
      */
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* printf("About to get context id \n"); fflush(stdout); */
     /* In the multi-threaded case, MPIR_Get_contextid_sparse assumes that the
      * calling routine already holds the single criticial section */
     new_context_id = 0;
     mpi_errno = MPIR_Get_contextid_sparse((*new_intracomm_ptr), &new_context_id, FALSE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(new_context_id != 0);
 
     /* We release this communicator that was involved just to
      * get valid context id and create true one
      */
     mpi_errno = MPIR_Comm_release(*new_intracomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Comm_create(new_intracomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*new_intracomm_ptr)->remote_size = (*new_intracomm_ptr)->local_size = new_size;
     (*new_intracomm_ptr)->pof2 = MPL_pof2(new_size);
@@ -183,12 +174,10 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     (*new_intracomm_ptr)->recvcontext_id = new_context_id;
 
     mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_KIND__INTERCOMM_MERGE_IMPL);
@@ -302,8 +291,7 @@ int MPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm * newintracomm)
             acthigh = high ? 1 : 0;     /* Clamp high into 1 or 0 */
             mpi_errno = MPIR_Allreduce(MPI_IN_PLACE, &acthigh, 1, MPI_INT,
                                        MPI_SUM, comm_ptr->local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
             /* acthigh must either == 0 or the size of the local comm */
             if (acthigh != 0 && acthigh != comm_ptr->local_size) {

--- a/src/mpi/datatype/get_elements.c
+++ b/src/mpi/datatype/get_elements.c
@@ -105,8 +105,7 @@ int MPI_Get_elements(const MPI_Status * status, MPI_Datatype datatype, int *coun
 
     byte_count = MPIR_STATUS_GET_COUNT(*status);
     mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, &count_x);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* clip the value if it cannot be correctly returned to the user */
     *count = (count_x > INT_MAX) ? MPI_UNDEFINED : (int) count_x;

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -405,8 +405,7 @@ int MPI_Get_elements_x(const MPI_Status * status, MPI_Datatype datatype, MPI_Cou
 
     byte_count = MPIR_STATUS_GET_COUNT(*status);
     mpi_errno = MPIR_Get_elements_x_impl(&byte_count, datatype, count);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/status_set_elements.c
+++ b/src/mpi/datatype/status_set_elements.c
@@ -80,8 +80,7 @@ int MPI_Status_set_elements(MPI_Status * status, MPI_Datatype datatype, int coun
     /* ... body of routine ... */
 
     mpi_errno = MPIR_Status_set_elements_x_impl(status, datatype, (MPI_Count) count);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/status_set_elements_x.c
+++ b/src/mpi/datatype/status_set_elements_x.c
@@ -109,8 +109,7 @@ int MPI_Status_set_elements_x(MPI_Status * status, MPI_Datatype datatype, MPI_Co
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Status_set_elements_x_impl(status, datatype, count);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -62,8 +62,7 @@ int MPIR_Type_commit_impl(MPI_Datatype * datatype)
         goto fn_exit;
 
     mpi_errno = MPIR_Type_commit(datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -131,8 +130,7 @@ int MPI_Type_commit(MPI_Datatype * datatype)
     /* ... body of routine ... */
 
     mpi_errno = MPIR_Type_commit_impl(datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -252,8 +252,7 @@ int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype)
     /* ... body of routine ... */
 
     mpi_errno = MPIR_Type_contiguous_impl(count, oldtype, newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/type_create_hindexed_block.c
+++ b/src/mpi/datatype/type_create_hindexed_block.c
@@ -39,8 +39,7 @@ int MPIR_Type_create_hindexed_block_impl(int count, int blocklength,
 
     mpi_errno = MPIR_Type_blockindexed(count, blocklength, array_of_displacements, 1,
                                        oldtype, &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     ints[0] = count;
     ints[1] = blocklength;
@@ -50,8 +49,7 @@ int MPIR_Type_create_hindexed_block_impl(int count, int blocklength,
                                            count,       /* aints */
                                            1,   /* types */
                                            ints, array_of_displacements, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_create_indexed_block.c
+++ b/src/mpi/datatype/type_create_indexed_block.c
@@ -40,8 +40,7 @@ int MPIR_Type_create_indexed_block_impl(int count,
 
     mpi_errno = MPIR_Type_blockindexed(count, blocklength, array_of_displacements, 0,   /* dispinbytes */
                                        oldtype, &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 2) * sizeof(int), mpi_errno,
                                "content description", MPL_MEM_BUFFER);
@@ -57,8 +56,7 @@ int MPIR_Type_create_indexed_block_impl(int count,
                                            0,   /* aints */
                                            1,   /* types */
                                            ints, NULL, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_create_struct.c
+++ b/src/mpi/datatype/type_create_struct.c
@@ -43,8 +43,7 @@ int MPIR_Type_create_struct_impl(int count,
                                  array_of_blocklengths,
                                  array_of_displacements, array_of_types, &new_handle);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno,
@@ -59,8 +58,7 @@ int MPIR_Type_create_struct_impl(int count,
                                            count,       /* aints (disps) */
                                            count,       /* types */
                                            ints, array_of_displacements, array_of_types);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_create_subarray.c
+++ b/src/mpi/datatype/type_create_subarray.c
@@ -184,22 +184,19 @@ int MPI_Type_create_subarray(int ndims,
         else {
             mpi_errno = MPIR_Type_vector(array_of_subsizes[1], array_of_subsizes[0], (MPI_Aint) (array_of_sizes[0]), 0, /* stride in types */
                                          oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             size = ((MPI_Aint) (array_of_sizes[0])) * extent;
             for (i = 2; i < ndims; i++) {
                 size *= (MPI_Aint) (array_of_sizes[i - 1]);
                 mpi_errno = MPIR_Type_vector(array_of_subsizes[i], 1, size, 1,  /* stride in bytes */
                                              tmp1, &tmp2);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Type_free_impl(&tmp1);
                 tmp1 = tmp2;
             }
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* add displacement and UB */
 
@@ -215,14 +212,12 @@ int MPI_Type_create_subarray(int ndims,
         /* dimension ndims-1 changes fastest */
         if (ndims == 1) {
             mpi_errno = MPIR_Type_contiguous(array_of_subsizes[0], oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
         } else {
             mpi_errno = MPIR_Type_vector(array_of_subsizes[ndims - 2], array_of_subsizes[ndims - 1], (MPI_Aint) (array_of_sizes[ndims - 1]), 0, /* stride in types */
                                          oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             size = (MPI_Aint) (array_of_sizes[ndims - 1]) * extent;
             for (i = ndims - 3; i >= 0; i--) {
@@ -232,8 +227,7 @@ int MPI_Type_create_subarray(int ndims,
                                              1, /* stride in bytes */
                                              tmp1,      /* old type */
                                              &tmp2);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 MPIR_Type_free_impl(&tmp1);
                 tmp1 = tmp2;
@@ -266,12 +260,10 @@ int MPI_Type_create_subarray(int ndims,
 
     mpi_errno = MPIR_Type_blockindexed(1, 1, &disps[1], 1,      /* 1 means disp is in bytes */
                                        tmp1, &tmp2);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_create_resized(tmp2, 0, disps[2], &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Type_free_impl(&tmp1);
     MPIR_Type_free_impl(&tmp2);
@@ -302,8 +294,7 @@ int MPI_Type_create_subarray(int ndims,
                                            0,   /* aints */
                                            1,   /* types */
                                            ints, NULL, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -36,9 +36,7 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
     if (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN) {
         /* create a new type and commit it. */
         mpi_errno = MPIR_Type_contiguous(1, oldtype, newtype);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* allocate new datatype object and handle */
         new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
@@ -167,9 +165,7 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
                                            NULL, NULL, &oldtype);
 
     mpi_errno = MPIR_Type_commit(&new_handle);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Copy attributes, executing the attribute copy functions */
     /* This accesses the attribute dup function through the perprocess

--- a/src/mpi/datatype/type_hvector.c
+++ b/src/mpi/datatype/type_hvector.c
@@ -36,8 +36,7 @@ int MPIR_Type_hvector_impl(int count, int blocklength, MPI_Aint stride, MPI_Data
 
     mpi_errno = MPIR_Type_vector(count, blocklength, (MPI_Aint) stride, 1,      /* stride in bytes */
                                  oldtype, &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     ints[0] = count;
     ints[1] = blocklength;
@@ -46,8 +45,7 @@ int MPIR_Type_hvector_impl(int count, int blocklength, MPI_Aint stride, MPI_Data
                                            1,   /* aints */
                                            1,   /* types */
                                            ints, &stride, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -221,8 +221,7 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
 
     mpi_errno = MPIR_Type_indexed(count, array_of_blocklengths, array_of_displacements, 0,      /* displacements not in bytes */
                                   oldtype, &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* copy all integer values into a temporary buffer; this
      * includes the count, the blocklengths, and the displacements.
@@ -243,8 +242,7 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
                                            0,   /* aints  */
                                            1,   /* types */
                                            ints, NULL, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_size.c
+++ b/src/mpi/datatype/type_size.c
@@ -96,8 +96,7 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Type_size_x_impl(datatype, &size_x);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(size_x >= 0);
     /* handle overflow: see MPI-3 p.104 */

--- a/src/mpi/datatype/type_size_x.c
+++ b/src/mpi/datatype/type_size_x.c
@@ -100,8 +100,7 @@ int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count * size)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Type_size_x_impl(datatype, size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -379,8 +379,7 @@ int MPIR_Type_struct_impl(int count, const int *array_of_blocklengths,
     mpi_errno = MPIR_Type_struct(count,
                                  array_of_blocklengths,
                                  array_of_displacements, array_of_types, &new_handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array",
@@ -397,8 +396,7 @@ int MPIR_Type_struct_impl(int count, const int *array_of_blocklengths,
                                            count,       /* types */
                                            ints, array_of_displacements, array_of_types);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -156,8 +156,7 @@ int MPIR_Type_vector_impl(int count, int blocklength, int stride, MPI_Datatype o
     mpi_errno = MPIR_Type_vector(count, blocklength, (MPI_Aint) stride, 0,      /* stride not in bytes, in extents */
                                  oldtype, &new_handle);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     ints[0] = count;
     ints[1] = blocklength;
@@ -167,8 +166,7 @@ int MPIR_Type_vector_impl(int count, int blocklength, int stride, MPI_Datatype o
                                            0,   /* aints */
                                            1,   /* types */
                                            ints, NULL, &oldtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*newtype, new_handle);
 

--- a/src/mpi/datatype/typerep/dataloop/darray_support.c
+++ b/src/mpi/datatype/typerep/dataloop/darray_support.c
@@ -58,24 +58,21 @@ int MPII_Dataloop_convert_darray(int size,
                                                 coords[i], array_of_dargs[i],
                                                 order, orig_extent,
                                                 type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
                 case MPI_DISTRIBUTE_CYCLIC:
                     mpi_errno = MPII_Type_cyclic(array_of_gsizes, i, ndims,
                                                  array_of_psizes[i], coords[i],
                                                  array_of_dargs[i], order,
                                                  orig_extent, type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
                 case MPI_DISTRIBUTE_NONE:
                     /* treat it as a block distribution on 1 process */
                     mpi_errno = MPII_Type_block(array_of_gsizes, i, ndims, 1, 0,
                                                 MPI_DISTRIBUTE_DFLT_DARG, order,
                                                 orig_extent, type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
             }
             if (i)
@@ -102,24 +99,21 @@ int MPII_Dataloop_convert_darray(int size,
                     mpi_errno = MPII_Type_block(array_of_gsizes, i, ndims, array_of_psizes[i],
                                                 coords[i], array_of_dargs[i], order,
                                                 orig_extent, type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
                 case MPI_DISTRIBUTE_CYCLIC:
                     mpi_errno = MPII_Type_cyclic(array_of_gsizes, i, ndims,
                                                  array_of_psizes[i], coords[i],
                                                  array_of_dargs[i], order,
                                                  orig_extent, type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
                 case MPI_DISTRIBUTE_NONE:
                     /* treat it as a block distribution on 1 process */
                     mpi_errno = MPII_Type_block(array_of_gsizes, i, ndims, array_of_psizes[i],
                                                 coords[i], MPI_DISTRIBUTE_DFLT_DARG, order,
                                                 orig_extent, type_old, &type_new, st_offsets + i);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     break;
             }
             if (i != ndims - 1)
@@ -152,8 +146,7 @@ int MPII_Dataloop_convert_darray(int size,
     MPL_free(coords);
 
     mpi_errno = MPIR_Type_struct_impl(3, blklens, disps, types, newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Type_free_impl(&type_new);
 
@@ -199,26 +192,22 @@ static int MPII_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs,
     if (order == MPI_ORDER_FORTRAN) {
         if (dim == 0) {
             mpi_errno = MPIR_Type_contiguous_impl(mysize, type_old, type_new);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             for (i = 0; i < dim; i++)
                 stride *= (MPI_Aint) (array_of_gsizes[i]);
             mpi_errno = MPIR_Type_hvector_impl(mysize, 1, stride, type_old, type_new);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     } else {
         if (dim == ndims - 1) {
             mpi_errno = MPIR_Type_contiguous_impl(mysize, type_old, type_new);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             for (i = ndims - 1; i > dim; i--)
                 stride *= (MPI_Aint) (array_of_gsizes[i]);
             mpi_errno = MPIR_Type_hvector_impl(mysize, 1, stride, type_old, type_new);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -278,8 +267,7 @@ static int MPII_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nprocs
             stride *= (MPI_Aint) (array_of_gsizes[i]);
 
     mpi_errno = MPIR_Type_hvector_impl(count, blksize, stride, type_old, type_new);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (rem) {
         /* if the last block is of size less than blksize, include
@@ -293,8 +281,7 @@ static int MPII_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nprocs
         blklens[1] = rem;
 
         mpi_errno = MPIR_Type_struct_impl(2, blklens, disps, types, &type_tmp);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Type_free_impl(type_new);
         *type_new = type_tmp;
@@ -313,8 +300,7 @@ static int MPII_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nprocs
         blklens[0] = blklens[1] = blklens[2] = 1;
 
         mpi_errno = MPIR_Type_struct_impl(3, blklens, disps, types, &type_tmp);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Type_free_impl(type_new);
         *type_new = type_tmp;

--- a/src/mpi/datatype/typerep/dataloop/subarray_support.c
+++ b/src/mpi/datatype/typerep/dataloop/subarray_support.c
@@ -27,21 +27,18 @@ int MPII_Dataloop_convert_subarray(int ndims,
         /* dimension 0 changes fastest */
         if (ndims == 1) {
             mpi_errno = MPIR_Type_contiguous_impl(array_of_subsizes[0], oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Type_vector_impl(array_of_subsizes[1],
                                               array_of_subsizes[0],
                                               array_of_sizes[0], oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             size = (MPI_Aint) (array_of_sizes[0]) * extent;
             for (i = 2; i < ndims; i++) {
                 size *= (MPI_Aint) (array_of_sizes[i - 1]);
                 mpi_errno = MPIR_Type_hvector_impl(array_of_subsizes[i], 1, size, tmp1, &tmp2);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Type_free_impl(&tmp1);
                 tmp1 = tmp2;
             }
@@ -62,21 +59,18 @@ int MPII_Dataloop_convert_subarray(int ndims,
         /* dimension ndims-1 changes fastest */
         if (ndims == 1) {
             mpi_errno = MPIR_Type_contiguous_impl(array_of_subsizes[0], oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Type_vector_impl(array_of_subsizes[ndims - 2],
                                               array_of_subsizes[ndims - 1],
                                               array_of_sizes[ndims - 1], oldtype, &tmp1);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             size = (MPI_Aint) (array_of_sizes[ndims - 1]) * extent;
             for (i = ndims - 3; i >= 0; i--) {
                 size *= (MPI_Aint) (array_of_sizes[i + 1]);
                 mpi_errno = MPIR_Type_hvector_impl(array_of_subsizes[i], 1, size, tmp1, &tmp2);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Type_free_impl(&tmp1);
                 tmp1 = tmp2;
             }
@@ -104,8 +98,7 @@ int MPII_Dataloop_convert_subarray(int ndims,
     types[2] = MPI_UB;
 
     mpi_errno = MPIR_Type_struct_impl(3, blklens, disps, types, newtype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Type_free_impl(&tmp1);
 

--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -63,8 +63,7 @@ int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     flatten_hdr->max_contig_blocks = datatype_ptr->max_contig_blocks;
 
     mpi_errno = MPIR_Dataloop_flatten(datatype_ptr, flattened_dataloop);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -103,8 +102,7 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     datatype_ptr->contents = NULL;
 
     mpi_errno = MPIR_Dataloop_unflatten(datatype_ptr, flattened_dataloop);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -173,8 +173,7 @@ int MPIR_Datatype_init(void)
                     (void *) (MPIR_Datatype_direct + HANDLE_INDEX(mpi_pairtypes[i])));
 
         mpi_errno = MPIR_Type_create_pairtype(mpi_pairtypes[i], (MPIR_Datatype *) ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Add_finalize(MPIR_Datatype_finalize, 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);

--- a/src/mpi/group/group_compare.c
+++ b/src/mpi/group/group_compare.c
@@ -151,8 +151,7 @@ int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Group_compare_impl(group_ptr1, group_ptr2, result);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/group/group_excl.c
+++ b/src/mpi/group/group_excl.c
@@ -40,8 +40,7 @@ int MPIR_Group_excl_impl(MPIR_Group * group_ptr, int n, const int ranks[],
 
     /* Allocate a new group and lrank_to_lpid array */
     mpi_errno = MPIR_Group_create(size - n, new_group_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*new_group_ptr)->rank = MPI_UNDEFINED;
     /* Use flag fields to mark the members to *exclude* . */

--- a/src/mpi/group/group_free.c
+++ b/src/mpi/group/group_free.c
@@ -32,8 +32,7 @@ int MPIR_Group_free_impl(MPIR_Group * group_ptr)
     /* Do not free MPI_GROUP_EMPTY */
     if (group_ptr->handle != MPI_GROUP_EMPTY) {
         mpi_errno = MPIR_Group_release(group_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/group/group_intersection.c
+++ b/src/mpi/group/group_intersection.c
@@ -70,8 +70,7 @@ int MPIR_Group_intersection_impl(MPIR_Group * group_ptr1, MPIR_Group * group_ptr
     }
 
     mpi_errno = MPIR_Group_create(nnew, new_group_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*new_group_ptr)->rank = MPI_UNDEFINED;
     (*new_group_ptr)->is_local_dense_monotonic = TRUE;

--- a/src/mpi/group/group_translate_ranks.c
+++ b/src/mpi/group/group_translate_ranks.c
@@ -194,8 +194,7 @@ int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[],
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Group_translate_ranks_impl(group_ptr1, n, ranks1, group_ptr2, ranks2);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/group/group_union.c
+++ b/src/mpi/group/group_union.c
@@ -92,8 +92,7 @@ int MPIR_Group_union_impl(MPIR_Group * group_ptr1, MPIR_Group * group_ptr2,
 
     /* Allocate a new group and lrank_to_lpid array */
     mpi_errno = MPIR_Group_create(nnew, new_group_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* If this process is in group1, then we can set the rank now.
      * If we are not in this group, this assignment will set the

--- a/src/mpi/info/info_create.c
+++ b/src/mpi/info/info_create.c
@@ -65,8 +65,7 @@ int MPI_Info_create(MPI_Info * info)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Info_alloc(&info_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *info = info_ptr->handle;
     /* (info_ptr)->cookie = MPIR_INFO_COOKIE; */

--- a/src/mpi/info/info_dup.c
+++ b/src/mpi/info/info_dup.c
@@ -43,15 +43,13 @@ int MPIR_Info_dup_impl(MPIR_Info * info_ptr, MPIR_Info ** new_info_ptr)
      * it two steps: count and then allocate */
     /* FIXME : multithreaded */
     mpi_errno = MPIR_Info_alloc(&curr_new);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     *new_info_ptr = curr_new;
 
     curr_old = info_ptr->next;
     while (curr_old) {
         mpi_errno = MPIR_Info_alloc(&curr_new->next);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         curr_new = curr_new->next;
         curr_new->key = MPL_strdup(curr_old->key);

--- a/src/mpi/info/info_set.c
+++ b/src/mpi/info/info_set.c
@@ -153,8 +153,7 @@ int MPIR_Info_set_impl(MPIR_Info * info_ptr, const char *key, const char *value)
     if (!curr_ptr) {
         /* Key not present, insert value */
         mpi_errno = MPIR_Info_alloc(&curr_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /*printf("Inserting new elm %x at %x\n", curr_ptr->id, prev_ptr->id); */
         prev_ptr->next = curr_ptr;

--- a/src/mpi/init/async.c
+++ b/src/mpi/init/async.c
@@ -81,8 +81,7 @@ int MPIR_Init_async_thread(void)
     /* Dup comm world for the progress thread */
     MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
     mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, &progress_comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_Thread_cond_create(&progress_cond, &err);
     MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**cond_create", "**cond_create %s",

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -201,14 +201,12 @@ int MPI_Finalize(void)
      * in MPID_Finalize) */
     if (MPIR_Process.attr_free && MPIR_Process.comm_self->attributes) {
         mpi_errno = MPIR_Process.attr_free(MPI_COMM_SELF, &MPIR_Process.comm_self->attributes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_self->attributes = 0;
     }
     if (MPIR_Process.attr_free && MPIR_Process.comm_world->attributes) {
         mpi_errno = MPIR_Process.attr_free(MPI_COMM_WORLD, &MPIR_Process.comm_world->attributes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_world->attributes = 0;
     }
 
@@ -252,16 +250,13 @@ int MPI_Finalize(void)
 #endif
 
     mpi_errno = MPID_Finalize();
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Free complete request */
     MPIR_Request_free(MPIR_Process.lw_req);
 
     mpi_errno = MPII_Coll_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Call the low-priority (post Finalize) callbacks */
     MPIR_Call_finalize_callbacks(0, MPIR_FINALIZE_CALLBACK_PRIO - 1);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -407,8 +407,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 #if defined(MPICH_IS_THREADED)
     mpi_errno = thread_cs_init();
     cs_initialized = true;
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* FIXME: Move to os-dependent interface? */
@@ -574,13 +573,11 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_cc_set(&MPIR_Process.lw_req->cc, 0);
 
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided, &has_args, &has_env);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize collectives infrastructure */
     mpi_errno = MPII_Coll_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Set tag_ub as function of tag_bits set by the device */
     MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -1457,13 +1457,11 @@ int MPIR_Netloc_parse_topology(netloc_topology_t netloc_topology,
 {
     int mpi_errno = MPI_SUCCESS;
     mpi_errno = get_tree_attributes(MPIR_Process.netloc_topology, network_attr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (network_attr->type == MPIR_NETLOC_NETWORK_TYPE__INVALID) {
         mpi_errno = get_torus_attributes(MPIR_Process.netloc_topology, network_attr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -1521,8 +1519,7 @@ int MPIR_Netloc_get_network_end_point(MPIR_Netloc_network_attributes network_att
         char *physical_address = NULL;
         /* Check if the physical id of the io device matches a node in netloc topology tree */
         mpi_errno = get_physical_address(io_device, &physical_address);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (physical_address != NULL) {
             /* Find the node in netloc tree with the same physical id */
             hti = netloc_dt_lookup_table_iterator_t_construct(*host_nodes);

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -177,8 +177,7 @@ int MPIR_Bsend_detach(void *bufferp, int *size)
         while (p) {
             MPI_Request r = p->request->handle;
             mpi_errno = MPIR_Wait(&r, MPI_STATUS_IGNORE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             p = p->next;
         }
     }
@@ -224,8 +223,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
     /* We check the active buffer first.  This helps avoid storage
      * fragmentation */
     mpi_errno = MPIR_Bsend_check_active();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (dtype != MPI_PACKED)
         MPIR_Pack_size_impl(count, dtype, &packsize);
@@ -261,8 +259,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
                 void *pbuf = (void *) ((char *) p->msg.msgbuf + p->msg.count);
                 mpi_errno =
                     MPIR_Typerep_pack(buf, count, dtype, 0, pbuf, packsize, &actual_pack_bytes);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 p->msg.count += actual_pack_bytes;
             } else {
                 MPIR_Memcpy(p->msg.msgbuf, buf, count);
@@ -465,8 +462,7 @@ static int MPIR_Bsend_check_active(void)
             /* XXX DJG FIXME-MT should we be checking this? */
             if (MPIR_Object_get_ref(active->request) == 1) {
                 mpi_errno = MPIR_Test(&r, &flag, MPI_STATUS_IGNORE);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else {
                 /* We need to invoke the progress engine in case we
                  * need to advance other, incomplete communication.  */
@@ -474,13 +470,11 @@ static int MPIR_Bsend_check_active(void)
                 MPID_Progress_start(&progress_state);
                 mpi_errno = MPID_Progress_test();
                 MPID_Progress_end(&progress_state);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         } else {
             mpi_errno = MPIR_Test(&r, &flag, MPI_STATUS_IGNORE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         if (flag) {
             /* We're done.  Remove this segment */

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -69,19 +69,16 @@ PMPI_LOCAL int MPIR_Ibsend_cancel(void *extra, int complete)
 
     /* Try to cancel the underlying request */
     mpi_errno = MPIR_Cancel(req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Wait(&req_hdl, &status);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     ibsend_info->cancelled = MPIR_STATUS_GET_CANCEL_BIT(status);
 
     /* If the cancelation is successful, free the memory in the
      * attached buffer used by the request */
     if (ibsend_info->cancelled) {
         mpi_errno = MPIR_Bsend_free_req_seg(ibsend_info->req);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
   fn_exit:
     return mpi_errno;
@@ -107,8 +104,7 @@ int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest
     ibinfo->cancelled = 0;
     mpi_errno = MPIR_Grequest_start(MPIR_Ibsend_query, MPIR_Ibsend_free,
                                     MPIR_Ibsend_cancel, ibinfo, &new_request_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* The request is immediately complete because the MPIR_Bsend_isend has
      * already moved the data out of the user's buffer */
     MPIR_Grequest_complete(new_request_ptr);

--- a/src/mpi/pt2pt/improbe.c
+++ b/src/mpi/pt2pt/improbe.c
@@ -103,8 +103,7 @@ int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message * mes
 
     *message = MPI_MESSAGE_NULL;
     mpi_errno = MPID_Improbe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, flag, &msgp, status);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (*flag) {
         MPIR_Assert(msgp != NULL);

--- a/src/mpi/pt2pt/imrecv.c
+++ b/src/mpi/pt2pt/imrecv.c
@@ -95,8 +95,7 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * messag
             /* MPI_MESSAGE_NO_PROC should yield a "proc null" status */
             if (*message != MPI_MESSAGE_NO_PROC) {
                 MPIR_Request_valid_ptr(msgp, mpi_errno);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_ERR_CHKANDJUMP((msgp->kind != MPIR_REQUEST_KIND__MPROBE),
                                     mpi_errno, MPI_ERR_ARG, "**reqnotmsg");
             }
@@ -111,8 +110,7 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * messag
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Imrecv(buf, count, datatype, msgp, &rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(rreq != NULL);
     *request = rreq->handle;

--- a/src/mpi/pt2pt/mprobe.c
+++ b/src/mpi/pt2pt/mprobe.c
@@ -98,8 +98,7 @@ int MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message * message, MPI_St
 
     *message = MPI_MESSAGE_NULL;
     mpi_errno = MPID_Mprobe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, &msgp, status);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(msgp != NULL);
     *message = msgp->handle;

--- a/src/mpi/pt2pt/mrecv.c
+++ b/src/mpi/pt2pt/mrecv.c
@@ -94,8 +94,7 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * message
             /* MPI_MESSAGE_NO_PROC should yield a "proc null" status */
             if (*message != MPI_MESSAGE_NO_PROC) {
                 MPIR_Request_valid_ptr(msgp, mpi_errno);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 MPIR_ERR_CHKANDJUMP((msgp->kind != MPIR_REQUEST_KIND__MPROBE),
                                     mpi_errno, MPI_ERR_ARG, "**reqnotmsg");
             }
@@ -110,19 +109,16 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * message
 
 
     mpi_errno = MPID_Mrecv(buf, count, datatype, msgp, status, &rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* rreq == NULL implies message = MPI_MESSAGE_NO_PROC.
      * I.e, status was set and no need to wait on rreq */
     if (rreq != NULL) {
         mpi_errno = MPID_Wait(rreq, status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Request_completion_processing(rreq, status);
         MPIR_Request_free(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *message = MPI_MESSAGE_NULL;

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -133,8 +133,7 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     /* If a request was returned, then we need to block until the request
      * is complete */
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -136,8 +136,7 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
     }
 
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -186,12 +186,10 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
         }
 
         mpi_errno = MPID_Wait(rreq, MPI_STATUS_IGNORE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Wait(sreq, MPI_STATUS_IGNORE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (status != MPI_STATUS_IGNORE) {
             *status = rreq->status;

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -132,8 +132,7 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     /* If a request was returned, then we need to block until the request
      * is complete */
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = request_ptr->status.MPI_ERROR;
     MPIR_Request_free(request_ptr);

--- a/src/mpi/request/cancel.c
+++ b/src/mpi/request/cancel.c
@@ -34,16 +34,14 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
         case MPIR_REQUEST_KIND__SEND:
             {
                 mpi_errno = MPID_Cancel_send(request_ptr);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
             }
 
         case MPIR_REQUEST_KIND__RECV:
             {
                 mpi_errno = MPID_Cancel_recv(request_ptr);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
             }
 
@@ -67,8 +65,7 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
                          */
                         request_ptr->cc_ptr = request_ptr->u.persist.real_request->cc_ptr;
                         mpi_errno = MPID_Cancel_send(request_ptr->u.persist.real_request);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     } else {
                         /* This is needed for persistent Bsend requests */
                         /* FIXME why do we directly access the partner request's
@@ -78,8 +75,7 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
                                                          MPIR_cc_is_complete(&request_ptr->
                                                                              u.persist.
                                                                              real_request->cc));
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 } else {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**requestpersistactive");
@@ -91,8 +87,7 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
             {
                 if (request_ptr->u.persist.real_request != NULL) {
                     mpi_errno = MPID_Cancel_recv(request_ptr->u.persist.real_request);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } else {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**requestpersistactive");
                 }
@@ -103,8 +98,7 @@ int MPIR_Cancel(MPIR_Request * request_ptr)
             {
                 mpi_errno =
                     MPIR_Grequest_cancel(request_ptr, MPIR_cc_is_complete(&request_ptr->cc));
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 break;
             }
 

--- a/src/mpi/request/test.c
+++ b/src/mpi/request/test.c
@@ -31,13 +31,11 @@ int MPIR_Test_impl(MPIR_Request * request_ptr, int *flag, MPI_Status * status)
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPID_Progress_test();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_Request_has_poll_fn(request_ptr)) {
         mpi_errno = MPIR_Grequest_poll(request_ptr, status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (MPIR_Request_is_complete(request_ptr))
@@ -68,8 +66,7 @@ int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status)
     MPIR_Assert(request_ptr != NULL);
 
     mpi_errno = MPID_Test(request_ptr, flag, status);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (*flag) {
         mpi_errno = MPIR_Request_completion_processing(request_ptr, status);
@@ -77,8 +74,7 @@ int MPIR_Test(MPI_Request * request, int *flag, MPI_Status * status)
             MPIR_Request_free(request_ptr);
             *request = MPI_REQUEST_NULL;
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* Fall through to the exit */
     } else if (unlikely(MPIR_Request_is_anysrc_mismatched(request_ptr))) {
         MPIR_ERR_SET(mpi_errno, MPIX_ERR_PROC_FAILED_PENDING, "**failure_pending");

--- a/src/mpi/request/testall.c
+++ b/src/mpi/request/testall.c
@@ -39,15 +39,13 @@ int MPIR_Testall_impl(int count, MPIR_Request * request_ptrs[], int *flag,
     int n_completed = 0;
 
     mpi_errno = MPID_Progress_test();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (requests_property & MPIR_REQUESTS_PROPERTY__NO_GREQUESTS) {
         for (i = 0; i < count; i++) {
             if ((i + 1) % MPIR_CVAR_REQUEST_POLL_FREQ == 0) {
                 mpi_errno = MPID_Progress_test();
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
             if (request_ptrs[i] == NULL || MPIR_Request_is_complete(request_ptrs[i])) {
@@ -60,15 +58,13 @@ int MPIR_Testall_impl(int count, MPIR_Request * request_ptrs[], int *flag,
         for (i = 0; i < count; i++) {
             if ((i + 1) % MPIR_CVAR_REQUEST_POLL_FREQ == 0) {
                 mpi_errno = MPID_Progress_test();
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
             if (request_ptrs[i] != NULL) {
                 if (MPIR_Request_has_poll_fn(request_ptrs[i])) {
                     mpi_errno = MPIR_Grequest_poll(request_ptrs[i], &array_of_statuses[i]);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
                 if (MPIR_Request_is_complete(request_ptrs[i])) {
                     n_completed++;

--- a/src/mpi/request/testany.c
+++ b/src/mpi/request/testany.c
@@ -39,15 +39,13 @@ int MPIR_Testany_impl(int count, MPIR_Request * request_ptrs[],
 
     mpi_errno = MPID_Progress_test();
     /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* --END ERROR HANDLING-- */
 
     for (i = 0; i < count; i++) {
         if ((i + 1) % MPIR_CVAR_REQUEST_POLL_FREQ == 0) {
             mpi_errno = MPID_Progress_test();
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         if (request_ptrs[i] != NULL && MPIR_Request_has_poll_fn(request_ptrs[i])) {
@@ -224,8 +222,7 @@ int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx,
             MPIR_Request_free(request_ptrs[*indx]);
             array_of_requests[*indx] = MPI_REQUEST_NULL;
         }
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 

--- a/src/mpi/request/testsome.c
+++ b/src/mpi/request/testsome.c
@@ -40,8 +40,7 @@ int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[],
 
     mpi_errno = MPID_Progress_test();
     /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* --END ERROR HANDLING-- */
 
     n_inactive = 0;
@@ -50,8 +49,7 @@ int MPIR_Testsome_impl(int incount, MPIR_Request * request_ptrs[],
     for (i = 0; i < incount; i++) {
         if ((i + 1) % MPIR_CVAR_REQUEST_POLL_FREQ == 0) {
             mpi_errno = MPID_Progress_test();
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         if (request_ptrs[i] != NULL && MPIR_Request_has_poll_fn(request_ptrs[i])) {

--- a/src/mpi/request/wait.c
+++ b/src/mpi/request/wait.c
@@ -82,16 +82,14 @@ int MPIR_Wait(MPI_Request * request, MPI_Status * status)
         if (MPIR_Request_has_poll_fn(request_ptr)) {
             while (!MPIR_Request_is_complete(request_ptr)) {
                 mpi_errno = MPIR_Grequest_poll(request_ptr, status);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 /* Avoid blocking other threads since I am inside an infinite loop */
                 MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
             }
         } else {
             mpi_errno = MPID_Wait(request_ptr, status);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -100,8 +98,7 @@ int MPIR_Wait(MPI_Request * request, MPI_Status * status)
         MPIR_Request_free(request_ptr);
         *request = MPI_REQUEST_NULL;
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/request/waitall.c
+++ b/src/mpi/request/waitall.c
@@ -119,8 +119,7 @@ int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of
                     MPID_BEGIN_ERROR_CHECKS;
                     {
                         MPIR_Request_valid_ptr(request_ptrs[i], mpi_errno);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         MPIR_ERR_CHKANDJUMP1((request_ptrs[i]->kind == MPIR_REQUEST_KIND__MPROBE),
                                              mpi_errno, MPI_ERR_ARG, "**msgnotreq",
                                              "**msgnotreq %d", i);
@@ -165,8 +164,7 @@ int MPIR_Waitall(int count, MPI_Request array_of_requests[], MPI_Status array_of
         }
 
         mpi_errno = MPID_Waitall(icount, &request_ptrs[ii], array_of_statuses, requests_property);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (requests_property == MPIR_REQUESTS_PROPERTY__OPT_ALL && ignoring_statuses) {
             /* NOTE-O1: high-message-rate optimization.  For simple send and recv

--- a/src/mpi/request/waitany.c
+++ b/src/mpi/request/waitany.c
@@ -61,8 +61,7 @@ int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_S
 
             if (MPIR_Request_has_poll_fn(request_ptrs[i])) {
                 mpi_errno = MPIR_Grequest_poll(request_ptrs[i], status);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
             if (MPIR_Request_is_complete(request_ptrs[i])) {
                 if (MPIR_Request_is_active(request_ptrs[i])) {
@@ -90,8 +89,7 @@ int MPIR_Waitany_impl(int count, MPIR_Request * request_ptrs[], int *indx, MPI_S
         }
 
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* Avoid blocking other threads since I am inside an infinite loop */
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
@@ -237,8 +235,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
         }
 
         mpi_errno = MPID_Waitany(count - first_nonnull, &request_ptrs[first_nonnull], indx, status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (*indx != MPI_UNDEFINED) {
             *indx += first_nonnull;
@@ -252,8 +249,7 @@ int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Statu
         MPIR_Request_free(request_ptrs[*indx]);
         array_of_requests[*indx] = MPI_REQUEST_NULL;
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/request/waitsome.c
+++ b/src/mpi/request/waitsome.c
@@ -68,8 +68,7 @@ int MPIR_Waitsome_impl(int incount, MPIR_Request * request_ptrs[],
             if (request_ptrs[i] != NULL) {
                 if (MPIR_Request_has_poll_fn(request_ptrs[i])) {
                     mpi_errno = MPIR_Grequest_poll(request_ptrs[i], &array_of_statuses[i]);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
                 if (MPIR_Request_is_complete(request_ptrs[i])) {
                     if (MPIR_Request_is_active(request_ptrs[i])) {

--- a/src/mpi/spawn/comm_join.c
+++ b/src/mpi/spawn/comm_join.c
@@ -166,19 +166,16 @@ int MPI_Comm_join(int fd, MPI_Comm * intercomm)
         MPIR_Comm *comm_self_ptr;
         MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
         mpi_errno = MPIR_Comm_accept_impl(local_port, NULL, 0, comm_self_ptr, &intercomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIR_Comm *comm_self_ptr;
         MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
         mpi_errno = MPIR_Comm_connect_impl(remote_port, NULL, 0, comm_self_ptr, &intercomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIR_Close_port_impl(local_port);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*intercomm, intercomm_ptr->handle);
 

--- a/src/mpi/topo/cart_create.c
+++ b/src/mpi/topo/cart_create.c
@@ -64,8 +64,7 @@ int MPIR_Cart_create(MPIR_Comm * comm_ptr, int ndims, const int dims[],
             MPIR_Comm *comm_self_ptr;
             MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
             mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, &newcomm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* Create the topology structure */
             MPIR_CHKPMEM_MALLOC(cart_ptr, MPIR_Topology *, sizeof(MPIR_Topology),
@@ -98,8 +97,7 @@ int MPIR_Cart_create(MPIR_Comm * comm_ptr, int ndims, const int dims[],
              * processes */
             mpi_errno = MPIR_Cart_map_impl(comm_ptr, ndims, (const int *) dims,
                                            (const int *) periods, &rank);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* Create the new communicator with split, since we need to reorder
              * the ranks (including the related internals, such as the connection
@@ -107,13 +105,11 @@ int MPIR_Cart_create(MPIR_Comm * comm_ptr, int ndims, const int dims[],
             mpi_errno = MPIR_Comm_split_impl(comm_ptr,
                                              rank == MPI_UNDEFINED ? MPI_UNDEFINED : 1,
                                              rank, &newcomm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
         } else {
             mpi_errno = MPII_Comm_copy((MPIR_Comm *) comm_ptr, newsize, &newcomm_ptr);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             rank = comm_ptr->rank;
         }
 
@@ -151,8 +147,7 @@ int MPIR_Cart_create(MPIR_Comm * comm_ptr, int ndims, const int dims[],
 
     /* Place this topology onto the communicator */
     mpi_errno = MPIR_Topology_put(newcomm_ptr, cart_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*comm_cart, newcomm_ptr->handle);
 
@@ -176,14 +171,12 @@ int MPIR_Cart_create_impl(MPIR_Comm * comm_ptr, int ndims, const int dims[],
         mpi_errno = comm_ptr->topo_fns->cartCreate(comm_ptr, ndims,
                                                    (const int *) dims,
                                                    (const int *) periods, reorder, comm_cart);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* --END USEREXTENSION-- */
     } else {
         mpi_errno = MPIR_Cart_create(comm_ptr, ndims,
                                      (const int *) dims, (const int *) periods, reorder, comm_cart);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpi/topo/cart_map.c
+++ b/src/mpi/topo/cart_map.c
@@ -71,14 +71,12 @@ int MPIR_Cart_map_impl(const MPIR_Comm * comm_ptr, int ndims, const int dims[],
         /* --BEGIN USEREXTENSION-- */
         mpi_errno = comm_ptr->topo_fns->cartMap(comm_ptr, ndims,
                                                 (const int *) dims, (const int *) periods, newrank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* --END USEREXTENSION-- */
     } else {
         mpi_errno = MPIR_Cart_map(comm_ptr, ndims,
                                   (const int *) dims, (const int *) periods, newrank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -166,8 +164,7 @@ int MPI_Cart_map(MPI_Comm comm, int ndims, const int dims[], const int periods[]
     /* ... body of routine ...  */
     mpi_errno = MPIR_Cart_map_impl(comm_ptr, ndims,
                                    (const int *) dims, (const int *) periods, newrank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
 
   fn_exit:

--- a/src/mpi/topo/cart_shift.c
+++ b/src/mpi/topo/cart_shift.c
@@ -157,8 +157,7 @@ int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source, int
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Cart_shift_impl(comm_ptr, direction, disp, rank_source, rank_dest);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/topo/cart_sub.c
+++ b/src/mpi/topo/cart_sub.c
@@ -119,8 +119,7 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm * newcomm)
         /* ndims=0, or all entries in remain_dims are false.
          * MPI 2.1 says return a 0D Cartesian topology. */
         mpi_errno = MPIR_Cart_create_impl(comm_ptr, 0, NULL, NULL, 0, newcomm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Determine the number of remaining dimensions */
         ndims_in_subcomm = 0;
@@ -144,8 +143,7 @@ int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm * newcomm)
             }
         }
         mpi_errno = MPIR_Comm_split_impl(comm_ptr, color, key, &newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *newcomm = newcomm_ptr->handle;
 

--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -887,8 +887,7 @@ int MPI_Dims_create(int nnodes, int ndims, int dims[])
     } else {
         mpi_errno = MPIR_Dims_create_impl(nnodes, ndims, dims);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
 
   fn_exit:

--- a/src/mpi/topo/dist_gr_create.c
+++ b/src/mpi/topo/dist_gr_create.c
@@ -163,8 +163,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
     /* following the spirit of the old topo interface, attributes do not
      * propagate to the new communicator (see MPI-2.1 pp. 243 line 11) */
     mpi_errno = MPII_Comm_copy(comm_ptr, comm_size, &comm_dist_graph_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(comm_dist_graph_ptr != NULL);
 
     /* rin is an array of size comm_size containing pointers to arrays of
@@ -267,8 +266,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
     /* compute the number of peers I will recv from */
     mpi_errno =
         MPIR_Reduce_scatter_block(rs, in_out_peers, 2, MPI_INT, MPI_SUM, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     MPIR_Assert(in_out_peers[0] <= comm_size && in_out_peers[0] >= 0);
@@ -285,16 +283,14 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
             mpi_errno =
                 MPIC_Isend(&rin[i][0], rin_sizes[i], MPI_INT, i, MPIR_TOPO_A_TAG, comm_ptr,
                            &reqs[idx++], &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         if (rout_sizes[i]) {
             /* send edges where i is a source to process i */
             mpi_errno =
                 MPIC_Isend(&rout[i][0], rout_sizes[i], MPI_INT, i, MPIR_TOPO_B_TAG, comm_ptr,
                            &reqs[idx++], &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     MPIR_Assert(idx <= (2 * comm_size));
@@ -332,8 +328,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
         int *buf;
         /* receive inbound edges */
         mpi_errno = MPIC_Probe(MPI_ANY_SOURCE, MPIR_TOPO_A_TAG, comm_old, &status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Get_count_impl(&status, MPI_INT, &count);
         /* can't use CHKLMEM macros b/c we are in a loop */
         /* FIXME: Why not - there is only one allocated at a time. Is it only
@@ -345,8 +340,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
             MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_A_TAG, comm_ptr,
                       MPI_STATUS_IGNORE, &errflag);
         /* FIXME: buf is never freed on error! */
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         for (j = 0; j < count / 2; ++j) {
             int deg = dist_graph_ptr->indegree++;
@@ -373,8 +367,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
         int *buf;
         /* receive outbound edges */
         mpi_errno = MPIC_Probe(MPI_ANY_SOURCE, MPIR_TOPO_B_TAG, comm_old, &status);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Get_count_impl(&status, MPI_INT, &count);
         /* can't use CHKLMEM macros b/c we are in a loop */
         /* Why not? */
@@ -385,8 +378,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
             MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_B_TAG, comm_ptr,
                       MPI_STATUS_IGNORE, &errflag);
         /* FIXME: buf is never freed on error! */
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         for (j = 0; j < count / 2; ++j) {
             int deg = dist_graph_ptr->outdegree++;
@@ -408,8 +400,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
     }
 
     mpi_errno = MPIC_Waitall(idx, reqs, MPI_STATUSES_IGNORE, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* remove any excess memory allocation */
     MPIR_REALLOC_ORJUMP(dist_graph_ptr->in, dist_graph_ptr->indegree * sizeof(int), MPL_MEM_COMM,
@@ -424,8 +415,7 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
     }
 
     mpi_errno = MPIR_Topology_put(comm_dist_graph_ptr, topo_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_COMMIT();
 

--- a/src/mpi/topo/dist_gr_create_adj.c
+++ b/src/mpi/topo/dist_gr_create_adj.c
@@ -145,8 +145,7 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
     /* following the spirit of the old topo interface, attributes do not
      * propagate to the new communicator (see MPI-2.1 pp. 243 line 11) */
     mpi_errno = MPII_Comm_copy(comm_ptr, comm_ptr->local_size, &comm_dist_graph_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Create the topology structure */
     MPIR_CHKPMEM_MALLOC(topo_ptr, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "topo_ptr",
@@ -178,8 +177,7 @@ int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old,
     }
 
     mpi_errno = MPIR_Topology_put(comm_dist_graph_ptr, topo_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_OBJ_PUBLISH_HANDLE(*comm_dist_graph, comm_dist_graph_ptr->handle);
     MPIR_CHKPMEM_COMMIT();

--- a/src/mpi/topo/dist_gr_neighb.c
+++ b/src/mpi/topo/dist_gr_neighb.c
@@ -138,8 +138,7 @@ int MPI_Dist_graph_neighbors(MPI_Comm comm,
     mpi_errno = MPIR_Dist_graph_neighbors_impl(comm_ptr,
                                                maxindegree, sources, sourceweights,
                                                maxoutdegree, destinations, destweights);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/topo/dist_gr_neighb_count.c
+++ b/src/mpi/topo/dist_gr_neighb_count.c
@@ -114,8 +114,7 @@ int MPI_Dist_graph_neighbors_count(MPI_Comm comm, int *indegree, int *outdegree,
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Dist_graph_neighbors_count_impl(comm_ptr, indegree, outdegree, weighted);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/topo/graph_map.c
+++ b/src/mpi/topo/graph_map.c
@@ -50,14 +50,12 @@ int MPIR_Graph_map_impl(const MPIR_Comm * comm_ptr, int nnodes,
         /* --BEGIN USEREXTENSION-- */
         mpi_errno = comm_ptr->topo_fns->graphMap(comm_ptr, nnodes,
                                                  (const int *) indx, (const int *) edges, newrank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* --END USEREXTENSION-- */
     } else {
         mpi_errno = MPIR_Graph_map(comm_ptr, nnodes,
                                    (const int *) indx, (const int *) edges, newrank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -140,8 +138,7 @@ int MPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[]
 
     mpi_errno = MPIR_Graph_map_impl(comm_ptr, nnodes, (const int *) indx,
                                     (const int *) edges, newrank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/topo/graph_nbr.c
+++ b/src/mpi/topo/graph_nbr.c
@@ -129,8 +129,7 @@ int MPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors, int neighbors
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Graph_neighbors_impl(comm_ptr, rank, maxneighbors, neighbors);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     /* ... end of body of routine ... */

--- a/src/mpi/topo/graphcreate.c
+++ b/src/mpi/topo/graphcreate.c
@@ -57,21 +57,18 @@ int MPIR_Graph_create(MPIR_Comm * comm_ptr, int nnodes,
         /* Allow the cart map routine to remap the assignment of ranks to
          * processes */
         mpi_errno = MPIR_Graph_map_impl(comm_ptr, nnodes, indx, edges, &nrank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         /* Create the new communicator with split, since we need to reorder
          * the ranks (including the related internals, such as the connection
          * tables */
         mpi_errno = MPIR_Comm_split_impl(comm_ptr,
                                          nrank == MPI_UNDEFINED ? MPI_UNDEFINED : 1,
                                          nrank, &newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Just use the first nnodes processes in the communicator */
         mpi_errno = MPII_Comm_copy((MPIR_Comm *) comm_ptr, nnodes, &newcomm_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
 

--- a/src/mpi/topo/graphnbrcnt.c
+++ b/src/mpi/topo/graphnbrcnt.c
@@ -119,8 +119,7 @@ int MPI_Graph_neighbors_count(MPI_Comm comm, int rank, int *nneighbors)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Graph_neighbors_count_impl(comm_ptr, rank, nneighbors);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -58,13 +58,11 @@ int MPIR_Topology_put(MPIR_Comm * comm_ptr, MPIR_Topology * topo_ptr)
         mpi_errno = MPIR_Comm_create_keyval_impl(MPIR_Topology_copy_fn,
                                                  MPIR_Topology_delete_fn, &MPIR_Topology_keyval, 0);
         /* Register the finalize handler */
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Add_finalize(MPIR_Topology_finalize, (void *) 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
     }
     mpi_errno = MPIR_Comm_set_attr_impl(comm_ptr, MPIR_Topology_keyval, topo_ptr, MPIR_ATTR_PTR);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -261,13 +259,11 @@ int MPIR_Topo_canon_nhb_count(MPIR_Comm * comm_ptr, int *indegree, int *outdegre
     /* TODO consider dispatching via a vtable instead of doing if/else */
     if (topo_ptr->kind == MPI_DIST_GRAPH) {
         mpi_errno = MPIR_Dist_graph_neighbors_count_impl(comm_ptr, indegree, outdegree, weighted);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (topo_ptr->kind == MPI_GRAPH) {
         int nneighbors = 0;
         mpi_errno = MPIR_Graph_neighbors_count_impl(comm_ptr, comm_ptr->rank, &nneighbors);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         *indegree = *outdegree = nneighbors;
         *weighted = FALSE;
     } else if (topo_ptr->kind == MPI_CART) {
@@ -302,13 +298,11 @@ int MPIR_Topo_canon_nhb(MPIR_Comm * comm_ptr,
         mpi_errno = MPIR_Dist_graph_neighbors_impl(comm_ptr,
                                                    indegree, sources, inweights,
                                                    outdegree, dests, outweights);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (topo_ptr->kind == MPI_GRAPH) {
         MPIR_Assert(indegree == outdegree);
         mpi_errno = MPIR_Graph_neighbors_impl(comm_ptr, comm_ptr->rank, indegree, sources);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Memcpy(dests, sources, outdegree * sizeof(*dests));
         /* ignore inweights/outweights */
     } else if (topo_ptr->kind == MPI_CART) {
@@ -319,8 +313,7 @@ int MPIR_Topo_canon_nhb(MPIR_Comm * comm_ptr,
 
         for (d = 0; d < topo_ptr->topo.cart.ndims; ++d) {
             mpi_errno = MPIR_Cart_shift_impl(comm_ptr, d, 1, &sources[2 * d], &sources[2 * d + 1]);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             dests[2 * d] = sources[2 * d];
             dests[2 * d + 1] = sources[2 * d + 1];

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -143,7 +143,7 @@ static int MPIR_Topology_copy_fn(MPI_Comm comm ATTRIBUTE((unused)),
                 MPIR_Copy_array(old_topology->topo.kind_.count_field_, \
                                 old_topology->topo.kind_.array_field_, \
                                 &mpi_errno); \
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno); \
+            MPIR_ERR_CHECK(mpi_errno); \
             MPIR_CHKPMEM_REGISTER(copy_topology->topo.kind_.array_field_); \
         } while (0)
 

--- a/src/mpi_t/cat_get_categories.c
+++ b/src/mpi_t/cat_get_categories.c
@@ -91,8 +91,7 @@ int MPI_T_category_get_categories(int cat_index, int len, int indices[])
         goto fn_exit;
 
     mpi_errno = MPIR_T_category_get_categories_impl(cat_index, len, indices);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/cat_get_cvars.c
+++ b/src/mpi_t/cat_get_cvars.c
@@ -91,8 +91,7 @@ int MPI_T_category_get_cvars(int cat_index, int len, int indices[])
         goto fn_exit;
 
     mpi_errno = MPIR_T_category_get_cvars_impl(cat_index, len, indices);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/cat_get_pvars.c
+++ b/src/mpi_t/cat_get_pvars.c
@@ -91,8 +91,7 @@ int MPI_T_category_get_pvars(int cat_index, int len, int indices[])
         goto fn_exit;
 
     mpi_errno = MPIR_T_category_get_pvars_impl(cat_index, len, indices);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/cvar_handle_alloc.c
+++ b/src/mpi_t/cvar_handle_alloc.c
@@ -121,8 +121,7 @@ int MPI_T_cvar_handle_alloc(int cvar_index, void *obj_handle, MPI_T_cvar_handle 
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_T_cvar_handle_alloc_impl(cvar_index, obj_handle, handle, count);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/cvar_read.c
+++ b/src/mpi_t/cvar_read.c
@@ -117,8 +117,7 @@ int MPI_T_cvar_read(MPI_T_cvar_handle handle, void *buf)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_T_cvar_read_impl(handle, buf);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/cvar_write.c
+++ b/src/mpi_t/cvar_write.c
@@ -126,8 +126,7 @@ int MPI_T_cvar_write(MPI_T_cvar_handle handle, const void *buf)
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_T_cvar_write_impl(handle, buf);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpi_t/pvar_handle_free.c
+++ b/src/mpi_t/pvar_handle_free.c
@@ -111,8 +111,7 @@ int MPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle * handl
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_T_pvar_handle_free_impl(session, handle);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* ... end of body of routine ... */
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -164,8 +164,7 @@ typedef struct {
 					       __func__,		\
 					       fi_strerror(-_ret));	\
 				mpi_errno = MPID_nem_ofi_poll(0);	\
-				if (mpi_errno != MPI_SUCCESS)		\
-					MPIR_ERR_POP(mpi_errno);	\
+                                MPIR_ERR_CHECK(mpi_errno);	        \
 		} while (_ret == -FI_EAGAIN);				\
 	} while (0)
 
@@ -189,7 +188,7 @@ typedef struct {
   do                                                        \
     {                                                       \
       mpi_errno  = FUNC;                                    \
-      if (mpi_errno) MPIR_ERR_POP(mpi_errno);               \
+      MPIR_ERR_CHECK(mpi_errno);                            \
     } while (0);
 
 #define VC_READY_CHECK(vc)                      \

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_ckpt.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_ckpt.c
@@ -79,8 +79,7 @@ int MPID_nem_tcp_ckpt_continue_vc(MPIDI_VC_t * vc)
     mpi_errno =
         MPID_nem_tcp_iStartContigMsg_paused(vc, &upkt, sizeof(MPIDI_nem_tcp_pkt_unpause_t), NULL, 0,
                                             &unpause_req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (unpause_req) {
         if (unpause_req->status.MPI_ERROR)
             MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**fail");
@@ -113,8 +112,7 @@ int MPID_nem_tcp_ckpt_restart_vc(MPIDI_VC_t * vc)
     pkt->subtype = MPIDI_NEM_TCP_PKT_UNPAUSE;
 
     mpi_errno = MPID_nem_tcp_iStartContigMsg_paused(vc, pkt, sizeof(pkt), NULL, 0, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (sreq != NULL) {
         if (sreq->status.MPI_ERROR != MPI_SUCCESS) {

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_finalize.c
@@ -15,11 +15,9 @@ int MPID_nem_tcp_finalize(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_TCP_FINALIZE);
 
     mpi_errno = MPID_nem_tcp_send_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPID_nem_tcp_sm_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPID_nem_tcp_g_lstn_sc.fd) {
         CHECK_EINTR(ret, close(MPID_nem_tcp_g_lstn_sc.fd));

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
@@ -38,8 +38,7 @@ int MPID_nem_tcp_get_vc_from_conninfo(char *pg_id, int pg_rank, struct MPIDI_VC 
                     (MPL_DBG_FDEST, "pg_id=%s pg_rank=%d", pg_id, pg_rank));
 
     mpi_errno = MPIDI_PG_Find(pg_id, &pg);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_ERR_CHKINTERNAL(pg == NULL, mpi_errno, "invalid PG");
     MPIR_ERR_CHKINTERNAL(pg_rank < 0 ||

--- a/src/mpid/ch3/channels/nemesis/src/ch3_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_finalize.c
@@ -14,7 +14,7 @@ int MPIDI_CH3_Finalize(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_FINALIZE);
 
     mpi_errno = MPIDI_CH3I_Progress_finalize();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
     mpi_errno = MPID_nem_finalize();
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -27,8 +27,7 @@ static int split_type(MPIR_Comm * user_comm_ptr, int stype, int key,
 
     mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, stype == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
                                      key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (stype == MPI_UNDEFINED) {
         *newcomm_ptr = NULL;
@@ -49,7 +48,7 @@ static int split_type(MPIR_Comm * user_comm_ptr, int stype, int key,
         mpi_errno = MPIR_Comm_split_type(comm_ptr, stype, key, info_ptr, newcomm_ptr);
     }
 
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (comm_ptr)
@@ -110,7 +109,7 @@ int MPIDI_CH3_Init(int has_parent, MPIDI_PG_t *pg_p, int pg_rank)
     for (i = 0; i < pg_p->size; i++)
     {
 	mpi_errno = MPIDI_CH3_VC_Init(&pg_p->vct[i]);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
  fn_exit:
@@ -142,7 +141,7 @@ int MPIDI_CH3_Get_business_card(int myRank, char *value, int length)
     MPIR_FUNC_VERBOSE_ENTER(MPIDI_STATE_MPIDI_CH3_GET_BUSINESS_CARD);
 
     mpi_errno = MPID_nem_get_business_card(myRank, value, length);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPIDI_STATE_MPIDI_CH3_GET_BUSINESS_CARD);
@@ -338,7 +337,7 @@ int MPIDI_CH3_InitCompleted(void)
     while (ep)
     {
         mpi_errno = ep->callback();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         ep_tmp = ep;
         ep = ep->next;
         MPL_free(ep_tmp);

--- a/src/mpid/ch3/channels/nemesis/src/ch3_isend.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_isend.c
@@ -64,9 +64,7 @@ int MPIDI_CH3_iSend (MPIDI_VC_t *vc, MPIR_Request *sreq, void * hdr, intptr_t hd
             {
                 MPIR_Assert (MPIDI_Request_get_type (sreq) != MPIDI_REQUEST_TYPE_GET_RESP);
                 mpi_errno = MPID_Request_complete(sreq);
-                if (mpi_errno != MPI_SUCCESS) {
-                    MPIR_ERR_POP(mpi_errno);
-                }
+                MPIR_ERR_CHECK(mpi_errno);
             }
             else
             {
@@ -110,7 +108,7 @@ int MPIDI_CH3_iSend (MPIDI_VC_t *vc, MPIR_Request *sreq, void * hdr, intptr_t hd
            check to see if we can send any now */
         MPIDI_CH3I_Sendq_enqueue(&MPIDI_CH3I_shm_sendq, sreq);
         mpi_errno = MPIDI_CH3I_Shm_send_progress();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     
     goto fn_exit;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_isendv.c
@@ -122,9 +122,7 @@ int MPIDI_CH3_iSendv (MPIDI_VC_t *vc, MPIR_Request *sreq, MPL_IOV *iov, int n_io
             {
                 MPIR_Assert (MPIDI_Request_get_type (sreq) != MPIDI_REQUEST_TYPE_GET_RESP);
                 mpi_errno = MPID_Request_complete (sreq);
-                if (mpi_errno != MPI_SUCCESS) {
-                    MPIR_ERR_POP(mpi_errno);
-                }
+                MPIR_ERR_CHECK(mpi_errno);
                 MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, ".... complete");
             }
             else
@@ -175,7 +173,7 @@ int MPIDI_CH3_iSendv (MPIDI_VC_t *vc, MPIR_Request *sreq, MPL_IOV *iov, int n_io
            check to see if we can send any now */
         MPIDI_CH3I_Sendq_enqueue(&MPIDI_CH3I_shm_sendq, sreq);
         mpi_errno = MPIDI_CH3I_Shm_send_progress();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
  fn_exit:

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
@@ -107,7 +107,7 @@ int MPIDI_CH3_iStartMsg (MPIDI_VC_t *vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
             /* FIXME we are sometimes called from within the progress engine, we
              * shouldn't be calling the progress engine again */
             mpi_errno = MPIDI_CH3I_Shm_send_progress();
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     
 	*sreq_ptr = sreq;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
@@ -171,7 +171,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, MPL_IOV *iov, int n_iov, MPIR_Request 
                check to see if we can send any now */
             MPIDI_CH3I_Sendq_enqueue(&MPIDI_CH3I_shm_sendq, sreq);
             mpi_errno = MPIDI_CH3I_Shm_send_progress();
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -19,9 +19,7 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
 
     if (win_ptr->comm_ptr->node_comm == NULL) {
         mpi_errno = MPIDI_CH3U_Win_shared_query(win_ptr, target_rank, size, disp_unit, baseptr);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -92,8 +90,7 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win ** win_ptr)
                 MPL_shm_seg_detach((*win_ptr)->shm_segment_handle,
                                      &(*win_ptr)->shm_base_addr,
                                      (*win_ptr)->shm_segment_len);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPL_shm_hnd_finalize(&(*win_ptr)->shm_segment_handle);
         }
@@ -122,8 +119,7 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win ** win_ptr)
         mpi_errno =
             MPL_shm_seg_detach((*win_ptr)->shm_mutex_segment_handle,
                                  (void **) &(*win_ptr)->shm_mutex, sizeof(MPIDI_CH3I_SHM_MUTEX));
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPL_shm_hnd_finalize(&(*win_ptr)->shm_mutex_segment_handle);
     }
@@ -133,8 +129,7 @@ int MPIDI_CH3_SHM_Win_free(MPIR_Win ** win_ptr)
         mpi_errno = MPL_shm_seg_detach((*win_ptr)->info_shm_segment_handle,
                                          &(*win_ptr)->info_shm_base_addr,
                                          (*win_ptr)->info_shm_segment_len);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPL_shm_hnd_finalize(&(*win_ptr)->info_shm_segment_handle);
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3i_eagernoncontig.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3i_eagernoncontig.c
@@ -32,8 +32,7 @@ int MPIDI_CH3I_SendNoncontig( MPIDI_VC_t *vc, MPIR_Request *sreq, void *header, 
         /* translate segments to iovs and combine with the extended header iov. */
         mpi_errno = MPIDI_CH3_SendNoncontig_iov(vc, sreq, header, hdr_sz,
                                                 hdr_iov, n_hdr_iov);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -51,7 +50,7 @@ int MPIDI_CH3I_SendNoncontig( MPIDI_VC_t *vc, MPIR_Request *sreq, void *header, 
 
         MPIDI_CH3I_Sendq_enqueue(&MPIDI_CH3I_shm_sendq, sreq);
         mpi_errno = MPIDI_CH3I_Shm_send_progress();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -88,16 +87,14 @@ int MPIDI_CH3I_SendNoncontig( MPIDI_VC_t *vc, MPIR_Request *sreq, void *header, 
     {
         MPIR_Assert(MPIDI_Request_get_type(sreq) != MPIDI_REQUEST_TYPE_GET_RESP);
         mpi_errno = MPID_Request_complete(sreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, VERBOSE, ".... complete %d bytes", (int) (sreq->dev.msgsize));
     }
     else
     {
         int complete = 0;
         mpi_errno = sreq->dev.OnDataAvail(vc, sreq, &complete);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(complete); /* all data has been sent, we should always complete */
 
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, VERBOSE, ".... complete %d bytes", (int) (sreq->dev.msgsize));

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
@@ -422,7 +422,7 @@ int MPIDI_nem_ckpt_start(void)
 
         if (!vc_ch->is_local) {
             mpi_errno = vc_ch->ckpt_pause_send_vc(vc);
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     
@@ -449,7 +449,7 @@ int MPIDI_nem_ckpt_finish(void)
        channels, just make sure no one is sending or receiving during
        the checkpoint */
     mpi_errno = MPIDU_shm_barrier(MPID_nem_mem_region.barrier, MPID_nem_mem_region.num_local);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     do {
         ret = sem_post(&ckpt_sem);
@@ -462,7 +462,7 @@ int MPIDI_nem_ckpt_finish(void)
     MPIR_ERR_CHKANDJUMP1(ret, mpi_errno, MPI_ERR_OTHER, "**sem_wait", "**sem_wait %s", MPIR_Strerror(errno));
 
     mpi_errno = MPIDU_shm_barrier(MPID_nem_mem_region.barrier, MPID_nem_mem_region.num_local);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (ckpt_result == CKPT_CONTINUE) {
         for (i = 0; i < MPIDI_Process.my_pg->size; ++i) {
@@ -476,7 +476,7 @@ int MPIDI_nem_ckpt_finish(void)
             vc_ch = &vc->ch;
             if (!vc_ch->is_local) {
                 mpi_errno = vc_ch->ckpt_continue_vc(vc);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -503,7 +503,7 @@ static int pkt_ckpt_marker_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *d
 
     if (!checkpointing) {
         mpi_errno = MPIDI_nem_ckpt_start();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Assert(current_wave == ckpt_pkt->wave);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -152,7 +152,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPID_nem_hostname[MAX_HOSTNAME_LEN-1] = '\0';
 
     mpi_errno = get_local_procs(pg_p, pg_rank, &num_local, &local_procs, &local_rank);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MEM_REGION_IN_HEAP
     MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region_ptr, MPID_nem_mem_region_t *, sizeof(MPID_nem_mem_region_t), mpi_errno, "mem_region", MPL_MEM_SHM);
@@ -232,24 +232,24 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     /* Request fastboxes region */
     mpi_errno = MPIDU_shm_seg_alloc(MPL_MAX((num_local*((num_local-1)*sizeof(MPID_nem_fastbox_t))), MPID_NEM_ASYMM_NULL_VAL),
                                      (void **)&fastboxes_p, MPL_MEM_SHM);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
     /* Request data cells region */
     mpi_errno = MPIDU_shm_seg_alloc(num_local * MPID_NEM_NUM_CELLS * sizeof(MPID_nem_cell_t), (void **)&cells_p, MPL_MEM_SHM);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Request free q region */
     mpi_errno = MPIDU_shm_seg_alloc(num_local * sizeof(MPID_nem_queue_t), (void **)&free_queues_p, MPL_MEM_SHM);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Request recv q region */
     mpi_errno = MPIDU_shm_seg_alloc(num_local * sizeof(MPID_nem_queue_t), (void **)&recv_queues_p, MPL_MEM_SHM);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Request shared collectives barrier vars region */
     mpi_errno = MPIDU_shm_seg_alloc(MPID_NEM_NUM_BARRIER_VARS * sizeof(MPID_nem_barrier_vars_t),
                                      (void **)&MPID_nem_mem_region.barrier_vars, MPL_MEM_SHM);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Actually allocate the segment and assign regions to the pointers */
     mpi_errno = MPIDU_shm_seg_commit(&MPID_nem_mem_region.memory, &MPID_nem_mem_region.barrier,
@@ -305,21 +305,21 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
        the netmod hooks, giving the netmod an opportunity to override the
        nemesis collective function table. */
     mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_CH3I_comm_create, NULL);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* network init */
     if (MPID_nem_num_netmods)
     {
         mpi_errno = MPID_nem_choose_netmod();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 	mpi_errno = MPID_nem_netmod_func->init(pg_p, pg_rank, &bc_val, &val_max_remaining);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* Register detroy hooks after netmod init so the netmod hooks get called
        before nemesis hooks. */
     mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_CH3I_comm_destroy, NULL);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
     /* set default route for external processes through network */
     for (idx = 0 ; idx < MPID_nem_mem_region.ext_procs ; idx++)
@@ -348,7 +348,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     
     /* local barrier */
     mpi_errno = MPIDU_shm_barrier(MPID_nem_mem_region.barrier, num_local);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     
     /* Allocate table of pointers to fastboxes */
@@ -394,19 +394,19 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     /* publish business card */
     mpi_errno = MPIDI_PG_SetConnInfo(pg_rank, (const char *)publish_bc_orig);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPL_free(publish_bc_orig);
 
 
     mpi_errno = MPIDU_shm_barrier(MPID_nem_mem_region.barrier, num_local);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPID_nem_mpich_init();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIDU_shm_barrier(MPID_nem_mem_region.barrier, num_local);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #ifdef ENABLE_CHECKPOINTING
     mpi_errno = MPIDI_nem_ckpt_init();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
 #ifdef PAPI_MONITOR
@@ -582,7 +582,7 @@ MPID_nem_vc_init (MPIDI_VC_t *vc)
                              ));
         
         mpi_errno = MPID_nem_netmod_func->vc_init(vc);
-	if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+	MPIR_ERR_CHECK(mpi_errno);
 
 /* FIXME: DARIUS -- enable this assert once these functions are implemented */
 /*         /\* iStartContigMsg iSendContig and sendNoncontig_fn must */
@@ -620,7 +620,7 @@ MPID_nem_vc_destroy(MPIDI_VC_t *vc)
     MPL_free(vc_ch->pending_pkt);
 
     mpi_errno = MPID_nem_netmod_func->vc_destroy(vc);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_VC_DESTROY);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
@@ -169,7 +169,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV s_coo
     {
         int i;
         mpi_errno = MPID_nem_allocate_shm_region(&vc_ch->lmt_copy_buf, vc_ch->lmt_copy_buf_handle);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         vc_ch->lmt_copy_buf->sender_present.val   = 0;
         vc_ch->lmt_copy_buf->receiver_present.val = 0;
@@ -197,7 +197,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV s_coo
 
     /* make progress on that vc */
     mpi_errno = lmt_shm_progress_vc(vc, &done);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* MT: not thread safe, another thread may have enqueued another
        lmt after we did, and added this vc to the progress list.  In
@@ -245,7 +245,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
         if(mpi_errno != MPI_SUCCESS) { MPIR_ERR_POP(mpi_errno); }
 
         mpi_errno = MPID_nem_attach_shm_region(&vc_ch->lmt_copy_buf, vc_ch->lmt_copy_buf_handle);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "attached to remote copy_buf");
     }
     else{
@@ -255,7 +255,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
         if (strncmp(ser_lmt_copy_buf_handle, r_cookie.MPL_IOV_BUF, r_cookie.MPL_IOV_LEN) < 0){
             /* Each side allocated its own buffer, lexicographically lower valued buffer handle is deleted */
             mpi_errno = MPID_nem_delete_shm_region(&(vc_ch->lmt_copy_buf), &(vc_ch->lmt_copy_buf_handle));
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             vc_ch->lmt_copy_buf = NULL;
 
@@ -267,7 +267,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
             if(mpi_errno != MPI_SUCCESS) { MPIR_ERR_POP(mpi_errno); }
 
             mpi_errno = MPID_nem_attach_shm_region(&vc_ch->lmt_copy_buf, vc_ch->lmt_copy_buf_handle);
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             LMT_SHM_Q_ENQUEUE_AT_HEAD(&vc_ch->lmt_queue, vc_ch->lmt_active_lmt); /* MT: not thread safe */
             vc_ch->lmt_active_lmt = NULL;
@@ -285,7 +285,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV r_coo
 
     /* make progress on that vc */
     mpi_errno = lmt_shm_progress_vc(vc, &done);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* MT: not thread safe, another thread may have enqueued another
        lmt after we did, and added this vc to the progress list.  In
@@ -478,9 +478,7 @@ static int lmt_shm_send_progress(MPIDI_VC_t *vc, MPIR_Request *req, int *done)
 
     *done = TRUE;
     mpi_errno = MPID_Request_complete(req);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "completed req local_req=%d", req->handle);
 
 
@@ -622,9 +620,7 @@ static int lmt_shm_recv_progress(MPIDI_VC_t *vc, MPIR_Request *req, int *done)
 
     *done = TRUE;
     mpi_errno = MPID_Request_complete(req);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     copy_buf->receiver_present.val = FALSE;
@@ -679,7 +675,7 @@ static inline int lmt_shm_progress_vc(MPIDI_VC_t *vc, int *done)
     if (vc_ch->lmt_active_lmt == NULL)
     {
         mpi_errno = get_next_req(vc);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (vc_ch->lmt_active_lmt == NULL)
         {
@@ -694,7 +690,7 @@ static inline int lmt_shm_progress_vc(MPIDI_VC_t *vc, int *done)
 
     we = vc_ch->lmt_active_lmt;
     mpi_errno = we->progress(vc, we->req, &done_req);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (done_req)
     {
@@ -727,7 +723,7 @@ int MPID_nem_lmt_shm_progress(void)
         int done = FALSE;
 
         mpi_errno = lmt_shm_progress_vc(pe->vc, &done);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (done)
         {
@@ -827,7 +823,7 @@ static int MPID_nem_allocate_shm_region(MPID_nem_copy_buf_t **buf_p, MPL_shm_hnd
     }
 
     mpi_errno = MPL_shm_seg_create_and_attach(handle, sizeof(MPID_nem_copy_buf_t), (void **)buf_p, 0);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_ALLOCATE_SHM_REGION);
@@ -850,10 +846,10 @@ static int MPID_nem_attach_shm_region(MPID_nem_copy_buf_t **buf_p, MPL_shm_hnd_t
     }
 
     mpi_errno = MPL_shm_seg_attach(handle, sizeof(MPID_nem_copy_buf_t), (void **)buf_p, 0);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPL_shm_seg_remove(handle);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_ATTACH_SHM_REGION);
@@ -870,7 +866,7 @@ static int MPID_nem_detach_shm_region(MPID_nem_copy_buf_t **buf_p, MPL_shm_hnd_t
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_DETACH_SHM_REGION);
 
     mpi_errno = MPL_shm_seg_detach(handle, (void **)buf_p, sizeof(MPID_nem_copy_buf_t));
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_DETACH_SHM_REGION);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -101,8 +101,7 @@ int MPID_nem_send_iov(MPIDI_VC_t *vc, MPIR_Request **sreq_ptr, MPL_IOV *iov, int
 
         /* header and remaining iovs */
         mpi_errno = vc->ch.iSendIov(vc, sreq, iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN, &iov[1], n_iov - 1);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *sreq_ptr = sreq;
         goto fn_exit;
@@ -137,7 +136,7 @@ int MPID_nem_send_iov(MPIDI_VC_t *vc, MPIR_Request **sreq_ptr, MPL_IOV *iov, int
     }
 
     mpi_errno = vc->ch.iSendContig(vc, sreq, iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN, sreq->dev.tmpbuf, data_sz);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *sreq_ptr = sreq;
 

--- a/src/mpid/ch3/channels/sock/src/ch3_finalize.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_finalize.c
@@ -15,9 +15,7 @@ int MPIDI_CH3_Finalize(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_CH3_FINALIZE);
 
     mpi_errno = MPIDI_CH3I_Progress_finalize();
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CH3_FINALIZE);

--- a/src/mpid/ch3/channels/sock/src/ch3_init.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_init.c
@@ -28,13 +28,11 @@ int MPIDI_CH3_Init(int has_parent, MPIDI_PG_t * pg_p, int pg_rank)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_CH3_INIT);
 
     mpi_errno = MPIDI_CH3I_Progress_init();
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize the business card */
     mpi_errno = MPIDI_CH3I_BCInit(&bc_val, &val_max_remaining);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     publish_bc_orig = bc_val;
 
     /* initialize aspects specific to sockets  */
@@ -48,8 +46,7 @@ int MPIDI_CH3_Init(int has_parent, MPIDI_PG_t * pg_p, int pg_rank)
      * (note that publish_bc_orig is the head of bc_val) */
     MPIDI_CH3I_BCFree(publish_bc_orig);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CH3_INIT);

--- a/src/mpid/ch3/channels/sock/src/ch3_isend.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isend.c
@@ -59,14 +59,11 @@ int MPIDI_CH3_iSend(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hd
                     if (!reqFn) {
                         MPIR_Assert(MPIDI_Request_get_type(sreq) != MPIDI_REQUEST_TYPE_GET_RESP);
                         mpi_errno = MPID_Request_complete(sreq);
-                        if (mpi_errno != MPI_SUCCESS) {
-                            MPIR_ERR_POP(mpi_errno);
-                        }
+                        MPIR_ERR_CHECK(mpi_errno);
                     } else {
                         int complete;
                         mpi_errno = reqFn(vc, sreq, &complete);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         if (!complete) {
                             MPIDI_CH3I_SendQ_enqueue_head(vcch, sreq);
                             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL, VERBOSE,
@@ -153,9 +150,7 @@ int MPIDI_CH3_iSend(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hd
         update_request(sreq, hdr, hdr_sz, 0);
         MPIDI_CH3I_SendQ_enqueue(vcch, sreq);
         mpi_errno = MPIDI_CH3I_VC_post_connect(vc);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (vcch->state != MPIDI_CH3I_VC_STATE_FAILED) {
         /* Unable to send data at the moment, so queue it for later */
         MPL_DBG_VCUSE(vc, "still connecting. Enqueuing request");

--- a/src/mpid/ch3/channels/sock/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isendv.c
@@ -110,14 +110,11 @@ int MPIDI_CH3_iSendv(MPIDI_VC_t * vc, MPIR_Request * sreq, MPL_IOV * iov, int n_
                     if (!reqFn) {
                         MPIR_Assert(MPIDI_Request_get_type(sreq) != MPIDI_REQUEST_TYPE_GET_RESP);
                         mpi_errno = MPID_Request_complete(sreq);
-                        if (mpi_errno != MPI_SUCCESS) {
-                            MPIR_ERR_POP(mpi_errno);
-                        }
+                        MPIR_ERR_CHECK(mpi_errno);
                     } else {
                         int complete;
                         mpi_errno = reqFn(vc, sreq, &complete);
-                        if (mpi_errno)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                         if (!complete) {
                             MPIDI_CH3I_SendQ_enqueue_head(vcch, sreq);
                             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_CHANNEL, VERBOSE,
@@ -181,9 +178,7 @@ int MPIDI_CH3_iSendv(MPIDI_VC_t * vc, MPIR_Request * sreq, MPL_IOV * iov, int n_
         update_request(sreq, iov, n_iov, 0, 0);
         MPIDI_CH3I_SendQ_enqueue(vcch, sreq);
         mpi_errno = MPIDI_CH3I_VC_post_connect(vc);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (vcch->state != MPIDI_CH3I_VC_STATE_FAILED) {
         /* Unable to send data at the moment, so queue it for later */
         MPL_DBG_VCUSE(vc, "still connecting.  enqueuing request");

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -1620,9 +1620,7 @@ int MPIDI_CH3I_Sock_post_connect_ifaddr(struct MPIDI_CH3I_Sock_set *sock_set,
      * Set and verify the socket buffer size
      */
     mpi_errno = MPIDI_CH3I_Sock_SetSockBufferSize(fd, 1);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /*
      * Attempt to establish the connection
@@ -1880,9 +1878,7 @@ int MPIDI_CH3I_Sock_listen(struct MPIDI_CH3I_Sock_set *sock_set, void *user_ptr,
      * Set and verify the socket buffer size
      */
     mpi_errno = MPIDI_CH3I_Sock_SetSockBufferSize(fd, 1);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /*
      * Start listening for incoming connections...
@@ -2364,9 +2360,7 @@ int MPIDI_CH3I_Sock_accept(struct MPIDI_CH3I_Sock *listener,
      * made at that time? */
 #if 1
     mpi_errno = MPIDI_CH3I_Sock_SetSockBufferSize(fd, 1);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     if (MPIDI_CH3I_Socki_socket_bufsz > 0) {
         int bufsz;

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -349,8 +349,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
                                              0, rma_op->origin_count * origin_type_size, &curr_req);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (curr_req != NULL) {
@@ -480,8 +479,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
                                              stream_offset, stream_size, &curr_req);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (curr_req != NULL) {
             if (rma_op->reqs_size == 0) {
@@ -706,8 +704,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
                                              stream_offset, stream_size, &curr_req);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (curr_req != NULL) {
             MPIR_Request_free(curr_req);
@@ -991,8 +988,7 @@ static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
         MPIR_Datatype_get_size_macro(rma_op->origin_datatype, origin_dtp_size);
         mpi_errno = issue_from_origin_buffer(rma_op, vc, NULL, 0,       /*ext_hdr_ptr, ext_hdr_sz */
                                              0, 1 * origin_dtp_size, &curr_req);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (curr_req != NULL) {
@@ -1050,8 +1046,7 @@ static inline int issue_rma_op(MPIDI_RMA_Op_t * op_ptr, MPIR_Win * win_ptr,
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**winInvalidOp");
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_ISSUE_RMA_OP);

--- a/src/mpid/ch3/include/mpid_rma_oplist.h
+++ b/src/mpid/ch3/include/mpid_rma_oplist.h
@@ -282,8 +282,7 @@ static inline int MPIDI_CH3I_Win_create_target(MPIR_Win * win_ptr, int target_ra
     t = MPIDI_CH3I_Win_target_alloc(win_ptr);
     if (t == NULL) {
         mpi_errno = MPIDI_CH3I_RMA_Cleanup_target_aggressive(win_ptr, &t);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     t->target_rank = target_rank;
@@ -336,12 +335,10 @@ static inline int MPIDI_CH3I_Win_enqueue_op(MPIR_Win * win_ptr, MPIDI_RMA_Op_t *
     MPIDI_RMA_Target_t *target = NULL;
 
     mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, op->target_rank, &target);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     if (target == NULL) {
         mpi_errno = MPIDI_CH3I_Win_create_target(win_ptr, op->target_rank, &target);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (win_ptr->states.access_state == MPIDI_RMA_PER_TARGET ||
             win_ptr->states.access_state == MPIDI_RMA_LOCK_ALL_GRANTED) {
@@ -419,8 +416,7 @@ static inline int MPIDI_CH3I_Win_target_dequeue_and_free(MPIR_Win * win_ptr, MPI
     DL_DELETE(slot->target_list_head, e);
 
     mpi_errno = MPIDI_CH3I_Win_target_free(win_ptr, e);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -437,8 +433,7 @@ static inline int MPIDI_CH3I_RMA_Cleanup_targets_win(MPIR_Win * win_ptr)
         for (target = win_ptr->slots[i].target_list_head; target;) {
             next_target = target->next;
             mpi_errno = MPIDI_CH3I_Win_target_dequeue_and_free(win_ptr, target);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             target = next_target;
         }
     }
@@ -462,8 +457,7 @@ static inline int MPIDI_CH3I_Win_get_op(MPIR_Win * win_ptr, MPIDI_RMA_Op_t ** e)
             break;
 
         mpi_errno = MPIDI_CH3I_RMA_Cleanup_ops_aggressive(win_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     (*e) = new_ptr;

--- a/src/mpid/ch3/include/mpid_rma_shm.h
+++ b/src/mpid/ch3/include/mpid_rma_shm.h
@@ -236,9 +236,7 @@ static inline int shm_copy(const void *src, int scount, MPI_Datatype stype,
     }
 
     mpi_errno = MPIR_Localcopy(src, scount, stype, dest, dcount, dtype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -273,9 +271,7 @@ static inline int MPIDI_CH3I_Shm_put_op(const void *origin_addr, int origin_coun
 
     mpi_errno = shm_copy(origin_addr, origin_count, origin_datatype,
                          (char *) base + disp_unit * target_disp, target_count, target_datatype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_MPIDI_CH3I_SHM_PUT_OP);
@@ -330,8 +326,7 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         goto fn_exit;
     }
@@ -383,8 +378,7 @@ static inline int MPIDI_CH3I_Shm_acc_op(const void *origin_addr, int origin_coun
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPL_free(packed_buf);
     }
@@ -441,9 +435,7 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
     /* Perform the local get first, then the accumulate */
     mpi_errno = shm_copy((char *) base + disp_unit * target_disp, target_count, target_datatype,
                          result_addr, result_count, result_datatype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (is_empty_origin == TRUE || MPIR_DATATYPE_IS_PREDEFINED(origin_datatype)) {
 
@@ -455,8 +447,7 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         goto fn_exit;
     }
@@ -500,8 +491,7 @@ static inline int MPIDI_CH3I_Shm_get_acc_op(const void *origin_addr, int origin_
                                      target_count, target_datatype, stream_offset, op,
                                      MPIDI_RMA_ACC_SRCBUF_PACKED);
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPL_free(packed_buf);
     }
@@ -549,9 +539,7 @@ static inline int MPIDI_CH3I_Shm_get_op(void *origin_addr, int origin_count,
 
     mpi_errno = shm_copy((char *) base + disp_unit * target_disp, target_count, target_datatype,
                          origin_addr, origin_count, origin_datatype);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_MPIDI_CH3I_SHM_GET_OP);

--- a/src/mpid/ch3/src/ch3u_buffer.c
+++ b/src/mpid/ch3/src/ch3u_buffer.c
@@ -184,9 +184,7 @@ int MPIDI_CH3_RecvFromSelf( MPIR_Request *rreq, void *buf, MPI_Aint count,
 			       &rreq->status.MPI_ERROR);
 	MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
 	mpi_errno = MPID_Request_complete(sreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else
     {
@@ -198,9 +196,7 @@ int MPIDI_CH3_RecvFromSelf( MPIR_Request *rreq, void *buf, MPI_Aint count,
     /* no other thread can possibly be waiting on rreq, so it is safe to 
        reset ref_count and cc */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     return mpi_errno;

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -64,7 +64,7 @@ int MPIDI_CH3I_Comm_init(void)
 
     /* register hooks for keeping track of communicators */
     mpi_errno = MPIDI_CH3U_Comm_register_create_hook(comm_created, NULL);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #if defined HAVE_LIBHCOLL
     {
@@ -94,14 +94,14 @@ int MPIDI_CH3I_Comm_init(void)
 #endif
 
         mpi_errno = MPIDI_CH3U_Comm_register_create_hook(hcoll_comm_create, NULL);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(hcoll_comm_destroy, NULL);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
 
     mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(comm_destroyed, NULL);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3U_COMM_INIT);
@@ -314,15 +314,15 @@ int MPIDI_CH3I_Comm_destroy_hook(MPIR_Comm *comm)
 
     LL_FOREACH(destroy_hooks_head, elt) {
         mpi_errno = elt->hook_fn(comm, elt->param);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIDI_VCRT_Release(comm->dev.vcrt, comm->dev.is_disconnected);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
         mpi_errno = MPIDI_VCRT_Release(comm->dev.local_vcrt, comm->dev.is_disconnected);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
  fn_exit:
@@ -511,7 +511,7 @@ int MPIDI_CH3I_Comm_handle_failed_procs(MPIR_Group *new_failed_procs)
             continue;
 
         mpi_errno = nonempty_intersection(comm, new_failed_procs, &flag);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (flag) {
             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER, VERBOSE,

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -124,7 +124,7 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 	/* FIXME: info may be needed for port name */
         mpi_errno = MPID_Open_port(NULL, port_name);
 	/* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 	/* --END ERROR HANDLING-- */
 
 	/* Spawn the processes */
@@ -245,20 +245,20 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
     if (errcodes != MPI_ERRCODES_IGNORE) {
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
         mpi_errno = MPIR_Bcast(&should_accept, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Bcast(&total_num_processes, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         
         mpi_errno = MPIR_Bcast(errcodes, total_num_processes, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
     }
 
     if (should_accept) {
         mpi_errno = MPID_Comm_accept(port_name, NULL, root, comm_ptr, intercomm); 
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**pmi_spawn_multiple");

--- a/src/mpid/ch3/src/ch3u_eager.c
+++ b/src/mpid/ch3/src/ch3u_eager.c
@@ -140,7 +140,7 @@ int MPIDI_CH3_EagerNoncontigSend( MPIR_Request **sreq_p,
                                      sizeof(MPIDI_CH3_Pkt_eager_send_t),
                                      NULL, 0);
     MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     return mpi_errno;
@@ -488,9 +488,7 @@ int MPIDI_CH3_PktHandler_EagerShortSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, v
      * also kicks the progress engine, which was previously done here via
      * MPIDI_CH3_Progress_signal_completion(). */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_fail:
     /* MT note: it may be possible to narrow this CS after careful
@@ -625,9 +623,7 @@ int MPIDI_CH3_PktHandler_EagerSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *
         /* return the number of bytes processed in this function */
         *buflen = 0;
         mpi_errno = MPID_Request_complete(rreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 	*rreqp = NULL;
     }
     else {
@@ -651,9 +647,7 @@ int MPIDI_CH3_PktHandler_EagerSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *
         if (complete) 
         {
             mpi_errno = MPID_Request_complete(rreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
             *rreqp = NULL;
         }
         else
@@ -710,9 +704,7 @@ int MPIDI_CH3_PktHandler_ReadySend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *
             /* return the number of bytes processed in this function */
             *buflen = data_len;;
             mpi_errno = MPID_Request_complete(rreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	    *rreqp = NULL;
 	}
 	else {
@@ -731,9 +723,7 @@ int MPIDI_CH3_PktHandler_ReadySend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *
             if (complete) 
             {
                 mpi_errno = MPID_Request_complete(rreq);
-                if (mpi_errno != MPI_SUCCESS) {
-                    MPIR_ERR_POP(mpi_errno);
-                }
+                MPIR_ERR_CHECK(mpi_errno);
                 *rreqp = NULL;
             }
             else
@@ -776,9 +766,7 @@ int MPIDI_CH3_PktHandler_ReadySend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *
 	{
 	    /* mark data transfer as complete and decrement CC */
             mpi_errno = MPID_Request_complete(rreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	    *rreqp = NULL;
 	}
         /* we didn't process anything but the header in this case */

--- a/src/mpid/ch3/src/ch3u_eagersync.c
+++ b/src/mpid/ch3/src/ch3u_eagersync.c
@@ -99,7 +99,7 @@ int MPIDI_CH3_EagerSyncNoncontigSend( MPIR_Request **sreq_p,
         mpi_errno = vc->sendNoncontig_fn(vc, sreq, es_pkt, sizeof(MPIDI_CH3_Pkt_eager_sync_send_t),
                                          NULL, 0);
 	MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
  fn_exit:
@@ -176,9 +176,7 @@ int MPIDI_CH3_EagerSyncAck( MPIDI_VC_t *vc, MPIR_Request *rreq )
     MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
     mpi_errno = MPIDI_CH3_iStartMsg(vc, esa_pkt, sizeof(*esa_pkt), &esa_req);
     MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     if (esa_req != NULL)
     {
 	MPIR_Request_free(esa_req);
@@ -248,9 +246,7 @@ int MPIDI_CH3_PktHandler_EagerSyncSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
 	if (rreq->dev.recv_data_sz == 0) {
             *buflen = 0;
             mpi_errno = MPID_Request_complete(rreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	    *rreqp = NULL;
 	}
 	else {
@@ -266,9 +262,7 @@ int MPIDI_CH3_PktHandler_EagerSyncSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
             if (complete) 
             {
                 mpi_errno = MPID_Request_complete(rreq);
-                if (mpi_errno != MPI_SUCCESS) {
-                    MPIR_ERR_POP(mpi_errno);
-                }
+                MPIR_ERR_CHECK(mpi_errno);
                 *rreqp = NULL;
             }
             else
@@ -297,9 +291,7 @@ int MPIDI_CH3_PktHandler_EagerSyncSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
 	if (rreq->dev.recv_data_sz == 0) {
             *buflen = 0;
             mpi_errno = MPID_Request_complete(rreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	    *rreqp = NULL;
 	}
 	else {
@@ -315,9 +307,7 @@ int MPIDI_CH3_PktHandler_EagerSyncSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
             if (complete) 
             {
                 mpi_errno = MPID_Request_complete(rreq);
-                if (mpi_errno != MPI_SUCCESS) {
-                    MPIR_ERR_POP(mpi_errno);
-                }
+                MPIR_ERR_CHECK(mpi_errno);
                 *rreqp = NULL;
             }
             else
@@ -347,9 +337,7 @@ int MPIDI_CH3_PktHandler_EagerSyncAck( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, voi
 
     /* FIXME: This sometimes segfaults */
     mpi_errno = MPID_Request_complete(sreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     
     *buflen = 0;
     *rreqp = NULL;

--- a/src/mpid/ch3/src/ch3u_handle_connection.c
+++ b/src/mpid/ch3/src/ch3u_handle_connection.c
@@ -68,7 +68,7 @@ int MPIDI_CH3U_Handle_connection(MPIDI_VC_t * vc, MPIDI_VC_Event_t event)
 		    {
 			MPIDI_CH3_Progress_signal_completion();
                         mpi_errno = MPIDI_CH3_Channel_close();
-                        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 		    }
 
 		    break;
@@ -133,7 +133,7 @@ int MPIDI_CH3U_Handle_connection(MPIDI_VC_t * vc, MPIDI_VC_Event_t event)
 		    if (MPIDI_Outstanding_close_ops == 0) {
 			MPIDI_CH3_Progress_signal_completion();
                         mpi_errno = MPIDI_CH3_Channel_close();
-                        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 		    }
                     
                     break;
@@ -390,7 +390,7 @@ static int terminate_failed_VCs(MPIR_Group *new_failed_group)
         /* FIXME: This won't work for dynamic procs */
         MPIDI_PG_Get_vc(MPIDI_Process.my_pg, new_failed_group->lrank_to_lpid[i].lpid, &vc);
         mpi_errno = MPIDI_CH3_Connection_terminate(vc);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     
  fn_exit:
@@ -462,13 +462,13 @@ int MPIDI_CH3U_Get_failed_group(int last_rank, MPIR_Group **failed_group)
     /* Create group of failed processes for comm_world.  Failed groups for other
        communicators can be created from this one using group_intersection. */
     mpi_errno = MPIR_Comm_group_impl(MPIR_Process.comm_world, &world_group);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Group_incl_impl(world_group, i, ut_int_array(failed_procs), failed_group);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Group_release(world_group);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_GET_FAILED_GROUP);
@@ -497,7 +497,7 @@ int MPIDI_CH3U_Check_for_failed_procs(void)
        with the rank, then we need to create the failed group from
        something bigger than comm_world. */
     mpi_errno = MPIDI_PG_GetConnKVSname(&kvsname);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #ifdef USE_PMI2_API
     {
         int vallen = 0;
@@ -527,23 +527,23 @@ int MPIDI_CH3U_Check_for_failed_procs(void)
 
     /* get group of newly failed processes */
     mpi_errno = MPIR_Group_difference_impl(MPIDI_Failed_procs_group, prev_failed_group, &new_failed_group);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (new_failed_group != MPIR_Group_empty) {
         mpi_errno = MPIDI_CH3I_Comm_handle_failed_procs(new_failed_group);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = terminate_failed_VCs(new_failed_group);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Group_release(new_failed_group);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* free prev group */
     if (prev_failed_group != MPIR_Group_empty) {
         mpi_errno = MPIR_Group_release(prev_failed_group);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
  fn_exit:

--- a/src/mpid/ch3/src/ch3u_handle_op_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_op_req.c
@@ -31,9 +31,7 @@ int MPIDI_CH3_Req_handler_rma_op_complete(MPIR_Request * sreq)
         /* get user request */
         MPIR_Request_get_ptr(sreq->dev.request_handle, ureq);
         mpi_errno = MPID_Request_complete(ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -23,9 +23,7 @@ int MPIDI_CH3U_Handle_recv_req(MPIDI_VC_t * vc, MPIR_Request * rreq, int *comple
     if (!reqFn) {
         MPIR_Assert(MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_RECV);
         mpi_errno = MPID_Request_complete(rreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         *complete = TRUE;
     }
     else {
@@ -67,9 +65,7 @@ int MPIDI_CH3_ReqHandler_RecvComplete(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -111,9 +107,7 @@ int MPIDI_CH3_ReqHandler_PutRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -121,8 +115,7 @@ int MPIDI_CH3_ReqHandler_PutRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
                                     pkt_flags, source_win_handle);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -199,18 +192,14 @@ int MPIDI_CH3_ReqHandler_AccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq,
     if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* free the temporary buffer */
     MPIDI_CH3U_SRBuf_free(rreq);
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -218,8 +207,7 @@ int MPIDI_CH3_ReqHandler_AccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq,
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
                                     pkt_flags, source_win_handle);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -339,8 +327,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     resp_req->dev.OnFinal = MPIDI_CH3_ReqHandler_GaccumSendComplete;
     resp_req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_GaccumSendComplete;
@@ -377,9 +364,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
   fn_exit:
@@ -467,8 +452,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Send back data */
     MPIDI_Pkt_init(fop_resp_pkt, MPIDI_CH3_PKT_FOP_RESP);
@@ -503,9 +487,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -725,8 +707,7 @@ int MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete(MPIDI_VC_t * vc,
 
         /* There is no origin data coming, directly call final req handler. */
         mpi_errno = MPIDI_CH3_ReqHandler_GaccumRecvComplete(vc, rreq, complete);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIR_Datatype_get_size_macro(basic_dtp, basic_type_size);
@@ -847,9 +828,7 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
     /* mark receive data transfer as complete and decrement CC in receive
      * request */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -885,9 +864,7 @@ int MPIDI_CH3_ReqHandler_UnpackUEBufComplete(MPIDI_VC_t * vc ATTRIBUTE((unused))
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -922,9 +899,7 @@ int MPIDI_CH3_ReqHandler_UnpackSRBufComplete(MPIDI_VC_t * vc, MPIR_Request * rre
     else {
         /* mark data transfer as complete and decrement CC */
         mpi_errno = MPID_Request_complete(rreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         *complete = TRUE;
     }
@@ -992,24 +967,21 @@ static inline int perform_put_in_lock_queue(MPIR_Win * win_ptr,
         /* all data fits in packet header */
         mpi_errno = MPIR_Localcopy((void *) &put_pkt->info.data, put_pkt->count, put_pkt->datatype,
                                    put_pkt->addr, put_pkt->count, put_pkt->datatype);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIR_Assert(put_pkt->type == MPIDI_CH3_PKT_PUT);
 
         mpi_errno = MPIR_Localcopy(target_lock_entry->data, put_pkt->count, put_pkt->datatype,
                                    put_pkt->addr, put_pkt->count, put_pkt->datatype);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* do final action */
     mpi_errno =
         finish_op_on_target(win_ptr, target_lock_entry->vc, FALSE /* has no response data */ ,
                             put_pkt->pkt_flags, put_pkt->source_win_handle);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1080,8 +1052,7 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
     if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
         void *src = (void *) (get_pkt->addr), *dest = (void *) &get_resp_pkt->info.data;
         mpi_errno = immed_copy(src, dest, len);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* All origin data is in packet header, issue the header. */
         iov[0].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) get_resp_pkt;
@@ -1175,14 +1146,12 @@ static inline int perform_acc_in_lock_queue(MPIR_Win * win_ptr,
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         finish_op_on_target(win_ptr, target_lock_entry->vc, FALSE /* has no response data */ ,
                             acc_pkt->pkt_flags, acc_pkt->source_win_handle);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1277,8 +1246,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* here we increment the Active Target counter to guarantee the GET-like
          * operation are completed when counter reaches zero. */
@@ -1342,8 +1310,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* here we increment the Active Target counter to guarantee the GET-like
      * operation are completed when counter reaches zero. */
@@ -1487,8 +1454,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
     }
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (fop_pkt->type == MPIDI_CH3_PKT_FOP_IMMED) {
         /* send back the original data */
@@ -1537,8 +1503,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
     /* do final action */
     mpi_errno = finish_op_on_target(win_ptr, target_lock_entry->vc, TRUE /* has response data */ ,
                                     fop_pkt->pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1623,8 +1588,7 @@ static inline int perform_cas_in_lock_queue(MPIR_Win * win_ptr,
     /* do final action */
     mpi_errno = finish_op_on_target(win_ptr, target_lock_entry->vc, TRUE /* has response data */ ,
                                     cas_pkt->pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1650,16 +1614,14 @@ static inline int perform_op_in_lock_queue(MPIR_Win * win_ptr,
         if (target_lock_entry->vc == my_vc) {
             mpi_errno = handle_lock_ack(win_ptr, win_ptr->comm_ptr->rank,
                                         MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         else {
             mpi_errno = MPIDI_CH3I_Send_lock_ack_pkt(target_lock_entry->vc, win_ptr,
                                                      MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED,
                                                      lock_pkt->source_win_handle,
                                                      lock_pkt->request_handle);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     else {
@@ -1668,36 +1630,30 @@ static inline int perform_op_in_lock_queue(MPIR_Win * win_ptr,
         case (MPIDI_CH3_PKT_PUT):
         case (MPIDI_CH3_PKT_PUT_IMMED):
             mpi_errno = perform_put_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         case (MPIDI_CH3_PKT_GET):
             mpi_errno = perform_get_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         case (MPIDI_CH3_PKT_ACCUMULATE):
         case (MPIDI_CH3_PKT_ACCUMULATE_IMMED):
             mpi_errno = perform_acc_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         case (MPIDI_CH3_PKT_GET_ACCUM):
         case (MPIDI_CH3_PKT_GET_ACCUM_IMMED):
             mpi_errno = perform_get_acc_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         case (MPIDI_CH3_PKT_FOP):
         case (MPIDI_CH3_PKT_FOP_IMMED):
             mpi_errno = perform_fop_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         case (MPIDI_CH3_PKT_CAS_IMMED):
             mpi_errno = perform_cas_in_lock_queue(win_ptr, target_lock_entry);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             break;
         default:
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER,
@@ -1783,14 +1739,12 @@ int MPIDI_CH3I_Release_lock(MPIR_Win * win_ptr)
 
                         /* perform this OP */
                         mpi_errno = perform_op_in_lock_queue(win_ptr, target_lock_entry);
-                        if (mpi_errno != MPI_SUCCESS)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         /* free this entry */
                         mpi_errno =
                             MPIDI_CH3I_Win_target_lock_entry_free(win_ptr, target_lock_entry);
-                        if (mpi_errno != MPI_SUCCESS)
-                            MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
 
                         /* if the granted lock is exclusive,
                          * no need to continue */
@@ -1873,13 +1827,11 @@ int MPIDI_CH3_ReqHandler_PiggybackLockOpRecvComplete(MPIDI_VC_t * vc,
 
             /* perform this OP */
             mpi_errno = perform_op_in_lock_queue(win_ptr, target_lock_queue_entry);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* free this entry */
             mpi_errno = MPIDI_CH3I_Win_target_lock_entry_free(win_ptr, target_lock_queue_entry);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         /* If try acquiring lock failed, just leave the lock queue entry in the queue with
          * all_data_recved marked as 1, release_lock() function will traverse the queue
@@ -1889,9 +1841,7 @@ int MPIDI_CH3_ReqHandler_PiggybackLockOpRecvComplete(MPIDI_VC_t * vc,
     /* mark receive data transfer as complete and decrement CC in receive
      * request */
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 

--- a/src/mpid/ch3/src/ch3u_handle_send_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_send_req.c
@@ -26,9 +26,7 @@ int MPIDI_CH3U_Handle_send_req(MPIDI_VC_t * vc, MPIR_Request * sreq, int *comple
     else {
         mpi_errno = reqFn(vc, sreq, complete);
     }
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3U_HANDLE_SEND_REQ);
@@ -78,9 +76,7 @@ int MPIDI_CH3_ReqHandler_GetSendComplete(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     /* mark data transfer as complete and decrement CC */
     mpi_errno = MPID_Request_complete(sreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -88,8 +84,7 @@ int MPIDI_CH3_ReqHandler_GetSendComplete(MPIDI_VC_t * vc ATTRIBUTE((unused)),
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                     pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -139,9 +134,7 @@ int MPIDI_CH3_ReqHandler_GaccumSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     MPIR_Assert(win_ptr->at_completion_counter >= 0);
 
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -149,8 +142,7 @@ int MPIDI_CH3_ReqHandler_GaccumSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                     pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -203,9 +195,7 @@ int MPIDI_CH3_ReqHandler_CASSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     MPIR_Assert(win_ptr->at_completion_counter >= 0);
 
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -213,8 +203,7 @@ int MPIDI_CH3_ReqHandler_CASSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                     pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 
@@ -266,9 +255,7 @@ int MPIDI_CH3_ReqHandler_FOPSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     MPIR_Assert(win_ptr->at_completion_counter >= 0);
 
     mpi_errno = MPID_Request_complete(rreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* NOTE: finish_op_on_target() must be called after we complete this request,
      * because inside finish_op_on_target() we may call this request handler
@@ -276,8 +263,7 @@ int MPIDI_CH3_ReqHandler_FOPSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                     pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *complete = TRUE;
 

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -571,9 +571,7 @@ int MPID_Request_complete(MPIR_Request *req)
         /* trigger request_completed callback function */
         if (req->dev.request_completed_cb != NULL) {
             mpi_errno = req->dev.request_completed_cb(req);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* decrement completion_notification counter */

--- a/src/mpid/ch3/src/ch3u_rma_ops.c
+++ b/src/mpid/ch3/src/ch3u_rma_ops.c
@@ -81,15 +81,12 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
         (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id)) {
         mpi_errno = MPIDI_CH3I_Shm_put_op(origin_addr, origin_count, origin_datatype, target_rank,
                                           target_disp, target_count, target_datatype, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (ureq) {
             /* Complete user request and release the ch3 ref */
             mpi_errno = MPID_Request_complete(ureq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     else {
@@ -100,8 +97,7 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
 
         /* queue it up */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_START(RMA, rma_rmaqueue_set);
 
@@ -169,26 +165,22 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(put_pkt->info.data);
             mpi_errno = immed_copy(src, dest, data_sz);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -251,15 +243,12 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
         (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id)) {
         mpi_errno = MPIDI_CH3I_Shm_get_op(origin_addr, origin_count, origin_datatype, target_rank,
                                           target_disp, target_count, target_datatype, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (ureq) {
             /* Complete user request and release the ch3 ref */
             mpi_errno = MPID_Request_complete(ureq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     else {
@@ -271,8 +260,7 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
 
         /* queue it up */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_START(RMA, rma_rmaqueue_set);
 
@@ -337,19 +325,16 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -413,15 +398,12 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
         mpi_errno = MPIDI_CH3I_Shm_acc_op(origin_addr, origin_count, origin_datatype,
                                           target_rank, target_disp, target_count, target_datatype,
                                           op, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (ureq) {
             /* Complete user request and release the ch3 ref */
             mpi_errno = MPID_Request_complete(ureq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     else {
@@ -436,8 +418,7 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
 
         /* queue it up */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_START(RMA, rma_rmaqueue_set);
 
@@ -533,26 +514,22 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(accum_pkt->info.data);
             mpi_errno = immed_copy(src, dest, data_sz);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -620,15 +597,12 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
                                               result_addr, result_count, result_datatype,
                                               target_rank, target_disp, target_count,
                                               target_datatype, op, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (ureq) {
             /* Complete user request and release the ch3 ref */
             mpi_errno = MPID_Request_complete(ureq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
     else {
@@ -649,8 +623,7 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
 
         /* Append the operation to the window's RMA ops queue */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* TODO: Can we use the MPIDI_RMA_ACC_CONTIG optimization? */
 
@@ -777,26 +750,22 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(get_accum_pkt->info.data);
             mpi_errno = immed_copy(src, dest, orig_data_sz);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -951,8 +920,7 @@ int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
         (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id)) {
         mpi_errno = MPIDI_CH3I_Shm_cas_op(origin_addr, compare_addr, result_addr,
                                           datatype, target_rank, target_disp, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIDI_RMA_Op_t *op_ptr = NULL;
@@ -962,8 +930,7 @@ int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
 
         /* Append this operation to the RMA ops queue */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_START(RMA, rma_rmaqueue_set);
 
@@ -996,30 +963,25 @@ int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
 
         src = (void *) origin_addr, dest = (void *) (&(cas_pkt->origin_data));
         mpi_errno = immed_copy(src, dest, type_size);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         src = (void *) compare_addr, dest = (void *) (&(cas_pkt->compare_data));
         mpi_errno = immed_copy(src, dest, type_size);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
@@ -1076,8 +1038,7 @@ int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
         (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id)) {
         mpi_errno = MPIDI_CH3I_Shm_fop_op(origin_addr, result_addr, datatype,
                                           target_rank, target_disp, op, win_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIDI_RMA_Op_t *op_ptr = NULL;
@@ -1088,8 +1049,7 @@ int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
 
         /* Append this operation to the RMA ops queue */
         mpi_errno = MPIDI_CH3I_Win_get_op(win_ptr, &op_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_T_PVAR_TIMER_START(RMA, rma_rmaqueue_set);
 
@@ -1134,26 +1094,22 @@ int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(fop_pkt->info.data);
             mpi_errno = immed_copy(src, dest, type_size);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
         mpi_errno = MPIDI_CH3I_Win_enqueue_op(win_ptr, op_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIDI_CH3I_RMA_Make_progress_target(win_ptr, target_rank, &made_progress);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD >= 0 &&
             MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
             while (MPIDI_CH3I_RMA_Active_req_cnt >= MPIR_CVAR_CH3_RMA_ACTIVE_REQ_THRESHOLD) {
                 mpi_errno = wait_progress_engine();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -247,8 +247,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIR_Win_get_ptr(put_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &req);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (acquire_lock_fail) {
         (*rreqp) = req;
@@ -269,8 +268,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         /* trigger final action */
         mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
                                         put_pkt->pkt_flags, put_pkt->source_win_handle);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *buflen = 0;
         *rreqp = NULL;
@@ -312,8 +310,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
             if (complete) {
                 mpi_errno = MPIDI_CH3_ReqHandler_PutRecvComplete(vc, req, &complete);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 if (complete) {
                     *rreqp = NULL;
                     goto fn_exit;
@@ -408,8 +405,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIR_Win_get_ptr(get_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &req);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (acquire_lock_fail) {
         (*rreqp) = req;
@@ -470,8 +466,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
             MPIR_Assign_trunc(len, get_pkt->count * type_size, size_t);
             void *src = (void *) (get_pkt->addr), *dest = (void *) &(get_resp_pkt->info.data);
             mpi_errno = immed_copy(src, dest, len);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             iov[0].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) get_resp_pkt;
             iov[0].MPL_IOV_LEN = sizeof(*get_resp_pkt);
@@ -605,8 +600,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
     MPIR_Win_get_ptr(accum_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &req);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (acquire_lock_fail) {
         (*rreqp) = req;
@@ -627,15 +621,12 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
         if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* trigger final action */
         mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
                                         accum_pkt->pkt_flags, accum_pkt->source_win_handle);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *buflen = 0;
         *rreqp = NULL;
@@ -666,8 +657,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
                                                        (!MPIR_DATATYPE_IS_PREDEFINED
                                                         (accum_pkt->datatype)),
                                                        &req->dev.ext_hdr_ptr, &req->dev.ext_hdr_sz);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_DATATYPE_IS_PREDEFINED(accum_pkt->datatype)) {
             MPIDI_Request_set_type(req, MPIDI_REQUEST_TYPE_ACCUM_RECV);
@@ -721,8 +711,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
 
                 if (complete) {
                     mpi_errno = MPIDI_CH3_ReqHandler_AccumRecvComplete(vc, req, &complete);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     if (complete) {
                         *rreqp = NULL;
                         goto fn_exit;
@@ -821,8 +810,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
     MPIR_Win_get_ptr(get_accum_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &req);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (acquire_lock_fail) {
         (*rreqp) = req;
@@ -899,8 +887,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         iov[0].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) get_accum_resp_pkt;
         iov[0].MPL_IOV_LEN = sizeof(*get_accum_resp_pkt);
@@ -943,8 +930,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         mpi_errno = MPIDI_CH3_ExtPktHandler_GetAccumulate(req->dev.pkt_flags, is_derived_dt,
                                                           &req->dev.ext_hdr_ptr,
                                                           &req->dev.ext_hdr_sz);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (MPIR_DATATYPE_IS_PREDEFINED(get_accum_pkt->datatype)) {
             MPI_Aint type_size;
@@ -1013,8 +999,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
                 if (complete) {
                     mpi_errno = MPIDI_CH3_ReqHandler_GaccumRecvComplete(vc, req, &complete);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     if (complete) {
                         *rreqp = NULL;
                         goto fn_exit;
@@ -1113,8 +1098,7 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIR_Win_get_ptr(cas_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &rreq);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(rreq == NULL);  /* CAS should not have request because all data
                                  * can fit in packet header */
 
@@ -1186,8 +1170,7 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                     cas_pkt->pkt_flags, MPI_WIN_NULL);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_rmapkt_cas);
@@ -1223,17 +1206,14 @@ int MPIDI_CH3_PktHandler_CASResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     /* decrement ack_counter on this target */
     if (cas_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
         mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, cas_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = handle_lock_ack(win_ptr, target_rank, cas_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     if (cas_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Datatype_get_size_macro(req->dev.datatype, len);
@@ -1241,9 +1221,7 @@ int MPIDI_CH3_PktHandler_CASResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     MPIR_Memcpy(req->dev.user_buf, (void *) &cas_resp_pkt->info.data, len);
 
     mpi_errno = MPID_Request_complete(req);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *buflen = 0;
     *rreqp = NULL;
@@ -1280,8 +1258,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIR_Win_get_ptr(fop_pkt->target_win_handle, win_ptr);
 
     mpi_errno = check_piggyback_lock(win_ptr, vc, pkt, data, buflen, &acquire_lock_fail, &rreq);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (acquire_lock_fail) {
         (*rreqp) = rreq;
@@ -1331,8 +1308,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
         }
 
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* send back the original data */
         MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
@@ -1362,8 +1338,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
                                         fop_pkt->pkt_flags, MPI_WIN_NULL);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         MPIR_Assert(pkt->type == MPIDI_CH3_PKT_FOP);
@@ -1423,8 +1398,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         if (complete) {
             mpi_errno = MPIDI_CH3_ReqHandler_FOPRecvComplete(vc, req, &complete);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             if (complete) {
                 *rreqp = NULL;
                 goto fn_exit;
@@ -1469,17 +1443,14 @@ int MPIDI_CH3_PktHandler_FOPResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     /* decrement ack_counter */
     if (fop_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
         mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, fop_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = handle_lock_ack(win_ptr, target_rank, fop_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     if (fop_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     data_len = *buflen;
@@ -1510,9 +1481,7 @@ int MPIDI_CH3_PktHandler_FOPResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     if (complete) {
         mpi_errno = MPID_Request_complete(req);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         *rreqp = NULL;
     }
 
@@ -1552,16 +1521,13 @@ int MPIDI_CH3_PktHandler_Get_AccumResp(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
     /* decrement ack_counter on target */
     if (get_accum_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
         mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_accum_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = handle_lock_ack(win_ptr, target_rank, get_accum_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     if (get_accum_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     data_len = *buflen;
@@ -1641,9 +1607,7 @@ int MPIDI_CH3_PktHandler_Get_AccumResp(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
     }
     if (complete) {
         mpi_errno = MPID_Request_complete(req);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         *rreqp = NULL;
     }
@@ -1688,15 +1652,13 @@ int MPIDI_CH3_PktHandler_Lock(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data
         mpi_errno = MPIDI_CH3I_Send_lock_ack_pkt(vc, win_ptr, MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED,
                                                  lock_pkt->source_win_handle,
                                                  lock_pkt->request_handle);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     else {
         MPIR_Request *req = NULL;
         mpi_errno = enqueue_lock_origin(win_ptr, vc, pkt, data, buflen, &req);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(req == NULL);
     }
 
@@ -1734,17 +1696,14 @@ int MPIDI_CH3_PktHandler_GetResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     /* decrement ack_counter on target */
     if (get_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
         mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = handle_lock_ack(win_ptr, target_rank, get_resp_pkt->pkt_flags);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     if (get_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     data_len = *buflen;
@@ -1774,9 +1733,7 @@ int MPIDI_CH3_PktHandler_GetResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     if (complete) {
         mpi_errno = MPID_Request_complete(req);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         *rreqp = NULL;
     }
@@ -1820,8 +1777,7 @@ int MPIDI_CH3_PktHandler_LockAck(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
     }
 
     mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_ack_pkt->pkt_flags);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *rreqp = NULL;
     MPIDI_CH3_Progress_signal_completion();
@@ -1862,18 +1818,15 @@ int MPIDI_CH3_PktHandler_LockOpAck(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
     }
 
     mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, lock_op_ack_pkt->pkt_flags);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_op_ack_pkt->pkt_flags);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         MPIR_Assert(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED);
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *rreqp = NULL;
@@ -1908,8 +1861,7 @@ int MPIDI_CH3_PktHandler_Ack(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
 
     /* decrement ack_counter on target */
     mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *rreqp = NULL;
     MPIDI_CH3_Progress_signal_completion();
@@ -1946,8 +1898,7 @@ int MPIDI_CH3_PktHandler_DecrAtCnt(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     if (decr_at_cnt_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) {
         mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, decr_at_cnt_pkt->source_win_handle);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIDI_CH3_Progress_signal_completion();
@@ -1984,8 +1935,7 @@ int MPIDI_CH3_PktHandler_Unlock(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
     if (!(unlock_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK_NO_ACK)) {
         mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, unlock_pkt->source_win_handle);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIDI_CH3_Progress_signal_completion();
@@ -2021,8 +1971,7 @@ int MPIDI_CH3_PktHandler_Flush(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
     MPIR_Win_get_ptr(flush_pkt->target_win_handle, win_ptr);
 
     mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, flush_pkt->source_win_handle);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_rmapkt_flush);

--- a/src/mpid/ch3/src/ch3u_rma_reqops.c
+++ b/src/mpid/ch3/src/ch3u_rma_reqops.c
@@ -45,15 +45,11 @@ int MPID_Rput(const void *origin_addr, int origin_count,
                                    origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win_ptr, ureq);
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         mpi_errno = MPID_Request_complete(ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *request = ureq;
@@ -103,15 +99,11 @@ int MPID_Rget(void *origin_addr, int origin_count,
                                    origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win_ptr, ureq);
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         mpi_errno = MPID_Request_complete(ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *request = ureq;
@@ -161,15 +153,11 @@ int MPID_Raccumulate(const void *origin_addr, int origin_count,
                                           origin_datatype, target_rank,
                                           target_disp, target_count,
                                           target_datatype, op, win_ptr, ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         mpi_errno = MPID_Request_complete(ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *request = ureq;
@@ -223,15 +211,11 @@ int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
                                               result_count, result_datatype,
                                               target_rank, target_disp,
                                               target_count, target_datatype, op, win_ptr, ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
         mpi_errno = MPID_Request_complete(ureq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     *request = ureq;

--- a/src/mpid/ch3/src/ch3u_rndv.c
+++ b/src/mpid/ch3/src/ch3u_rndv.c
@@ -279,9 +279,7 @@ int MPIDI_CH3_PktHandler_RndvSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *d
     if (req->dev.recv_data_sz == 0) {
         *buflen = 0;
         mpi_errno = MPID_Request_complete(req);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 	*rreqp = NULL;
     }
     else {
@@ -297,9 +295,7 @@ int MPIDI_CH3_PktHandler_RndvSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *d
         if (complete) 
         {
             mpi_errno = MPID_Request_complete(req);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
             *rreqp = NULL;
         }
         else

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -68,9 +68,7 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
                                tmp_buf, 4, MPI_AINT, (*win_ptr)->comm_ptr, &errflag);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
     k = 0;
@@ -102,15 +100,13 @@ int MPIDI_CH3U_Win_create(void *base, MPI_Aint size, int disp_unit, MPIR_Info * 
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_MPIDI_CH3U_WIN_CREATE);
 
     mpi_errno = MPIDI_CH3U_Win_fns.gather_info(base, size, disp_unit, info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if ((*win_ptr)->info_args.alloc_shm == TRUE && MPIDI_CH3U_Win_fns.detect_shm != NULL) {
         /* Detect if shared buffers are specified for the processes in the
          * current node. If so, enable shm RMA.*/
         mpi_errno = MPIDI_CH3U_Win_fns.detect_shm(win_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -132,8 +128,7 @@ int MPIDI_CH3U_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_W
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_MPIDI_CH3U_WIN_CREATE_DYNAMIC);
 
     mpi_errno = MPIDI_CH3U_Win_fns.gather_info(MPI_BOTTOM, 0, 1, info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_MPIDI_CH3U_WIN_CREATE_DYNAMIC);
@@ -194,15 +189,13 @@ int MPIDI_CH3U_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info,
         if (MPIDI_CH3U_Win_fns.allocate_shm != NULL) {
             mpi_errno =
                 MPIDI_CH3U_Win_fns.allocate_shm(size, disp_unit, info, comm_ptr, baseptr, win_ptr);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         }
     }
 
     mpi_errno = MPIDI_CH3U_Win_allocate_no_shm(size, disp_unit, info, comm_ptr, baseptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_MPIDI_CH3U_WIN_ALLOCATE);
@@ -236,9 +229,7 @@ int MPIDI_CH3U_Win_allocate_no_shm(MPI_Aint size, int disp_unit, MPIR_Info * inf
     (*win_ptr)->base = *base_pp;
 
     mpi_errno = MPIDI_CH3U_Win_fns.gather_info(*base_pp, size, disp_unit, info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_RMA_EXIT(MPID_STATE_MPIDI_CH3U_WIN_ALLOCATE_NO_SHM);
@@ -411,9 +402,7 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
 
     /* Allocate an empty info object */
     mpi_errno = MPIR_Info_alloc(info_used);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Populate the predefined info keys */
     if (win->info_args.no_locks)
@@ -421,9 +410,7 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "no_locks", "false");
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     {
 #define BUFSIZE 32
@@ -444,9 +431,7 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
         }
 
         MPIR_Info_set_impl(*info_used, "accumulate_ordering", buf);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 #undef BUFSIZE
     }
 
@@ -455,44 +440,34 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "accumulate_ops", "same_op_no_op");
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (win->info_args.alloc_shm == TRUE)
         mpi_errno = MPIR_Info_set_impl(*info_used, "alloc_shm", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "alloc_shm", "false");
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (win->info_args.alloc_shared_noncontig)
         mpi_errno = MPIR_Info_set_impl(*info_used, "alloc_shared_noncontig", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "alloc_shared_noncontig", "false");
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (win->info_args.same_size)
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_size", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_size", "false");
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (win->info_args.same_disp_unit)
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_disp_unit", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_disp_unit", "false");
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_GET_INFO);

--- a/src/mpid/ch3/src/mpid_cancel_recv.c
+++ b/src/mpid/ch3/src/mpid_cancel_recv.c
@@ -37,9 +37,7 @@ int MPID_Cancel_recv(MPIR_Request * rreq)
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
         MPIR_STATUS_SET_COUNT(rreq->status, 0);
         mpi_errno = MPID_Request_complete(rreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else
     {

--- a/src/mpid/ch3/src/mpid_cancel_send.c
+++ b/src/mpid/ch3/src/mpid_cancel_send.c
@@ -73,9 +73,7 @@ int MPID_Cancel_send(MPIR_Request * sreq)
 
 	    MPIR_STATUS_SET_CANCEL_BIT(sreq->status, TRUE);
             mpi_errno = MPID_Request_complete(sreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	}
 	else
 	{
@@ -324,9 +322,7 @@ int MPIDI_CH3_PktHandler_CancelSendResp( MPIDI_VC_t *vc ATTRIBUTE((unused)),
     }
     
     mpi_errno = MPID_Request_complete(sreq);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     *rreqp = NULL;
 

--- a/src/mpid/ch3/src/mpid_comm_disconnect.c
+++ b/src/mpid/ch3/src/mpid_comm_disconnect.c
@@ -35,11 +35,11 @@ int MPID_Comm_disconnect(MPIR_Comm *comm_ptr)
     /* MPIU_PG_Printall( stdout ); */
     comm_ptr->dev.is_disconnected = 1;
     mpi_errno = MPIR_Comm_release(comm_ptr);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* If any of the VCs were released by this Comm_release, wait
      for those close operations to complete */
     mpi_errno = MPIDI_CH3U_VC_WaitForClose();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /* MPIU_PG_Printall( stdout ); */
 
 

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -101,7 +101,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
     MPIDI_CH3U_Check_for_failed_procs();
 
     mpi_errno = MPIDI_CH3U_Get_failed_group(-2, &local_fail);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Generate a bitarray based on the list of failed procs */
     group_to_bitarray(local_fail, comm_ptr, &bitarray, &bitarray_size);

--- a/src/mpid/ch3/src/mpid_finalize.c
+++ b/src/mpid/ch3/src/mpid_finalize.c
@@ -99,7 +99,7 @@ int MPID_Finalize(void)
     /* FIXME: The close actions should use the same code as the other
        connection close code */
     mpi_errno = MPIDI_PG_Close_VCs();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     /*
      * Wait for all VCs to finish the close protocol
      */
@@ -109,14 +109,14 @@ int MPID_Finalize(void)
 
 #ifdef MPID_NEEDS_ICOMM_WORLD
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.icomm_world);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_self);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Comm_release_always(MPIR_Process.comm_world);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Note that the CH3I_Progress_finalize call has been removed; the
        CH3_Finalize routine should call it */

--- a/src/mpid/ch3/src/mpid_get_universe_size.c
+++ b/src/mpid/ch3/src/mpid_get_universe_size.c
@@ -28,7 +28,7 @@ int MPID_Get_universe_size(int  * universe_size)
     char *endptr;
     
     mpi_errno = PMI2_Info_GetJobAttr("universeSize", val, sizeof(val), &found);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!found)
 	*universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;

--- a/src/mpid/ch3/src/mpid_improbe.c
+++ b/src/mpid/ch3/src/mpid_improbe.c
@@ -36,11 +36,11 @@ int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
             if (!*flag) {
                 /* not found, check network */
                 mpi_errno = MPIDI_Anysource_improbe_fn(tag, comm, context_offset, flag, message, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 if (!*flag) {
                     /* still not found, make some progress*/
                     mpi_errno = MPIDI_CH3_Progress_poke();
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     /* check shm again */
                     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_MSGQ_MUTEX);
                     *message = MPIDI_CH3U_Recvq_FDU_matchonly(source, tag, context_id, comm, flag);
@@ -48,7 +48,7 @@ int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
                     if (!*flag) {
                         /* check network again */
                         mpi_errno = MPIDI_Anysource_improbe_fn(tag, comm, context_offset, flag, message, status);
-                        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 }
             }
@@ -60,7 +60,7 @@ int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
             MPIDI_Comm_get_vc_set_active(comm, source, &vc);
             if (vc->comm_ops && vc->comm_ops->improbe) {
                 mpi_errno = vc->comm_ops->improbe(vc, source, tag, comm, context_offset, flag, message, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 goto fn_exit;
             }
             /* fall-through to shm case */
@@ -80,7 +80,7 @@ int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
            a second test of the receive queue if we knew that nothing
            had changed */
         mpi_errno = MPID_Progress_poke();
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_MSGQ_MUTEX);
         *message = MPIDI_CH3U_Recvq_FDU_matchonly(source, tag, context_id, comm, flag);
         MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_MSGQ_MUTEX);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -62,7 +62,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
         {
             MPIDI_Comm_get_vc_set_active(comm, rreq->dev.match.parts.rank, &vc);
             mpi_errno = MPIDI_CH3_EagerSyncAck(vc, rreq);
-            if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* the request was found in the unexpected queue, so it has a
@@ -106,7 +106,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
         MPIDI_Comm_get_vc_set_active(comm, rreq->dev.match.parts.rank, &vc);
 
         mpi_errno = vc->rndvRecv_fn(vc, rreq);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
         {
             MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
@@ -116,7 +116,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
     else if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_SELF_MSG)
     {
         mpi_errno = MPIDI_CH3_RecvFromSelf(rreq, buf, count, datatype);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else
     {

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -61,7 +61,7 @@ static int finalize_failed_procs_group(void *param)
     int mpi_errno = MPI_SUCCESS;
     if (MPIDI_Failed_procs_group != MPIR_Group_empty) {
         mpi_errno = MPIR_Group_free_impl(MPIDI_Failed_procs_group);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     
  fn_fail:
@@ -113,7 +113,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
 
     /* initialization routine for ch3u_comm.c */
     mpi_errno = MPIDI_CH3I_Comm_init();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
     /* init group of failed processes, and set finalize callback */
     MPIDI_Failed_procs_group = MPIR_Group_empty;
@@ -178,7 +178,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     /* Ideally this wouldn't be needed.  Once we have PMIv2 support for node
        information we should probably eliminate this function. */
     mpi_errno = MPIDI_Populate_vc_node_ids(pg, pg_rank);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize Window functions table with defaults, then call the channel's
        init function. */
@@ -210,7 +210,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
 
     /* setup receive queue statistics */
     mpi_errno = MPIDI_CH3U_Recvq_init();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Ask channel to expose Window packet ordering. */
     MPIDI_CH3_Win_pkt_orderings_init(&MPIDI_CH3U_Win_pkt_orderings);
@@ -240,7 +240,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     }
 
     mpi_errno = MPIR_Comm_commit(comm);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /*
      * Initialize the MPI_COMM_SELF object
@@ -261,7 +261,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     MPIDI_VCR_Dup(&pg->vct[pg_rank], &comm->dev.vcrt->vcr_table[0]);
 
     mpi_errno = MPIR_Comm_commit(comm);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Currently, mpidpre.h always defines MPID_NEEDS_ICOMM_WORLD. */
 #ifdef MPID_NEEDS_ICOMM_WORLD
@@ -279,7 +279,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     comm->dev.vcrt = MPIR_Process.comm_world->dev.vcrt;
     
     mpi_errno = MPIR_Comm_commit(comm);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
     
     /*
@@ -348,10 +348,10 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided,
     mpi_errno = MPIR_Comm_register_hint("eager_rendezvous_threshold",
                                         set_eager_threshold,
                                         NULL);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_RMA_init();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_INIT);
@@ -421,7 +421,7 @@ static int init_pg( int *argc, char ***argv,
 
 #ifdef USE_PMI2_API
         mpi_errno = PMI2_Init(has_parent, &pg_size, &pg_rank, &appnum);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 #else
 	pmi_errno = PMI_Init(has_parent);
 	if (pmi_errno != PMI_SUCCESS) {
@@ -463,7 +463,7 @@ static int init_pg( int *argc, char ***argv,
 	}
 
         mpi_errno = PMI2_Job_GetId(pg_id, MAX_JOBID_LEN);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         
 
 #else
@@ -526,7 +526,7 @@ static int init_pg( int *argc, char ***argv,
     if (usePMI) {
 	/* Tell the process group how to get connection information */
         mpi_errno = MPIDI_PG_InitConnKVS( pg );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* FIXME: Who is this for and where does it belong? */

--- a/src/mpid/ch3/src/mpid_iprobe.c
+++ b/src/mpid/ch3/src/mpid_iprobe.c
@@ -39,11 +39,11 @@ int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
             if (!found) {
                 /* not found, check network */
                 mpi_errno = MPIDI_Anysource_iprobe_fn(tag, comm, context_offset, &found, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 if (!found) {
                     /* still not found, make some progress*/
                     mpi_errno = MPIDI_CH3_Progress_poke();
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     /* check shm again */
                     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_MSGQ_MUTEX);
                     found = MPIDI_CH3U_Recvq_FU(source, tag, context, status);
@@ -51,7 +51,7 @@ int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
                     if (!found) {
                         /* check network again */
                         mpi_errno = MPIDI_Anysource_iprobe_fn(tag, comm, context_offset, &found, status);
-                        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                        MPIR_ERR_CHECK(mpi_errno);
                     }
                 }
             }
@@ -63,7 +63,7 @@ int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
             MPIDI_Comm_get_vc_set_active(comm, source, &vc);
             if (vc->comm_ops && vc->comm_ops->iprobe) {
                 mpi_errno = vc->comm_ops->iprobe(vc, source, tag, comm, context_offset, &found, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 *flag = found;
                 goto fn_exit;
             }

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -63,7 +63,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 	    {
 		MPIDI_Comm_get_vc_set_active(comm, rreq->dev.match.parts.rank, &vc);
 		mpi_errno = MPIDI_CH3_EagerSyncAck( vc, rreq );
-		if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+		MPIR_ERR_CHECK(mpi_errno);
 	    }
 
             /* the request was found in the unexpected queue, so it has a
@@ -117,7 +117,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 	else if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_SELF_MSG)
 	{
 	    mpi_errno = MPIDI_CH3_RecvFromSelf( rreq, buf, count, datatype );
-	    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+	    MPIR_ERR_CHECK(mpi_errno);
 	}
 	else
 	{

--- a/src/mpid/ch3/src/mpid_mprobe.c
+++ b/src/mpid/ch3/src/mpid_mprobe.c
@@ -34,14 +34,14 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
                 if (found) goto fn_exit;
 
                 mpi_errno = MPIDI_Anysource_improbe_fn(tag, comm, context_offset, &found, message, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 if (found) goto fn_exit;
 
                 MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 
                 /* FIXME could this be replaced with a progress_wait? */
                 mpi_errno = MPIDI_CH3_Progress_test();
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } while (1);
         }
         else {
@@ -54,14 +54,14 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
                 do {
                     mpi_errno = vc->comm_ops->improbe(vc, source, tag, comm, context_offset, &found,
                                                       message, status);
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     if (found) goto fn_exit;
 
                     MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 
                     /* FIXME could this be replaced with a progress_wait? */
                     mpi_errno = MPIDI_CH3_Progress_test();
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } while (1);
             }
             /* fall-through to shm case */
@@ -91,7 +91,7 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
     }
     while(mpi_errno == MPI_SUCCESS);
     MPIDI_CH3_Progress_end(&progress_state);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (*message) {
         (*message)->kind = MPIR_REQUEST_KIND__MPROBE;

--- a/src/mpid/ch3/src/mpid_mrecv.c
+++ b/src/mpid/ch3/src/mpid_mrecv.c
@@ -23,7 +23,7 @@ int MPID_Mrecv(void *buf, int count, MPI_Datatype datatype,
      * creating a request unnecessarily for messages that are already present
      * and eligible for immediate completion. */
     mpi_errno = MPID_Imrecv(buf, count, datatype, message, rreq);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 fn_exit:
     return mpi_errno;

--- a/src/mpid/ch3/src/mpid_port.c
+++ b/src/mpid/ch3/src/mpid_port.c
@@ -58,9 +58,7 @@ int MPID_Open_port(MPIR_Info *info_ptr, char *port_name)
        those channels will set the function pointer to NULL */
     if (portFns.OpenPort) {
 	mpi_errno = portFns.OpenPort( info_ptr, port_name );
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else {
 	MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**notimpl" );
@@ -103,9 +101,7 @@ int MPID_Close_port(const char *port_name)
        init check above; such a function may be named MPIDI_CH3_Close_port */
     if (portFns.ClosePort) {
 	mpi_errno = portFns.ClosePort( port_name );
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else {
 	MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**notimpl" );
@@ -137,9 +133,7 @@ int MPID_Comm_accept(const char * port_name, MPIR_Info * info, int root,
     if (portFns.CommAccept) {
 	mpi_errno = portFns.CommAccept( port_name, info, root, comm, 
 					newcomm_ptr );
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else {
 	MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**notimpl" );
@@ -171,9 +165,7 @@ int MPID_Comm_connect(const char * port_name, MPIR_Info * info, int root,
     if (portFns.CommConnect) {
 	mpi_errno = portFns.CommConnect( port_name, info, root, comm, 
 					 newcomm_ptr );
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else {
 	MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**notimpl" );

--- a/src/mpid/ch3/src/mpid_probe.c
+++ b/src/mpid/ch3/src/mpid_probe.c
@@ -38,13 +38,13 @@ int MPID_Probe(int source, int tag, MPIR_Comm * comm, int context_offset,
                 if (found) goto fn_exit;
 
                 mpi_errno = MPIDI_Anysource_iprobe_fn(tag, comm, context_offset, &found, status);
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
                 if (found) goto fn_exit;
 
                 MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
                 
                 mpi_errno = MPIDI_CH3_Progress_test();
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } while (1);
         } else {
             /* it's not anysource, see if this is for the netmod */
@@ -58,13 +58,13 @@ int MPID_Probe(int source, int tag, MPIR_Comm * comm, int context_offset,
                     
                     mpi_errno = vc->comm_ops->iprobe(vc, source, tag, comm, context_offset, &found,
                                                      status);
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                     if (found) goto fn_exit;
                     
                     MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
                     
                     mpi_errno = MPIDI_CH3_Progress_test();
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 } while (1);
             }
             /* fall-through to shm case */

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -66,7 +66,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 		MPIDI_Comm_get_vc_set_active(comm, rreq->dev.match.parts.rank, &vc);
         MPIR_ERR_CHKANDJUMP1(vc->state == MPIDI_VC_STATE_MORIBUND, mpi_errno, MPIX_ERR_PROC_FAILED, "**comm_fail", "**comm_fail %d", rreq->dev.match.parts.rank);
 		mpi_errno = MPIDI_CH3_EagerSyncAck( vc, rreq );
-		if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+		MPIR_ERR_CHECK(mpi_errno);
 	    }
 	    
             /* the request was found in the unexpected queue, so it has a
@@ -118,7 +118,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 	    MPIDI_Comm_get_vc_set_active(comm, rreq->dev.match.parts.rank, &vc);
         MPIR_ERR_CHKANDJUMP1(vc->state == MPIDI_VC_STATE_MORIBUND, mpi_errno, MPIX_ERR_PROC_FAILED, "**comm_fail", "**comm_fail %d", rreq->dev.match.parts.rank);
 	    mpi_errno = vc->rndvRecv_fn( vc, rreq );
-	    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+	    MPIR_ERR_CHECK(mpi_errno);
 	    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
 	    {
 		MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
@@ -128,7 +128,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 	else if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_SELF_MSG)
 	{
 	    mpi_errno = MPIDI_CH3_RecvFromSelf( rreq, buf, count, datatype );
-	    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+	    MPIR_ERR_CHECK(mpi_errno);
 	    if (status != MPI_STATUS_IGNORE)
 	    {
 		*status = rreq->status;

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -70,14 +70,12 @@ int MPID_Win_create(void *base, MPI_Aint size, int disp_unit, MPIR_Info * info,
 
     mpi_errno =
         win_init(size, disp_unit, MPI_WIN_FLAVOR_CREATE, MPI_WIN_UNIFIED, info, comm_ptr, win_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*win_ptr)->base = base;
 
     mpi_errno = MPIDI_CH3U_Win_fns.create(base, size, disp_unit, info, comm_ptr, win_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_CREATE);
@@ -96,14 +94,10 @@ int MPID_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info,
     mpi_errno =
         win_init(size, disp_unit, MPI_WIN_FLAVOR_ALLOCATE, MPI_WIN_UNIFIED, info, comm_ptr,
                  win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_CH3U_Win_fns.allocate(size, disp_unit, info, comm_ptr, baseptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_ALLOCATE);
@@ -123,15 +117,12 @@ int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_Win ** 
                          1 /* spec defines disp_unit to be 1 */ ,
                          MPI_WIN_FLAVOR_DYNAMIC, MPI_WIN_UNIFIED, info, comm_ptr, win_ptr);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     (*win_ptr)->base = MPI_BOTTOM;
 
     mpi_errno = MPIDI_CH3U_Win_fns.create_dynamic(info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_CREATE_DYNAMIC);
@@ -180,13 +171,11 @@ int MPID_Win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info * info, MPI
 
     mpi_errno =
         win_init(size, disp_unit, MPI_WIN_FLAVOR_SHARED, MPI_WIN_UNIFIED, info, comm_ptr, win_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIDI_CH3U_Win_fns.allocate_shared(size, disp_unit, info, comm_ptr, base_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_ALLOCATE_SHARED);
@@ -202,9 +191,7 @@ int MPID_Win_shared_query(MPIR_Win * win, int rank, MPI_Aint * size, int *disp_u
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_SHARED_QUERY);
 
     mpi_errno = MPIDI_CH3U_Win_fns.shared_query(win, rank, size, disp_unit, baseptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_SHARED_QUERY);
@@ -240,8 +227,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
                          "**nomem %s", "MPIR_Win_mem");
 
     mpi_errno = MPIR_Comm_dup_impl(comm_ptr, &win_comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Object_set_ref(*win_ptr, 1);
 
@@ -292,8 +278,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
 
     /* Set info_args on window based on info provided by user */
     mpi_errno = MPID_Win_set_info((*win_ptr), info);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_MALLOC((*win_ptr)->op_pool_start, MPIDI_RMA_Op_t *,
                         sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE, mpi_errno,
@@ -338,9 +323,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
         /* this is the first window, register RMA progress hook */
         mpi_errno = MPID_Progress_register_hook(MPIDI_CH3I_RMA_Make_progress_global,
                                                 &MPIDI_CH3I_RMA_Progress_hook_id);
-        if (mpi_errno) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     DL_APPEND(MPIDI_RMA_Win_inactive_list_head, (*win_ptr));
@@ -349,8 +332,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
         mpi_errno =
             MPIDI_CH3U_Win_hooks.win_init(size, disp_unit, create_flavor, model, info, comm_ptr,
                                           win_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -504,7 +504,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
                                       remote_size, 1, MPI_INT,
                                       remote_leader, cts_tag,
                                       peer_comm_ptr, MPI_STATUS_IGNORE, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST, "local size = %d, remote size = %d", local_size,
                                        *remote_size ));
@@ -516,7 +516,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         MPIR_CHKLMEM_MALLOC(local_lpids,int*,local_size*sizeof(int), mpi_errno,"local_lpids", MPL_MEM_DYNAMIC);
 
         mpi_errno = MPIDI_GPID_GetAllInComm( local_comm_ptr, local_size, local_gpids, &singlePG );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Exchange the lpid arrays */
         mpi_errno = MPIC_Sendrecv( local_gpids, local_size*sizeof(MPIDI_Gpid), MPI_BYTE,
@@ -524,16 +524,16 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
                                       remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE,
                                       remote_leader, cts_tag, peer_comm_ptr,
                                       MPI_STATUS_IGNORE, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
 
         /* Convert the remote gpids to the lpids */
         mpi_errno = MPIDI_GPID_ToLpidArray( *remote_size, remote_gpids, *remote_lpids );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Get our own lpids */
         mpi_errno = MPIDI_LPID_GetAllInComm( local_comm_ptr, local_size, local_lpids );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
 #       ifdef HAVE_ERROR_CHECKING
         {
@@ -542,7 +542,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
                 /* Now that we have both the local and remote processes,
                    check for any overlap */
                 mpi_errno = check_disjoint_lpids( local_lpids, local_size, *remote_lpids, *remote_size );
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
             MPID_END_ERROR_CHECKS;
         }
@@ -566,11 +566,11 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         comm_info[1] = *is_low_group;
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"About to bcast on local_comm");
         mpi_errno = MPIR_Bcast( comm_info, 2, MPI_INT, local_leader, local_comm_ptr, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
                                      local_comm_ptr, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER,VERBOSE,"end of bcast on local_comm of size %d",
                        local_comm_ptr->local_size );
@@ -580,14 +580,14 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         /* we're the other processes */
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"About to receive bcast on local_comm");
         mpi_errno = MPIR_Bcast( comm_info, 2, MPI_INT, local_leader, local_comm_ptr, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
         *remote_size = comm_info[0];
         MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids", MPL_MEM_DYNAMIC);
         *remote_lpids = (int*) MPL_malloc((*remote_size)*sizeof(int), MPL_MEM_ADDRESS);
         mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
                                      local_comm_ptr, &errflag );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
 
         /* Extract the context and group sign informatin */
@@ -616,7 +616,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
        group information */
     if (local_comm_ptr->rank != local_leader) {
         mpi_errno = MPIDI_GPID_ToLpidArray( *remote_size, remote_gpids, *remote_lpids );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
 fn_exit:
@@ -753,7 +753,7 @@ int MPIDI_PG_ForwardPGInfo( MPIR_Comm *peer_ptr, MPIR_Comm *comm_ptr,
 
     /* See if everyone is happy */
     mpi_errno = MPIR_Allreduce( MPI_IN_PLACE, &allfound, 1, MPI_INT, MPI_LAND, comm_ptr, &errflag );
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_ERR_CHKANDJUMP(errflag, mpi_errno, MPI_ERR_OTHER, "**coll_fail");
     
     if (allfound) return MPI_SUCCESS;
@@ -852,7 +852,7 @@ int MPIDI_Populate_vc_node_ids(MPIDI_PG_t *pg, int our_pg_rank)
     out_nodemap = (int *) MPL_malloc(pg->size * sizeof(int), MPL_MEM_ADDRESS);
 
     mpi_errno = MPIR_NODEMAP_build_nodemap(pg->size, our_pg_rank, out_nodemap, &g_max_node_id);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(g_max_node_id >= 0);
 
     for (i = 0; i < pg->size; i++) {

--- a/src/mpid/ch3/src/mpidi_isend_self.c
+++ b/src/mpid/ch3/src/mpidi_isend_self.c
@@ -90,14 +90,10 @@ int MPIDI_Isend_self(const void * buf, MPI_Aint count, MPI_Datatype datatype, in
 			       rreq->dev.user_buf, rreq->dev.user_count, rreq->dev.datatype, &data_sz, &rreq->status.MPI_ERROR);
 	MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
         mpi_errno = MPID_Request_complete(rreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Request_complete(sreq);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else
     {
@@ -134,9 +130,7 @@ int MPIDI_Isend_self(const void * buf, MPI_Aint count, MPI_Datatype datatype, in
 	    
 	    /* sreq has never been seen by the user or outside this thread, so it is safe to reset ref_count and cc */
             mpi_errno = MPID_Request_complete(sreq);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 	    /* --END ERROR HANDLING-- */
 	}
 	    

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -449,7 +449,7 @@ int MPIDI_PG_Create_from_string(const char * str, MPIDI_PG_t ** pg_pptr,
        it to the find routine */
     /* printf( "Looking for pg with id %s\n", str );fflush(stdout); */
     mpi_errno = MPIDI_PG_Find((void *)str, &existing_pg);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (existing_pg != NULL) {
 	/* return the existing PG */
@@ -467,9 +467,7 @@ int MPIDI_PG_Create_from_string(const char * str, MPIDI_PG_t ** pg_pptr,
     vct_sz = atoi(p);
 
     mpi_errno = MPIDI_PG_Create(vct_sz, (void *)str, pg_pptr);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     
     pg_ptr = *pg_pptr;
     pg_ptr->id = MPL_strdup( str );
@@ -552,10 +550,10 @@ int MPIDI_PG_SetConnInfo( int rank, const char *connString )
     MPIR_ERR_CHKANDJUMP1(len < 0 || len > sizeof(key), mpi_errno, MPI_ERR_OTHER, "**snprintf", "**snprintf %d", len);
 
     mpi_errno = PMI2_KVS_Put(key, connString);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = PMI2_KVS_Fence();
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PG_SetConnInfo);
@@ -640,7 +638,7 @@ static int getConnInfoKVS( int rank, char *buf, int bufsize, MPIDI_PG_t *pg )
     if (mpi_errno) {
 	MPIDI_PG_CheckForSingleton();
 	mpi_errno = PMI2_KVS_Get(pg->connData, PMI2_ID_NULL, key, buf, bufsize, &vallen);
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
  fn_exit:
     return mpi_errno;
@@ -778,7 +776,7 @@ int MPIDI_PG_InitConnKVS( MPIDI_PG_t *pg )
     }
     
     mpi_errno = PMI2_Job_GetId(pg->connData, MAX_JOBID_LEN);
-    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     int pmi_errno, kvs_name_sz;
     int mpi_errno = MPI_SUCCESS;
@@ -1129,7 +1127,7 @@ int MPIDI_PG_Close_VCs( void )
 	    if (vc->state == MPIDI_VC_STATE_ACTIVE ||
 		vc->state == MPIDI_VC_STATE_REMOTE_CLOSE) {
 		mpi_errno = MPIDI_CH3U_VC_SendClose( vc, i );
-                if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 	    } else if (vc->state == MPIDI_VC_STATE_INACTIVE ||
                        vc->state == MPIDI_VC_STATE_MORIBUND) {
                 /* XXX DJG FIXME-MT should we be checking this? */

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -162,19 +162,16 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
            (*win_ptr)->target_lock_queue_head != NULL ||
            (*win_ptr)->current_target_lock_data_bytes != 0 || (*win_ptr)->sync_request_cnt != 0) {
         mpi_errno = wait_progress_engine();
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     mpi_errno = MPIR_Barrier((*win_ptr)->comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Free window resources in lower layer. */
     if (MPIDI_CH3U_Win_hooks.win_free != NULL) {
         mpi_errno = MPIDI_CH3U_Win_hooks.win_free(win_ptr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* dequeue window from the global list */
@@ -184,15 +181,12 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
     if (MPIDI_RMA_Win_inactive_list_head == NULL && MPIDI_RMA_Win_active_list_head == NULL) {
         /* this is the last window, de-register RMA progress hook */
         mpi_errno = MPID_Progress_deregister_hook(MPIDI_CH3I_RMA_Progress_hook_id);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     comm_ptr = (*win_ptr)->comm_ptr;
     mpi_errno = MPIR_Comm_free_impl(comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPL_free((*win_ptr)->basic_info_table);
     MPL_free((*win_ptr)->op_pool_start);

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -223,9 +223,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
     mpi_errno = MPIDI_CH3I_Sock_get_conninfo_from_bc( port_name, host_description,
 						 sizeof(host_description),
 						 &port, &ifaddr, &hasIfaddr );
-    if (mpi_errno) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIDI_GetTagFromPort(port_name, &port_name_tag);
     if (mpi_errno != MPL_STR_SUCCESS) {
 	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**argstr_port_name_tag");
@@ -234,9 +232,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
     MPL_DBG_MSG_D(MPIDI_CH3_DBG_CONNECT,VERBOSE,"port tag %d",port_name_tag);
 
     mpi_errno = MPIDI_CH3I_Connection_alloc(&conn);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* conn->pg_id is not used for this conection */
 
@@ -523,9 +519,7 @@ int MPIDI_CH3_Sockconn_handle_accept_event( void )
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_SOCKCONN_HANDLE_ACCEPT_EVENT);
     
     mpi_errno = MPIDI_CH3I_Connection_alloc(&conn);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIDI_CH3I_Sock_accept(MPIDI_CH3I_listener_conn->sock,
 				  MPIDI_CH3I_sock_set, conn, &conn->sock);
     if (mpi_errno != MPI_SUCCESS) {
@@ -539,9 +533,7 @@ int MPIDI_CH3_Sockconn_handle_accept_event( void )
     conn->recv_active = NULL;
     
     mpi_errno = connection_post_recv_pkt(conn);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3_SOCKCONN_HANDLE_ACCEPT_EVENT);
@@ -648,7 +640,7 @@ int MPIDI_CH3_Sockconn_handle_close_event( MPIDI_CH3I_Connection_t * conn )
 
                     /* Handle_connection takes care of updating the state on the VC */
                     mpi_errno = MPIDI_CH3U_Handle_connection(conn->vc, MPIDI_VC_EVENT_TERMINATED);
-                    if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             }
 
@@ -661,9 +653,7 @@ int MPIDI_CH3_Sockconn_handle_close_event( MPIDI_CH3I_Connection_t * conn )
             MPL_DBG_MSG(MPIDI_CH3_DBG_DISCONNECT,TYPICAL,"CLosing sock (Post_close)");
             conn->state = CONN_STATE_CLOSING;
             mpi_errno = MPIDI_CH3I_Sock_post_close(conn->sock);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-	    }
+	    MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         }
 	else {
@@ -706,9 +696,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
 	mpi_errno = MPIDI_CH3I_Sock_post_read(conn->sock, conn->pg_id,
 					 openpkt->pg_id_len, 
 					 openpkt->pg_id_len, NULL);   
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else if (conn->pkt.type == MPIDI_CH3I_PKT_SC_CONN_ACCEPT) {
 	MPIDI_VC_t *vc; 
@@ -770,9 +758,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
 	    MPIR_Assert(vcch->sock == conn->sock);
 	    
 	    mpi_errno = connection_post_recv_pkt(conn);
-	    if (mpi_errno != MPI_SUCCESS) {
-		MPIR_ERR_POP(mpi_errno);
-	    }
+	    MPIR_ERR_CHECK(mpi_errno);
 	    mpi_errno = connection_post_sendq_req(conn);
 	    if (mpi_errno != MPI_SUCCESS) {
 		MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_INTERN,
@@ -811,9 +797,7 @@ int MPIDI_CH3_Sockconn_handle_conn_event( MPIDI_CH3I_Connection_t * conn )
                socket set, so no more polling on this socket*/
 	    MPL_DBG_MSG(MPIDI_CH3_DBG_DISCONNECT,TYPICAL,"CLosing sock (Post_close)");
 	    mpi_errno = MPIDI_CH3I_Sock_post_close(conn->sock);
-	    if (mpi_errno != MPI_SUCCESS) {
-		MPIR_ERR_POP(mpi_errno);
-	    }
+	    MPIR_ERR_CHECK(mpi_errno);
 	}
     }
     /* --BEGIN ERROR HANDLING-- */
@@ -979,9 +963,7 @@ int MPIDI_CH3_Sockconn_handle_connwrite( MPIDI_CH3I_Connection_t * conn )
             conn->state = CONN_STATE_OPEN_CRECV;
         }
 	mpi_errno = connection_post_recv_pkt(conn);
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     else if (conn->state == CONN_STATE_OPEN_LSEND) {
 	MPIDI_CH3I_Pkt_sc_open_resp_t *openresp = 
@@ -995,9 +977,7 @@ int MPIDI_CH3_Sockconn_handle_connwrite( MPIDI_CH3I_Connection_t * conn )
 	    MPL_DBG_VCCHSTATECHANGE(conn->vc,VC_STATE_CONNECTED);
 	    vcch->state = MPIDI_CH3I_VC_STATE_CONNECTED;
 	    mpi_errno = connection_post_recv_pkt(conn);
-	    if (mpi_errno != MPI_SUCCESS) {
-		MPIR_ERR_POP(mpi_errno);
-	    }
+	    MPIR_ERR_CHECK(mpi_errno);
 	    
 	    mpi_errno = connection_post_sendq_req(conn);
 	    if (mpi_errno != MPI_SUCCESS) {
@@ -1080,9 +1060,7 @@ int MPIDI_CH3I_VC_post_sockconnect(MPIDI_VC_t * vc)
          goto fn_exit;
     }
     mpi_errno = MPIDI_PG_GetConnString( vc->pg, vc->pg_rank, val, sizeof(val));
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_CH3I_Sock_connect( vc, val, sizeof(val) );
 
@@ -1137,9 +1115,7 @@ int MPIDI_CH3I_Sock_connect( MPIDI_VC_t *vc, const char val[], int vallen )
     mpi_errno = MPIDI_CH3I_Sock_get_conninfo_from_bc( val, host_description,
 						 sizeof(host_description),
 						 &port, &ifaddr, &hasIfaddr );
-    if (mpi_errno) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_CH3I_Connection_alloc(&conn);
     if (mpi_errno == MPI_SUCCESS)
@@ -1213,9 +1189,7 @@ static int connection_post_recv_pkt(MPIDI_CH3I_Connection_t * conn)
 
     mpi_errno = MPIDI_CH3I_Sock_post_read(conn->sock, &conn->pkt, sizeof(conn->pkt),
 				     sizeof(conn->pkt), NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
  fn_fail:    
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CONNECTION_POST_RECV_PKT);
@@ -1233,9 +1207,7 @@ static int connection_post_send_pkt(MPIDI_CH3I_Connection_t * conn)
     MPL_DBG_PKT(conn,&conn->pkt,"connect");
     mpi_errno = MPIDI_CH3I_Sock_post_write(conn->sock, &conn->pkt, sizeof(conn->pkt),
 				      sizeof(conn->pkt), NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     
  fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CONNECTION_POST_SEND_PKT);
@@ -1257,9 +1229,7 @@ static int connection_post_send_pkt_and_pgid(MPIDI_CH3I_Connection_t * conn)
 
     MPL_DBG_PKT(conn,&conn->pkt,"connect-pgid");
     mpi_errno = MPIDI_CH3I_Sock_post_writev(conn->sock, conn->iov, 2, NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     
  fn_fail:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CONNECTION_POST_SEND_PKT_AND_PGID);
@@ -1284,9 +1254,7 @@ static int connection_post_sendq_req(MPIDI_CH3I_Connection_t * conn)
 					   conn->send_active->dev.iov, 
 					   conn->send_active->dev.iov_count, 
 					   NULL);
-	if (mpi_errno != MPI_SUCCESS) {
-	    MPIR_ERR_POP(mpi_errno);
-	}
+	MPIR_ERR_CHECK(mpi_errno);
     }
     
  fn_fail:

--- a/src/mpid/ch3/util/sock/ch3u_getinterfaces.c
+++ b/src/mpid/ch3/util/sock/ch3u_getinterfaces.c
@@ -104,7 +104,7 @@ int MPIDU_CH3U_GetSockInterfaceAddr( int myRank, char *ifname, int maxIfname,
 
 	/* If we have nothing, then use the host name */
 	mpi_errno = MPID_Get_processor_name(ifname, maxIfname, &len );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 	ifname_string = ifname;
 
 	/* If we didn't find a specific name, then try to get an IP address
@@ -112,7 +112,7 @@ int MPIDU_CH3U_GetSockInterfaceAddr( int myRank, char *ifname, int maxIfname,
 	   this platform.  Otherwise, we'll drop into the next step that uses 
 	   the ifname */
 	mpi_errno = MPIDI_CH3U_GetIPInterface( ifaddr, &ifaddrFound );
-        if (mpi_errno) MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     else {
 	/* Copy this name into the output name */

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -51,187 +51,147 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vcis)
     MPIR_Assert(MPIDI_global.buf_pool);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SEND, &MPIDIG_send_origin_cb, &MPIDIG_send_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_REQ, NULL /* Injection only */ ,
                                  &MPIDIG_send_long_req_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_ACK, NULL /* Injection only */ ,
                                  &MPIDIG_send_long_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SEND_LONG_LMT,
                                  &MPIDIG_send_long_lmt_origin_cb,
                                  &MPIDIG_send_long_lmt_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SSEND_REQ,
                                  &MPIDIG_send_origin_cb, &MPIDIG_ssend_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_SSEND_ACK,
                                  &MPIDIG_ssend_ack_origin_cb, &MPIDIG_ssend_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_PUT_REQ, &MPIDIG_put_origin_cb, &MPIDIG_put_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_PUT_ACK, NULL, &MPIDIG_put_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_REQ, &MPIDIG_get_origin_cb, &MPIDIG_get_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACK,
                                  &MPIDIG_get_ack_origin_cb, &MPIDIG_get_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_CSWAP_REQ,
                                  &MPIDIG_cswap_origin_cb, &MPIDIG_cswap_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_CSWAP_ACK,
                                  &MPIDIG_cswap_ack_origin_cb, &MPIDIG_cswap_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_ACC_REQ, &MPIDIG_acc_origin_cb, &MPIDIG_acc_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACC_REQ,
                                  &MPIDIG_get_acc_origin_cb, &MPIDIG_get_acc_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_ACC_ACK, NULL, &MPIDIG_acc_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACC_ACK,
                                  &MPIDIG_get_acc_ack_origin_cb, &MPIDIG_get_acc_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_COMPLETE, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_POST, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_LOCK_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCK_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_LOCKALL_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_WIN_UNLOCKALL_ACK, NULL, &MPIDIG_win_ctrl_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_PUT_IOV_REQ,
                                  &MPIDIG_put_iov_origin_cb, &MPIDIG_put_iov_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_PUT_IOV_ACK, NULL, &MPIDIG_put_iov_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_PUT_DAT_REQ,
                                  &MPIDIG_put_data_origin_cb, &MPIDIG_put_data_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_ACC_IOV_REQ,
                                  &MPIDIG_acc_iov_origin_cb, &MPIDIG_acc_iov_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACC_IOV_REQ,
                                  &MPIDIG_get_acc_iov_origin_cb, &MPIDIG_get_acc_iov_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_ACC_IOV_ACK, NULL, &MPIDIG_acc_iov_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACC_IOV_ACK,
                                  NULL, &MPIDIG_get_acc_iov_ack_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_ACC_DAT_REQ,
                                  &MPIDIG_acc_data_origin_cb, &MPIDIG_acc_data_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_GET_ACC_DAT_REQ,
                                  &MPIDIG_get_acc_data_origin_cb,
                                  &MPIDIG_get_acc_data_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_COMM_ABORT,
                                  &MPIDIG_comm_abort_origin_cb, &MPIDIG_comm_abort_target_msg_cb);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     mpi_errno = MPIDIG_init_comm(comm_world);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_init_comm(comm_self);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIU_map_create((void **) &(MPIDI_global.win_map), MPL_MEM_RMA);
 
     mpi_errno = MPIDIG_RMA_Init_sync_pvars();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_RMA_Init_targetcb_pvars();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDI_global.is_ch4u_initialized = 1;
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_INIT);

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -104,8 +104,7 @@ static inline int MPIDIG_handle_unexpected(void *buf, MPI_Aint count, MPI_Dataty
      * matched. */
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
         mpi_errno = MPIDIG_reply_ssend(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     /* Decrement the refrence counter for the request object (for the reference held by the sending
@@ -158,15 +157,13 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
             else
                 mpi_errno = MPIDI_NM_am_recv(unexp_req);
 #endif
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         } else {
             *request = unexp_req;
             mpi_errno =
                 MPIDIG_handle_unexpected(buf, count, datatype, root_comm, context_id, unexp_req);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         }
     }
@@ -186,8 +183,7 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
 
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     mpi_errno = MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 
     if (!unexp_req) {
@@ -223,8 +219,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_recv(void *buf,
 
     mpi_errno =
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_RECV);
@@ -264,8 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
 #endif
     } else {
         mpi_errno = MPIDIG_handle_unexp_mrecv(message);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     /* MPIDI_CS_EXIT(); */
 
@@ -290,8 +284,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
 
     mpi_errno =
         MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, request, 1, 0ULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IRECV);
     return mpi_errno;

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -93,8 +93,7 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
         }
     }
 #endif
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_AM_ISEND_IMPL);
@@ -119,8 +118,7 @@ static inline int MPIDIG_isend_coll_impl(const void *buf, MPI_Aint count, MPI_Da
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, is_blocking, type, *errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_AM_ISEND_COLL);
@@ -142,8 +140,7 @@ static inline int MPIDIG_am_isend(const void *buf, MPI_Aint count, MPI_Datatype 
 
     mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                   request, is_blocking, type, MPI_SUCCESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_AM_ISEND);

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -120,8 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Waitall(int count, MPIR_Request * request_ptrs
     mpi_errno = MPIR_Waitall_impl(count, request_ptrs, array_of_statuses, request_properties);
 
     MPIR_Thread_sync_free(sync);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -150,8 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Wait(MPIR_Request * request_ptr, MPI_Status * 
     mpi_errno = MPIR_Wait_impl(request_ptr, status);
 
     MPIR_Thread_sync_free(sync);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -137,8 +137,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
     mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
@@ -159,8 +158,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
                                     am_hdr, am_hdr_sz);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
@@ -184,8 +182,7 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
         MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(req, context_id),
                                    MPIDIG_REQUEST(req, rank), MPIDIG_SEND_LONG_ACK, &msg,
                                    sizeof(msg));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_RECV);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -284,8 +284,7 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
     MPIDI_OFI_am_clear_request(rreq);
     mpi_errno = MPIDI_OFI_am_init_request(NULL, 0, rreq);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_cc_incr(rreq->cc_ptr, &c);
 
@@ -378,8 +377,7 @@ static inline int MPIDI_OFI_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr)
     lmt_msg = (MPIDI_OFI_lmt_msg_payload_t *) ((char *) msg_hdr->payload + msg_hdr->am_hdr_sz);
     mpi_errno = MPIDI_OFI_do_handle_long_am(msg_hdr, lmt_msg, msg_hdr->payload);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_HANDLE_LONG_AM);
@@ -414,8 +412,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */
     mpi_errno = MPIDIG_global.origin_cbs[handler_id] (sreq);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_HANDLE_LMT_ACK);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -211,8 +211,7 @@ static inline int MPIDI_OFI_do_am_isend_header(int rank,
     MPIDI_OFI_AMREQUEST(sreq, req_hdr) = NULL;
     mpi_errno = MPIDI_OFI_am_init_request(am_hdr, am_hdr_sz, sreq);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(handler_id < (1 << MPIDI_OFI_AM_HANDLER_ID_BITS));
     MPIR_Assert(am_hdr_sz < (1ULL << MPIDI_OFI_AM_HDR_SZ_BITS));
@@ -419,22 +418,19 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
         MPIDIG_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_REQ,
                                          &lreq_hdr, sizeof(lreq_hdr));
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
     MPIDI_OFI_AMREQUEST(sreq, req_hdr) = NULL;
     mpi_errno = MPIDI_OFI_am_init_request(am_hdr, am_hdr_sz, sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!dt_contig) {
         send_buf = (char *) MPL_malloc(data_sz, MPL_MEM_BUFFER);
 
         mpi_errno = MPIR_Typerep_pack(buf, count, datatype, 0, send_buf, data_sz, &last);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer) = send_buf;
     } else {
@@ -450,8 +446,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
             MPIDI_OFI_am_isend_long(rank, comm, handler_id, MPIDI_OFI_AMREQUEST_HDR(sreq, am_hdr),
                                     am_hdr_sz, send_buf, data_sz, sreq);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_AM_ISEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -71,7 +71,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
                                    fi_strerror(-_ret));                 \
             mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vci_idx */);    \
             if (mpi_errno != MPI_SUCCESS)                                \
-                MPIR_ERR_POP(mpi_errno);                                \
+                MPIR_ERR_CHECK(mpi_errno);                               \
         } while (_ret == -FI_EAGAIN);                                   \
     } while (0)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -37,8 +37,7 @@ static inline int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * errfla
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_BARRIER);
 
@@ -81,8 +80,7 @@ static inline int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Datatype datat
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_BCAST);
 
@@ -123,8 +121,7 @@ static inline int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf, int
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
 
@@ -173,8 +170,7 @@ static inline int MPIDI_NM_mpi_allgather(const void *sendbuf, int sendcount, MPI
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLGATHER);
 
@@ -224,8 +220,7 @@ static inline int MPIDI_NM_mpi_allgatherv(const void *sendbuf, int sendcount, MP
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLGATHERV);
 
@@ -262,8 +257,7 @@ static inline int MPIDI_NM_mpi_gather(const void *sendbuf, int sendcount, MPI_Da
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_GATHER);
 
@@ -302,8 +296,7 @@ static inline int MPIDI_NM_mpi_gatherv(const void *sendbuf, int sendcount, MPI_D
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_GATHERV);
 
@@ -341,8 +334,7 @@ static inline int MPIDI_NM_mpi_scatter(const void *sendbuf, int sendcount, MPI_D
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SCATTER);
 
@@ -381,8 +373,7 @@ static inline int MPIDI_NM_mpi_scatterv(const void *sendbuf, const int *sendcoun
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SCATTERV);
 
@@ -436,8 +427,7 @@ static inline int MPIDI_NM_mpi_alltoall(const void *sendbuf, int sendcount, MPI_
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLTOALL);
 
@@ -486,8 +476,7 @@ static inline int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const int *sendcou
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLTOALLV);
 
@@ -536,8 +525,7 @@ static inline int MPIDI_NM_mpi_alltoallw(const void *sendbuf, const int sendcoun
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ALLTOALLW);
 
@@ -579,8 +567,7 @@ static inline int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, int co
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_REDUCE);
 
@@ -633,8 +620,7 @@ static inline int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_REDUCE_SCATTER);
 
@@ -688,8 +674,7 @@ static inline int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *r
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_REDUCE_SCATTER_BLOCK);
 
@@ -725,8 +710,7 @@ static inline int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, int coun
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SCAN);
 
@@ -762,8 +746,7 @@ static inline int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, int co
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_EXSCAN);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -500,8 +500,7 @@ static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_AM_ISEND_EVENT);
@@ -532,8 +531,7 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
                          "Enqueueing it to the queue.\n",
                          expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
         mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(am_hdr);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -545,32 +543,28 @@ static int am_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         case MPIDI_AMTYPE_SHORT_HDR:
             mpi_errno = MPIDI_OFI_handle_short_am_hdr(am_hdr, am_hdr->payload);
 
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             break;
 
         case MPIDI_AMTYPE_SHORT:
             mpi_errno = MPIDI_OFI_handle_short_am(am_hdr);
 
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             break;
 
         case MPIDI_AMTYPE_LMT_REQ:
             mpi_errno = MPIDI_OFI_handle_long_am(am_hdr);
 
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             break;
 
         case MPIDI_AMTYPE_LMT_ACK:
             mpi_errno = MPIDI_OFI_handle_lmt_ack(am_hdr);
 
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             break;
 
@@ -620,8 +614,7 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
                                        MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).sreq_ptr,
                                        MPIDI_AMTYPE_LMT_ACK);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_Request_complete(rreq);        /* FIXME: Should not call MPIDI in NM ? */
     ofi_req->req_hdr->target_cmpl_cb(rreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -53,7 +53,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
 #define MPIDI_OFI_PROGRESS()                                      \
     do {                                                          \
         mpi_errno = MPIDI_OFI_progress(0, 0);                     \
-        if (mpi_errno!=MPI_SUCCESS) MPIR_ERR_POP(mpi_errno);      \
+        MPIR_ERR_CHECK(mpi_errno);                                \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
     } while (0)
 
@@ -102,8 +102,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
         mpi_errno = MPIDI_OFI_retry_progress();                      \
         MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);        \
-        if (mpi_errno != MPI_SUCCESS)                                \
-            MPIR_ERR_POP(mpi_errno);                                 \
+        MPIR_ERR_CHECK(mpi_errno);                               \
         _retry--;                                           \
     } while (_ret == -FI_EAGAIN);                           \
     } while (0)
@@ -132,7 +131,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
   do                                                                 \
     {                                                                \
       mpi_errno = FUNC;                                              \
-      if (unlikely(mpi_errno!=MPI_SUCCESS)) MPIR_ERR_POP(mpi_errno); \
+      MPIR_ERR_CHECK(mpi_errno); \
     } while (0)
 
 #define MPIDI_OFI_STR_CALL(FUNC,STR)                                   \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -670,8 +670,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 
     /* Print some debugging output to give the user some hints */
     mpi_errno = application_hints(rank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDI_OFI_global.prov_use = fi_dupinfo(prov_use);
     MPIR_Assert(MPIDI_OFI_global.prov_use);
@@ -867,8 +866,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
                                           &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
                                           TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, NULL);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* -------------------------------- */
         /* Table is constructed.  Map it    */
@@ -923,8 +921,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* Initialize Active Message          */
     /* ---------------------------------- */
     mpi_errno = MPIDIG_init(comm_world, comm_self, *n_vcis_provided);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDI_OFI_ENABLE_AM) {
         /* Maximum possible message size for short message send (=eager send)
@@ -992,8 +989,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 #endif
 
     mpi_errno = MPIR_Comm_register_hint("eagain", set_eagain, NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
 

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -188,9 +188,7 @@ static int dynproc_create_intercomm(const char *port_name, int remote_size, int 
 
     /* set mapping for remote group */
     mpi_errno = MPIDIU_alloc_mlut(&mlut, remote_size);
-    if (mpi_errno) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     MPIDI_COMM(tmp_comm_ptr, map).mode = MPIDI_RANK_MAP_MLUT;
     MPIDI_COMM(tmp_comm_ptr, map).size = remote_size;
     MPIDI_COMM(tmp_comm_ptr, map).avtid = -1;
@@ -261,8 +259,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
                             FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA), trecv);
             do {
                 mpi_errno = MPID_Progress_test();
-                if (mpi_errno != MPI_SUCCESS)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 MPID_Wtime(&time_now);
                 MPID_Wtime_diff(&time_sta, &time_now, &time_gap);
@@ -290,8 +287,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
         MPID_Wtime(&time_sta);
         do {
             mpi_errno = MPID_Progress_test();
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPID_Wtime(&time_now);
             MPID_Wtime_diff(&time_sta, &time_now, &time_gap);
@@ -579,8 +575,7 @@ int MPIDI_OFI_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root
         if (mpi_errno == MPI_ERR_PORT || mpi_errno == MPI_SUCCESS) {
             root_errno = mpi_errno;
             mpi_errno = MPIR_Bcast_intra_auto(&root_errno, 1, MPI_INT, root, comm_ptr, &errflag);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             if (root_errno != MPI_SUCCESS) {
                 mpi_errno = root_errno;
                 MPIR_ERR_POP(mpi_errno);
@@ -603,8 +598,7 @@ int MPIDI_OFI_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root
 
     if (rank != root) {
         mpi_errno = MPIR_Bcast_intra_auto(&root_errno, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (root_errno != MPI_SUCCESS) {
             mpi_errno = root_errno;
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -208,8 +208,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0,
                                MPI_DATATYPE_NULL,
                                winfo, sizeof(*winfo), MPI_BYTE, comm_ptr, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
         first = winfo[0].disp_unit;
@@ -712,12 +711,10 @@ int MPIDI_OFI_mpi_win_allocate_hook(MPIR_Win * win)
     /* This hook is called by CH4 generic call after CH4 initialization */
     if (MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = win_init(win);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -737,12 +734,10 @@ int MPIDI_OFI_mpi_win_allocate_shared_hook(MPIR_Win * win)
     /* This hook is called by CH4 generic call after CH4 initialization */
     if (MPIDI_OFI_ENABLE_RMA) {
         mpi_errno = win_init(win);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -767,12 +762,10 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
         win->size = (uintptr_t) UINTPTR_MAX - (uintptr_t) MPI_BOTTOM;
 
         mpi_errno = win_init(win);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = win_allgather(win, win->base, win->disp_unit);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -92,8 +92,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         MPIDIG_REQUEST(sreq, rank) = rank;
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_REQ,
                                          &lreq_hdr, sizeof(lreq_hdr));
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -120,8 +119,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         mpi_errno =
             MPIR_Typerep_pack(data, count, datatype, 0, send_buf + am_hdr_sz + sizeof(ucx_hdr),
                               data_sz, &actual_pack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
     }
 
@@ -203,8 +201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
         mpi_errno =
             MPIR_Typerep_pack(data, count, datatype, 0, send_buf + sizeof(ucx_hdr) + am_hdr_sz,
                               data_sz, &actual_pack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
     }
     ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
@@ -280,8 +277,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
         mpi_errno =
             MPIR_Typerep_pack(data, count, datatype, 0, send_buf + am_hdr_sz + sizeof(ucx_hdr),
                               data_sz, &actual_pack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
     }
     ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
@@ -432,8 +428,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req)
     mpi_errno = MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(req, context_id),
                                            MPIDIG_REQUEST(req, rank), MPIDIG_SEND_LONG_ACK, &msg,
                                            sizeof(msg));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_RECV);

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -106,7 +106,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_source(uint64_t match_bits)
 #define MPIDI_UCX_MPI_ERROR(_errno)                                     \
     do                                                                  \
     {                                                                   \
-        if (unlikely(_errno!=MPI_SUCCESS)) MPIR_ERR_POP(mpi_errno);     \
+        MPIR_ERR_CHECK(mpi_errno);                                      \
     } while (0)
 
 #define MPIDI_UCX_STR_ERRCHK(_errno)                            \

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -76,8 +76,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                               (int) MPIDI_UCX_global.addrname_len, FALSE,
                               MPIR_CVAR_CH4_ROOTS_ONLY_PMI,
                               (void **) &MPIDI_UCX_global.pmi_addr_table, &bc_indices);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
         int *node_roots, num_nodes;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -112,8 +112,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
     MPI_Aint actual_pack_bytes;
     mpi_errno = MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype, 0, buffer, size,
                                   &actual_pack_bytes);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(actual_pack_bytes == size);
 
     base = win_info->addr;
@@ -395,8 +394,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rput(const void *origin_addr,
         mpi_errno = MPIDI_UCX_do_put(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype,
                                      win, addr, &sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (sreq == NULL) {
             /* create a completed request for user if issuing is completed immediately. */
@@ -501,8 +499,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_rget(void *origin_addr,
         mpi_errno = MPIDI_UCX_do_get(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype,
                                      win, addr, &sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (sreq == NULL) {
             /* create a completed request for user if issuing is completed immediately. */

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -76,8 +76,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     rkey_sizes[comm_ptr->rank] = (int) rkey_size;
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 1, MPI_INT, rkey_sizes, 1, MPI_INT, comm_ptr, &err);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     recv_disps = (int *) MPL_malloc(sizeof(int) * comm_ptr->local_size, MPL_MEM_OTHER);
 
@@ -93,8 +92,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     mpi_errno = MPIR_Allgatherv(rkey_buffer, rkey_size, MPI_BYTE,
                                 rkey_recv_buff, rkey_sizes, recv_disps, MPI_BYTE, comm_ptr, &err);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* If we use the shared memory support in UCX, we have to distinguish between local
      * and remote windows (at least now). If win_create is used, the key cannot be unpackt -
@@ -123,8 +121,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     mpi_errno =
         MPIR_Allgather(MPI_IN_PLACE, sizeof(struct ucx_share), MPI_BYTE, share_data,
                        sizeof(struct ucx_share), MPI_BYTE, comm_ptr, &err);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (i = 0; i < comm_ptr->local_size; i++) {
         MPIDI_UCX_WIN_INFO(win, i).disp = share_data[i].disp;

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
@@ -76,16 +76,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     mpi_errno =
         MPIDU_shm_seg_alloc(MPIDI_POSIX_global.num_local * MPIDI_POSIX_global.num_local *
                             sizeof(MPIDI_POSIX_fastbox_t), (void **) &fastboxes_p, MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Actually allocate the segment and assign regions to the pointers */
     mpi_errno = MPIDU_shm_seg_commit(&MPIDI_POSIX_eager_fbox_control_global.memory,
                                      &MPIDI_POSIX_global.barrier,
                                      MPIDI_POSIX_global.num_local, MPIDI_POSIX_global.my_local_rank,
                                      MPIDI_POSIX_global.local_rank_0, rank, MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Allocate table of pointers to fastboxes */
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.mailboxes.in,
@@ -109,8 +107,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     }
 
     mpi_errno = MPIDU_shm_barrier(MPIDI_POSIX_global.barrier, MPIDI_POSIX_global.num_local);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_COMMIT();
 
@@ -133,8 +130,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_finalize()
 
     mpi_errno = MPIDU_shm_barrier(MPIDI_POSIX_global.barrier, MPIDI_POSIX_global.num_local);
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPL_free(MPIDI_POSIX_eager_fbox_control_global.seg);
     MPL_free(MPIDI_POSIX_eager_fbox_control_global.mailboxes.in);

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -37,8 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
 
         mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz,
                                                 &MPIDI_POSIX_AMREQUEST(sreq, req_hdr), sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
     }
@@ -132,8 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         /* Prepare private storage with information about the pack buffer. */
         mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz,
                                                 &MPIDI_POSIX_AMREQUEST(sreq, req_hdr), sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         curr_sreq_hdr = MPIDI_POSIX_AMREQUEST(sreq, req_hdr);
 
@@ -146,8 +144,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         mpi_errno = MPIR_Typerep_pack(data, count, datatype, 0,
                                       MPIDI_POSIX_AMREQUEST_HDR(sreq, pack_buffer),
                                       data_sz, &actual_pack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
 
         send_buf = (uint8_t *) curr_sreq_hdr->pack_buffer;
@@ -173,8 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
                                                    msg_hdr_p, iov_left_ptr, iov_num_left, data_sz,
                                                    sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         goto fn_exit;
     }
@@ -197,8 +193,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
         mpi_errno = MPIDI_POSIX_am_enqueue_request(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
                                                    msg_hdr_p, iov_left_ptr, iov_num_left, data_sz,
                                                    sreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         goto fn_exit;
     }
@@ -211,8 +206,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     }
 
     mpi_errno = MPIDIG_global.origin_cbs[handler_id] (sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POSIX_AM_ISEND);
@@ -321,8 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, 
 
     /* Prepare private storage */
     mpi_errno = MPIDI_POSIX_am_init_req_hdr(am_hdr, am_hdr_sz, &curr_sreq_hdr, NULL);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     curr_sreq_hdr->handler_id = handler_id;
     curr_sreq_hdr->dst_grank = grank;
@@ -374,8 +367,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
     if (unlikely(MPIDI_POSIX_global.postponed_queue)) {
         mpi_errno = MPIDI_POSIX_am_enqueue_req_hdr(am_hdr, am_hdr_sz, handler_id, grank, msg_hdr,
                                                    iov_num_left);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
 
         POSIX_TRACE("Direct OUT HDR [ POSIX AM HDR [handler_id %" PRIu64 ", am_hdr_sz %" PRIu64
@@ -440,8 +432,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_recv(MPIR_Request * req)
     mpi_errno = MPIDI_POSIX_am_send_hdr_reply(MPIDIG_REQUEST(req, context_id),
                                               MPIDIG_REQUEST(req, rank), MPIDIG_SEND_LONG_ACK, &msg,
                                               sizeof(msg));
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POSIX_AM_RECV);

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -41,8 +41,7 @@ static inline int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * err
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_BARRIER);
 
@@ -97,8 +96,7 @@ static inline int MPIDI_POSIX_mpi_bcast(void *buffer, int count, MPI_Datatype da
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_BCAST);
 
@@ -150,8 +148,7 @@ static inline int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void *recvbuf, 
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLREDUCE);
 
@@ -201,8 +198,7 @@ static inline int MPIDI_POSIX_mpi_allgather(const void *sendbuf, int sendcount,
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLGATHER);
 
@@ -253,8 +249,7 @@ static inline int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, int sendcount,
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLGATHERV);
 
@@ -291,8 +286,7 @@ static inline int MPIDI_POSIX_mpi_gather(const void *sendbuf, int sendcount, MPI
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_GATHER);
 
@@ -331,8 +325,7 @@ static inline int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, int sendcount, MP
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_GATHERV);
 
@@ -370,8 +363,7 @@ static inline int MPIDI_POSIX_mpi_scatter(const void *sendbuf, int sendcount, MP
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_SCATTER);
 
@@ -410,8 +402,7 @@ static inline int MPIDI_POSIX_mpi_scatterv(const void *sendbuf, const int *sendc
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_SCATTERV);
 
@@ -465,8 +456,7 @@ static inline int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, int sendcount,
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLTOALL);
 
@@ -515,8 +505,7 @@ static inline int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf, const int *send
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLTOALLV);
 
@@ -566,8 +555,7 @@ static inline int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf, const int sendc
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_ALLTOALLW);
 
@@ -622,8 +610,7 @@ static inline int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf, int
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_REDUCE);
 
@@ -676,8 +663,7 @@ static inline int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf, void *recv
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_REDUCE_SCATTER);
 
@@ -733,8 +719,7 @@ static inline int MPIDI_POSIX_mpi_reduce_scatter_block(const void *sendbuf, void
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_REDUCE_SCATTER_BLOCK);
 
@@ -770,8 +755,7 @@ static inline int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *recvbuf, int c
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_SCAN);
 
@@ -807,8 +791,7 @@ static inline int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *recvbuf, int
             break;
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_MPI_EXSCAN);
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -120,15 +120,13 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     choose_posix_eager();
 
     mpi_errno = MPIDI_POSIX_eager_init(rank, size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* There is no restriction on the tag_bits from the posix shmod side */
     *tag_bits = MPIR_TAG_BITS_DEFAULT;
 
     mpi_errno = MPIDI_POSIX_coll_init(rank, size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_COMMIT();
 
@@ -149,16 +147,14 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_FINALIZE_HOOK);
 
     mpi_errno = MPIDI_POSIX_eager_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIU_destroy_buf_pool(MPIDI_POSIX_global.am_buf_pool);
 
     MPL_free(MPIDI_POSIX_global.active_rreq);
 
     mpi_errno = MPIDI_POSIX_coll_finalize();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPL_free(MPIDI_POSIX_global.local_ranks);
     MPL_free(MPIDI_POSIX_global.local_procs);
@@ -181,20 +177,17 @@ int MPIDI_POSIX_coll_init(int rank, int size)
      * intra-node collectives */
     mpi_errno =
         MPIDU_shm_seg_alloc(sizeof(int), (void **) &MPIDI_POSIX_shm_limit_counter, MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Actually allocate the segment and assign regions to the pointers */
     mpi_errno =
         MPIDU_shm_seg_commit(&MPIDI_POSIX_global.memory, &MPIDI_POSIX_global.barrier,
                              MPIDI_POSIX_global.num_local, MPIDI_POSIX_global.my_local_rank,
                              MPIDI_POSIX_global.local_rank_0, rank, MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_shm_barrier(MPIDI_POSIX_global.barrier, MPIDI_POSIX_global.num_local);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Set the counter to 0 */
     zm_atomic_store(MPIDI_POSIX_shm_limit_counter, 0, zm_memord_relaxed);

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -308,12 +308,10 @@ int MPIDI_POSIX_progress(int blocking)
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = progress_recv(blocking);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = progress_send(blocking);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_PROGRESS);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -36,8 +36,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
         mpi_errno = MPIDIG_compute_acc_op(origin_addr, origin_count, origin_datatype, target_addr,
                                           target_count, target_datatype, op,
                                           MPIDIG_ACC_SRCBUF_DEFAULT);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         goto fn_exit;
     }
@@ -71,8 +70,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_compute_accumulate(void *origin_addr,
     MPI_Aint actual_pack_bytes;
     mpi_errno = MPIR_Typerep_pack(origin_addr, origin_count, origin_datatype, 0,
                                   packed_buf, total_len, &actual_pack_bytes);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(actual_pack_bytes == total_len);
 
     mpi_errno = MPIDIG_compute_acc_op((void *) packed_buf, (int) predefined_dtp_count, basic_type,
@@ -219,16 +217,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
 
     mpi_errno = MPIR_Localcopy((char *) base + disp_unit * target_disp, target_count,
                                target_datatype, result_addr, result_count, result_datatype);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (op != MPI_NO_OP) {
         mpi_errno = MPIDI_POSIX_compute_accumulate((void *) origin_addr, origin_count,
                                                    origin_datatype,
                                                    (char *) base + disp_unit * target_disp,
                                                    target_count, target_datatype, op);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -368,8 +364,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
 
     mpi_errno = MPIDI_POSIX_do_put(origin_addr, origin_count, origin_datatype,
                                    target_rank, target_disp, target_count, target_datatype, win);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
@@ -474,8 +469,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
     mpi_errno = MPIDI_POSIX_do_accumulate(origin_addr, origin_count, origin_datatype,
                                           target_rank, target_disp, target_count,
                                           target_datatype, op, win);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
@@ -524,8 +518,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_
                                               result_addr, result_count, result_datatype,
                                               target_rank, target_disp, target_count,
                                               target_datatype, op, win);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
@@ -636,8 +629,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
 
     mpi_errno = MPIDI_POSIX_do_get(origin_addr, origin_count, origin_datatype,
                                    target_rank, target_disp, target_count, target_datatype, win);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);

--- a/src/mpid/ch4/shm/posix/posix_win.c
+++ b/src/mpid/ch4/shm/posix/posix_win.c
@@ -283,8 +283,7 @@ int MPIDI_POSIX_mpi_win_free_hook(MPIR_Win * win)
         mpi_errno = MPIDIU_destroy_shm_segment(sizeof(MPL_proc_mutex_t),
                                                &posix_win->shm_mutex_segment_handle,
                                                (void **) &posix_win->shm_mutex_ptr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -78,8 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_beta(MPIR_Comm * co
     const void *barrier_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
     mpi_errno = MPIDI_NM_mpi_barrier(comm, errflag, barrier_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -98,8 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_inter_composition_alpha(MPIR_Comm * c
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Barrier_inter_auto(comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -228,8 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, i
     const void *bcast_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);
 
     mpi_errno = MPIDI_NM_mpi_bcast(buffer, count, datatype, root, comm, errflag, bcast_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -250,8 +247,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_inter_composition_alpha(void *buffer, i
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Bcast_inter_auto(buffer, count, datatype, root, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -356,8 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
     mpi_errno =
         MPIDI_NM_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag,
                                allred_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -388,8 +383,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
         MPIDI_NM_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag,
                                allred_container);
 #endif
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -412,8 +406,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_inter_composition_alpha(const void 
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allreduce_inter_auto(sendbuf, recvbuf, count, datatype, op, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -679,8 +672,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_gamma(const void *se
     mpi_errno =
         MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root,
                             comm, errflag, reduce_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -703,8 +695,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_inter_composition_alpha(const void *se
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_inter_auto(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -730,8 +721,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
     mpi_errno =
         MPIDI_NM_mpi_alltoall(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag, alltoall_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -757,8 +747,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_inter_composition_alpha(const void *
 
     mpi_errno = MPIR_Alltoall_inter_auto(sendbuf, sendcount, sendtype, recvbuf,
                                          recvcount, recvtype, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -788,8 +777,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallv_intra_composition_alpha(const void 
         MPIDI_NM_mpi_alltoallv(sendbuf, sendcounts, sdispls,
                                sendtype, recvbuf, recvcounts,
                                rdispls, recvtype, comm_ptr, errflag, alltoallv_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -818,8 +806,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallv_inter_composition_alpha(const void 
     mpi_errno = MPIR_Alltoallv_inter_auto(sendbuf, sendcounts, sdispls,
                                           sendtype, recvbuf, recvcounts,
                                           rdispls, recvtype, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -851,8 +838,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallw_intra_composition_alpha(const void 
         MPIDI_NM_mpi_alltoallw(sendbuf, sendcounts, sdispls,
                                sendtypes, recvbuf, recvcounts,
                                rdispls, recvtypes, comm_ptr, errflag, alltoallw_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -883,8 +869,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoallw_inter_composition_alpha(const void 
     mpi_errno = MPIR_Alltoallw_inter_auto(sendbuf, sendcounts, sdispls,
                                           sendtypes, recvbuf, recvcounts,
                                           rdispls, recvtypes, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -912,8 +897,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_intra_composition_alpha(const void 
         MPIDI_NM_mpi_allgather(sendbuf, sendcount, sendtype,
                                recvbuf, recvcount, recvtype,
                                comm_ptr, errflag, allgather_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -939,8 +923,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_inter_composition_alpha(const void 
 
     mpi_errno = MPIR_Allgather_inter_auto(sendbuf, sendcount, sendtype,
                                           recvbuf, recvcount, recvtype, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -969,8 +952,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_intra_composition_alpha(const void
         MPIDI_NM_mpi_allgatherv(sendbuf, sendcount, sendtype,
                                 recvbuf, recvcounts, displs,
                                 recvtype, comm_ptr, errflag, allgatherv_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -998,8 +980,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgatherv_inter_composition_alpha(const void
     mpi_errno = MPIR_Allgatherv_inter_auto(sendbuf, sendcount, sendtype,
                                            recvbuf, recvcounts, displs,
                                            recvtype, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1024,8 +1005,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gather_intra_composition_alpha(const void *se
     mpi_errno =
         MPIDI_NM_mpi_gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                             recvtype, root, comm, errflag, gather_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1050,8 +1030,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gather_inter_composition_alpha(const void *se
 
     mpi_errno = MPIR_Gather_inter_auto(sendbuf, sendcount, sendtype, recvbuf,
                                        recvcount, recvtype, root, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1078,8 +1057,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_intra_composition_alpha(const void *s
     mpi_errno =
         MPIDI_NM_mpi_gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
                              displs, recvtype, root, comm, errflag, gatherv_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1106,8 +1084,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Gatherv_inter_composition_alpha(const void *s
 
     mpi_errno = MPIR_Gatherv_inter_auto(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcounts, displs, recvtype, root, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1133,8 +1110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatter_intra_composition_alpha(const void *s
     mpi_errno =
         MPIDI_NM_mpi_scatter(sendbuf, sendcount, sendtype, recvbuf, recvcount,
                              recvtype, root, comm, errflag, scatter_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1161,8 +1137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatter_inter_composition_alpha(const void *s
 
     mpi_errno = MPIR_Scatter_inter_auto(sendbuf, sendcount, sendtype, recvbuf,
                                         recvcount, recvtype, root, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1189,8 +1164,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_intra_composition_alpha(const void *
     mpi_errno =
         MPIDI_NM_mpi_scatterv(sendbuf, sendcounts, displs, sendtype, recvbuf,
                               recvcount, recvtype, root, comm, errflag, scatterv_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1217,8 +1191,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scatterv_inter_composition_alpha(const void *
 
     mpi_errno = MPIR_Scatterv_inter_auto(sendbuf, sendcounts, displs, sendtype, recvbuf,
                                          recvcount, recvtype, root, comm, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1245,8 +1218,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_inter_composition_alpha(const 
 
     mpi_errno = MPIR_Reduce_scatter_inter_auto(sendbuf, recvbuf, recvcounts, datatype,
                                                op, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1275,8 +1247,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_intra_composition_alpha(const 
     mpi_errno =
         MPIDI_NM_mpi_reduce_scatter(sendbuf, recvbuf, recvcounts, datatype,
                                     op, comm_ptr, errflag, reduce_scatter_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1305,8 +1276,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_block_inter_composition_alpha(
 
     mpi_errno = MPIR_Reduce_scatter_block_inter_auto(sendbuf, recvbuf, recvcount, datatype,
                                                      op, comm_ptr, errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1337,8 +1307,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_scatter_block_intra_composition_alpha(
     mpi_errno =
         MPIDI_NM_mpi_reduce_scatter_block(sendbuf, recvbuf, recvcount, datatype,
                                           op, comm_ptr, errflag, reduce_scatter_block_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1532,8 +1501,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_beta(const void *sendb
 
     mpi_errno =
         MPIDI_NM_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag, scan_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;
@@ -1558,8 +1526,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Exscan_intra_composition_alpha(const void *se
     mpi_errno =
         MPIDI_NM_mpi_exscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag,
                             exscan_container);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -102,8 +102,7 @@ int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key, MP
 
     mpi_errno = MPIR_Comm_split_impl(user_comm_ptr, split_type == MPI_UNDEFINED ? MPI_UNDEFINED : 0,
                                      key, &comm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (split_type == MPI_UNDEFINED) {
         *newcomm_ptr = NULL;
@@ -118,8 +117,7 @@ int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key, MP
     }
 
     mpi_errno = MPIR_Comm_split_type_node_topo(comm_ptr, split_type, key, info_ptr, newcomm_ptr);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     if (comm_ptr)
@@ -185,14 +183,10 @@ int MPID_Comm_create_hook(MPIR_Comm * comm)
     }
 
     mpi_errno = MPIDI_NM_mpi_comm_create_hook(comm);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_comm_create_hook(comm);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
 #ifdef HAVE_DEBUGGER_SUPPORT
@@ -273,14 +267,10 @@ int MPID_Comm_free_hook(MPIR_Comm * comm)
     }
 
     mpi_errno = MPIDI_NM_mpi_comm_free_hook(comm);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_comm_free_hook(comm);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -354,8 +344,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                   remote_leader, cts_tag,
                                   &remote_size_recv, 1, MPI_INT,
                                   remote_leader, cts_tag, peer_comm, MPI_STATUS_IGNORE, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (remote_size_recv & MPIDI_DYNPROC_MASK)
             pure_intracomm = 0;
@@ -382,15 +371,13 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                 mpi_errno, "remote_upid_size", MPL_MEM_ADDRESS);
 
             mpi_errno = MPIDI_NM_get_local_upids(local_comm, &local_upid_size, &local_upids);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIC_Sendrecv(local_upid_size, local_size, MPI_UNSIGNED_LONG,
                                       remote_leader, cts_tag,
                                       remote_upid_size, *remote_size, MPI_UNSIGNED_LONG,
                                       remote_leader, cts_tag,
                                       peer_comm, MPI_STATUS_IGNORE, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             upid_send_size = 0;
             for (i = 0; i < local_size; i++)
                 upid_send_size += local_upid_size[i];
@@ -404,8 +391,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       remote_upids, upid_recv_size, MPI_BYTE,
                                       remote_leader, cts_tag,
                                       peer_comm, MPI_STATUS_IGNORE, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_CHKLMEM_MALLOC(local_node_ids, int *,
                                 local_size * sizeof(int), mpi_errno, "local_node_ids",
@@ -420,8 +406,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       remote_node_ids, (*remote_size) * sizeof(int),
                                       MPI_BYTE, remote_leader, cts_tag, peer_comm,
                                       MPI_STATUS_IGNORE, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* Stage 1.2 convert remote UPID to LUPID and get LUPID for local group */
             MPIDIU_upids_to_lupids(*remote_size, remote_upid_size, remote_upids,
@@ -433,8 +418,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                       *remote_lupids, *remote_size, MPI_INT,
                                       remote_leader, cts_tag,
                                       peer_comm, MPI_STATUS_IGNORE, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
         /* Stage 1.3 check if local/remote groups are disjoint */
 
@@ -458,8 +442,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                  * check for any overlap */
                 mpi_errno = MPIDI_check_disjoint_lupids(local_lupids, local_size,
                                                         *remote_lupids, *remote_size);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
             MPID_END_ERROR_CHECKS;
         }
@@ -501,8 +484,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                                  remote_size, is_low_group, pure_intracomm,
                                                  remote_upid_size, remote_upids,
                                                  remote_lupids, remote_node_ids);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_COMMIT();
   fn_exit:

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -414,7 +414,7 @@ static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group
 #define MPIDIU_PROGRESS()                                   \
     do {                                                        \
         mpi_errno = MPID_Progress_test();                       \
-        if (mpi_errno != MPI_SUCCESS) MPIR_ERR_POP(mpi_errno);  \
+        MPIR_ERR_CHECK(mpi_errno);  \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
     } while (0)
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -397,8 +397,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided, int *has_ar
 
     /* setup receive queue statistics */
     mpi_errno = MPIDIG_recvq_init();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     int i;
@@ -408,8 +407,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided, int *has_ar
     mpi_errno = MPIDIU_build_nodemap(MPIR_Process.comm_world->rank, MPIR_Process.comm_world,
                                      MPIR_Process.comm_world->local_size,
                                      MPIDI_global.node_map[0], &MPIDI_global.max_node_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "MPIDI_global.max_node_id = %d", MPIDI_global.max_node_id));
@@ -462,11 +460,9 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided, int *has_ar
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
 
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* -------------------------------- */
     /* Return MPICH Parameters          */
@@ -510,12 +506,10 @@ int MPID_Finalize(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_FINALIZE);
 
     mpi_errno = MPIDI_NM_mpi_finalize_hook();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_finalize_hook();
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     int i;
@@ -675,9 +669,7 @@ int MPID_Free_mem(void *ptr)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_FREE_MEM);
     mpi_errno = MPIDI_NM_mpi_free_mem(ptr);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_FREE_MEM);
@@ -741,9 +733,7 @@ int MPID_Create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const in
     MPIDI_COMM(newcomm_ptr, map).mode = MPIDI_RANK_MAP_MLUT;
     MPIDI_COMM(newcomm_ptr, map).avtid = -1;
     mpi_errno = MPIDIU_alloc_mlut(&mlut, size);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
     MPIDI_COMM(newcomm_ptr, map).size = size;
     MPIDI_COMM(newcomm_ptr, map).irreg.mlut.t = mlut;
     MPIDI_COMM(newcomm_ptr, map).irreg.mlut.gpid = mlut->gpid;
@@ -793,14 +783,10 @@ int MPID_Type_commit_hook(MPIR_Datatype * type)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_TYPE_COMMIT_HOOK);
 
     mpi_errno = MPIDI_NM_mpi_type_commit_hook(type);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_type_commit_hook(type);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -818,14 +804,10 @@ int MPID_Type_free_hook(MPIR_Datatype * type)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_TYPE_FREE_HOOK);
 
     mpi_errno = MPIDI_NM_mpi_type_free_hook(type);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_type_free_hook(type);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -843,14 +825,10 @@ int MPID_Op_commit_hook(MPIR_Op * op)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_OP_COMMIT_HOOK);
 
     mpi_errno = MPIDI_NM_mpi_op_commit_hook(op);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_op_commit_hook(op);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -868,14 +846,10 @@ int MPID_Op_free_hook(MPIR_Op * op)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_OP_FREE_HOOK);
 
     mpi_errno = MPIDI_NM_mpi_op_free_hook(op);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_op_free_hook(op);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -28,9 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
 #else
     if (unlikely(source == MPI_ANY_SOURCE)) {
         mpi_errno = MPIDI_SHM_mpi_iprobe(source, tag, comm, context_offset, flag, status);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         if (!*flag)
             mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
     } else if (MPIDI_rank_is_local(source, comm)) {
@@ -39,9 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_unsafe(int source,
         mpi_errno = MPIDI_NM_mpi_iprobe(source, tag, comm, context_offset, av, flag, status);
     }
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PROBE_UNSAFE);
@@ -66,30 +62,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_unsafe(int source,
 #else
     if (unlikely(source == MPI_ANY_SOURCE)) {
         mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, context_offset, flag, message, status);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (*flag) {
             MPIDI_REQUEST(*message, is_local) = 1;
         } else {
             mpi_errno =
                 MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             if (*flag) {
                 MPIDI_REQUEST(*message, is_local) = 0;
             }
         }
     } else if (MPIDI_av_is_local(av)) {
         mpi_errno = MPIDI_SHM_mpi_improbe(source, tag, comm, context_offset, flag, message, status);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (*flag)
             MPIDI_REQUEST(*message, is_local) = 1;
     } else {
         mpi_errno =
             MPIDI_NM_mpi_improbe(source, tag, comm, context_offset, av, flag, message, status);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         if (*flag)
             MPIDI_REQUEST(*message, is_local) = 0;
     }
@@ -119,8 +111,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IPROBE_SAFE);
@@ -148,8 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMPROBE_SAFE);
@@ -171,14 +161,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
     av = MPIDIU_comm_rank_to_av(comm, source);
     while (!flag) {
         mpi_errno = MPIDI_iprobe_safe(source, tag, comm, context_offset, av, &flag, status);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
   fn_exit:
@@ -205,14 +191,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
     while (!flag) {
         mpi_errno =
             MPIDI_improbe_safe(source, tag, comm, context_offset, av, &flag, message, status);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
   fn_exit:
@@ -237,15 +219,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
     av = MPIDIU_comm_rank_to_av(comm, source);
 
     mpi_errno = MPIDI_improbe_safe(source, tag, comm, context_offset, av, flag, message, status);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!*flag) {
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -270,15 +248,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iprobe(int source,
     av = MPIDIU_comm_rank_to_av(comm, source);
 
     mpi_errno = MPIDI_iprobe_safe(source, tag, comm, context_offset, av, flag, status);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!*flag) {
         mpi_errno = MPID_Progress_test();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_progress.c
+++ b/src/mpid/ch4/src/ch4_progress.c
@@ -23,8 +23,7 @@ int MPIDI_Progress_test(int flags)
     if (MPIDI_global.sigusr1_count > MPIDI_global.my_sigusr1_count) {
         MPIDI_global.my_sigusr1_count = MPIDI_global.sigusr1_count;
         mpi_errno = MPIDI_check_for_failed_procs();
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
 
@@ -37,8 +36,7 @@ int MPIDI_Progress_test(int flags)
                 func_ptr = MPIDI_global.progress_hooks[i].func_ptr;
                 MPIR_Assert(func_ptr != NULL);
                 mpi_errno = func_ptr(&made_progress);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
             } else {
                 MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
@@ -48,8 +46,7 @@ int MPIDI_Progress_test(int flags)
     /* todo: progress unexp_list */
 
     mpi_errno = MPIDI_workq_vci_progress();
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
 

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -35,9 +35,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
         mpi_errno =
             MPIDI_SHM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIDI_REQUEST(*request, is_local) = 1;
 
@@ -45,9 +43,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
             mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                            av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)));
 
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIDI_REQUEST(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
 
@@ -80,9 +76,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
     }
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RECV_UNSAFE);
     return mpi_errno;
@@ -111,18 +105,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
         mpi_errno =
             MPIDI_SHM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
 
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Assert(*request);
         if (!MPIR_Request_is_complete(*request) && !MPIDIG_REQUEST_IN_PROGRESS(*request)) {
             mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                            av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)));
 
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIDI_REQUEST(*request, is_local) = 1;
             MPIDI_REQUEST(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request), is_local) = 0;
@@ -156,9 +146,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
     }
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IRECV_UNSAFE);
     return mpi_errno;
@@ -201,8 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
         if (unlikely(partner_rreq)) {
             /* Canceling MPI_ANY_SOURCE receive -- first cancel NM recv, then SHM */
             mpi_errno = MPIDI_NM_mpi_cancel_recv(partner_rreq);
-            if (mpi_errno != MPI_SUCCESS)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_Request_free(partner_rreq);
         }
         mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
@@ -210,8 +197,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
         mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq);
     }
 #endif
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CANCEL_RECV_UNSAFE);
@@ -344,8 +330,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IRECV_SAFE);
@@ -374,9 +359,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
     mpi_errno =
         MPIDI_recv_safe(buf, count, datatype, rank, tag, comm, context_offset, av, status, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RECV);
     return mpi_errno;
@@ -448,9 +431,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
     *rreq = message;
 
     mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_MRECV);
@@ -477,9 +458,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
     *rreqp = message;
 
     mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_IMRECV);
     return mpi_errno;
@@ -504,9 +483,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     mpi_errno =
         MPIDI_irecv_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_IRECV);
     return mpi_errno;
@@ -522,9 +499,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request * rreq)
 
     mpi_errno = MPIDI_cancel_recv_safe(rreq);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CANCEL_RECV);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -40,9 +40,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
                                      target_rank, target_disp, target_count, target_datatype, win,
                                      av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_UNSAFE);
     return mpi_errno;
@@ -77,9 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
                                      target_rank, target_disp, target_count, target_datatype, win,
                                      av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_UNSAFE);
     return mpi_errno;
@@ -117,9 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
                                             target_rank, target_disp, target_count,
                                             target_datatype, op, win, av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACCUMULATE_UNSAFE);
     return mpi_errno;
@@ -152,9 +146,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_ad
         mpi_errno = MPIDI_NM_mpi_compare_and_swap(origin_addr, compare_addr, result_addr,
                                                   datatype, target_rank, target_disp, win, av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMPARE_AND_SWAP_UNSAFE);
     return mpi_errno;
@@ -194,9 +186,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
                                              target_rank, target_disp, target_count,
                                              target_datatype, op, win, av, request);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE_UNSAFE);
     return mpi_errno;
@@ -241,9 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_add
                                                  target_rank, target_disp, target_count,
                                                  target_datatype, op, win, av, request);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_ACCUMULATE_UNSAFE);
     return mpi_errno;
@@ -276,9 +264,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
         mpi_errno = MPIDI_NM_mpi_fetch_and_op(origin_addr, result_addr,
                                               datatype, target_rank, target_disp, op, win, av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FETCH_AND_OP_UNSAFE);
     return mpi_errno;
@@ -316,9 +302,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
                                       target_rank, target_disp, target_count,
                                       target_datatype, win, av, request);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_UNSAFE);
     return mpi_errno;
@@ -356,9 +340,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
                                       target_rank, target_disp, target_count,
                                       target_datatype, win, av, request);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RPUT_UNSAFE);
     return mpi_errno;
@@ -402,9 +384,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr
                                                 target_rank, target_disp, target_count,
                                                 target_datatype, op, win, av);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACCUMULATE_UNSAFE);
     return mpi_errno;
@@ -436,8 +416,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
         MPIDI_workq_vci_progress_unsafe();
         mpi_errno = MPIDI_put_unsafe(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype, win);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -474,8 +453,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
         MPIDI_workq_vci_progress_unsafe();
         mpi_errno = MPIDI_get_unsafe(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype, win);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -507,8 +485,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
@@ -538,8 +515,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
@@ -573,9 +549,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
     return mpi_errno;
@@ -610,8 +584,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
@@ -639,8 +612,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
@@ -672,8 +644,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RGET_SAFE);
@@ -704,8 +675,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RPUT_SAFE);
@@ -739,8 +709,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
 
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
 
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
@@ -764,9 +733,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Put(const void *origin_addr,
 
     mpi_errno = MPIDI_put_safe(origin_addr, origin_count, origin_datatype,
                                target_rank, target_disp, target_count, target_datatype, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PUT);
     return mpi_errno;
@@ -788,9 +755,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get(void *origin_addr,
 
     mpi_errno = MPIDI_get_safe(origin_addr, origin_count, origin_datatype,
                                target_rank, target_disp, target_count, target_datatype, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_GET);
     return mpi_errno;
@@ -813,9 +778,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *origin_addr,
 
     mpi_errno = MPIDI_accumulate_safe(origin_addr, origin_count, origin_datatype, target_rank,
                                       target_disp, target_count, target_datatype, op, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ACCUMULATE);
     return mpi_errno;
@@ -836,9 +799,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Compare_and_swap(const void *origin_addr,
 
     mpi_errno = MPIDI_compare_and_swap_safe(origin_addr, compare_addr, result_addr,
                                             datatype, target_rank, target_disp, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMPARE_AND_SWAP);
     return mpi_errno;
@@ -863,9 +824,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Raccumulate(const void *origin_addr,
                                        target_disp, target_count, target_datatype, op, win,
                                        request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RACCUMULATE);
     return mpi_errno;
@@ -893,9 +852,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget_accumulate(const void *origin_addr,
     mpi_errno = MPIDI_rget_accumulate_safe(origin_addr, origin_count, origin_datatype, result_addr,
                                            result_count, result_datatype, target_rank, target_disp,
                                            target_count, target_datatype, op, win, request);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RGET_ACCUMULATE);
     return mpi_errno;
@@ -915,9 +872,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Fetch_and_op(const void *origin_addr,
 
     mpi_errno = MPIDI_fetch_and_op_safe(origin_addr, result_addr,
                                         datatype, target_rank, target_disp, op, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_FETCH_AND_OP);
     return mpi_errno;
@@ -941,9 +896,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rget(void *origin_addr,
 
     mpi_errno = MPIDI_rget_safe(origin_addr, origin_count, origin_datatype, target_rank,
                                 target_disp, target_count, target_datatype, win, request);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RGET);
     return mpi_errno;
@@ -967,9 +920,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rput(const void *origin_addr,
 
     mpi_errno = MPIDI_rput_safe(origin_addr, origin_count, origin_datatype, target_rank,
                                 target_disp, target_count, target_datatype, win, request);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RPUT);
     return mpi_errno;
@@ -996,9 +947,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Get_accumulate(const void *origin_addr,
     mpi_errno = MPIDI_get_accumulate_safe(origin_addr, origin_count, origin_datatype,
                                           result_addr, result_count, result_datatype, target_rank,
                                           target_disp, target_count, target_datatype, op, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_GET_ACCUMULATE);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -41,9 +41,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *buf,
         MPIDI_REQUEST(*request, is_local) = r;
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_UNSAFE);
@@ -84,9 +82,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_unsafe(const void *buf,
         MPIDI_REQUEST(*request, is_local) = r;
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_COLL_UNSAFE);
@@ -123,9 +119,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_unsafe(const void *buf,
         MPIDI_REQUEST(*request, is_local) = r;
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_UNSAFE);
     return mpi_errno;
@@ -165,9 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_unsafe(const void *buf,
         MPIDI_REQUEST(*request, is_local) = r;
 #endif
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_COLL_UNSAFE);
     return mpi_errno;
@@ -202,9 +194,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_unsafe(const void *buf,
     if (mpi_errno == MPI_SUCCESS && *req)
         MPIDI_REQUEST(*req, is_local) = r;
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_UNSAFE);
     return mpi_errno;
@@ -238,9 +228,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *buf,
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*req, is_local) = r;
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISSEND_UNSAFE);
     return mpi_errno;
@@ -494,9 +482,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SEND);
     return mpi_errno;
@@ -521,9 +507,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
     mpi_errno = MPIDI_send_coll_safe(buf, count, datatype, rank, tag, comm, context_offset, av,
                                      request, errflag);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SEND_COLL);
     return mpi_errno;
@@ -549,9 +533,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     mpi_errno =
         MPIDI_isend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ISEND);
     return mpi_errno;
@@ -577,9 +559,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
         MPIDI_isend_coll_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request,
                               errflag);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ISEND_COLL);
     return mpi_errno;
@@ -610,9 +590,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RSEND);
     return mpi_errno;
@@ -643,9 +621,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     mpi_errno =
         MPIDI_isend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_IRSEND);
     return mpi_errno;
@@ -670,9 +646,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
     mpi_errno =
         MPIDI_ssend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SSEND);
     return mpi_errno;
@@ -697,9 +671,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
     mpi_errno =
         MPIDI_issend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_ISSEND);
     return mpi_errno;
@@ -764,8 +736,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SEND,
                                  buf, count, datatype, rank, tag, comm, context_offset, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SEND_INIT);
@@ -788,8 +759,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SSEND,
                                  buf, count, datatype, rank, tag, comm, context_offset, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_SSEND_INIT);
@@ -812,8 +782,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
 
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_BSEND,
                                  buf, count, datatype, rank, tag, comm, context_offset, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_BSEND_INIT);
@@ -838,8 +807,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
     /* TODO: Currently we don't distinguish SEND and RSEND */
     mpi_errno = MPIDI_psend_init(MPIDI_PTYPE_SEND,
                                  buf, count, datatype, rank, tag, comm, context_offset, request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_RSEND_INIT);
@@ -862,9 +830,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request * sreq)
     else
         mpi_errno = MPIDI_NM_mpi_cancel_send(sreq);
 #endif
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CANCEL_SEND);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -63,8 +63,7 @@ static int mpi_to_pmi_keyvals(MPIR_Info * info_ptr, PMI_keyval_t ** kv_ptr, int 
 
     for (i = 0; i < nkeys; i++) {
         mpi_errno = MPIR_Info_get_nthkey_impl(info_ptr, i, key);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_Info_get_valuelen_impl(info_ptr, key, &vallen, &flag);
         kv[i].key = (const char *) MPL_strdup(key);
         kv[i].val = (char *) MPL_malloc(vallen + 1, MPL_MEM_BUFFER);
@@ -127,8 +126,7 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
             pmi_errcodes[i] = 0;
 
         mpi_errno = MPID_Open_port(NULL, port_name);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         info_keyval_sizes = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!info_keyval_sizes, mpi_errno, MPI_ERR_OTHER, "**nomem");
@@ -144,8 +142,7 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
             for (i = 0; i < count; i++) {
                 mpi_errno = mpi_to_pmi_keyvals(info_ptrs[i], &info_keyval_vectors[i],
                                                &info_keyval_sizes[i]);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
         preput_keyval_vector.key = MPIDI_PARENT_PORT_KVSKEY;
@@ -173,38 +170,31 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
     if (errcodes != MPI_ERRCODES_IGNORE) {
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
         mpi_errno = MPIR_Bcast(&should_accept, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Bcast(&pmi_errno, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Bcast(&total_num_processes, 1, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Bcast(errcodes, total_num_processes, MPI_INT, root, comm_ptr, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (should_accept) {
         mpi_errno = MPID_Comm_accept(port_name, NULL, root, comm_ptr, intercomm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         if ((pmi_errno == PMI_SUCCESS) && (errcodes[0] != 0)) {
             mpi_errno = MPIR_Comm_create(intercomm);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
     if (comm_ptr->rank == root) {
         mpi_errno = MPID_Close_port(port_name);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -242,9 +232,7 @@ int MPID_Comm_connect(const char *port_name, MPIR_Info * info, int root, MPIR_Co
     }
     mpi_errno = MPIDI_NM_mpi_comm_connect(port_name, info, root, timeout, comm, newcomm_ptr);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMM_CONNECT);
@@ -260,9 +248,7 @@ int MPID_Comm_disconnect(MPIR_Comm * comm_ptr)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_DISCONNECT);
     mpi_errno = MPIDI_NM_mpi_comm_disconnect(comm_ptr);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMM_DISCONNECT);
@@ -278,9 +264,7 @@ int MPID_Open_port(MPIR_Info * info_ptr, char *port_name)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_OPEN_PORT);
     mpi_errno = MPIDI_NM_mpi_open_port(info_ptr, port_name);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_OPEN_PORT);
@@ -296,9 +280,7 @@ int MPID_Close_port(const char *port_name)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_CLOSE_PORT);
     mpi_errno = MPIDI_NM_mpi_close_port(port_name);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CLOSE_PORT);
@@ -315,9 +297,7 @@ int MPID_Comm_accept(const char *port_name, MPIR_Info * info, int root, MPIR_Com
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COMM_ACCEPT);
     mpi_errno = MPIDI_NM_mpi_comm_accept(port_name, info, root, comm, newcomm_ptr);
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMM_ACCEPT);

--- a/src/mpid/ch4/src/ch4_win.c
+++ b/src/mpid/ch4/src/ch4_win.c
@@ -20,14 +20,10 @@ int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_set_info(win, info);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_set_info(win, info);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -45,14 +41,10 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_get_info(win, info_p_p);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_get_info(win, info_p_p);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -70,13 +62,10 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_free(win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_free(win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -94,13 +83,10 @@ int MPID_Win_create(void *base, MPI_Aint length, int disp_unit, MPIR_Info * info
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_CREATE);
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_create(base, length, disp_unit, info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_create(base, length, disp_unit, info, comm_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -118,13 +104,10 @@ int MPID_Win_attach(MPIR_Win * win, void *base, MPI_Aint size)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_attach(win, base, size);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_attach(win, base, size);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -143,14 +126,11 @@ int MPID_Win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info * info_ptr,
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_allocate_shared(size, disp_unit,
                                                  info_ptr, comm_ptr, base_ptr, win_ptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_allocate_shared(size, disp_unit, info_ptr, comm_ptr, base_ptr,
                                                win_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_ALLOCATE_SHARED);
@@ -167,13 +147,10 @@ int MPID_Win_detach(MPIR_Win * win, const void *base)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_detach(win, base);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_detach(win, base);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_DETACH);
@@ -190,13 +167,10 @@ int MPID_Win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info, MPIR_Comm 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_ALLOCATE);
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_allocate(size, disp_unit, info, comm, baseptr, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_allocate(size, disp_unit, info, comm, baseptr, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_ALLOCATE);
@@ -212,13 +186,10 @@ int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_CREATE_DYNAMIC);
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_create_dynamic(info, comm, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_create_dynamic(info, comm, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_CREATE_DYNAMIC);

--- a/src/mpid/ch4/src/ch4_win.h
+++ b/src/mpid/ch4/src/ch4_win.h
@@ -25,13 +25,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_start(group, assert, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_start(group, assert, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -53,13 +50,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_complete(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_complete(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -81,13 +75,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_post(group, assert, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_post(group, assert, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -109,13 +100,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_wait(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_wait(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -138,13 +126,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_test(win, flag);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_test(win, flag);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -166,13 +151,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock(lock_type, rank, assert, win, NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_lock(lock_type, rank, assert, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -194,13 +176,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock(rank, win, NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_unlock(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -222,13 +201,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_fence(assert, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_fence(assert, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -250,13 +226,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local(rank, win, NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_flush_local(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -276,13 +249,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_shared_query(MPIR_Win * win,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_SHARED_QUERY);
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_shared_query(win, rank, size, disp_unit, baseptr);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_shared_query(win, rank, size, disp_unit, baseptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -303,13 +273,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush(rank, win, NULL);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_flush(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -331,13 +298,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_local_all(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_flush_local_all(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -359,13 +323,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_unlock_all(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_unlock_all(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -387,13 +348,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_sync(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_sync(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -415,13 +373,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_flush_all(win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_flush_all(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -443,13 +398,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_NM_mpi_win_lock_all(assert, win);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno = MPIDIG_mpi_win_lock_all(assert, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4i_comm.c
+++ b/src/mpid/ch4/src/ch4i_comm.c
@@ -118,8 +118,7 @@ static int src_comm_to_mlut(MPIDI_rank_map_t * src, MPIDI_rank_map_t * dest, int
 
     if (!mapper_offset) {
         mpi_errno = MPIDIU_alloc_mlut(&mlut, total_mapper_size);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         dest->size = total_mapper_size;
         dest->mode = MPIDI_RANK_MAP_MLUT;
         dest->avtid = -1;
@@ -216,8 +215,7 @@ static int src_mlut_to_mlut(MPIDI_rank_map_t * src, MPIDI_rank_map_t * dest,
 
     if (!mapper_offset) {
         mpi_errno = MPIDIU_alloc_mlut(&mlut, total_mapper_size);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         dest->size = total_mapper_size;
     }
 
@@ -252,8 +250,7 @@ static int src_map_to_lut(MPIDI_rank_map_t * src, MPIDI_rank_map_t * dest, MPIR_
 
     if (!mapper_offset) {
         mpi_errno = MPIDIU_alloc_lut(&lut, total_mapper_size);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         dest->size = total_mapper_size;
     }
 
@@ -575,8 +572,7 @@ static int check_convert_mlut_to_lut(MPIDI_rank_map_t * src)
         src->mode = MPIDI_RANK_MAP_LUT;
     }
     mpi_errno = MPIDIU_alloc_lut(&lut, src->size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     for (i = 0; i < src->size; i++) {
         lut->lpid[i] = src->irreg.mlut.gpid[i].lpid;
     }

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -147,8 +147,7 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
                                                         MPIDI_SHM : MPIDI_NETMOD,
                                                         &continue_matching);
 
-                    if (MPI_SUCCESS != mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
 
                     MPIR_Request_free(MPIDI_REQUEST_ANYSOURCE_PARTNER(match_req));
                     MPIDI_REQUEST_ANYSOURCE_PARTNER(match_req) = NULL;
@@ -206,8 +205,7 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
                                         MPIDIG_REQUEST(match_req, count),
                                         MPIDIG_REQUEST(match_req, datatype), 0,
                                         &actual_unpack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (actual_unpack_bytes != (MPI_Aint) nbytes) {
             mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
@@ -226,8 +224,7 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
     /* If this is a synchronous send, send the reply back to the sender to unlock them. */
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
         mpi_errno = MPIDIG_reply_ssend(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (unlikely(anysource_partner)) {
@@ -324,8 +321,7 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
 
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_UNEXPECTED) {
         mpi_errno = handle_unexp_cmpl(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -334,8 +330,7 @@ static int recv_target_cmpl_cb(MPIR_Request * rreq)
 
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
         mpi_errno = MPIDIG_reply_ssend(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq)) {
@@ -553,8 +548,7 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data
                                                     MPIDI_REQUEST(rreq, is_local) ?
                                                     MPIDI_SHM : MPIDI_NETMOD, &continue_matching);
 
-                if (MPI_SUCCESS != mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
 
                 MPIDI_REQUEST_ANYSOURCE_PARTNER(rreq) = NULL;
                 MPIDI_REQUEST_ANYSOURCE_PARTNER(anysource_partner) = NULL;
@@ -612,8 +606,7 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data
             mpi_errno = MPIDI_NM_am_recv(rreq);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (unlikely(anysource_partner)) {
@@ -664,8 +657,7 @@ int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     mpi_errno =
         MPIDIG_send_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_local, is_contig,
                                   target_cmpl_cb, req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Assert(req);
     MPIDIG_REQUEST(*req, req->rreq.peer_req_ptr) = msg_hdr->sreq_ptr;
@@ -737,8 +729,7 @@ int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void **data
                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (target_cmpl_cb)
         *target_cmpl_cb = MPIDIG_send_origin_cb;

--- a/src/mpid/ch4/src/ch4r_comm.c
+++ b/src/mpid/ch4/src/ch4r_comm.c
@@ -20,9 +20,7 @@ int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upi
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_UPIDS_TO_LUPIDS);
 
     mpi_errno = MPIDI_NM_upids_to_lupids(size, remote_upid_size, remote_upids, remote_lupids);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* update node_map */
     for (i = 0; i < size; i++) {
@@ -48,9 +46,7 @@ int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upi
         }
     }
 
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
-    }
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_UPIDS_TO_LUPIDS);
@@ -90,31 +86,26 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         map_info[2] = *is_low_group;
         map_info[3] = pure_intracomm;
         mpi_errno = MPIR_Bcast_intra_auto(map_info, 4, MPI_INT, local_leader, local_comm, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (!pure_intracomm) {
             mpi_errno = MPIR_Bcast_intra_auto(remote_upid_size, *remote_size, MPI_UNSIGNED_LONG,
                                               local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Bcast_intra_auto(remote_upids, upid_recv_size, MPI_BYTE,
                                               local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             mpi_errno =
                 MPIR_Bcast_intra_auto(remote_node_ids, (*remote_size) * sizeof(int), MPI_BYTE,
                                       local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Bcast_intra_auto(*remote_lupids, *remote_size, MPI_INT,
                                               local_leader, local_comm, &errflag);
         }
     } else {
         mpi_errno = MPIR_Bcast_intra_auto(map_info, 4, MPI_INT, local_leader, local_comm, &errflag);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         *remote_size = map_info[0];
         upid_recv_size = map_info[1];
         *is_low_group = map_info[2];
@@ -127,22 +118,19 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
                                 mpi_errno, "_remote_upid_size", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_intra_auto(_remote_upid_size, *remote_size, MPI_UNSIGNED_LONG,
                                               local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_CHKLMEM_MALLOC(_remote_upids, char *, upid_recv_size * sizeof(char),
                                 mpi_errno, "_remote_upids", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_intra_auto(_remote_upids, upid_recv_size, MPI_BYTE,
                                               local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_CHKLMEM_MALLOC(_remote_node_ids, int *,
                                 (*remote_size) * sizeof(int),
                                 mpi_errno, "_remote_node_ids", MPL_MEM_COMM);
             mpi_errno =
                 MPIR_Bcast_intra_auto(_remote_node_ids, (*remote_size) * sizeof(int), MPI_BYTE,
                                       local_leader, local_comm, &errflag);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIDIU_upids_to_lupids(*remote_size, _remote_upid_size, _remote_upids,
                                    remote_lupids, _remote_node_ids);

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -38,8 +38,7 @@ static inline int MPIDIG_reply_ssend(MPIR_Request * rreq)
                                     sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_REPLY_SSEND);
     return mpi_errno;
@@ -88,8 +87,7 @@ static inline int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
         MPI_Aint actual_unpack_bytes;
         mpi_errno = MPIR_Typerep_unpack(MPIDIG_REQUEST(rreq, buffer), nbytes, buf,
                                         count, datatype, 0, &actual_unpack_bytes);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (actual_unpack_bytes != (MPI_Aint) nbytes) {
             mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
@@ -106,8 +104,7 @@ static inline int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
 
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_PEER_SSEND) {
         mpi_errno = MPIDIG_reply_ssend(rreq);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
     MPID_Request_complete(rreq);
 

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -52,8 +52,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
                                    origin_count,
                                    origin_datatype,
                                    (char *) win->base + offset, target_count, target_datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -96,8 +95,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
                                           origin_count, origin_datatype, sreq);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -162,8 +160,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
                                           am_iov[1].iov_len, MPI_BYTE, sreq);
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     *sreq_ptr = sreq;
@@ -208,8 +205,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
         mpi_errno = MPIR_Localcopy((char *) win->base + offset,
                                    target_count,
                                    target_datatype, origin_addr, origin_count, origin_datatype);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -257,8 +253,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
                                           NULL, 0, MPI_DATATYPE_NULL, sreq);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -293,8 +288,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
                                       sizeof(struct iovec) * am_hdr.n_iov, MPI_BYTE, sreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     *sreq_ptr = sreq;
@@ -396,8 +390,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
                                           sreq);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -467,8 +460,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
                                           am_iov[1].iov_len, MPI_BYTE, sreq);
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     *sreq_ptr = sreq;
@@ -585,8 +577,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
                                           sreq);
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -656,8 +647,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
                                           am_iov[1].iov_len, MPI_BYTE, sreq);
         }
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     *sreq_ptr = sreq;
@@ -680,8 +670,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, int origin_
 
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     /* always release my ref, only request-ops track. */
@@ -707,8 +696,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, int origin
 
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
@@ -735,8 +723,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, int origin_count,
 
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     /* always release my ref, only request-ops track. */
@@ -762,8 +749,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, int origin_count
 
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
@@ -791,8 +777,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, int
 
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                      target_disp, target_count, target_datatype, op, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
@@ -819,8 +804,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, int 
 
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                      target_disp, target_count, target_datatype, op, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     /* always release my ref, only request-ops track. */
@@ -852,8 +836,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget_accumulate(const void *origin_addr,
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                          result_count, result_datatype, target_rank, target_disp,
                                          target_count, target_datatype, op, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (sreq == NULL)
         /* create a completed request for user if issuing is completed immediately. */
@@ -885,8 +868,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get_accumulate(const void *origin_addr,
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                          result_count, result_datatype, target_rank, target_disp,
                                          target_count, target_datatype, op, win, &sreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     /* always release my ref, only request-ops track. */
@@ -958,8 +940,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
         mpi_errno = MPIDI_NM_am_isend(target_rank, win->comm_ptr, MPIDIG_CSWAP_REQ,
                                       &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq);
     }
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);
     return mpi_errno;
@@ -978,8 +959,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_fetch_and_op(const void *origin_addr, vo
 
     mpi_errno = MPIDIG_mpi_get_accumulate(origin_addr, 1, datatype, result_addr, 1, datatype,
                                           target_rank, target_disp, 1, datatype, op, win);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_FETCH_AND_OP);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -251,8 +251,7 @@ static int ack_put(MPIR_Request * rreq)
                                        &ack_msg, sizeof(ack_msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACK_PUT);
     return mpi_errno;
@@ -295,8 +294,7 @@ static int ack_cswap(MPIR_Request * rreq)
                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACK_CSWAP);
     return mpi_errno;
@@ -330,8 +328,7 @@ static int ack_acc(MPIR_Request * rreq)
                                        &ack_msg, sizeof(ack_msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACK_ACC);
     return mpi_errno;
@@ -371,8 +368,7 @@ static int ack_get_acc(MPIR_Request * rreq)
                                     MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACK_GET_ACC);
     return mpi_errno;
@@ -424,13 +420,11 @@ static int win_lock_advance(MPIR_Win * win)
                                                    lock->rank, handler_id, &msg, sizeof(msg));
         }
 
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPL_free(lock);
 
         mpi_errno = win_lock_advance(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -518,8 +512,7 @@ static void win_unlock_proc(const MPIDIG_win_cntrl_msg_t * info, int is_local, M
                                                MPIDIG_WIN_UNLOCK_ACK, &msg, sizeof(msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_WIN_UNLOCK_PROC);
     return;
@@ -595,8 +588,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_enter_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         shm_locked = 1;
     }
@@ -611,8 +603,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
                                           MPIDIG_REQUEST(rreq, req->areq.target_datatype),
                                           MPIDIG_REQUEST(rreq, req->areq.op),
                                           MPIDIG_ACC_SRCBUF_DEFAULT);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         iov = (struct iovec *) MPIDIG_REQUEST(rreq, req->areq.dt_iov);
         src_ptr = (char *) MPIDIG_REQUEST(rreq, req->areq.data);
@@ -626,8 +617,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
                                               MPIDIG_REQUEST(rreq, req->areq.target_datatype),
                                               MPIDIG_REQUEST(rreq, req->areq.op),
                                               MPIDIG_ACC_SRCBUF_DEFAULT);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             src_ptr += count * basic_sz;
         }
         MPL_free(iov);
@@ -636,8 +626,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_exit_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
 
@@ -646,8 +635,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
 
     MPIDIG_REQUEST(rreq, req->areq.data) = NULL;
     mpi_errno = ack_acc(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_Request_complete(rreq);
   fn_exit:
@@ -691,8 +679,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_enter_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         shm_locked = 1;
     }
 #endif
@@ -710,8 +697,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
                                           MPIDIG_REQUEST(rreq, req->areq.target_datatype),
                                           MPIDIG_REQUEST(rreq, req->areq.op),
                                           MPIDIG_ACC_SRCBUF_DEFAULT);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         iov = (struct iovec *) MPIDIG_REQUEST(rreq, req->areq.dt_iov);
         src_ptr = (char *) MPIDIG_REQUEST(rreq, req->areq.data);
@@ -728,8 +714,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
                                               MPIDIG_REQUEST(rreq, req->areq.target_datatype),
                                               MPIDIG_REQUEST(rreq, req->areq.op),
                                               MPIDIG_ACC_SRCBUF_DEFAULT);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             src_ptr += count * basic_sz;
         }
         MPL_free(iov);
@@ -738,8 +723,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_exit_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
 
@@ -748,8 +732,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
 
     MPIDIG_REQUEST(rreq, req->areq.data) = original;
     mpi_errno = ack_get_acc(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_Request_complete(rreq);
 
@@ -848,8 +831,7 @@ static int get_target_cmpl_cb(MPIR_Request * req)
         }
 
         MPID_Request_complete(req);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
@@ -888,8 +870,7 @@ static int get_target_cmpl_cb(MPIR_Request * req)
     }
 
     MPID_Request_complete(req);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_TARGET_CMPL_CB);
     return mpi_errno;
@@ -911,8 +892,7 @@ static int put_target_cmpl_cb(MPIR_Request * rreq)
     MPL_free(MPIDIG_REQUEST(rreq, req->preq.dt_iov));
 
     mpi_errno = ack_put(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPID_Request_complete(rreq);
   fn_exit:
@@ -951,8 +931,7 @@ static int put_iov_target_cmpl_cb(MPIR_Request * rreq)
                                        &ack_msg, sizeof(ack_msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PUT_IOV_TARGET_CMPL_CB);
@@ -989,8 +968,7 @@ static int acc_iov_target_cmpl_cb(MPIR_Request * rreq)
                                        &ack_msg, sizeof(ack_msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACC_IOV_TARGET_CMPL_CB);
@@ -1027,8 +1005,7 @@ static int get_acc_iov_target_cmpl_cb(MPIR_Request * rreq)
                                        &ack_msg, sizeof(ack_msg));
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_IOV_TARGET_CMPL_CB);
@@ -1060,8 +1037,7 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
     win = MPIDIG_REQUEST(rreq, req->creq.win_ptr);
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_enter_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
 
@@ -1076,15 +1052,13 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDIG_WIN(win, shm_allocated)) {
         mpi_errno = MPIDI_SHM_rma_op_cs_exit_hook(win);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 #endif
     /* MPIDI_CS_EXIT(); */
 
     mpi_errno = ack_cswap(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPID_Request_complete(rreq);
     MPIDIG_progress_compl_list();
   fn_exit:
@@ -1106,8 +1080,7 @@ static int acc_target_cmpl_cb(MPIR_Request * rreq)
         return mpi_errno;
 
     mpi_errno = handle_acc_cmpl(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIG_progress_compl_list();
   fn_exit:
@@ -1127,8 +1100,7 @@ static int get_acc_target_cmpl_cb(MPIR_Request * rreq)
         return mpi_errno;
 
     mpi_errno = handle_get_acc_cmpl(rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIG_progress_compl_list();
   fn_exit:
@@ -1614,8 +1586,7 @@ int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
                                             rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->preq.origin_datatype));
 
     *target_cmpl_cb = NULL;
@@ -1673,8 +1644,7 @@ int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
                                             rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
     *target_cmpl_cb = NULL;
@@ -1733,8 +1703,7 @@ int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **da
                                             rreq);
     }
 
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
     *target_cmpl_cb = NULL;

--- a/src/mpid/ch4/src/ch4r_symheap.c
+++ b/src/mpid/ch4/src/ch4r_symheap.c
@@ -317,23 +317,19 @@ static int allreduce_maxloc(size_t mysz, int myloc, MPIR_Comm * comm, size_t * m
     disps[1] = (MPI_Aint) ((uintptr_t) & maxloc.loc - (uintptr_t) & maxloc.sz);
 
     mpi_errno = MPIR_Type_create_struct_impl(2, blocks, disps, types, &maxloc_type);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Type_commit_impl(&maxloc_type);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Op_create_impl(ull_maxloc_op_func, 0, &maxloc_op);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     maxloc.sz = (unsigned long long) mysz;
     maxloc.loc = myloc;
 
     mpi_errno = MPIR_Allreduce(&maxloc, &maxloc_result, 1, maxloc_type, maxloc_op, comm, &errflag);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *maxsz_loc = maxloc_result.loc;
     *maxsz = (size_t) maxloc_result.sz;
@@ -447,8 +443,7 @@ int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offsets, MPIR_Comm 
             if (shm_comm_ptr != NULL) {
                 /* destroy successful shm segment */
                 mpi_errno = MPIDIU_destroy_shm_segment(mapsize, shm_segment_hdl_ptr, base_ptr);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             } else
                 MPL_munmap(base_ptr, mapsize, MPL_MEM_RMA);
         }

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -272,8 +272,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     /* Duplicate the original communicator here to avoid having collisions
      * between internal collectives */
     mpi_errno = MPIR_Comm_dup_impl(comm_ptr, &win_comm_ptr);
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIG_WIN(win, targets) = targets;
 
@@ -320,8 +319,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
 
     if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
         mpi_errno = win_set_info(win, info, TRUE /* is_init */);
-        if (MPI_SUCCESS != mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
 
@@ -372,13 +370,11 @@ static int win_finalize(MPIR_Win ** win_ptr)
     } while (all_completed != 1);
 
     mpi_errno = MPIDI_NM_mpi_win_free_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_free_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     MPIDIG_win_target_cleanall(win);
@@ -393,8 +389,7 @@ static int win_finalize(MPIR_Win ** win_ptr)
                 mpi_errno = MPIDIU_destroy_shm_segment(MPIDIG_WIN(win, mmap_sz),
                                                        &MPIDIG_WIN(win, shm_segment_handle),
                                                        &MPIDIG_WIN(win, mmap_addr));
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
+                MPIR_ERR_CHECK(mpi_errno);
             }
 
             /* if shared memory allocation fails or zero size window, free the table at allocation. */
@@ -639,8 +634,7 @@ int MPIDIG_mpi_win_set_info(MPIR_Win * win, MPIR_Info * info)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_SET_INFO);
 
     mpi_errno = win_set_info(win, info, FALSE /* is_init */);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
   fn_exit:
@@ -667,8 +661,7 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "no_locks", "false");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     {
 #define BUFSIZE 32
@@ -694,8 +687,7 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
         }
 
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_ordering", buf);
-        if (MPI_SUCCESS != mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 #undef BUFSIZE
     }
 
@@ -704,56 +696,49 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_ops", "same_op_no_op");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).alloc_shared_noncontig)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shared_noncontig", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shared_noncontig", "false");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).same_size)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_size", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_size", "false");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).same_disp_unit)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_disp_unit", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "same_disp_unit", "false");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).alloc_shm)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shm", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "alloc_shm", "false");
 
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     {   /* Keep buf as a local variable for which_accumulate_ops key. */
         char buf[128];
         get_info_accu_ops_str(MPIDIG_WIN(win, info_args).which_accumulate_ops, &buf[0],
                               sizeof(buf));
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "which_accumulate_ops", buf);
-        if (MPI_SUCCESS != mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (MPIDIG_WIN(win, info_args).accumulate_noncontig_dtype)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_noncontig_dtype", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_noncontig_dtype", "false");
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).accumulate_max_bytes >= 0) {
         char buf[32];           /* make sure 64-bit integer can fit */
@@ -761,15 +746,13 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_max_bytes", buf);
     } else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "accumulate_max_bytes", "unlimited");
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "disable_shm_accumulate", "true");
     else
         mpi_errno = MPIR_Info_set_impl(*info_p_p, "disable_shm_accumulate", "false");
-    if (MPI_SUCCESS != mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_GET_INFO);
@@ -825,13 +808,11 @@ int MPIDIG_mpi_win_create(void *base, MPI_Aint length, int disp_unit, MPIR_Info 
     win->base = base;
 
     mpi_errno = MPIDI_NM_mpi_win_create_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_create_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
@@ -856,13 +837,11 @@ int MPIDIG_mpi_win_attach(MPIR_Win * win, void *base, MPI_Aint size)
                         MPI_ERR_RMA_FLAVOR, goto fn_fail, "**rmaflavor");
 
     mpi_errno = MPIDI_NM_mpi_win_attach_hook(win, base, size);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_attach_hook(win, base, size);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -883,25 +862,21 @@ int MPIDIG_mpi_win_allocate_shared(MPI_Aint size, int disp_unit, MPIR_Info * inf
 
     mpi_errno = win_init(size, disp_unit, win_ptr, info_ptr, comm_ptr, MPI_WIN_FLAVOR_SHARED,
                          MPI_WIN_UNIFIED);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = win_shm_alloc_impl(size, disp_unit, comm_ptr, base_ptr, win_ptr, SHM_WIN_REQUIRED);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     win = *win_ptr;
     win->base = *base_ptr;
     win->size = size;
 
     mpi_errno = MPIDI_NM_mpi_win_allocate_shared_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_allocate_shared_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     mpi_errno = MPIR_Barrier(comm_ptr, &errflag);
@@ -924,13 +899,11 @@ int MPIDIG_mpi_win_detach(MPIR_Win * win, const void *base)
                         MPI_ERR_RMA_FLAVOR, goto fn_fail, "**rmaflavor");
 
     mpi_errno = MPIDI_NM_mpi_win_detach_hook(win, base);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_detach_hook(win, base);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
   fn_exit:
@@ -966,13 +939,11 @@ int MPIDIG_mpi_win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info, MPIR
     win->size = size;
 
     mpi_errno = MPIDI_NM_mpi_win_allocate_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_allocate_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     mpi_errno = MPIR_Barrier(comm, &errflag);
@@ -1009,13 +980,11 @@ int MPIDIG_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win *
     win->base = MPI_BOTTOM;
 
     mpi_errno = MPIDI_NM_mpi_win_create_dynamic_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_mpi_win_create_dynamic_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     mpi_errno = MPIR_Barrier(comm, &errflag);

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -67,17 +67,14 @@ static inline int MPIDIG_fill_ranks_in_win_grp(MPIR_Win * win_ptr, MPIR_Group * 
         ranks_in_grp[i] = i;
 
     mpi_errno = MPIR_Comm_group_impl(win_ptr->comm_ptr, &win_grp_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Group_translate_ranks_impl(group_ptr, group_ptr->size,
                                                 ranks_in_grp, win_grp_ptr, ranks_in_win_grp);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Group_free_impl(win_grp_ptr);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPL_free(ranks_in_grp);
@@ -137,13 +134,11 @@ static inline int MPIDIG_mpi_win_complete(MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     msg.win_id = MPIDIG_WIN(win, win_id);
@@ -154,8 +149,7 @@ static inline int MPIDIG_mpi_win_complete(MPIR_Win * win)
     MPIR_Assert(ranks_in_win_grp);
 
     mpi_errno = MPIDIG_fill_ranks_in_win_grp(win, group, ranks_in_win_grp);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* FIXME: now we simply set per-target counters for PSCW, can it be optimized ? */
     do {
@@ -229,8 +223,7 @@ static inline int MPIDIG_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win *
     MPIR_Assert(ranks_in_win_grp);
 
     mpi_errno = MPIDIG_fill_ranks_in_win_grp(win, group, ranks_in_win_grp);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     for (win_grp_idx = 0; win_grp_idx < group->size; ++win_grp_idx) {
         peer = ranks_in_win_grp[win_grp_idx];
@@ -393,13 +386,11 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations */
@@ -464,13 +455,11 @@ static inline int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations */
@@ -564,13 +553,11 @@ static inline int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations issued to the target.
@@ -607,13 +594,11 @@ static inline int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_local_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_local_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations */
@@ -649,13 +634,11 @@ static inline int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations */
@@ -719,13 +702,11 @@ static inline int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win)
 
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_local_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_target_local_cmpl_hook(rank, win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations issued to the target.
@@ -778,13 +759,11 @@ static inline int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
-    if (mpi_errno != MPI_SUCCESS)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 
     /* Ensure completion of AM operations */

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -20,11 +20,9 @@ int MPIDU_bc_table_destroy(void *bc_table)
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIDU_shm_seg_destroy(&memory, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPL_free(indices);
@@ -43,8 +41,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
     int rank = MPIR_Comm_rank(comm), size = MPIR_Comm_size(comm);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!same_len) {
         bc_len *= 2;
@@ -59,8 +56,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
     }
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (rank == local_leader) {
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
@@ -71,8 +67,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
     }
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     *bc_table = segment;
 
@@ -106,13 +101,11 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     if (!same_len)
         bc_len = VALLEN;
     mpi_errno = MPIDU_shm_seg_alloc(bc_len * size, (void **) &segment, MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno =
         MPIDU_shm_seg_commit(&memory, &barrier, local_size, local_rank, local_leader, rank,
                              MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (size == 1) {
         memcpy(segment, bc, my_bc_len);
@@ -181,8 +174,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         }
     }
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   single:
     if (!same_len) {
@@ -219,13 +211,11 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     if (!same_len)
         bc_len = PMI2_MAX_VALLEN;
     mpi_errno = MPIDU_shm_seg_alloc(bc_len * size, (void **) &segment, MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno =
         MPIDU_shm_seg_commit(&memory, &barrier, local_size, local_rank, local_leader, rank,
                              MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (size == 1) {
         memcpy(segment, bc, my_bc_len);
@@ -280,8 +270,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPL_free(node_roots);
     }
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   single:
     if (!same_len) {
@@ -327,13 +316,11 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     if (!same_len)
         bc_len = val_max;
     mpi_errno = MPIDU_shm_seg_alloc(bc_len * size, (void **) &segment, MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno =
         MPIDU_shm_seg_commit(&memory, &barrier, local_size, local_rank, local_leader, rank,
                              MPL_MEM_ADDRESS);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (size == 1) {
         memcpy(segment, bc, my_bc_len);
@@ -395,8 +382,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPL_free(node_roots);
     }
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
   single:
     if (!same_len) {

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -98,14 +98,12 @@ int hcoll_initialize(void)
 #endif
 
     mpi_errno = hcoll_init_with_opts(&init_opts);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!hcoll_initialized) {
         hcoll_initialized = 1;
         mpi_errno = MPID_Progress_register_hook(hcoll_do_progress, &hcoll_progress_hook_id);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         MPID_Progress_activate_hook(hcoll_progress_hook_id);
     }
@@ -138,8 +136,7 @@ int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
 
     if (0 == hcoll_initialized) {
         mpi_errno = hcoll_initialize();
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (0 == hcoll_enable) {

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -275,8 +275,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
             mpi_errno =
                 MPIR_Reduce_local(e->u.reduce.inbuf, e->u.reduce.inoutbuf, e->u.reduce.count,
                                   e->u.reduce.datatype, e->u.reduce.op);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_Op_release_if_not_builtin(e->u.reduce.op);
             MPIR_Datatype_release_if_not_builtin(e->u.reduce.datatype);
             e->status = MPIDU_SCHED_ENTRY_STATUS_COMPLETE;
@@ -285,8 +284,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "starting COPY entry %d\n", (int) idx);
             mpi_errno = MPIR_Localcopy(e->u.copy.inbuf, e->u.copy.incount, e->u.copy.intype,
                                        e->u.copy.outbuf, e->u.copy.outcount, e->u.copy.outtype);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_Datatype_release_if_not_builtin(e->u.copy.intype);
             MPIR_Datatype_release_if_not_builtin(e->u.copy.outtype);
             e->status = MPIDU_SCHED_ENTRY_STATUS_COMPLETE;
@@ -369,8 +367,7 @@ static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
             mpi_errno = MPIDU_Sched_start_entry(s, i, e);
             /* Sched entries list can be reallocated inside callback */
             e = &s->entries[i];
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         /* _start_entry may have completed the operation, but won't update s->idx */
@@ -487,8 +484,7 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
      * engine about this req+sched, otherwise we have more MT issues to worry
      * about.  Skipping this step will increase latency. */
     mpi_errno = MPIDU_Sched_continue(s);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* finally, enqueue in the list of all pending schedules so that the
      * progress engine can make progress on it */
@@ -556,8 +552,7 @@ int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
     struct MPIDU_Sched_entry *e = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_SEND;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -592,8 +587,7 @@ int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, in
     struct MPIDU_Sched_entry *e = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_SEND;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -628,8 +622,7 @@ int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype
     struct MPIDU_Sched_entry *e = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_SEND;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -663,8 +656,7 @@ int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, in
     struct MPIDU_Sched_entry *e = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_RECV;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -694,8 +686,7 @@ int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, 
     struct MPIDU_Sched_entry *e = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_RECV;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -726,8 +717,7 @@ int MPIDU_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Da
     struct MPIDU_Sched_reduce *reduce = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_REDUCE;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -764,8 +754,7 @@ int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
     struct MPIDU_Sched_copy *copy = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_COPY;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -826,8 +815,7 @@ int MPIDU_Sched_cb(MPIR_Sched_cb_t * cb_p, void *cb_state, MPIR_Sched_t s)
     struct MPIDU_Sched_cb *cb = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_CB;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -853,8 +841,7 @@ int MPIDU_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MP
     struct MPIDU_Sched_cb *cb = NULL;
 
     mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     e->type = MPIDU_SCHED_ENTRY_CB;
     e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
@@ -940,8 +927,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                 if (e->is_barrier) {
                     /* post/perform the next round of operations */
                     mpi_errno = MPIDU_Sched_continue(s);
-                    if (mpi_errno)
-                        MPIR_ERR_POP(mpi_errno);
+                    MPIR_ERR_CHECK(mpi_errno);
                 }
             } else if (e->is_barrier && e->status < MPIDU_SCHED_ENTRY_STATUS_COMPLETE) {
                 /* don't process anything after this barrier entry */
@@ -970,9 +956,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
             }
 
             mpi_errno = MPID_Request_complete(s->req);
-            if (mpi_errno != MPI_SUCCESS) {
-                MPIR_ERR_POP(mpi_errno);
-            }
+            MPIR_ERR_CHECK(mpi_errno);
 
             s->req = NULL;
             MPL_free(s->entries);

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -26,14 +26,12 @@ int MPIDU_Init_shm_init(int rank, int size, int *nodemap)
     mpi_errno =
         MPIDU_shm_seg_alloc(local_size * sizeof(MPIDU_Init_shm_block_t), (void **) &baseaddr,
                             MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno =
         MPIDU_shm_seg_commit(&memory, &barrier, local_size, my_local_rank, local_leader, rank,
                              MPL_MEM_SHM);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
 
@@ -52,8 +50,7 @@ int MPIDU_Init_shm_finalize(void)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_FINALIZE);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_shm_seg_destroy(&memory, local_size);
 

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -204,8 +204,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
         mpi_errno =
             MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIR_CHKLMEM_MALLOC(key, char *, PMI2_MAX_KEYLEN, mpi_errno, "key", MPL_MEM_SHM);
         MPL_snprintf(key, PMI2_MAX_KEYLEN, "sharedFilename-%d", num_segments);
@@ -231,8 +230,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* The opa and barrier initializations must come before we (the
              * leader) put the sharedFilename attribute.  Since this is a
@@ -240,8 +238,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
              * ensures that these initializations have occurred before any peer
              * attempts to use the resources. */
             mpi_errno = PMI2_Info_PutNodeAttr(key, serialized_hnd);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         } else {
             int found = FALSE;
 
@@ -250,8 +247,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             /* get name of shared file */
             mpi_errno = PMI2_Info_GetNodeAttr(key, val, PMI2_MAX_VALLEN, &found, TRUE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             MPIR_ERR_CHKINTERNAL(!found, mpi_errno, "nodeattr not found");
 
             mpl_err = MPL_shm_hnd_deserialize(memory->hnd, val, strlen(val));
@@ -277,13 +273,11 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, FALSE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         mpi_errno = MPIDU_shm_barrier(*barrier, num_local);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank == 0) {
             mpl_err = MPL_shm_seg_remove(memory->hnd);
@@ -315,8 +309,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
         mpi_errno =
             MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         pmix_proc_t proc, *procs;
         char *nodename = NULL;
@@ -349,8 +342,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             /* The opa and barrier initializations must come before we (the
              * leader) put the sharedFilename attribute.  Since this is a
@@ -422,13 +414,11 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, FALSE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         mpi_errno = MPIDU_shm_barrier(*barrier, num_local);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank == 0) {
             mpl_err = MPL_shm_seg_remove(memory->hnd);
@@ -464,8 +454,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 #endif
         mpi_errno =
             MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Allocate space for pmi key and val */
         pmi_errno = PMI_KVS_Get_key_length_max(&key_max_sz);
@@ -477,8 +466,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
         MPIR_CHKLMEM_MALLOC(val, char *, val_max_sz, mpi_errno, "val", class);
 
         mpi_errno = PMI_KVS_Get_my_name(kvs_name, 256);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank == 0) {
             mpl_err =
@@ -510,8 +498,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, TRUE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
 
             pmi_errno = PMI_Barrier();
             MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -543,13 +530,11 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
             mpi_errno =
                 MPIDU_shm_barrier_init((MPIDU_shm_barrier_t *) memory->base_addr, barrier, FALSE);
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
         }
 
         mpi_errno = MPIDU_shm_barrier(*barrier, num_local);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank == 0) {
             mpl_err = MPL_shm_seg_remove(memory->hnd);
@@ -595,8 +580,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
     while (!ALLOCQ_EMPTY());
 
     mpi_errno = check_alloc(memory, *barrier, num_local, local_rank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_CHKPMEM_COMMIT();
   fn_exit:
@@ -656,8 +640,7 @@ static int check_alloc(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t * barrier,
     }
 
     mpi_errno = MPIDU_shm_barrier(barrier, num_local);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (asym_check_region_p->base_ptr != memory->base_addr)
         OPA_store_int(&asym_check_region_p->is_asym, 1);
@@ -665,8 +648,7 @@ static int check_alloc(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t * barrier,
     OPA_read_write_barrier();
 
     mpi_errno = MPIDU_shm_barrier(barrier, num_local);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (OPA_load_int(&asym_check_region_p->is_asym)) {
         memory->symmetrical = 0;

--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -258,8 +258,7 @@ static inline int MPIR_NODEMAP_populate_ids_from_mapping(char *mapping,
     *did_map = 1;       /* reset upon failure */
 
     mpi_errno = MPIR_NODEMAP_parse_mapping(mapping, &mt, &mb, &nblocks);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_NODEMAP_NULL_MAPPING == mt)
         goto fn_fail;
@@ -399,15 +398,13 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
         mpi_errno =
             PMI2_Info_GetJobAttr("PMI_process_mapping", process_mapping, sizeof(process_mapping),
                                  &found);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKINTERNAL(!found, mpi_errno, "PMI_process_mapping attribute not found");
         /* this code currently assumes pg is comm_world */
         mpi_errno =
             MPIR_NODEMAP_populate_ids_from_mapping(process_mapping, sz, out_nodemap,
                                                    out_max_node_id, &did_map);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
         MPIR_ERR_CHKINTERNAL(!did_map, mpi_errno,
                              "unable to populate node ids from PMI_process_mapping");
     }
@@ -469,8 +466,7 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
                 MPIR_NODEMAP_populate_ids_from_mapping(value, sz, out_nodemap, out_max_node_id,
                                                        &did_map);
             g_max_node_id = *out_max_node_id;
-            if (mpi_errno)
-                MPIR_ERR_POP(mpi_errno);
+            MPIR_ERR_CHECK(mpi_errno);
             if (did_map) {
                 goto cliques;
             }
@@ -480,8 +476,7 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
 
     /* fallback algorithm */
     mpi_errno = MPIR_NODEMAP_publish_node_id(sz, myrank);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Allocate temporary structures.  These would need to be persistent if
      * we somehow were able to support dynamic processes via this method. */

--- a/src/util/procmap/local_proc.c
+++ b/src/util/procmap/local_proc.c
@@ -55,8 +55,7 @@ int MPIR_Find_local(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
         intranode_table[i] = -1;
 
     mpi_errno = MPID_Get_node_id(comm, comm->rank, &my_node_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(my_node_id >= 0);
 
     local_size = 0;
@@ -65,8 +64,7 @@ int MPIR_Find_local(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
     /* Scan through the list of processes in comm. */
     for (i = 0; i < comm->remote_size; ++i) {
         mpi_errno = MPID_Get_node_id(comm, i, &node_id);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* The upper level can catch this non-fatal error and should be
          * able to recover gracefully. */
@@ -164,8 +162,7 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
                         "internode_table", MPL_MEM_COMM);
 
     mpi_errno = MPID_Get_max_node_id(comm, &max_node_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(max_node_id >= 0);
     MPIR_CHKLMEM_MALLOC(nodes, int *, sizeof(int) * (max_node_id + 1), mpi_errno, "nodes",
                         MPL_MEM_COMM);
@@ -179,8 +176,7 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
 
     for (i = 0; i < comm->remote_size; ++i) {
         mpi_errno = MPID_Get_node_id(comm, i, &node_id);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* The upper level can catch this non-fatal error and should be
          * able to recover gracefully. */


### PR DESCRIPTION
Replace the pattern 
```
      mpi_errno = func(...);
      if (mpi_errno)
            MPIR_ERR_POP(mpi_errno);
```
with 
```
    MPIR_CALL(func(...));
```