### PR TITLE
refactor: unroll BEGIN_FUNC/END_FUNC macros in ch3 ofi

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -20,8 +20,6 @@
 /* data contained in the process group, and a source.  The source/pg number */
 /* is enough to look up the VC.                                             */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(ofi_tag_to_vc)
 static inline MPIDI_VC_t *ofi_wc_to_vc(cq_tagged_entry_t * wc)
 {
     int pgid = 0, port = 0;
@@ -29,7 +27,8 @@ static inline MPIDI_VC_t *ofi_wc_to_vc(cq_tagged_entry_t * wc)
     MPIDI_PG_t *pg = NULL;
     uint64_t match_bits = wc->tag;
     int wc_pgid;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_OFI_TAG_TO_VC);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_OFI_TAG_TO_VC);
     if (gl_data.api_set == API_SET_1) {
         wc_pgid = get_pgid(match_bits);
     } else {
@@ -72,7 +71,7 @@ static inline MPIDI_VC_t *ofi_wc_to_vc(cq_tagged_entry_t * wc)
             MPIR_Assert(0);
         }
     }
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_OFI_TAG_TO_VC);
     return vc;
 }
 
@@ -92,8 +91,6 @@ static inline MPIDI_VC_t *ofi_wc_to_vc(cq_tagged_entry_t * wc)
 /* by the upper layers.  We handle the cm vc's slightly differently than    */
 /* other VC's because they may not be part of a process group.              */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_conn_req_callback)
 static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
     int ret, len, mpi_errno = MPI_SUCCESS;
@@ -103,7 +100,8 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
     char *addr = NULL;
     fi_addr_t direct_addr;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CONN_REQ_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CONN_REQ_CALLBACK);
 
     MPIR_Memcpy(bc, rreq->dev.user_buf, wc->len);
     bc[wc->len] = '\0';
@@ -141,7 +139,7 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
     MPIDI_CH3I_INCR_PROGRESS_COMPLETION_COUNT;
   fn_exit:
     MPL_free(addr);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CONN_REQ_CALLBACK);
     return mpi_errno;
   fn_fail:
     if (vc)
@@ -156,15 +154,14 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
 /* Notify CH3 that we have an incoming packet (if cc hits 1).  Otherwise    */
 /* decrement the ref counter via request completion                         */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_handle_packet)
 static inline int MPID_nem_ofi_handle_packet(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
                                              MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_VC_t *vc;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_HANDLE_PACKET);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_HANDLE_PACKET);
     if (MPIR_cc_get(rreq->cc) == 1) {
       vc = REQ_OFI(rreq)->vc;
       MPIR_Assert(vc);
@@ -172,7 +169,11 @@ static inline int MPID_nem_ofi_handle_packet(cq_tagged_entry_t * wc ATTRIBUTE((u
       MPL_free(REQ_OFI(rreq)->pack_buffer);
     }
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(rreq));
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_HANDLE_PACKET);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -180,15 +181,18 @@ static inline int MPID_nem_ofi_handle_packet(cq_tagged_entry_t * wc ATTRIBUTE((u
 /* A wrapper around MPID_nem_ofi_handle_packet that decrements              */
 /* the parent request's counter, and cleans up the CTS request              */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cts_send_callback)
 static inline int MPID_nem_ofi_cts_send_callback(cq_tagged_entry_t * wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CTS_SEND_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CTS_SEND_CALLBACK);
     MPIDI_CH3I_NM_OFI_RC(MPID_nem_ofi_handle_packet(wc, REQ_OFI(sreq)->parent));
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CTS_SEND_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -200,8 +204,6 @@ static inline int MPID_nem_ofi_cts_send_callback(cq_tagged_entry_t * wc, MPIR_Re
 /*   * Create a child request and send the CTS packet                       */
 /*   * Re-Post the RTS receive and handler to handle the next message       */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_preposted_callback)
 static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
     int c, mpi_errno = MPI_SUCCESS;
@@ -209,7 +211,8 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
     char *pack_buffer = NULL;
     MPIDI_VC_t *vc;
     MPIR_Request *new_rreq, *sreq;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_PREPOSTED_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_PREPOSTED_CALLBACK);
 
     vc = ofi_wc_to_vc(wc);
     MPIR_Assert(vc);
@@ -262,27 +265,34 @@ static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_R
     /* Return a proper error to MPI to indicate out of memory condition */
     MPIR_ERR_CHKANDJUMP1(pack_buffer == NULL, mpi_errno, MPI_ERR_OTHER,
                          "**nomem", "**nomem %s", "Pack Buffer alloc");
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_PREPOSTED_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
 /* MPID_nem_ofi_connect_to_root_callback                                    */
 /* Complete and clean up the request                                        */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_connect_to_root_callback)
 int MPID_nem_ofi_connect_to_root_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
                                           MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CONNECT_TO_ROOT_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CONNECT_TO_ROOT_CALLBACK);
 
     if (REQ_OFI(sreq)->pack_buffer)
         MPL_free(REQ_OFI(sreq)->pack_buffer);
 
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
 
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CONNECT_TO_ROOT_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -291,13 +301,12 @@ int MPID_nem_ofi_connect_to_root_callback(cq_tagged_entry_t * wc ATTRIBUTE((unus
 /* requests and a persistent data request to handle rendezvous SendContig   */
 /* messages.                                                                */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cm_init)
 int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *persistent_req, *conn_req;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CM_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CM_INIT);
 
     /* ------------------------------------- */
     /* Set up CH3 and netmod data structures */
@@ -354,7 +363,7 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
 
 
   fn_exit:
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CM_INIT);
     return mpi_errno;
 
   fn_fail:
@@ -365,12 +374,11 @@ int MPID_nem_ofi_cm_init(MPIDI_PG_t * pg_p, int pg_rank ATTRIBUTE((unused)))
 /* MPID_nem_ofi_cm_finalize                                                 */
 /* Clean up and cancle the requests initiated by the cm_init routine        */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cm_finalize)
 int MPID_nem_ofi_cm_finalize()
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CM_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CM_FINALIZE);
     FI_RC(fi_cancel((fid_t) gl_data.endpoint,
                     &(REQ_OFI(gl_data.persistent_req)->ofi_context)), cancel);
     MPIR_STATUS_SET_CANCEL_BIT(gl_data.persistent_req->status, TRUE);
@@ -382,7 +390,11 @@ int MPID_nem_ofi_cm_finalize()
     MPIR_STATUS_SET_CANCEL_BIT(gl_data.conn_req->status, TRUE);
     MPIR_STATUS_SET_COUNT(gl_data.conn_req->status, 0);
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(gl_data.conn_req));
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CM_FINALIZE);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -392,14 +404,13 @@ int MPID_nem_ofi_cm_finalize()
 /*     the fabric address name.                                             */
 /*   * Use fi_av_insert to register the address name with OFI               */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_vc_connect)
 int MPID_nem_ofi_vc_connect(MPIDI_VC_t * vc)
 {
     int len, ret, mpi_errno = MPI_SUCCESS;
     char bc[MPIDI_OFI_KVSAPPSTRLEN], *addr = NULL;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_VC_CONNECT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_VC_CONNECT);
     addr = MPL_malloc(gl_data.bound_addrlen, MPL_MEM_ADDRESS);
     MPIR_Assert(addr);
     MPIR_Assert(1 != VC_OFI(vc)->ready);
@@ -419,22 +430,21 @@ int MPID_nem_ofi_vc_connect(MPIDI_VC_t * vc)
   fn_exit:
     if (addr)
         MPL_free(addr);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_VC_CONNECT);
     return mpi_errno;
 
   fn_fail:
     goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_vc_init)
 int MPID_nem_ofi_vc_init(MPIDI_VC_t * vc)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_VC *const vc_ch = &vc->ch;
     MPID_nem_ofi_vc_t *const vc_ofi = VC_OFI(vc);
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_VC_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_VC_INIT);
     vc->sendNoncontig_fn = MPID_nem_ofi_SendNoncontig;
     vc_ch->iStartContigMsg = MPID_nem_ofi_iStartContigMsg;
     vc_ch->iSendContig = MPID_nem_ofi_iSendContig;
@@ -450,7 +460,7 @@ int MPID_nem_ofi_vc_init(MPIDI_VC_t * vc)
     }
     else {
     }
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_VC_INIT);
     return mpi_errno;
 }
 
@@ -459,11 +469,10 @@ int MPID_nem_ofi_vc_init(MPIDI_VC_t * vc)
 /* MPID_nem_ofi_vc_terminate                                                */
 /* TODO:  Verify this code has no leaks                                     */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_vc_destroy)
 int MPID_nem_ofi_vc_destroy(MPIDI_VC_t * vc)
 {
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_VC_DESTROY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_VC_DESTROY);
     if (gl_data.cm_vcs && vc && (VC_OFI(vc)->is_cmvc == 1)) {
         if (vc->pg != NULL) {
             printf("ERROR: VC Destroy (%p) pg = %s\n", vc, (char *) vc->pg->id);
@@ -486,19 +495,22 @@ int MPID_nem_ofi_vc_destroy(MPIDI_VC_t * vc)
         }
     }
     VC_OFI(vc)->ready = 0;
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_VC_DESTROY);
     return MPI_SUCCESS;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_vc_terminate)
 int MPID_nem_ofi_vc_terminate(MPIDI_VC_t * vc)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_VC_TERMINATE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_VC_TERMINATE);
     MPIDI_CH3I_NM_OFI_RC(MPIDI_CH3U_Handle_connection(vc, MPIDI_VC_EVENT_TERMINATED));
     VC_OFI(vc)->ready = 0;
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_VC_TERMINATE);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 
@@ -517,8 +529,6 @@ int MPID_nem_ofi_vc_terminate(MPIDI_VC_t * vc)
 /*    are not part of the process group, so they require special handling   */
 /*    during the SendContig family of routines.                             */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(nm_connect_to_root)
 int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
 {
     int len, ret, mpi_errno = MPI_SUCCESS, str_errno = MPI_SUCCESS;
@@ -527,7 +537,8 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     MPIR_Request *sreq;
     uint64_t conn_req_send_bits;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NM_CONNECT_TO_ROOT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NM_CONNECT_TO_ROOT);
     addr = MPL_malloc(gl_data.bound_addrlen, MPL_MEM_ADDRESS);
     bc = MPL_malloc(MPIDI_OFI_KVSAPPSTRLEN, MPL_MEM_ADDRESS);
     MPIR_Assertp(addr);
@@ -581,7 +592,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
   fn_exit:
     if (addr)
         MPL_free(addr);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NM_CONNECT_TO_ROOT);
     return mpi_errno;
   fn_fail:
     if (my_bc)
@@ -589,13 +600,12 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_get_business_card)
 int MPID_nem_ofi_get_business_card(int my_rank ATTRIBUTE((unused)),
                                    char **bc_val_p, int *val_max_sz_p)
 {
     int mpi_errno = MPI_SUCCESS, str_errno = MPL_STR_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_GET_BUSINESS_CARD);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_GET_BUSINESS_CARD);
     str_errno = MPL_str_add_binary_arg(bc_val_p,
                                         val_max_sz_p,
                                         "OFI",
@@ -604,5 +614,9 @@ int MPID_nem_ofi_get_business_card(int my_rank ATTRIBUTE((unused)),
         MPIR_ERR_CHKANDJUMP(str_errno == MPL_STR_NOMEM, mpi_errno, MPI_ERR_OTHER, "**buscard_len");
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**buscard");
     }
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_GET_BUSINESS_CARD);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -127,20 +127,6 @@ typedef struct {
 /* ******************************** */
 /* Logging and function macros      */
 /* ******************************** */
-#undef FUNCNAME
-#define FUNCNAME nothing
-#define BEGIN_FUNC(FUNCNAME)                    \
-  MPIR_FUNC_VERBOSE_STATE_DECL(FUNCNAME);                   \
-  MPIR_FUNC_VERBOSE_ENTER(FUNCNAME);
-#define END_FUNC(FUNCNAME)                      \
-  MPIR_FUNC_VERBOSE_EXIT(FUNCNAME);
-#define END_FUNC_RC(FUNCNAME) \
-  fn_exit:                    \
-  MPIR_FUNC_VERBOSE_EXIT(FUNCNAME);  \
-  return mpi_errno;           \
-fn_fail:                      \
-  goto fn_exit;
-
 #define __SHORT_FILE__                          \
   (strrchr(__FILE__,'/')                        \
    ? strrchr(__FILE__,'/')+1                    \
@@ -158,7 +144,7 @@ fn_fail:                      \
                            "**ofi_"#STR" %s %d %s %s",          \
                            __SHORT_FILE__,                      \
                            __LINE__,                            \
-                           FCNAME,                              \
+                           __func__,                            \
                            fi_strerror(-_ret));                 \
     } while (0)
 
@@ -175,7 +161,7 @@ fn_fail:                      \
 					       "**ofi_"#STR" %s %d %s %s", \
 					       __SHORT_FILE__,		\
 					       __LINE__,		\
-					       FCNAME,			\
+					       __func__,		\
 					       fi_strerror(-_ret));	\
 				mpi_errno = MPID_nem_ofi_poll(0);	\
 				if(mpi_errno != MPI_SUCCESS)		\
@@ -195,7 +181,7 @@ fn_fail:                      \
                            "**ofi_"#STR" %s %d %s %s",          \
                            __SHORT_FILE__,                      \
                            __LINE__,                            \
-                           FCNAME,                              \
+                           __func__,                            \
                            #STR);                               \
     } while (0)
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -40,8 +40,6 @@ cvars:
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_init)
 int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_max_sz_p)
 {
     int ret, fi_version, i, len, pmi_errno;
@@ -54,7 +52,8 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     fi_addr_t *fi_addrs = NULL;
     MPIDI_VC_t *vc;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_INIT);
     MPIR_CHKLMEM_DECL(2);
 
     compile_time_checking();
@@ -117,7 +116,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
           getinfo);
     MPIR_ERR_CHKANDJUMP4(prov_tagged == NULL, mpi_errno, MPI_ERR_OTHER,
                          "**ofi_getinfo", "**ofi_getinfo %s %d %s %s",
-                         __SHORT_FILE__, __LINE__, FCNAME, "No tag matching provider found");
+                         __SHORT_FILE__, __LINE__, __func__, "No tag matching provider found");
     /* ------------------------------------------------------------------------ */
     /* Open fabric                                                              */
     /* The getinfo struct returns a fabric attribute struct that can be used to */
@@ -293,19 +292,18 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     if (fi_addrs)
         MPL_free(fi_addrs);
     MPIR_CHKLMEM_FREEALL();
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_INIT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_finalize)
 int MPID_nem_ofi_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Errflag_t ret = MPIR_ERR_NONE;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_FINALIZE);
 
     while(gl_data.rts_cts_in_flight) {
         MPID_nem_ofi_poll(0);
@@ -322,11 +320,13 @@ int MPID_nem_ofi_finalize(void)
     FI_RC(fi_close((fid_t) gl_data.cq), cqclose);
     FI_RC(fi_close((fid_t) gl_data.domain), domainclose);
     FI_RC(fi_close((fid_t) gl_data.fabric), fabricclose);
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_FINALIZE);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_get_ordering)
 int MPID_nem_ofi_get_ordering(int *ordering)
 {
     (*ordering) = 1;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -115,15 +115,14 @@
 /* Handles SEND-side events only.  We cannot rely on wc->tag field being    */
 /* set for these events, so we must use the TAG stored in the sreq.         */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_data_callback)
 static int MPID_nem_ofi_data_callback(cq_tagged_entry_t * wc, MPIR_Request * sreq)
 {
     int complete = 0, mpi_errno = MPI_SUCCESS;
     MPIDI_VC_t *vc;
     req_fn reqFn;
     uint64_t tag = 0;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_DATA_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_DATA_CALLBACK);
     switch (REQ_OFI(sreq)->tag & MPIDI_OFI_PROTOCOL_MASK) {
     case MPIDI_OFI_MSG_CTS | MPIDI_OFI_MSG_RTS | MPIDI_OFI_MSG_DATA:
         /* Verify request is complete prior to freeing buffers.
@@ -155,7 +154,11 @@ static int MPID_nem_ofi_data_callback(cq_tagged_entry_t * wc, MPIR_Request * sre
         MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
         break;
     }
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_DATA_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
@@ -164,14 +167,13 @@ static int MPID_nem_ofi_data_callback(cq_tagged_entry_t * wc, MPIR_Request * sre
 /* Handles RECV-side events only.  We rely on wc->tag field being set for   */
 /* these events.                                                            */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cts_recv_callback)
 static int MPID_nem_ofi_cts_recv_callback(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *preq;
     MPIDI_VC_t *vc;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CTS_RECV_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CTS_RECV_CALLBACK);
     preq = REQ_OFI(rreq)->parent;
     switch (wc->tag & MPIDI_OFI_PROTOCOL_MASK) {
     case MPIDI_OFI_MSG_CTS | MPIDI_OFI_MSG_RTS:
@@ -204,15 +206,17 @@ static int MPID_nem_ofi_cts_recv_callback(cq_tagged_entry_t * wc, MPIR_Request *
     }
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(rreq));
 
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CTS_RECV_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
 /* The nemesis API implementations:                                         */
 /* Use packing if iovecs are not supported by the OFI provider              */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_iSendContig)
 int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
                              MPIR_Request * sreq,
                              void *hdr, intptr_t hdr_sz, void *data, intptr_t data_sz)
@@ -223,7 +227,8 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
     MPIR_Request *cts_req;
     intptr_t buf_offset = 0;
     size_t         pkt_len;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISENDCONTIG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISENDCONTIG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));
     MPID_nem_ofi_init_req(sreq);
     pkt_len = sizeof(MPIDI_CH3_Pkt_t) + sreq->dev.ext_hdr_sz + data_sz;
@@ -266,11 +271,13 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
       MPIR_Memcpy(pack_buffer + buf_offset, data, data_sz);
     }
     START_COMM();
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ISENDCONTIG);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_SendNoncontig)
 int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc,
                                MPIR_Request * sreq, void *hdr, intptr_t hdr_sz)
 {
@@ -283,7 +290,8 @@ int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc,
     intptr_t buf_offset = 0;
     void          *data       = NULL;
     size_t         pkt_len;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SENDNONCONTIG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SENDNONCONTIG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));
     MPID_nem_ofi_init_req(sreq);
     first = sreq->dev.segment_first;
@@ -302,11 +310,13 @@ int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc,
     MPIR_Segment_pack(sreq->dev.segment_ptr, first, &last, pack_buffer + buf_offset);
     START_COMM();
     MPID_nem_ofi_poll(MPID_NONBLOCKING_POLL);
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SENDNONCONTIG);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_iStartContigMsg)
 int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
                                  void *hdr,
                                  intptr_t hdr_sz,
@@ -318,7 +328,8 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
     char    *pack_buffer = NULL;
     uint64_t match_bits;
     size_t   pkt_len;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISTARTCONTIGMSG);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISTARTCONTIGMSG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));
 
     MPID_nem_ofi_create_req(&sreq, 2);
@@ -345,5 +356,9 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
     }
     START_COMM();
     *sreq_ptr = sreq;
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ISTARTCONTIGMSG);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
@@ -14,13 +14,12 @@
 /* ------------------------------------------------------------------------ */
 /* peek_callback called when a successful peek is completed                 */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(peek_callback)
 static int
 ADD_SUFFIX(peek_callback)(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_PEEK_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_PEEK_CALLBACK);
     REQ_OFI(rreq)->match_state = PEEK_FOUND;
 #if API_SET == API_SET_1
     rreq->status.MPI_SOURCE    = get_source(wc->tag);
@@ -30,12 +29,10 @@ ADD_SUFFIX(peek_callback)(cq_tagged_entry_t * wc, MPIR_Request * rreq)
     rreq->status.MPI_TAG       = get_tag(wc->tag);
     MPIR_STATUS_SET_COUNT(rreq->status, wc->len);
     rreq->status.MPI_ERROR     = MPI_SUCCESS;
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_PEEK_CALLBACK);
     return mpi_errno;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_iprobe_impl)
 int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(struct MPIDI_VC *vc,
                              int source,
                              int tag,
@@ -49,7 +46,8 @@ int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(struct MPIDI_VC *vc,
     size_t len;
     MPIR_Request rreq_s, *rreq;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_IPROBE_IMPL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_IPROBE_IMPL);
     if (rreq_ptr) {
         MPIDI_CH3I_NM_OFI_RC(MPID_nem_ofi_create_req(&rreq, 1));
         rreq->kind = MPIR_REQUEST_KIND__RECV;
@@ -108,7 +106,7 @@ int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(struct MPIDI_VC *vc,
     }
     MPIR_ERR_CHKANDJUMP4((ret < 0), mpi_errno, MPI_ERR_OTHER,
                          "**ofi_peek", "**ofi_peek %s %d %s %s",
-                         __SHORT_FILE__, __LINE__, FCNAME, fi_strerror(-ret));
+                         __SHORT_FILE__, __LINE__, __func__, fi_strerror(-ret));
 
     while (PEEK_INIT == REQ_OFI(rreq)->match_state)
         MPID_nem_ofi_poll(MPID_BLOCKING_POLL);
@@ -129,28 +127,29 @@ int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(struct MPIDI_VC *vc,
     if (rreq_ptr)
         MPIR_Request_add_ref(rreq);
     *flag = 1;
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_IPROBE_IMPL);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_iprobe)
 int ADD_SUFFIX(MPID_nem_ofi_iprobe)(struct MPIDI_VC *vc,
                         int source,
                         int tag,
                         MPIR_Comm * comm, int context_offset, int *flag, MPI_Status * status)
 {
     int rc;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_IPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_IPROBE);
     *flag = 0;
     rc = ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(vc, source,
                                               tag, comm, context_offset, flag, status, NULL);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_IPROBE);
     return rc;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_improbe)
 int ADD_SUFFIX(MPID_nem_ofi_improbe)(struct MPIDI_VC *vc,
                          int source,
                          int tag,
@@ -160,7 +159,8 @@ int ADD_SUFFIX(MPID_nem_ofi_improbe)(struct MPIDI_VC *vc,
 {
     int old_error = status->MPI_ERROR;
     int s;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_IMPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_IMPROBE);
     *flag = CLAIM_PEEK;
     s = ADD_SUFFIX(MPID_nem_ofi_iprobe_impl)(vc, source,
                                              tag, comm, context_offset, flag, status, message);
@@ -168,37 +168,35 @@ int ADD_SUFFIX(MPID_nem_ofi_improbe)(struct MPIDI_VC *vc,
         status->MPI_ERROR = old_error;
         (*message)->kind = MPIR_REQUEST_KIND__MPROBE;
     }
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_IMPROBE);
     return s;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_anysource_iprobe)
 int ADD_SUFFIX(MPID_nem_ofi_anysource_iprobe)(int tag,
                                   MPIR_Comm * comm,
                                   int context_offset, int *flag, MPI_Status * status)
 {
     int rc;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IPROBE);
     *flag = NORMAL_PEEK;
     rc = ADD_SUFFIX(MPID_nem_ofi_iprobe)(NULL, MPI_ANY_SOURCE,
                                          tag, comm, context_offset, flag, status);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IPROBE);
     return rc;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_anysource_improbe)
 int ADD_SUFFIX(MPID_nem_ofi_anysource_improbe)(int tag,
                                    MPIR_Comm * comm,
                                    int context_offset,
                                    int *flag, MPIR_Request ** message, MPI_Status * status)
 {
     int rc;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IMPROBE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IMPROBE);
     *flag = CLAIM_PEEK;
     rc = ADD_SUFFIX(MPID_nem_ofi_improbe)(NULL, MPI_ANY_SOURCE, tag, comm,
                               context_offset, flag, message, status);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_IMPROBE);
     return rc;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
@@ -31,8 +31,6 @@ static inline MPIR_Request *context_to_req(void *ofi_context)
 #include "ofi_probe_template.c"
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_poll)
 int MPID_nem_ofi_poll(int in_blocking_poll)
 {
     int complete = 0, mpi_errno = MPI_SUCCESS;
@@ -42,7 +40,8 @@ int MPID_nem_ofi_poll(int in_blocking_poll)
     MPIDI_VC_t *vc;
     MPIR_Request *req;
     req_fn reqFn;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_POLL);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_POLL);
     do {
         /* ----------------------------------------------------- */
         /* Poll the completion queue                             */
@@ -121,9 +120,13 @@ int MPID_nem_ofi_poll(int in_blocking_poll)
             else {
                 MPIR_ERR_CHKANDJUMP4(1, mpi_errno, MPI_ERR_OTHER, "**ofi_poll",
                                      "**ofi_poll %s %d %s %s", __SHORT_FILE__,
-                                     __LINE__, FCNAME, fi_strerror(-ret));
+                                     __LINE__, __func__, fi_strerror(-ret));
             }
         }
     } while (in_blocking_poll && (ret > 0));
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_POLL);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
@@ -35,44 +35,51 @@ MPID_nem_ofi_send_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
 /* ------------------------------------------------------------------------ */
 /* Receive callback called after sending a syncronous send acknowledgement. */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_sync_recv_callback)
 static inline int MPID_nem_ofi_sync_recv_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
                                                   MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SYNC_RECV_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SYNC_RECV_CALLBACK);
 
     MPIDI_CH3U_Recvq_DP(REQ_OFI(rreq)->parent);
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(REQ_OFI(rreq)->parent));
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(rreq));
 
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SYNC_RECV_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 /* ------------------------------------------------------------------------ */
 /* Send done callback                                                       */
 /* Free any temporary/pack buffers and complete the send request            */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_send_callback)
 static inline int MPID_nem_ofi_send_callback(cq_tagged_entry_t * wc ATTRIBUTE((unused)),
                                              MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
     if (REQ_OFI(sreq)->pack_buffer)
         MPL_free(REQ_OFI(sreq)->pack_buffer);
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#define DO_CANCEL(req)                                  \
-({                                                      \
+/* Use macro as the two functions share common body */
+#define DO_CANCEL(req, _FCID)                           \
   int mpi_errno = MPI_SUCCESS;                          \
   int ret;                                              \
-  BEGIN_FUNC(FCNAME);                                   \
+  MPIR_FUNC_VERBOSE_STATE_DECL(_FCID);                  \
+  MPIR_FUNC_VERBOSE_ENTER(_FCID);                       \
   MPID_nem_ofi_poll(MPID_NONBLOCKING_POLL);             \
   ret = fi_cancel((fid_t)gl_data.endpoint,              \
                   &(REQ_OFI(req)->ofi_context));        \
@@ -88,32 +95,26 @@ static inline int MPID_nem_ofi_send_callback(cq_tagged_entry_t * wc ATTRIBUTE((u
   } else {                                              \
     MPIR_STATUS_SET_CANCEL_BIT(req->status, FALSE);     \
   }                                                     \
-  END_FUNC(FCNAME);                                     \
-  return mpi_errno;                                     \
-})
+  MPIR_FUNC_VERBOSE_EXIT(_FCID);                        \
+  return mpi_errno;
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cancel_send)
 int MPID_nem_ofi_cancel_send(struct MPIDI_VC *vc ATTRIBUTE((unused)), struct MPIR_Request *sreq)
 {
-    DO_CANCEL(sreq);
+    DO_CANCEL(sreq, MPID_NEM_OFI_CANCEL_SEND);
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_cancel_recv)
 int MPID_nem_ofi_cancel_recv(struct MPIDI_VC *vc ATTRIBUTE((unused)), struct MPIR_Request *rreq)
 {
-    DO_CANCEL(rreq);
+    DO_CANCEL(rreq, MPID_NEM_OFI_CANCEL_RECV);
 }
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_anysource_matched)
 int MPID_nem_ofi_anysource_matched(MPIR_Request * rreq)
 {
     int matched = FALSE;
     int ret;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_MATCHED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_MATCHED);
     /* ----------------------------------------------------- */
     /* Netmod has notified us that it has matched an any     */
     /* source request on another device.  We have the chance */
@@ -138,6 +139,6 @@ int MPID_nem_ofi_anysource_matched(MPIR_Request * rreq)
          */
         matched = TRUE;
     }
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_MATCHED);
     return matched;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged_template.c
@@ -16,8 +16,6 @@
 /* Receive done callback                                                    */
 /* Handle an incoming receive completion event                              */
 /* ------------------------------------------------------------------------ */
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_recv_callback)
 static inline
 int ADD_SUFFIX(MPID_nem_ofi_recv_callback)(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
@@ -26,7 +24,8 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_callback)(cq_tagged_entry_t * wc, MPIR_Request 
     intptr_t sz;
     MPIDI_VC_t *vc;
     MPIR_Request *sync_req;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_RECV_CALLBACK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_RECV_CALLBACK);
     /* ---------------------------------------------------- */
     /* Populate the MPI Status and unpack noncontig buffer  */
     /* ---------------------------------------------------- */
@@ -101,11 +100,13 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_callback)(cq_tagged_entry_t * wc, MPIR_Request 
         MPIDI_CH3U_Recvq_DP(rreq);
         MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(rreq));
     }
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_RECV_CALLBACK);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(send_normal)
 static inline int ADD_SUFFIX(send_normal)(struct MPIDI_VC *vc,
                               const void *buf, int count, MPI_Datatype datatype,
                               int dest, int tag, MPIR_Comm *comm,
@@ -218,8 +219,6 @@ fn_fail:
     goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(send_lightweight)
 static inline int
 ADD_SUFFIX(send_lightweight)(struct MPIDI_VC *vc,
                              const void *buf,
@@ -258,8 +257,6 @@ ADD_SUFFIX(send_lightweight)(struct MPIDI_VC *vc,
 }
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(do_isend)
 static inline int
 ADD_SUFFIX(do_isend)(struct MPIDI_VC *vc,
          const void *buf,
@@ -277,7 +274,8 @@ ADD_SUFFIX(do_isend)(struct MPIDI_VC *vc,
     MPI_Aint dt_true_lb;
     intptr_t data_sz;
     MPIR_Datatype *dt_ptr;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_DO_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_DO_ISEND);
 
     VC_READY_CHECK(vc);
     *request = NULL;
@@ -299,11 +297,13 @@ ADD_SUFFIX(do_isend)(struct MPIDI_VC *vc,
                                 context_offset, request, dt_contig,
                                 data_sz, dt_ptr, dt_true_lb, send_type);
 
-    END_FUNC_RC(MPID_STATE_DO_ISEND);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_DO_ISEND);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_send)
 int ADD_SUFFIX(MPID_nem_ofi_send)(struct MPIDI_VC *vc,
                       const void *buf,
                       MPI_Aint count,
@@ -313,15 +313,14 @@ int ADD_SUFFIX(MPID_nem_ofi_send)(struct MPIDI_VC *vc,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SEND);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest, tag,
                          comm, context_offset, request, MPID_DONT_CREATE_REQ, MPID_NORMAL_SEND);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SEND);
     return mpi_errno;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_isend)
 int ADD_SUFFIX(MPID_nem_ofi_isend)(struct MPIDI_VC *vc,
                        const void *buf,
                        MPI_Aint count,
@@ -330,15 +329,14 @@ int ADD_SUFFIX(MPID_nem_ofi_isend)(struct MPIDI_VC *vc,
                        int tag, MPIR_Comm * comm, int context_offset, struct MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISEND);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest,
                          tag, comm, context_offset, request, MPID_CREATE_REQ, MPID_NORMAL_SEND);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ISEND);
     return mpi_errno;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_ssend)
 int ADD_SUFFIX(MPID_nem_ofi_ssend)(struct MPIDI_VC *vc,
                        const void *buf,
                        MPI_Aint count,
@@ -347,15 +345,14 @@ int ADD_SUFFIX(MPID_nem_ofi_ssend)(struct MPIDI_VC *vc,
                        int tag, MPIR_Comm * comm, int context_offset, struct MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SSEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SSEND);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest,
                          tag, comm, context_offset, request, MPID_CREATE_REQ, MPIDI_OFI_SYNC_SEND);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SSEND);
     return mpi_errno;
 }
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_issend)
 int ADD_SUFFIX(MPID_nem_ofi_issend)(struct MPIDI_VC *vc,
                         const void *buf,
                         MPI_Aint count,
@@ -365,16 +362,15 @@ int ADD_SUFFIX(MPID_nem_ofi_issend)(struct MPIDI_VC *vc,
                         MPIR_Comm * comm, int context_offset, struct MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISSEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISSEND);
     mpi_errno = ADD_SUFFIX(do_isend)(vc, buf, count, datatype, dest,
                          tag, comm, context_offset, request, MPID_CREATE_REQ, MPIDI_OFI_SYNC_SEND);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ISSEND);
     return mpi_errno;
 }
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_recv_posted)
 int ADD_SUFFIX(MPID_nem_ofi_recv_posted)(struct MPIDI_VC *vc, struct MPIR_Request *rreq)
 {
     int mpi_errno = MPI_SUCCESS, dt_contig, src, tag;
@@ -385,7 +381,8 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_posted)(struct MPIDI_VC *vc, struct MPIR_Reques
     MPIR_Datatype*dt_ptr;
     MPIR_Context_id_t context_id;
     char *recv_buffer;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_RECV_POSTED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_RECV_POSTED);
 
     /* ------------------------ */
     /* Initialize the request   */
@@ -445,17 +442,20 @@ int ADD_SUFFIX(MPID_nem_ofi_recv_posted)(struct MPIDI_VC *vc, struct MPIR_Reques
     msg.context   = (void *) &(REQ_OFI(rreq)->ofi_context);
     msg.data      = 0;
     FI_RC_RETRY(fi_trecvmsg(gl_data.endpoint,&msg,msgflags), trecv);
-    END_FUNC_RC(FCNAME);
+    fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_RECV_POSTED);
+    return mpi_errno;
+    fn_fail:
+    goto fn_exit;
 }
 
 
-#undef FCNAME
-#define FCNAME MPL_QUOTE(MPID_nem_ofi_anysource_posted)
 void ADD_SUFFIX(MPID_nem_ofi_anysource_posted)(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    BEGIN_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_POSTED);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_POSTED);
     mpi_errno = ADD_SUFFIX(MPID_nem_ofi_recv_posted)(NULL, rreq);
     MPIR_Assert(mpi_errno == MPI_SUCCESS);
-    END_FUNC(FCNAME);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_ANYSOURCE_POSTED);
 }

--- a/src/mpid/ch4/shm/posix/posix_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_impl.h
@@ -18,24 +18,4 @@
 #include "posix_eager.h"
 #include "posix_eager_impl.h"
 
-#undef FUNCNAME
-#define FUNCNAME nothing
-#define BEGIN_FUNC(FUNCNAME)                    \
-    MPIR_FUNC_VERBOSE_STATE_DECL(FUNCNAME);     \
-    MPIR_FUNC_VERBOSE_ENTER(FUNCNAME);
-#define END_FUNC(FUNCNAME)                      \
-    MPIR_FUNC_VERBOSE_EXIT(FUNCNAME);
-#define END_FUNC_RC(FUNCNAME)                   \
-  fn_exit:                                      \
-    MPIR_FUNC_VERBOSE_EXIT(FUNCNAME);           \
-    return mpi_errno;                           \
-  fn_fail:                                      \
-    goto fn_exit;
-
-#define __SHORT_FILE__                          \
-    (strrchr(__FILE__,'/')                      \
-     ? strrchr(__FILE__,'/')+1                  \
-     : __FILE__                                 \
-)
-
 #endif /* POSIX_IMPL_H_INCLUDED */


### PR DESCRIPTION
Make the practice consistent with the rest of the code base. Facilitate future refactoring.