### PR TITLE
Clean up MacOS Warnings

### DIFF
--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -81,6 +81,12 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 #endif
 /* -- End Profiling Symbol Block */
 
+/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
+   the MPI routines */
+#ifndef MPICH_MPI_FROM_PMPI
+#undef MPI_Iallgatherv
+#define MPI_Iallgatherv PMPI_Iallgatherv
+
 /* This function checks whether the displacements are in increasing order and
  * that there is no overlap or gap between the data of successive ranks. Some
  * algorithms can only handle ordered array of data and hence this function for
@@ -96,12 +102,6 @@ static int is_ordered(int comm_size, const int recvcounts[], const int displs[])
     }
     return 1;
 }
-
-/* Define MPICH_MPI_FROM_PMPI if weak symbols are not supported to build
-   the MPI routines */
-#ifndef MPICH_MPI_FROM_PMPI
-#undef MPI_Iallgatherv
-#define MPI_Iallgatherv PMPI_Iallgatherv
 
 /* This is the machine-independent implementation of allgatherv. The algorithm is:
 

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -14,6 +14,25 @@
 #include "mpiimpl.h"
 #include "tsp_gentran_types.h"
 
+/* Undefine the previous definitions to avoid redefinition warnings */
+#undef MPIR_TSP_TRANSPORT_NAME
+#undef MPIR_TSP_sched_t
+#undef MPIR_TSP_sched_create
+#undef MPIR_TSP_sched_isend
+#undef MPIR_TSP_sched_irecv
+#undef MPIR_TSP_sched_imcast
+#undef MPIR_TSP_sched_issend
+#undef MPIR_TSP_sched_reduce_local
+#undef MPIR_TSP_sched_localcopy
+#undef MPIR_TSP_sched_selective_sink
+#undef MPIR_TSP_sched_sink
+#undef MPIR_TSP_sched_fence
+#undef MPIR_TSP_sched_malloc
+#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_sched_free
+#undef MPIR_TSP_sched_optimize
+#undef MPIR_TSP_sched_reset
+
 #define MPIR_TSP_TRANSPORT_NAME           Gentran_
 
 /* Transport data structures */

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.h
@@ -11,6 +11,25 @@
 #ifndef TSP_STUBTRAN_H_INCLUDED
 #define TSP_STUBTRAN_H_INCLUDED
 
+/* Undefine the previous definitions to avoid redefinition warnings */
+#undef MPIR_TSP_TRANSPORT_NAME
+#undef MPIR_TSP_sched_t
+#undef MPIR_TSP_sched_create
+#undef MPIR_TSP_sched_isend
+#undef MPIR_TSP_sched_irecv
+#undef MPIR_TSP_sched_imcast
+#undef MPIR_TSP_sched_issend
+#undef MPIR_TSP_sched_reduce_local
+#undef MPIR_TSP_sched_localcopy
+#undef MPIR_TSP_sched_selective_sink
+#undef MPIR_TSP_sched_sink
+#undef MPIR_TSP_sched_fence
+#undef MPIR_TSP_sched_malloc
+#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_sched_free
+#undef MPIR_TSP_sched_optimize
+#undef MPIR_TSP_sched_reset
+
 #define MPIR_TSP_TRANSPORT_NAME             Stubtran_
 
 /* Stub transport data structures */

--- a/src/mpid/ch4/netmod/portals4/globals.c
+++ b/src/mpid/ch4/netmod/portals4/globals.c
@@ -11,4 +11,6 @@
 #include "ptl_impl.h"
 #include "ptl_types.h"
 
-MPIDI_PTL_global_t MPIDI_PTL_global = { 0 };
+/* *INDENT-OFF* */
+MPIDI_PTL_global_t MPIDI_PTL_global = { {0} };
+/* *INDENT-ON* */

--- a/src/mpid/ch4/netmod/ucx/globals.c
+++ b/src/mpid/ch4/netmod/ucx/globals.c
@@ -10,4 +10,6 @@
 #include "ucx_impl.h"
 #include "ucx_types.h"
 
-MPIDI_UCX_global_t MPIDI_UCX_global = { 0 };
+/* *INDENT-OFF* */
+MPIDI_UCX_global_t MPIDI_UCX_global = { {0} };
+/* *INDENT-ON* */

--- a/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/func_table.c
@@ -9,6 +9,7 @@
  */
 
 #ifndef POSIX_EAGER_INLINE
+#ifndef POSIX_EAGER_DISABLE_INLINES
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>
@@ -30,4 +31,5 @@ MPIDI_POSIX_eager_funcs_t MPIDI_POSIX_eager_fbox_funcs = {
     MPIDI_POSIX_eager_recv_completed_hook
 };
 
+#endif /* POSIX_EAGER_DIABLE_INLINES */
 #endif /* POSIX_EAGER_INLINE */

--- a/src/mpid/ch4/shm/posix/eager/fbox/globals.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/globals.c
@@ -12,7 +12,9 @@
 #include "fbox_impl.h"
 #include "fbox_types.h"
 
-MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global = { 0 };
+/* *INDENT-OFF* */
+MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global = { {0} };
+/* *INDENT-ON* */
 
 #ifdef MPL_USE_DBG_LOGGING
 MPL_dbg_class MPIDI_CH4_SHM_POSIX_FBOX_GENERAL;

--- a/src/mpid/ch4/shm/posix/eager/stub/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/stub/func_table.c
@@ -9,6 +9,8 @@
  */
 
 #ifndef POSIX_EAGER_INLINE
+
+#ifndef POSIX_EAGER_DISABLE_INLINES
 #define POSIX_EAGER_DISABLE_INLINES
 
 #include <mpidimpl.h>
@@ -29,4 +31,5 @@ MPIDI_POSIX_eager_funcs_t MPIDI_POSIX_eager_stub_funcs = {
     MPIDI_POSIX_eager_recv_completed_hook
 };
 
+#endif /* POSIX_EAGER_DIABLE_INLINES */
 #endif /* POSIX_EAGER_INLINE */

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -194,7 +194,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_set_runtime_configurations(void)
                "unless --enable-ch4-mt=runtime is given at the configure time.\n");
 #endif /* #ifdef MPIDI_CH4_USE_MT_RUNTIME */
 
-  fn_fail:
     return mpi_errno;
 }
 
@@ -574,7 +573,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_CS_finalize(void)
     MPIR_Assert(thr_err == 0);
     MPID_Thread_mutex_destroy(&MPIDI_CH4I_THREAD_UTIL_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
-  fn_exit:
+
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CS_FINALIZE);
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -197,12 +197,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *buf,
         mpi_errno = MPIDI_NM_mpi_imrecv(buf, count, datatype, message);
 #endif
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMRECV_UNSAFE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 #undef FUNCNAME

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -76,14 +76,11 @@ enum MPIDI_workq_op { SEND, ISEND, SSEND, ISSEND, RSEND, IRSEND, RECV, IRECV, IM
     IMPROBE, PUT, GET, ACC, CAS, FAO, GACC
 };
 
-typedef struct MPIDI_workq_elemt MPIDI_workq_elemt_t;
-typedef struct MPIDI_workq_list MPIDI_workq_list_t;
-
-typedef struct MPIDI_av_entry MPIDI_av_entry_t;
+struct MPIDI_av_entry;
 
 /* Structure to encapsulate MPI operations that are delegated to another thread
  * Can be allocated from an MPI object pool or embedded in another object (e.g. request) */
-struct MPIDI_workq_elemt {
+typedef struct MPIDI_workq_elemt {
     MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
     MPIDI_workq_op_t op;
     OPA_int_t *processed;       /* set to true by the progress thread when
@@ -98,7 +95,7 @@ struct MPIDI_workq_elemt {
                 int tag;
                 MPIR_Comm *comm_ptr;
                 int context_offset;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
                 MPIR_Request *request;
             } send;             /* also for ISEND SSEND ISSEND RSEND IRSEND */
             struct MPIDI_workq_recv {
@@ -109,7 +106,7 @@ struct MPIDI_workq_elemt {
                 int tag;
                 MPIR_Comm *comm_ptr;
                 int context_offset;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
                 MPI_Status *status;
                 MPIR_Request *request;
             } recv;
@@ -121,7 +118,7 @@ struct MPIDI_workq_elemt {
                 int tag;
                 MPIR_Comm *comm_ptr;
                 int context_offset;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
                 MPIR_Request *request;
             } irecv;
             struct MPIDI_workq_iprobe {
@@ -131,7 +128,7 @@ struct MPIDI_workq_elemt {
                 int tag;
                 MPIR_Comm *comm_ptr;
                 int context_offset;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
                 MPI_Status *status;
                 MPIR_Request *request;
                 int *flag;
@@ -143,7 +140,7 @@ struct MPIDI_workq_elemt {
                 int tag;
                 MPIR_Comm *comm_ptr;
                 int context_offset;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
                 MPI_Status *status;
                 MPIR_Request *request;
                 int *flag;
@@ -167,7 +164,7 @@ struct MPIDI_workq_elemt {
                 int target_count;
                 MPI_Datatype target_datatype;
                 MPIR_Win *win_ptr;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
             } put;
             struct MPIDI_workq_get {
                 void *origin_addr;
@@ -178,16 +175,16 @@ struct MPIDI_workq_elemt {
                 int target_count;
                 MPI_Datatype target_datatype;
                 MPIR_Win *win_ptr;
-                MPIDI_av_entry_t *addr;
+                struct MPIDI_av_entry *addr;
             } get;
         } rma;
     } params;
-};
+} MPIDI_workq_elemt_t;
 
 /* List structure to implement per-object (e.g. per-communicator, per-window) work queues */
 struct MPIDI_workq_list {
     MPIDI_workq_t pend_ops;
-    MPIDI_workq_list_t *next, *prev;
+    struct MPIDI_workq_list *next, *prev;
 };
 
 #endif /* CH4I_WORKQ_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -85,7 +85,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_CH4I_am_request_init(MPIR_Request *
     MPIR_Assert(MPIDI_CH4U_REQUEST(req, req));
     MPIDI_CH4U_REQUEST(req, req->status) = 0;
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_AM_REQUEST_INIT);
     return req;
 }
@@ -115,7 +114,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_CH4I_am_request_copy(MPIR_Request * dest, MP
     MPIDI_CH4U_REQUEST(dest, context_id) = MPIDI_CH4U_REQUEST(src, context_id);
     MPIDI_CH4U_REQUEST(dest, req->status) = MPIDI_CH4U_REQUEST(src, req->status);
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4I_AM_REQUEST_COPY);
     return;
 }

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -487,6 +487,11 @@ static inline int MPIDI_CH4R_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_o
             }
         }
     }
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_GET_SHM_SYMHEAP);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 #endif
 
     if (any_mapfail_flag) {
@@ -496,11 +501,8 @@ static inline int MPIDI_CH4R_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_o
         *fail_flag = 1;
     }
 
-  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH4R_GET_SHM_SYMHEAP);
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 #endif /* CH4R_SYMHEAP_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -391,12 +391,13 @@ static inline int MPIDI_CH4R_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_o
                                              MPIR_Comm * comm, MPIR_Win * win, int *fail_flag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int iter = MPIR_CVAR_CH4_SHM_SYMHEAP_RETRY;
     unsigned any_mapfail_flag = 1;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH4R_GET_SHM_SYMHEAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH4R_GET_SHM_SYMHEAP);
 
 #ifdef USE_SYM_HEAP
+    int iter = MPIR_CVAR_CH4_SHM_SYMHEAP_RETRY;
     MPL_shm_hnd_t *shm_segment_hdl_ptr = &MPIDI_CH4U_WIN(win, shm_segment_handle);
     void **base_ptr = &MPIDI_CH4U_WIN(win, mmap_addr);
 

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -54,14 +54,16 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
         case MPIDU_SCHED_ENTRY_SEND:
             {
                 struct MPIDU_Sched_send *s = &(e->u.send);
-                fprintf(fh, "\t\tSend: %llu of type %x from %d\n", s->count, s->datatype, s->dest);
+                fprintf(fh, "\t\tSend: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", s->count,
+                        s->datatype, s->dest);
                 fprintf(fh, "\t\t from buff: %p\n", s->buf);
             }
             break;
         case MPIDU_SCHED_ENTRY_RECV:
             {
                 struct MPIDU_Sched_recv *r = &(e->u.recv);
-                fprintf(fh, "\t\tRecv: %llu of type %x from %d\n", r->count, r->datatype, r->src);
+                fprintf(fh, "\t\tRecv: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", r->count,
+                        r->datatype, r->src);
                 fprintf(fh, "\t\t Into buff: %p\n", r->buf);
             }
             break;
@@ -69,16 +71,18 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             {
                 struct MPIDU_Sched_reduce *rd = &(e->u.reduce);
                 fprintf(fh, "\t\tReduce: %p -> %p\n", rd->inbuf, rd->inoutbuf);
-                fprintf(fh, "\t\t  %llu elements of type %x\n", rd->count, rd->datatype);
+                fprintf(fh, "\t\t  " MPI_AINT_FMT_DEC_SPEC " elements of type %x\n", rd->count,
+                        rd->datatype);
                 fprintf(fh, "\t\t Op: %x\n", rd->op);
             }
             break;
         case MPIDU_SCHED_ENTRY_COPY:
             {
                 struct MPIDU_Sched_copy *cp = &(e->u.copy);
-                fprintf(fh, "\t\tFrom: %p %llu of type %x\n", cp->inbuf, cp->incount, cp->intype);
-                fprintf(fh, "\t\tTo:   %p %llu of type %x\n", cp->outbuf, cp->outcount,
-                        cp->outtype);
+                fprintf(fh, "\t\tFrom: %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->inbuf,
+                        cp->incount, cp->intype);
+                fprintf(fh, "\t\tTo:   %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->outbuf,
+                        cp->outcount, cp->outtype);
             }
             break;
         case MPIDU_SCHED_ENTRY_NOP:

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -127,31 +127,27 @@ static HYD_status list_to_nodes(char *str)
 
             if (regexec(&rmatch_old, rpattern, MAX_RMATCH, rmatch, 0) == 0) {
                 /* matched range: (h)(00)-(h)(12) */
-                snprintf(basename, MAX_HOSTNAME_LEN, "%.*s%c",
-                         (int) (rmatch[1].rm_eo - rmatch[1].rm_so), rpattern + rmatch[1].rm_so,
-                         '\0');
-                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s%c",
-                         (int) (rmatch[2].rm_eo - rmatch[2].rm_so), rpattern + rmatch[2].rm_so,
-                         '\0');
-                snprintf(rend, MAX_NNODES_STRLEN, "%.*s%c",
-                         (int) (rmatch[4].rm_eo - rmatch[4].rm_so), rpattern + rmatch[4].rm_so,
-                         '\0');
+                snprintf(basename, MAX_HOSTNAME_LEN, "%.*s",
+                         (int) (rmatch[1].rm_eo - rmatch[1].rm_so), rpattern + rmatch[1].rm_so);
+                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s",
+                         (int) (rmatch[2].rm_eo - rmatch[2].rm_so), rpattern + rmatch[2].rm_so);
+                snprintf(rend, MAX_NNODES_STRLEN, "%.*s",
+                         (int) (rmatch[4].rm_eo - rmatch[4].rm_so), rpattern + rmatch[4].rm_so);
                 begin = atoi(rbegin);
                 end = atoi(rend);
 
                 /* expand range and add nodes to global node list */
                 for (j = begin; j <= end; j++) {
-                    snprintf(hostname, MAX_HOSTNAME_LEN, "%s%.*d%c",
-                             basename, (int) (rmatch[2].rm_eo - rmatch[2].rm_so), j, '\0');
+                    snprintf(hostname, MAX_HOSTNAME_LEN, "%s%.*d",
+                             basename, (int) (rmatch[2].rm_eo - rmatch[2].rm_so), j);
                     status =
                         HYDU_add_to_node_list(hostname, tasks_per_node[k++], &global_node_list);
                     HYDU_ERR_POP(status, "unable to add to node list\n");
                 }
             } else if (regexec(&ematch_old, epattern, MAX_EMATCH, ematch, 0) == 0) {
                 /* matched element: (h14) */
-                snprintf(hostname, MAX_HOSTNAME_LEN, "%.*s%c",
-                         (int) (ematch[1].rm_eo - ematch[1].rm_so), epattern + ematch[1].rm_so,
-                         '\0');
+                snprintf(hostname, MAX_HOSTNAME_LEN, "%.*s",
+                         (int) (ematch[1].rm_eo - ematch[1].rm_so), epattern + ematch[1].rm_so);
                 status = HYDU_add_to_node_list(hostname, tasks_per_node[k++], &global_node_list);
                 HYDU_ERR_POP(status, "unable to add to node list\n");
             }
@@ -173,9 +169,8 @@ static HYD_status list_to_nodes(char *str)
         *(gpattern[0] + gmatch[0][0].rm_eo) = 0;
 
         /* extranct basename from atom 2 in group-0 */
-        snprintf(basename, MAX_HOSTNAME_LEN, "%.*s%c",
-                 (int) (gmatch[0][2].rm_eo - gmatch[0][2].rm_so), gpattern[0] + gmatch[0][2].rm_so,
-                 '\0');
+        snprintf(basename, MAX_HOSTNAME_LEN, "%.*s",
+                 (int) (gmatch[0][2].rm_eo - gmatch[0][2].rm_so), gpattern[0] + gmatch[0][2].rm_so);
 
         /* select third atom in group-0 */
         gpattern[1] = gpattern[0] + gmatch[0][3].rm_so;
@@ -192,29 +187,26 @@ static HYD_status list_to_nodes(char *str)
 
             if (regexec(&rmatch_new, rpattern, MAX_RMATCH, rmatch, 0) == 0) {
                 /* matched range: (00)-(10) */
-                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s%c",
-                         (int) (rmatch[1].rm_eo - rmatch[1].rm_so), rpattern + rmatch[1].rm_so,
-                         '\0');
-                snprintf(rend, MAX_NNODES_STRLEN, "%.*s%c",
-                         (int) (rmatch[2].rm_eo - rmatch[2].rm_so), rpattern + rmatch[2].rm_so,
-                         '\0');
+                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s",
+                         (int) (rmatch[1].rm_eo - rmatch[1].rm_so), rpattern + rmatch[1].rm_so);
+                snprintf(rend, MAX_NNODES_STRLEN, "%.*s",
+                         (int) (rmatch[2].rm_eo - rmatch[2].rm_so), rpattern + rmatch[2].rm_so);
                 begin = atoi(rbegin);
                 end = atoi(rend);
 
                 /* expand range and add nodes to global node list */
                 for (j = begin; j <= end; j++) {
-                    snprintf(hostname, MAX_HOSTNAME_LEN, "%s%.*d%c",
-                             basename, (int) (rmatch[1].rm_eo - rmatch[1].rm_so), j, '\0');
+                    snprintf(hostname, MAX_HOSTNAME_LEN, "%s%.*d",
+                             basename, (int) (rmatch[1].rm_eo - rmatch[1].rm_so), j);
                     status =
                         HYDU_add_to_node_list(hostname, tasks_per_node[k++], &global_node_list);
                     HYDU_ERR_POP(status, "unable to add to node list\n");
                 }
             } else if (regexec(&ematch_new, epattern, MAX_EMATCH, ematch, 0) == 0) {
                 /* matched element: (14) */
-                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s%c",
-                         (int) (ematch[1].rm_eo - ematch[1].rm_so), epattern + ematch[1].rm_so,
-                         '\0');
-                snprintf(hostname, MAX_HOSTNAME_LEN, "%s%s%c", basename, rbegin, '\0');
+                snprintf(rbegin, MAX_NNODES_STRLEN, "%.*s",
+                         (int) (ematch[1].rm_eo - ematch[1].rm_so), epattern + ematch[1].rm_so);
+                snprintf(hostname, MAX_HOSTNAME_LEN, "%s%s", basename, rbegin);
                 status = HYDU_add_to_node_list(hostname, tasks_per_node[k++], &global_node_list);
                 HYDU_ERR_POP(status, "unable to add to node list\n");
             }


### PR DESCRIPTION
Clean up a bunch of warnings when using more recent versions of GCC and Clang on MacOS.