### PR TITLE
test/maint: xfail rqfreeb test for UCX

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -201,3 +201,5 @@ valgrind * * * * sed -i "s+\(^epochtest .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 valgrind * * * * sed -i "s+\(^putfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 valgrind * * * * sed -i "s+\(^getfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+# Bug - Github Issue https://github.com/pmodels/mpich/issues/3469
+* * debug ch4:ucx * sed -i "s+\(^rqfreeb .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist


### PR DESCRIPTION
This is a known bug which is reported in pmodels/mpich#3469.