### PR TITLE
Rename and use counter for registered hooks

### DIFF
--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     }
 #endif
 
-    if (OPA_load_int(&MPIDI_CH4_Global.active_progress_hooks) && (flags & MPIDI_PROGRESS_HOOKS)) {
+    if (OPA_load_int(&MPIDI_CH4_Global.registered_progress_hooks) && (flags & MPIDI_PROGRESS_HOOKS)) {
         for (i = 0; i < MAX_PROGRESS_HOOKS; i++) {
             progress_func_ptr_t func_ptr = NULL;
             MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX);
@@ -184,7 +184,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_register(int (*progress_fn) (int *), 
     if (i >= MAX_PROGRESS_HOOKS)
         goto fn_fail;
 
-    OPA_incr_int(&MPIDI_CH4_Global.active_progress_hooks);
+    OPA_incr_int(&MPIDI_CH4_Global.registered_progress_hooks);
 
     (*id) = i;
 
@@ -218,7 +218,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_deregister(int id)
     MPIDI_CH4_Global.progress_hooks[id].func_ptr = NULL;
     MPIDI_CH4_Global.progress_hooks[id].active = FALSE;
 
-    OPA_decr_int(&MPIDI_CH4_Global.active_progress_hooks);
+    OPA_decr_int(&MPIDI_CH4_Global.registered_progress_hooks);
     MPID_THREAD_CS_EXIT(VNI, MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX);
     MPID_THREAD_CS_EXIT(POBJ, MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_PROGRESS_DEREGISTER);

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -19,7 +19,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 {
-    int mpi_errno, made_progress, i;
+    int mpi_errno, made_progress, num_of_hooks, i;
     mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PROGRESS_TEST);
@@ -34,8 +34,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     }
 #endif
 
-    if (OPA_load_int(&MPIDI_CH4_Global.registered_progress_hooks) && (flags & MPIDI_PROGRESS_HOOKS)) {
-        for (i = 0; i < MAX_PROGRESS_HOOKS; i++) {
+    num_of_hooks = OPA_load_int(&MPIDI_CH4_Global.registered_progress_hooks);
+    if (num_of_hooks && (flags & MPIDI_PROGRESS_HOOKS)) {
+        for (i = 0; i < num_of_hooks; i++) {
             progress_func_ptr_t func_ptr = NULL;
             MPID_THREAD_CS_ENTER(POBJ, MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX);
             MPID_THREAD_CS_ENTER(VNI, MPIDI_CH4I_THREAD_PROGRESS_HOOK_MUTEX);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -287,7 +287,7 @@ typedef struct MPIDI_CH4_Global_t {
     int is_ch4u_initialized;
     int **node_map, max_node_id;
     MPIDI_CH4U_comm_req_list_t *comm_req_lists;
-    OPA_int_t active_progress_hooks;
+    OPA_int_t registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
     MPID_Thread_mutex_t m[3];


### PR DESCRIPTION
The first commit renames the `active_progress_hooks` counter to `registered_progress_hooks` since the counter is used to track the number of hooks that are currently registered.

Currently, the counter is only used to check if there are any registered hooks (which I think will always be the case even if the registered hook is inactive) before making any progress. The value of the counter can also be used to remove unnecessary iterations in the loop that calls progress on the registered hooks which in turn reduces the number of locks taken for multi-thread models that are not global.