### PR TITLE
mpl/shm: include system shm headers in mpl_shm headers

### DIFF
--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -11,10 +11,6 @@
 #ifndef CH4R_PROC_H_INCLUDED
 #define CH4R_PROC_H_INCLUDED
 
-#ifdef HAVE_SYS_MMAN_H
-#include <sys/mman.h>
-#endif
-
 #include "ch4_types.h"
 #include "build_nodemap.h"
 

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -14,15 +14,9 @@
 #include <mpichconf.h>
 
 #include <opa_primitives.h>
-#ifdef HAVE_SYS_MMAN_H
-#include <sys/mman.h>
-#endif /* HAVE_SYS_MMAN_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif /* HAVE_FCNTL_H */
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
 #endif /* HAVE_STDINT_H */

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -16,9 +16,6 @@
 #include "mpir_info.h"
 #include "ch4r_symheap.h"
 #include "uthash.h"
-#ifdef HAVE_SYS_MMAN_H
-#include <sys/mman.h>
-#endif /* HAVE_SYS_MMAN_H */
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===

--- a/src/mpl/include/mpl_shm_mmap.h
+++ b/src/mpl/include/mpl_shm_mmap.h
@@ -7,6 +7,12 @@
 #ifndef MPL_SHM_MMAP_H_INCLUDED
 #define MPL_SHM_MMAP_H_INCLUDED
 
+#include <fcntl.h>
+
+#ifdef MPL_HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+
 typedef intptr_t MPLI_shm_lhnd_t;
 
 typedef char *MPLI_shm_ghnd_t;

--- a/src/mpl/include/mpl_shm_sysv.h
+++ b/src/mpl/include/mpl_shm_sysv.h
@@ -7,6 +7,10 @@
 #ifndef MPL_SHM_SYSV_H_INCLUDED
 #define MPL_SHM_SYSV_H_INCLUDED
 
+#include <sys/stat.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+
 typedef int MPLI_shm_lhnd_t;
 
 typedef char *MPLI_shm_ghnd_t;

--- a/src/mpl/include/mpl_shm_win.h
+++ b/src/mpl/include/mpl_shm_win.h
@@ -7,6 +7,9 @@
 #ifndef MPL_SHM_WIN_H_INCLUDED
 #define MPL_SHM_WIN_H_INCLUDED
 
+#include <winsock2.h>
+#include <windows.h>
+
 typedef HANDLE MPL_shm_lhnd_t;
 
 typedef char *MPLI_shm_ghnd_t;

--- a/src/mpl/src/shm/mpl_shm_win.c
+++ b/src/mpl/src/shm/mpl_shm_win.c
@@ -11,8 +11,8 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #ifdef MPL_USE_NT_SHM
 
-#include<winsock2.h>
-#include<windows.h>
+#include <winsock2.h>
+#include <windows.h>
 
 /* A template function which creates/attaches shm seg handle
  * to the shared memory. Used by user-exposed functions below


### PR DESCRIPTION
These headers are needed where shm related constants (for example
MAP_SHARED for mmap) are referred. Include them in MPL header so that
the user won't need to manually include them where MPL shm is used.