### PR TITLE
init: Add thread initialization and finalization 

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -337,6 +337,14 @@ int MPI_Finalize(void)
     }
 #endif
 
+    /* Finalize the threading library after releasing all synchronization
+     * objects (e.g., mutexes) */
+    {
+        int thread_err;
+        MPL_thread_finalize(&thread_err);
+        MPIR_Assert(thread_err == 0);
+    }
+
     /* ... end of body of routine ... */
   fn_exit:
     MPIR_FUNC_TERSE_FINALIZE_EXIT(MPID_STATE_MPI_FINALIZE);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -356,6 +356,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     int thread_provided = 0;
     int exit_init_cs_on_failure = 0;
     MPIR_Info *info_ptr;
+#if defined(MPICH_IS_THREADED)
+    bool cs_initialized = false;
+#endif
 
     /* The threading library must be initialized at the very beginning because
      * it manages all synchronization objects (e.g., mutexes) that will be
@@ -401,6 +404,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
 #if defined(MPICH_IS_THREADED)
     mpi_errno = thread_cs_init();
+    cs_initialized = true;
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 #endif
@@ -675,7 +679,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
         MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
 #if defined(MPICH_IS_THREADED)
-    MPIR_Thread_CS_Finalize();
+    if (cs_initialized) {
+        MPIR_Thread_CS_Finalize();
+    }
 #endif
     return mpi_errno;
     /* --END ERROR HANDLING-- */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -357,15 +357,15 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     int exit_init_cs_on_failure = 0;
     MPIR_Info *info_ptr;
 
-#if (MPL_THREAD_PACKAGE_NAME == MPL_THREAD_PACKAGE_ARGOBOTS)
-    int rc = ABT_initialized();
-    if (rc != ABT_SUCCESS) {
-        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                         "MPI_Init_thread", __LINE__, MPI_ERR_OTHER,
-                                         "**argobots_uninitialized", 0);
-        goto fn_fail;
+    /* The threading library must be initialized at the very beginning because
+     * it manages all synchronization objects (e.g., mutexes) that will be
+     * initialized later */
+    {
+        int thread_err;
+        MPL_thread_init(&thread_err);
+        if (thread_err)
+            goto fn_fail;
     }
-#endif
 
 #ifdef HAVE_HWLOC
     MPIR_Process.bindset = hwloc_bitmap_alloc();

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -25,6 +25,26 @@ typedef ABT_key MPL_thread_tls_t;
  *    Creation and misc
  * ======================================================================*/
 
+#define MPL_thread_init(err_ptr_)                                             \
+    do {                                                                      \
+        int err__;                                                            \
+        err__ = ABT_init(0, NULL);                                            \
+        if (unlikely(err__))                                                  \
+            MPL_internal_sys_error_printf("ABT_init", err__,                  \
+                                          "    %s:%d\n", __FILE__, __LINE__); \
+        *(int *)(err_ptr_) = err__;                                           \
+    } while (0)
+
+#define MPL_thread_finalize(err_ptr_)                                         \
+    do {                                                                      \
+        int err__;                                                            \
+        err__ = ABT_finalize();                                               \
+        if (unlikely(err__))                                                  \
+            MPL_internal_sys_error_printf("ABT_finalize", err__,              \
+                                          "    %s:%d\n", __FILE__, __LINE__); \
+        *(int *)(err_ptr_) = err__;                                           \
+    } while (0)
+
 /* MPL_thread_create() defined in mpiu_thread_argobots.c */
 typedef void (*MPL_thread_func_t) (void *data);
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp, int *errp);

--- a/src/mpl/include/mpl_thread_posix.h
+++ b/src/mpl/include/mpl_thread_posix.h
@@ -28,6 +28,16 @@ int pthread_mutexattr_settype(pthread_mutexattr_t * attr, int kind);
 typedef void (*MPL_thread_func_t) (void *data);
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id, int *err);
 
+#define MPL_thread_init(err_ptr_)               \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
+#define MPL_thread_finalize(err_ptr_)           \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
 #define MPL_thread_exit()                       \
     do {                                        \
         pthread_exit(NULL);                     \

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -22,6 +22,16 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
  * Threads
  */
 
+#define MPL_thread_init(err_ptr_)               \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
+#define MPL_thread_finalize(err_ptr_)           \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
 #define MPL_thread_exit()                       \
     do {                                        \
         thr_exit(NULL);                         \

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -28,6 +28,16 @@ typedef struct MPL_thread_cond_t {
 
 typedef void (*MPL_thread_func_t) (void *data);
 
+#define MPL_thread_init(err_ptr_)               \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
+#define MPL_thread_finalize(err_ptr_)           \
+    do {                                        \
+        *(int *)(err_ptr_) = 0;                 \
+    } while (0)
+
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id, int *err);
 void MPL_thread_exit(void);
 void MPL_thread_self(MPL_thread_id_t * id);


### PR DESCRIPTION
Previously, if Argobots is enabled, `ABT_init` must be called before `MPI_Init`, which is very cumbersome
Now Argobots has an initialization counter inside and therefore can be initialized multiple times.
This PR adds `ABT_init` and corresponding `ABT_finalize` in MPI initialization and finalization.

The current implementation imposes a restriction derived from Argobots; when the Argobots option is enabled, the same thread needs to initialize and finalize the MPI runtime. See https://github.com/pmodels/argobots/issues/86 for details.
