### PR TITLE
config: Clean up hwloc options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1253,16 +1253,8 @@ PAC_APPEND_FLAG([-I${master_top_builddir}/modules/json-c],[CPPFLAGS])
 # HWLOC
 # ----------------------------------------------------------------------------
 # Allow the user to override the hwloc location (from embedded to user
-# path)
-# HWLOC
-AC_ARG_WITH([hwloc-prefix],
-            [AS_HELP_STRING([[--with-hwloc-prefix[=DIR]]],
-                            [use the HWLOC library installed in DIR,
-                             rather than the one included in src/hwloc.  Pass
-                             "embedded" to force usage of the HWLOC source
-                             distributed with MPICH.])],
-            [],dnl action-if-given
-            [with_hwloc_prefix=embedded]) dnl action-if-not-given
+# or system path)
+PAC_CHECK_PREFIX(hwloc)
 hwlocsrcdir=""
 AC_SUBST([hwlocsrcdir])
 hwloclibdir=""
@@ -1277,9 +1269,7 @@ elif test "$with_hwloc_prefix" = "embedded" ; then
    PAC_PUSH_FLAG([enable_visibility])
    enable_visibility=no;
    HWLOC_SETUP_CORE([src/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
-   # Only build hwloc in embedded mode
    if test "$have_hwloc" = "yes" ; then
-      use_embedded_hwloc=yes
       hwlocsrcdir="src/hwloc"
       hwloclib="$HWLOC_EMBEDDED_LDADD"
       PAC_PREPEND_FLAG([$HWLOC_EMBEDDED_LIBS], [WRAPPER_LIBS])
@@ -1290,12 +1280,15 @@ elif test "$with_hwloc_prefix" = "embedded" ; then
    PAC_POP_FLAG([enable_visibility])
 else
    AC_CHECK_HEADERS([hwloc.h])
+   PAC_PUSH_FLAG([LIBS])
    # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our
    # minimum required version
    AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
+   PAC_POP_FLAG([LIBS])
    AC_MSG_CHECKING([if non-embedded hwloc works])
    if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
       have_hwloc=yes
+      PAC_PREPEND_FLAG([-lhwloc], [WRAPPER_LIBS])
    else
       have_hwloc=no
    fi
@@ -1306,12 +1299,10 @@ else
    AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
 
    if test "$have_hwloc" = "yes" ; then
-      hwloclib="-lhwloc"
       if test -d ${with_hwloc_prefix}/lib64 ; then
          PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
-         hwloclibdir="-L${with_hwloc_prefix}/lib64"
       else
-	 hwloclibdir="-L${with_hwloc_prefix}/lib"
+         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib],[WRAPPER_LDFLAGS])
       fi
    fi
 fi


### PR DESCRIPTION
Make hwloc configure options in MPICH more consistent with established
options in Hydra. Use PAC_CHECK_PREFIX for setting appropriate flags
and delete extra cruft. Fixes linking MPICH with an external hwloc
installation.