### PR TITLE
Datatypes: Use flatten/unflatten instead of manually copying dataloops

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -385,10 +385,8 @@ foreach my $p (@cvars) {
     if ($p->{type} eq 'string') {
         # Need to cleanup after whatever was strduped by the init routine
 print OUTPUT_C <<EOT;
-    if (${var_name} != NULL) {
-        MPL_free((char *)${var_name});
-        ${var_name} = NULL;
-    }
+    MPL_free((char *)${var_name});
+    ${var_name} = NULL;
 
 EOT
     }

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -1980,7 +1980,7 @@ sub logical_array_in_decl {
 	print $OUTFD "    int _ctsize;\n";
     }
     print $OUTFD "    int *l$count=0;\n";
-    $clean_up .= "    if (l$count) { $free( l$count ); }\n";
+    $clean_up .= "    $free( l$count );\n";
 }
 sub logical_array_in_arg {
     my $count = $_[0];
@@ -2820,7 +2820,7 @@ sub fint2int_array_in_ftoc {
      }
     }
 ";
-	$clean_up .= "     if ($coutvar) { $free( $coutvar ); }\n";
+	$clean_up .= "     $free( $coutvar );\n";
     }
 }
 sub fint2int_array_inout_ftoc {
@@ -2851,7 +2851,7 @@ sub fint2int_array_out_ftoc {
 	print $OUTFD "\
     $coutvar = (int *)$malloc( $asize * sizeof(int), MPL_MEM_OTHER );
 ";
-        $clean_up .= "     if ($coutvar) { $free( $coutvar ); }\n";
+        $clean_up .= "     $free( $coutvar );\n";
     }
 }
 
@@ -2998,7 +2998,7 @@ sub fint2intinplace_array_in_ftoc {
      }
     }
 ";
-	$clean_up .= "     if ($coutvar) { $free( $coutvar ); }\n";
+	$clean_up .= "     $free( $coutvar );\n";
     }
 }
 sub fint2intinplace_array_in_decl {
@@ -3051,7 +3051,7 @@ sub fint2int_rangearray_in_ftoc {
      }
     }
 ";
-	$clean_up .= "     if ($coutvar) { $free( $coutvar ); }\n";
+	$clean_up .= "     $free( $coutvar );\n";
     }
 }
 sub fint2int_rangearray_in_decl {
@@ -3515,7 +3515,7 @@ sub intToAintArr_in_ctof {
     my $vname = $_[1];
     print $OUTFD "
 #ifdef HAVE_AINT_LARGER_THAN_FINT
-    if ($lname) { $free($lname); }
+    $free($lname);
 #endif\n";
 }
 # ---------------------------------------------------------------------------

--- a/src/include/mpir_dataloop.h
+++ b/src/include/mpir_dataloop.h
@@ -17,7 +17,6 @@ typedef struct MPIR_Dataloop MPIR_Dataloop;
 typedef struct MPIR_Segment MPIR_Segment;
 
 /* Dataloop functions */
-void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff);
 void MPIR_Dataloop_dup(MPIR_Dataloop * old_loop, MPI_Aint old_loop_sz, MPIR_Dataloop ** new_loop_p);
 
 void MPIR_Dataloop_free(MPIR_Dataloop ** dataloop);

--- a/src/include/mpir_dataloop.h
+++ b/src/include/mpir_dataloop.h
@@ -25,6 +25,9 @@ void MPIR_Dataloop_free(MPIR_Dataloop ** dataloop);
 void MPIR_Dataloop_create(MPI_Datatype type, MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
 
 void MPIR_Dataloop_printf(MPI_Datatype type, int depth, int header);
+int MPIR_Dataloop_flatten_size(MPIR_Datatype * dtp, int *flattened_dataloop_size);
+int MPIR_Dataloop_flatten(MPIR_Datatype * dtp, void *flattened_dataloop);
+int MPIR_Dataloop_unflatten(MPIR_Datatype * dtp, void *flattened_dataloop);
 
 /* Segment functions */
 MPIR_Segment *MPIR_Segment_alloc(const void *buf, MPI_Aint count, MPI_Datatype handle);
@@ -43,10 +46,6 @@ void MPIR_Segment_to_iov(struct MPIR_Segment *segp,
 
 void MPIR_Segment_from_iov(struct MPIR_Segment *segp,
                            MPI_Aint first, MPI_Aint * lastp, MPL_IOV * vector, int *lengthp);
-
-void MPIR_Segment_flatten(struct MPIR_Segment *segp,
-                          MPI_Aint first,
-                          MPI_Aint * lastp, MPI_Aint * offp, MPI_Aint * sizep, MPI_Aint * lengthp);
 
 void MPIR_Segment_pack_external32(struct MPIR_Segment *segp,
                                   MPI_Aint first, MPI_Aint * lastp, void *pack_buffer);

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -580,8 +580,10 @@ int MPIR_Type_get_contents(MPI_Datatype datatype, int max_integers, int max_addr
                            int max_datatypes, int array_of_integers[],
                            MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
 int MPIR_Type_create_pairtype(MPI_Datatype datatype, MPIR_Datatype * new_dtp);
-int MPIR_Type_flatten(MPI_Datatype type, MPI_Aint * off_array, MPI_Aint * size_array,
-                      MPI_Aint * array_len_p);
+
+int MPIR_Type_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_size);
+int MPIR_Type_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
+int MPIR_Type_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
 
 /* debugging helper functions */
 char *MPIR_Datatype_builtin_to_string(MPI_Datatype type);

--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -66,9 +66,7 @@ static inline int MPIR_Handle_free(void *((*indirect)[]), int indirect_size)
     for (i = 0; i < indirect_size; i++) {
         MPL_free((*indirect)[i]);
     }
-    if (indirect) {
-        MPL_free(indirect);
-    }
+    MPL_free(indirect);
     /* This does *not* remove any objects that the user created
      * and then did not destroy */
     return 0;

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -354,7 +354,7 @@ static inline void MPIR_Request_free(MPIR_Request * req)
             MPIR_Comm_release(req->comm);
         }
 
-        if (req->kind == MPIR_REQUEST_KIND__GREQUEST && req->u.ureq.greq_fns != NULL) {
+        if (req->kind == MPIR_REQUEST_KIND__GREQUEST) {
             MPL_free(req->u.ureq.greq_fns);
         }
 

--- a/src/mpi/comm/comm_create.c
+++ b/src/mpi/comm/comm_create.c
@@ -251,8 +251,7 @@ int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
     }
 
   fn_exit:
-    if (mapping)
-        MPL_free(mapping);
+    MPL_free(mapping);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_CREATE_INTRA);
     return mpi_errno;
@@ -443,8 +442,7 @@ PMPI_LOCAL int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_p
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
-    if (mapping)
-        MPL_free(mapping);
+    MPL_free(mapping);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_CREATE_INTER);
     return mpi_errno;

--- a/src/mpi/comm/comm_create_group.c
+++ b/src/mpi/comm/comm_create_group.c
@@ -107,8 +107,7 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
     }
 
   fn_exit:
-    if (mapping)
-        MPL_free(mapping);
+    MPL_free(mapping);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_CREATE_GROUP);
     return mpi_errno;

--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -824,8 +824,7 @@ static int compare_info_hint(const char *hintval, MPIR_Comm * comm_ptr, int *inf
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    if (hintval_global != NULL)
-        MPL_free(hintval_global);
+    MPL_free(hintval_global);
 
     *info_args_are_equal = hintval_equal_global;
     return mpi_errno;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -383,10 +383,8 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
              * any node awareness.  Node-aware collectives are an optimization. */
             MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE,
                           "MPIR_Find_local_and_external failed for comm_ptr=%p", comm);
-            if (comm->intranode_table)
-                MPL_free(comm->intranode_table);
-            if (comm->internode_table)
-                MPL_free(comm->internode_table);
+            MPL_free(comm->intranode_table);
+            MPL_free(comm->internode_table);
 
             mpi_errno = MPI_SUCCESS;
             goto fn_exit;
@@ -489,10 +487,8 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         MPIR_Comm_map_free(comm);
     }
 
-    if (external_procs != NULL)
-        MPL_free(external_procs);
-    if (local_procs != NULL)
-        MPL_free(local_procs);
+    MPL_free(external_procs);
+    MPL_free(local_procs);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_COMMIT);
     return mpi_errno;
@@ -810,10 +806,8 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
             MPIR_Comm_release(comm_ptr->node_comm);
         if (comm_ptr->node_roots_comm)
             MPIR_Comm_release(comm_ptr->node_roots_comm);
-        if (comm_ptr->intranode_table != NULL)
-            MPL_free(comm_ptr->intranode_table);
-        if (comm_ptr->internode_table != NULL)
-            MPL_free(comm_ptr->internode_table);
+        MPL_free(comm_ptr->intranode_table);
+        MPL_free(comm_ptr->internode_table);
 
         /* Free the context value.  This should come after freeing the
          * intra/inter-node communicators since those free calls won't

--- a/src/mpi/comm/intercomm_create.c
+++ b/src/mpi/comm/intercomm_create.c
@@ -148,10 +148,8 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
 
 
   fn_exit:
-    if (remote_lpids) {
-        MPL_free(remote_lpids);
-        remote_lpids = NULL;
-    }
+    MPL_free(remote_lpids);
+    remote_lpids = NULL;
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_KIND__INTERCOMM_CREATE_IMPL);
     return mpi_errno;
   fn_fail:

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -126,7 +126,7 @@ int MPIR_Dataloop_unflatten(MPIR_Datatype * dtp, void *flattened_dataloop)
 
     ptrdiff =
         (MPI_Aint) ((char *) (dtp->dataloop) - (char *) dloop_flatten_hdr->dataloop_local_addr);
-    MPIR_Dataloop_update(dtp->dataloop, ptrdiff);
+    MPII_Dataloop_update(dtp->dataloop, ptrdiff);
 
   fn_exit:
     return mpi_errno;
@@ -172,7 +172,7 @@ static void dloop_copy(void *dest, void *src, MPI_Aint size)
     /* copy region first */
     MPIR_Memcpy(dest, src, size);
 
-    /* Calculate difference in starting locations. MPIR_Dataloop_update()
+    /* Calculate difference in starting locations. MPII_Dataloop_update()
      * then traverses the new structure and updates internal pointers by
      * adding this difference to them. This way we can just copy the
      * structure, including pointers, in one big block.
@@ -180,14 +180,14 @@ static void dloop_copy(void *dest, void *src, MPI_Aint size)
     ptrdiff = (MPI_Aint) ((char *) dest - (char *) src);
 
     /* traverse structure updating pointers */
-    MPIR_Dataloop_update(dest, ptrdiff);
+    MPII_Dataloop_update(dest, ptrdiff);
 
     return;
 }
 
 
 /*@
-  MPIR_Dataloop_update - update pointers after a copy operation
+  MPII_Dataloop_update - update pointers after a copy operation
 
 Input Parameters:
 + dataloop - pointer to loop to update
@@ -196,7 +196,7 @@ Input Parameters:
   This function is used to recursively update all the pointers in a
   dataloop tree.
 @*/
-void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
+void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
 {
     /* OPT: only declare these variables down in the Struct case */
     int i;
@@ -227,7 +227,7 @@ void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
                     (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.cm_t.dataloop +
                      ptrdiff);
 
-                MPIR_Dataloop_update(dataloop->loop_params.cm_t.dataloop, ptrdiff);
+                MPII_Dataloop_update(dataloop->loop_params.cm_t.dataloop, ptrdiff);
             }
             break;
 
@@ -255,7 +255,7 @@ void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
                     (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.bi_t.dataloop +
                      ptrdiff);
 
-                MPIR_Dataloop_update(dataloop->loop_params.bi_t.dataloop, ptrdiff);
+                MPII_Dataloop_update(dataloop->loop_params.bi_t.dataloop, ptrdiff);
             }
             break;
 
@@ -294,7 +294,7 @@ void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
                     (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.i_t.dataloop +
                      ptrdiff);
 
-                MPIR_Dataloop_update(dataloop->loop_params.i_t.dataloop, ptrdiff);
+                MPII_Dataloop_update(dataloop->loop_params.i_t.dataloop, ptrdiff);
             }
             break;
 
@@ -348,7 +348,7 @@ void MPIR_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
             }
 
             for (i = 0; i < dataloop->loop_params.s_t.count; i++) {
-                MPIR_Dataloop_update(looparray[i], ptrdiff);
+                MPII_Dataloop_update(looparray[i], ptrdiff);
             }
             break;
         default:

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -73,6 +73,69 @@ void MPIR_Dataloop_free(MPIR_Dataloop ** dataloop)
     return;
 }
 
+struct dloop_flatten_hdr {
+    MPI_Aint dataloop_size;
+    MPIR_Dataloop *dataloop_local_addr;
+};
+
+int MPIR_Dataloop_flatten_size(MPIR_Datatype * dtp, int *flattened_dataloop_size)
+{
+    *flattened_dataloop_size = sizeof(struct dloop_flatten_hdr) + dtp->dataloop_size;
+
+    return MPI_SUCCESS;
+}
+
+int MPIR_Dataloop_flatten(MPIR_Datatype * dtp, void *flattened_dataloop)
+{
+    struct dloop_flatten_hdr *dloop_flatten_hdr = (struct dloop_flatten_hdr *) flattened_dataloop;
+    int mpi_errno = MPI_SUCCESS;
+
+    /*
+     * Our flattened layout contains three elements:
+     *    - The size of the dataloop
+     *    - The local address of the dataloop (needed to update the dataloop pointers when we unflatten)
+     *    - The actual dataloop itself
+     */
+
+    dloop_flatten_hdr->dataloop_size = dtp->dataloop_size;
+    dloop_flatten_hdr->dataloop_local_addr = dtp->dataloop;
+
+    MPIR_Memcpy(((char *) flattened_dataloop + sizeof(struct dloop_flatten_hdr)),
+                dtp->dataloop, dtp->dataloop_size);
+
+    return mpi_errno;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPIR_Dataloop_unflatten
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIR_Dataloop_unflatten(MPIR_Datatype * dtp, void *flattened_dataloop)
+{
+    struct dloop_flatten_hdr *dloop_flatten_hdr = (struct dloop_flatten_hdr *) flattened_dataloop;
+    MPI_Aint ptrdiff;
+    int mpi_errno = MPI_SUCCESS;
+
+    dtp->dataloop = MPL_malloc(dloop_flatten_hdr->dataloop_size, MPL_MEM_DATATYPE);
+    MPIR_ERR_CHKANDJUMP1(dtp->dataloop == NULL, mpi_errno, MPI_ERR_INTERN, "**nomem", "**nomem %s",
+                         "dataloop flatten hdr");
+
+    MPIR_Memcpy(dtp->dataloop, (char *) flattened_dataloop + sizeof(struct dloop_flatten_hdr),
+                dloop_flatten_hdr->dataloop_size);
+    dtp->dataloop_size = dloop_flatten_hdr->dataloop_size;
+
+    ptrdiff =
+        (MPI_Aint) ((char *) (dtp->dataloop) - (char *) dloop_flatten_hdr->dataloop_local_addr);
+    MPIR_Dataloop_update(dtp->dataloop, ptrdiff);
+
+  fn_exit:
+    return mpi_errno;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+
 /*@
   Dataloop_copy - Copy an arbitrary dataloop structure, updating
   pointers as necessary

--- a/src/mpi/datatype/dataloop/dataloop.h
+++ b/src/mpi/datatype/dataloop/dataloop.h
@@ -329,6 +329,8 @@ void MPII_Dataloop_segment_flatten(MPIR_Segment * segp,
                                    MPI_Aint * lastp,
                                    MPI_Aint * blklens, MPI_Aint * disps, MPI_Aint * lengthp);
 
+void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff);
+
 void MPII_Segment_manipulate(MPIR_Segment * segp,
                              MPI_Aint first,
                              MPI_Aint * lastp,

--- a/src/mpi/datatype/dataloop/looputil.c
+++ b/src/mpi/datatype/dataloop/looputil.c
@@ -103,13 +103,6 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p,
 static int contig_pack_to_iov(MPI_Aint * blocks_p,
                               MPI_Datatype el_type, MPI_Aint rel_off, void *bufp, void *v_paramp);
 
-static int contig_flatten(MPI_Aint * blocks_p,
-                          MPI_Datatype el_type, MPI_Aint rel_off, void *bufp, void *v_paramp);
-
-static int vector_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blksz, MPI_Aint stride, MPI_Datatype el_type, MPI_Aint rel_off, /* offset into buffer */
-                          void *bufp,   /* start of buffer */
-                          void *v_paramp);
-
 static inline int is_float_type(MPI_Datatype el_type)
 {
     return ((el_type == MPI_FLOAT) || (el_type == MPI_DOUBLE) ||
@@ -965,45 +958,6 @@ void MPIR_Segment_from_iov(struct MPIR_Segment *segp,
     return;
 }
 
-#undef FUNCNAME
-#define FUNCNAME MPIR_Segment_flatten
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-/* MPIR_Segment_flatten
-*
-* offp    - pointer to array to fill in with offsets
-* sizep   - pointer to array to fill in with sizes
-* lengthp - pointer to value holding size of arrays; # used is returned
-*
-* Internally, index is used to store the index of next array value to fill in.
-*
-* TODO: MAKE SIZES Aints IN ROMIO, CHANGE THIS TO USE INTS TOO.
-*/
-void MPIR_Segment_flatten(struct MPIR_Segment *segp,
-                          MPI_Aint first,
-                          MPI_Aint * lastp, MPI_Aint * offp, MPI_Aint * sizep, MPI_Aint * lengthp)
-{
-    struct piece_params packvec_params;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_SEGMENT_FLATTEN);
-
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_SEGMENT_FLATTEN);
-
-    packvec_params.u.flatten.offp = (int64_t *) offp;
-    packvec_params.u.flatten.sizep = sizep;
-    packvec_params.u.flatten.index = 0;
-    packvec_params.u.flatten.length = *lengthp;
-
-    MPIR_Assert(*lengthp > 0);
-
-    MPII_Segment_manipulate(segp, first, lastp, contig_flatten, vector_flatten, NULL,   /* blkidx fn */
-                            NULL, NULL, &packvec_params);
-
-    /* last value already handled by MPII_Segment_manipulate */
-    *lengthp = packvec_params.u.flatten.index;
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_FLATTEN);
-    return;
-}
-
 /*
 * EVERYTHING BELOW HERE IS USED ONLY WITHIN THIS FILE
 */
@@ -1169,122 +1123,5 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blks
      */
     MPIR_Assert(blocks_left == 0);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_VECTOR_PACK_TO_IOV);
-    return 0;
-}
-
-/********** FUNCTIONS FOR FLATTENING A TYPE **********/
-
-#undef FUNCNAME
-#define FUNCNAME contig_flatten
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static int contig_flatten(MPI_Aint * blocks_p,
-                          MPI_Datatype el_type, MPI_Aint rel_off, void *bufp, void *v_paramp)
-{
-    int idx, el_size;
-    MPI_Aint size;
-    struct piece_params *paramp = v_paramp;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_SEGMENT_CONTIG_FLATTEN);
-
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_SEGMENT_CONTIG_FLATTEN);
-
-    el_size = MPIR_Datatype_get_basic_size(el_type);
-    size = *blocks_p * (MPI_Aint) el_size;
-    idx = paramp->u.flatten.index;
-
-#ifdef MPID_SP_VERBOSE
-    MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
-                    (MPL_DBG_FDEST,
-                     "\t[contig flatten: idx = %d, loc = (" MPI_AINT_FMT_HEX_SPEC " + "
-                     MPI_AINT_FMT_HEX_SPEC ") = " MPI_AINT_FMT_HEX_SPEC ", size = "
-                     MPI_AINT_FMT_DEC_SPEC "]\n", idx, MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp,
-                     (MPI_Aint) rel_off, MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp + rel_off,
-                     (MPI_Aint) size));
-#endif
-
-    if (idx > 0 && ((MPI_Aint) MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp + rel_off) ==
-        ((paramp->u.flatten.offp[idx - 1]) + (MPI_Aint) paramp->u.flatten.sizep[idx - 1])) {
-        /* add this size to the last vector rather than using up another one */
-        paramp->u.flatten.sizep[idx - 1] += size;
-    } else {
-        paramp->u.flatten.offp[idx] =
-            ((int64_t) MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp) + (int64_t) rel_off;
-        paramp->u.flatten.sizep[idx] = size;
-
-        paramp->u.flatten.index++;
-        /* check to see if we have used our entire vector buffer, and if so
-         * return 1 to stop processing
-         */
-        if (paramp->u.flatten.index == paramp->u.flatten.length) {
-            MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_CONTIG_FLATTEN);
-            return 1;
-        }
-    }
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_CONTIG_FLATTEN);
-    return 0;
-}
-
-#undef FUNCNAME
-#define FUNCNAME vector_flatten
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-/* vector_flatten
- *
- * Notes:
- * - this is only called when the starting position is at the beginning
- *   of a whole block in a vector type.
- * - this was a virtual copy of MPIR_Segment_to_iov; now it has improvements
- *   that MPIR_Segment_to_iov needs.
- * - we return the number of blocks that we did process in region pointed to by
- *   blocks_p.
- */
-static int vector_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blksz, MPI_Aint stride, MPI_Datatype el_type, MPI_Aint rel_off, /* offset into buffer */
-                          void *bufp,   /* start of buffer */
-                          void *v_paramp)
-{
-    int i;
-    MPI_Aint size, blocks_left, basic_size;
-    struct piece_params *paramp = v_paramp;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_SEGMENT_VECTOR_FLATTEN);
-
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_SEGMENT_VECTOR_FLATTEN);
-
-    basic_size = (MPI_Aint) MPIR_Datatype_get_basic_size(el_type);
-    blocks_left = *blocks_p;
-
-    for (i = 0; i < count && blocks_left > 0; i++) {
-        int idx = paramp->u.flatten.index;
-
-        if (blocks_left > (MPI_Aint) blksz) {
-            size = ((MPI_Aint) blksz) * basic_size;
-            blocks_left -= (MPI_Aint) blksz;
-        } else {
-            /* last pass */
-            size = blocks_left * basic_size;
-            blocks_left = 0;
-        }
-
-        if (idx > 0 && ((MPI_Aint) MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp + rel_off) ==
-            ((paramp->u.flatten.offp[idx - 1]) + (MPI_Aint) paramp->u.flatten.sizep[idx - 1])) {
-            /* add this size to the last region rather than using up another one */
-            paramp->u.flatten.sizep[idx - 1] += size;
-        } else if (idx < paramp->u.flatten.length) {
-            /* take up another region */
-            paramp->u.flatten.offp[idx] = (MPI_Aint) MPIR_VOID_PTR_CAST_TO_MPI_AINT bufp + rel_off;
-            paramp->u.flatten.sizep[idx] = size;
-            paramp->u.flatten.index++;
-        } else {
-            /* we tried to add to the end of the last region and failed; add blocks back in */
-            *blocks_p = *blocks_p - blocks_left + (size / basic_size);
-            MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_VECTOR_FLATTEN);
-            return 1;
-        }
-        rel_off += stride;
-
-    }
-    /* --BEGIN ERROR HANDLING-- */
-    MPIR_Assert(blocks_left == 0);
-    /* --END ERROR HANDLING-- */
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIR_SEGMENT_VECTOR_FLATTEN);
     return 0;
 }

--- a/src/mpi/debugger/dbginit.c
+++ b/src/mpi/debugger/dbginit.c
@@ -534,9 +534,7 @@ static int MPIR_FreeProctable(void *ptable)
     int i;
     MPIR_PROCDESC *proctable = (MPIR_PROCDESC *) ptable;
     for (i = 0; i < MPIR_proctable_size; i++) {
-        if (proctable[i].host_name) {
-            MPL_free(proctable[i].host_name);
-        }
+        MPL_free(proctable[i].host_name);
     }
     MPL_free(proctable);
 

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -157,9 +157,7 @@ int MPIR_Err_set_msg(int code, const char *msg_string)
     MPL_strncpy(str, msg_string, msg_len + 1);
     if (errcode) {
         if (errcode < first_free_code) {
-            if (user_code_msgs[errcode]) {
-                MPL_free((void *) (user_code_msgs[errcode]));
-            }
+            MPL_free((void *) (user_code_msgs[errcode]));
             user_code_msgs[errcode] = (const char *) str;
         } else {
             /* FIXME : Unallocated error code? */
@@ -167,9 +165,7 @@ int MPIR_Err_set_msg(int code, const char *msg_string)
         }
     } else {
         if (errclass < first_free_class) {
-            if (user_class_msgs[errclass]) {
-                MPL_free((void *) (user_class_msgs[errclass]));
-            }
+            MPL_free((void *) (user_class_msgs[errclass]));
             user_class_msgs[errclass] = (const char *) str;
         } else {
             /* FIXME : Unallocated error code? */
@@ -323,13 +319,11 @@ static int MPIR_Dynerrcodes_finalize(void *p ATTRIBUTE((unused)))
     if (not_initialized == 0) {
 
         for (i = 0; i < first_free_class; i++) {
-            if (user_class_msgs[i])
-                MPL_free((char *) user_class_msgs[i]);
+            MPL_free((char *) user_class_msgs[i]);
         }
 
         for (i = 0; i < first_free_code; i++) {
-            if (user_code_msgs[i])
-                MPL_free((char *) user_code_msgs[i]);
+            MPL_free((char *) user_code_msgs[i]);
         }
     }
     return 0;

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -167,14 +167,12 @@ int MPI_Finalize(void)
 #ifdef HAVE_NETLOC
     switch (MPIR_Process.network_attr.type) {
         case MPIR_NETLOC_NETWORK_TYPE__TORUS:
-            if (MPIR_Process.network_attr.u.torus.geometry != NULL)
-                MPL_free(MPIR_Process.network_attr.u.torus.geometry);
+            MPL_free(MPIR_Process.network_attr.u.torus.geometry);
             break;
         case MPIR_NETLOC_NETWORK_TYPE__FAT_TREE:
         case MPIR_NETLOC_NETWORK_TYPE__CLOS_NETWORK:
         default:
-            if (MPIR_Process.network_attr.u.tree.node_levels != NULL)
-                MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
+            MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
             break;
     }
 #endif

--- a/src/mpi/init/netloc_util.c
+++ b/src/mpi/init/netloc_util.c
@@ -311,12 +311,8 @@ static int get_tree_attributes(netloc_topology_t topology,
   fn_exit:
     MPIR_CHKPMEM_COMMIT();
     MPIR_CHKPMEM_REAP();
-    if (host_nodes != NULL) {
-        MPL_free(host_nodes);
-    }
-    if (nodes != NULL) {
-        MPL_free(nodes);
-    }
+    MPL_free(host_nodes);
+    MPL_free(nodes);
     return mpi_errno;
 
   fn_fail:
@@ -771,15 +767,9 @@ static void find_augmenting_path(netloc_topology_t topology, netloc_node_t *** n
     }
 
   fn_exit:
-    if (forest != NULL) {
-        MPL_free(forest);
-    }
-    if (unmarked_vertices != NULL) {
-        MPL_free(unmarked_vertices);
-    }
-    if (unmarked_edges != NULL) {
-        MPL_free(unmarked_edges);
-    }
+    MPL_free(forest);
+    MPL_free(unmarked_vertices);
+    MPL_free(unmarked_edges);
     *augmenting_path = current_augmenting_path;
     *augmenting_path_length = path_length;
     return;
@@ -850,9 +840,7 @@ static void find_maximum_matching(netloc_topology_t topology, netloc_node_t *** 
     }
 
   fn_exit:
-    if (augmenting_path != NULL) {
-        MPL_free(augmenting_path);
-    }
+    MPL_free(augmenting_path);
     return;
 }
 
@@ -1452,21 +1440,11 @@ static int get_torus_attributes(netloc_topology_t topology,
         }
 
       cleanup:
-        if (traversal_order != NULL) {
-            MPL_free(traversal_order);
-        }
-        if (hypercube_labels != NULL) {
-            MPL_free(hypercube_labels);
-        }
-        if (semicube_edges != NULL) {
-            MPL_free(semicube_edges);
-        }
-        if (semicube_vertices != NULL) {
-            MPL_free(semicube_vertices);
-        }
-        if (maximum_matching != NULL) {
-            MPL_free(maximum_matching);
-        }
+        MPL_free(traversal_order);
+        MPL_free(hypercube_labels);
+        MPL_free(semicube_edges);
+        MPL_free(semicube_vertices);
+        MPL_free(maximum_matching);
     } else {
         network_attr->type = MPIR_NETLOC_NETWORK_TYPE__INVALID;
     }
@@ -1580,9 +1558,7 @@ int MPIR_Netloc_get_network_end_point(MPIR_Netloc_network_attributes network_att
     }
 
   fn_exit:
-    if (host_nodes != NULL) {
-        MPL_free(host_nodes);
-    }
+    MPL_free(host_nodes);
     *end_point = node_end_point;
     return mpi_errno;
 
@@ -1705,12 +1681,8 @@ int MPIR_Netloc_get_switches_at_level(netloc_topology_t topology,
     }
 
   fn_exit:
-    if (switches != NULL) {
-        MPL_free(switches);
-    }
-    if (switch_nodes != NULL) {
-        MPL_free(switch_nodes);
-    }
+    MPL_free(switches);
+    MPL_free(switch_nodes);
     *switches_at_level = switches;
     *switch_count = i;
     return mpi_errno;

--- a/src/mpi/topo/dist_gr_create.c
+++ b/src/mpi/topo/dist_gr_create.c
@@ -439,10 +439,8 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
 
   fn_exit:
     for (i = 0; i < comm_size; ++i) {
-        if (rin[i])
-            MPL_free(rin[i]);
-        if (rout[i])
-            MPL_free(rout[i]);
+        MPL_free(rin[i]);
+        MPL_free(rout[i]);
     }
 
     MPIR_CHKLMEM_FREEALL();
@@ -453,14 +451,12 @@ int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[],
 
     /* --BEGIN ERROR HANDLING-- */
   fn_fail:
-    if (dist_graph_ptr && dist_graph_ptr->in)
+    if (dist_graph_ptr) {
         MPL_free(dist_graph_ptr->in);
-    if (dist_graph_ptr && dist_graph_ptr->in_weights)
         MPL_free(dist_graph_ptr->in_weights);
-    if (dist_graph_ptr && dist_graph_ptr->out)
         MPL_free(dist_graph_ptr->out);
-    if (dist_graph_ptr && dist_graph_ptr->out_weights)
         MPL_free(dist_graph_ptr->out_weights);
+    }
     MPIR_CHKPMEM_REAP();
 #ifdef HAVE_ERROR_CHECKING
     mpi_errno =

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -226,10 +226,8 @@ static int MPIR_Topology_delete_fn(MPI_Comm comm ATTRIBUTE((unused)),
     } else if (topology->kind == MPI_DIST_GRAPH) {
         MPL_free(topology->topo.dist_graph.in);
         MPL_free(topology->topo.dist_graph.out);
-        if (topology->topo.dist_graph.in_weights)
-            MPL_free(topology->topo.dist_graph.in_weights);
-        if (topology->topo.dist_graph.out_weights)
-            MPL_free(topology->topo.dist_graph.out_weights);
+        MPL_free(topology->topo.dist_graph.in_weights);
+        MPL_free(topology->topo.dist_graph.out_weights);
         MPL_free(topology);
     }
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -63,7 +63,7 @@
    For optimization, we want the cell to start at a cacheline boundary
    and the cell length to be a multiple of cacheline size.  This will
    avoid false sharing.  We also want payload to start at an 8-byte
-   boundary to to optimize memcpys and dataloop operations on the
+   boundary to to optimize memcpys and datatype operations on the
    payload.  To ensure payload is 8-byte aligned, we add padding after
    the next pointer so the packet starts at the 8-byte boundary.
 

--- a/src/mpid/ch3/channels/nemesis/netmod/llc/llc_poll.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/llc/llc_poll.c
@@ -108,14 +108,13 @@ static void MPID_nem_llc_send_handler(void *cba, uint64_t * p_reqid)
                      * Exclude eager-short by requiring req->comm != 0. */
                     int is_contig;
                     MPIR_Datatype_is_contig(sreq->dev.datatype, &is_contig);
-                    if (!is_contig && REQ_FIELD(sreq, pack_buf)) {
+                    if (!is_contig) {
                         dprintf("llc_send_handler,non-contiguous,free pack_buf\n");
                         MPL_free(REQ_FIELD(sreq, pack_buf));
                     }
                 }
 
-                if ((REQ_FIELD(sreq, rma_buf) != NULL && sreq->dev.datatype_ptr &&
-                     sreq->dev.segment_size > 0)) {
+                if ((sreq->dev.datatype_ptr && sreq->dev.segment_size > 0)) {
                     MPL_free(REQ_FIELD(sreq, rma_buf)); // allocated in MPID_nem_llc_SendNoncontig
                     REQ_FIELD(sreq, rma_buf) = NULL;
                 }

--- a/src/mpid/ch3/channels/nemesis/netmod/llc/llc_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/llc/llc_send.c
@@ -568,10 +568,8 @@ ssize_t llc_writev(void *endpt, uint64_t raddr,
 
         lcmd = LLC_cmd_alloc2(1, 1, 1);
         if (lcmd == 0) {
-            if (buff != 0) {
-                MPL_free(buff);
-                buff = 0;
-            }
+            MPL_free(buff);
+            buff = 0;
             nw = -1;    /* ENOMEM */
             goto bad;
         }
@@ -648,10 +646,8 @@ ssize_t llc_writev(void *endpt, uint64_t raddr,
             if ((llc_errno == EAGAIN) || (llc_errno == ENOSPC)) {
                 nw = 0;
             } else {
-                if (lcmd->iov_local[0].addr != 0) {
-                    MPL_free((void *) lcmd->iov_local[0].addr);
-                    lcmd->iov_local[0].addr = 0;
-                }
+                MPL_free((void *) lcmd->iov_local[0].addr);
+                lcmd->iov_local[0].addr = 0;
                 (void) LLC_cmd_free(lcmd, 1);
                 nw = -1;
                 goto bad;
@@ -769,10 +765,8 @@ int llc_poll(int in_blocking_poll, llc_send_f sfnc, llc_recv_f rfnc)
                     }
                     (*sfnc) (vp_sreq, &reqid);
 
-                    if (lcmd->iov_local[0].addr != 0) {
-                        MPL_free((void *) lcmd->iov_local[0].addr);
-                        lcmd->iov_local[0].addr = 0;
-                    }
+                    MPL_free((void *) lcmd->iov_local[0].addr);
+                    lcmd->iov_local[0].addr = 0;
                     llc_errno = LLC_cmd_free(lcmd, 1);
                     MPIR_ERR_CHKANDJUMP(llc_errno, mpi_errno, MPI_ERR_OTHER, "**LLC_cmd_free");
 
@@ -909,10 +903,8 @@ int llc_poll(int in_blocking_poll, llc_send_f sfnc, llc_recv_f rfnc)
 
                         MPID_Request_complete(req);
 
-                        if (lcmd->iov_local[0].addr != 0) {
-                            MPL_free((void *) lcmd->iov_local[0].addr);
-                            lcmd->iov_local[0].addr = 0;
-                        }
+                        MPL_free((void *) lcmd->iov_local[0].addr);
+                        lcmd->iov_local[0].addr = 0;
                     } else if (lcmd->opcode == LLC_OPCODE_SEND || lcmd->opcode == LLC_OPCODE_SSEND) {
                         req->status.MPI_ERROR = MPI_SUCCESS;
                         MPIR_ERR_SET(req->status.MPI_ERROR, MPIX_ERR_PROC_FAIL_STOP, "**comm_fail");

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_init.c
@@ -530,8 +530,7 @@ static int _mxm_fini(void)
             _mxm_disconnect(&(_mxm_obj.endpoint[--_mxm_obj.mxm_np]));
         }
 
-        if (_mxm_obj.endpoint)
-            MPL_free(_mxm_obj.endpoint);
+        MPL_free(_mxm_obj.endpoint);
 
         _mxm_barrier();
 

--- a/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_poll.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/mxm/mxm_poll.c
@@ -333,8 +333,7 @@ static int _mxm_handle_rreq(MPIR_Request * req)
     MPIDI_CH3U_Handle_recv_req(req->ch.vc, req, &complete);
     MPIR_Assert(complete == TRUE);
 
-    if (tmp_buf)
-        MPL_free(tmp_buf);
+    MPL_free(tmp_buf);
 
     return complete;
 }

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -140,8 +140,7 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_CONN_REQ_CALLBACK);
     return mpi_errno;
   fn_fail:
-    if (vc)
-        MPL_free(vc);
+    MPL_free(vc);
     goto fn_exit;
 }
 
@@ -282,8 +281,7 @@ int MPID_nem_ofi_connect_to_root_callback(cq_tagged_entry_t * wc ATTRIBUTE((unus
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_CONNECT_TO_ROOT_CALLBACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_CONNECT_TO_ROOT_CALLBACK);
 
-    if (REQ_OFI(sreq)->pack_buffer)
-        MPL_free(REQ_OFI(sreq)->pack_buffer);
+    MPL_free(REQ_OFI(sreq)->pack_buffer);
 
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
 
@@ -426,8 +424,7 @@ int MPID_nem_ofi_vc_connect(MPIDI_VC_t * vc)
     VC_OFI(vc)->ready = 1;
 
   fn_exit:
-    if (addr)
-        MPL_free(addr);
+    MPL_free(addr);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_VC_CONNECT);
     return mpi_errno;
 
@@ -586,13 +583,11 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     VC_OFI(new_vc)->next = gl_data.cm_vcs;
     gl_data.cm_vcs = new_vc;
   fn_exit:
-    if (addr)
-        MPL_free(addr);
+    MPL_free(addr);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NM_CONNECT_TO_ROOT);
     return mpi_errno;
   fn_fail:
-    if (my_bc)
-        MPL_free(my_bc);
+    MPL_free(my_bc);
     goto fn_exit;
 }
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -197,10 +197,8 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* --------------------------- */
     /* Free providers info         */
     /* --------------------------- */
-    if (provname) {
-        MPL_free(provname);
-        hints->fabric_attr->prov_name = NULL;
-    }
+    MPL_free(provname);
+    hints->fabric_attr->prov_name = NULL;
 
     fi_freeinfo(hints);
     fi_freeinfo(prov_use);
@@ -289,8 +287,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
     /* --------------------------------------------- */
     MPIDI_CH3I_NM_OFI_RC(MPID_nem_ofi_cm_init(pg_p, pg_rank));
   fn_exit:
-    if (fi_addrs)
-        MPL_free(fi_addrs);
+    MPL_free(fi_addrs);
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_INIT);
     return mpi_errno;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -130,11 +130,9 @@ static int MPID_nem_ofi_data_callback(cq_tagged_entry_t * wc, MPIR_Request * sre
              * to store updated TAG values in the sreq.
              */
             if (MPIR_cc_get(sreq->cc) == 1) {
-                if (REQ_OFI(sreq)->pack_buffer)
-                    MPL_free(REQ_OFI(sreq)->pack_buffer);
+                MPL_free(REQ_OFI(sreq)->pack_buffer);
 
-                if (REQ_OFI(sreq)->real_hdr)
-                    MPL_free(REQ_OFI(sreq)->real_hdr);
+                MPL_free(REQ_OFI(sreq)->real_hdr);
 
                 reqFn = sreq->dev.OnDataAvail;
                 if (!reqFn) {

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_progress.c
@@ -63,9 +63,7 @@ int MPID_nem_ofi_poll(int in_blocking_poll)
                 }
                 reqFn = req->dev.OnDataAvail;
                 if (reqFn) {
-                    if (REQ_OFI(req)->pack_buffer) {
-                        MPL_free(REQ_OFI(req)->pack_buffer);
-                    }
+                    MPL_free(REQ_OFI(req)->pack_buffer);
                     vc = REQ_OFI(req)->vc;
 
                     complete = 0;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_tagged.c
@@ -62,8 +62,7 @@ static inline int MPID_nem_ofi_send_callback(cq_tagged_entry_t * wc ATTRIBUTE((u
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
-    if (REQ_OFI(sreq)->pack_buffer)
-        MPL_free(REQ_OFI(sreq)->pack_buffer);
+    MPL_free(REQ_OFI(sreq)->pack_buffer);
     MPIDI_CH3I_NM_OFI_RC(MPID_Request_complete(sreq));
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_NEM_OFI_SEND_CALLBACK);
@@ -127,9 +126,7 @@ int MPID_nem_ofi_anysource_matched(MPIR_Request * rreq)
          * If anysource was posted for non-contig dtype then don't forget
          * to clean up tmp space.
          */
-        if (REQ_OFI(rreq)->pack_buffer) {
-            MPL_free(REQ_OFI(rreq)->pack_buffer);
-        }
+        MPL_free(REQ_OFI(rreq)->pack_buffer);
         matched = FALSE;
     } else {
         /* Cancel failed. We can only fail in the case of the message

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_probe.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_probe.c
@@ -421,8 +421,7 @@ int MPID_nem_ptl_pkt_cancel_send_resp_handler(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t *
                 MPIR_ERR_POP(mpi_errno);
             }
         }
-        if (REQ_PTL(sreq)->get_me_p)
-            MPL_free(REQ_PTL(sreq)->get_me_p);
+        MPL_free(REQ_PTL(sreq)->get_me_p);
 
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, TYPICAL, "message cancelled");
     } else {

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_recv.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_recv.c
@@ -70,8 +70,7 @@ static int handler_recv_complete(const ptl_event_t * e)
     }
 
     for (i = 0; i < MPID_NEM_PTL_NUM_CHUNK_BUFFERS; ++i)
-        if (REQ_PTL(rreq)->chunk_buffer[i])
-            MPL_free(REQ_PTL(rreq)->chunk_buffer[i]);
+        MPL_free(REQ_PTL(rreq)->chunk_buffer[i]);
 
     mpi_errno = MPID_Request_complete(rreq);
     if (mpi_errno) {

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/ptl_send.c
@@ -81,11 +81,9 @@ static int handler_send(const ptl_event_t * e)
         }
 
         for (i = 0; i < MPID_NEM_PTL_NUM_CHUNK_BUFFERS; ++i)
-            if (REQ_PTL(sreq)->chunk_buffer[i])
-                MPL_free(REQ_PTL(sreq)->chunk_buffer[i]);
+            MPL_free(REQ_PTL(sreq)->chunk_buffer[i]);
 
-        if (REQ_PTL(sreq)->get_me_p)
-            MPL_free(REQ_PTL(sreq)->get_me_p);
+        MPL_free(REQ_PTL(sreq)->get_me_p);
     }
     mpi_errno = MPID_Request_complete(sreq);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/portals4/rptl.c
@@ -778,14 +778,10 @@ int MPID_nem_ptl_rptl_eqget(ptl_handle_eq_t eq_handle, ptl_event_t * event)
 
                 /* discard pending events, since we will retransmit
                  * this op anyway */
-                if (op->u.put.ack) {
-                    MPL_free(op->u.put.ack);
-                    op->u.put.ack = NULL;
-                }
-                if (op->u.put.send) {
-                    MPL_free(op->u.put.send);
-                    op->u.put.send = NULL;
-                }
+                MPL_free(op->u.put.ack);
+                op->u.put.ack = NULL;
+                MPL_free(op->u.put.send);
+                op->u.put.send = NULL;
             }
 
             if (op->op_type == RPTL_OP_PUT)

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_getip.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_getip.c
@@ -206,8 +206,7 @@ int MPIDI_GetIPInterface(MPIDI_CH3I_nem_tcp_ifaddr_t * ifaddr, int *found)
     }
 
   fn_exit:
-    if (NULL != buf_ptr)
-        MPL_free(buf_ptr);
+    MPL_free(buf_ptr);
     if (fd >= 0)
         close(fd);
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
@@ -605,7 +605,7 @@ int MPID_nem_lmt_dma_progress(void)
                         free_me = cur;
                         cur = cur->next;
                     }
-                    if (free_me) MPL_free(free_me);
+                    MPL_free(free_me);
                     --MPID_nem_local_lmt_pending;
                     continue;
                 }
@@ -632,7 +632,7 @@ int MPID_nem_lmt_dma_progress(void)
                     cur = cur->next;
                 }
 
-                if (free_me) MPL_free(free_me);
+                MPL_free(free_me);
                 --MPID_nem_local_lmt_pending;
                 continue;
                 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_vmsplice.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_vmsplice.c
@@ -354,7 +354,7 @@ int MPID_nem_lmt_vmsplice_progress(void)
                 free_me = cur;
                 cur = cur->next;
             }
-            if (free_me) MPL_free(free_me);
+            MPL_free(free_me);
             --MPID_nem_local_lmt_pending;
         }
 

--- a/src/mpid/ch3/channels/sock/src/ch3_init.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_init.c
@@ -59,9 +59,7 @@ int MPIDI_CH3_Init(int has_parent, MPIDI_PG_t * pg_p, int pg_rank)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CH3_INIT);
     return mpi_errno;
   fn_fail:
-    if (publish_bc_orig != NULL) {
-        MPL_free(publish_bc_orig);
-    }
+    MPL_free(publish_bc_orig);
     goto fn_exit;
 }
 

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -926,17 +926,9 @@ static int MPIDI_CH3I_Socki_sock_alloc(struct MPIDI_CH3I_Sock_set *sock_set,
 
     /* --BEGIN ERROR HANDLING-- */
   fn_fail:
-    if (pollinfos != NULL) {
-        MPL_free(pollinfos);
-    }
-
-    if (pollfds != NULL) {
-        MPL_free(pollfds);
-    }
-
-    if (sock != NULL) {
-        MPL_free(sock);
-    }
+    MPL_free(pollinfos);
+    MPL_free(pollfds);
+    MPL_free(sock);
 
     goto fn_exit;
     /* --END ERROR HANDLING-- */

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -123,11 +123,11 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
-        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_derived_t");
         }
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
 
         _ext_hdr_ptr->stream_offset = stream_offset;
 
@@ -142,11 +142,11 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
-        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_t");
         }
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
 
         _ext_hdr_ptr->stream_offset = stream_offset;
         (*ext_hdr_ptr) = _ext_hdr_ptr;
@@ -160,11 +160,11 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
         _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
-        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_derived_t");
         }
+        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
 
         dataloop_ptr = (void *) ((char *) _ext_hdr_ptr + _ext_hdr_sz);
         fill_in_derived_dtp_info(&_ext_hdr_ptr->dtype_info, dataloop_ptr, target_dtp);
@@ -438,11 +438,11 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
              * TODO: support extended header array */
             ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t) + target_dtp_ptr->dataloop_size;
             ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
-            MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
             if (!ext_hdr_ptr) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                      "**nomem %s", "MPIDI_CH3_Ext_pkt_put_derived_t");
             }
+            MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
 
             dataloop_ptr = (void *) ((char *) ext_hdr_ptr +
                                      sizeof(MPIDI_CH3_Ext_pkt_put_derived_t));
@@ -944,11 +944,11 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
          * TODO: support extended header array */
         ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t) + dtp->dataloop_size;
         ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
-        MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
         if (!ext_hdr_ptr) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
                                  "**nomem %s", "MPIDI_CH3_Ext_pkt_get_derived_t");
         }
+        MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
 
         dataloop_ptr = (void *) ((char *) ext_hdr_ptr + sizeof(MPIDI_CH3_Ext_pkt_get_derived_t));
         fill_in_derived_dtp_info(&ext_hdr_ptr->dtype_info, dataloop_ptr, dtp);

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -63,41 +63,6 @@ static inline int immed_copy(void *src, void *dest, size_t len)
 /*                  extended packet functions                  */
 /* =========================================================== */
 
-/* Copy derived datatype information issued within RMA operation. */
-#undef FUNCNAME
-#define FUNCNAME fill_in_derived_dtp_info
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline void fill_in_derived_dtp_info(MPIDI_RMA_dtype_info * dtype_info, void *dataloop,
-                                            MPIR_Datatype* dtp)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_FILL_IN_DERIVED_DTP_INFO);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_FILL_IN_DERIVED_DTP_INFO);
-
-    /* Derived datatype on target, fill derived datatype info. */
-    dtype_info->is_contig = dtp->is_contig;
-    dtype_info->max_contig_blocks = dtp->max_contig_blocks;
-    dtype_info->size = dtp->size;
-    dtype_info->extent = dtp->extent;
-    dtype_info->dataloop_size = dtp->dataloop_size;
-    dtype_info->basic_type = dtp->basic_type;
-    dtype_info->dataloop = dtp->dataloop;
-    dtype_info->ub = dtp->ub;
-    dtype_info->lb = dtp->lb;
-    dtype_info->true_ub = dtp->true_ub;
-    dtype_info->true_lb = dtp->true_lb;
-    dtype_info->has_sticky_ub = dtp->has_sticky_ub;
-    dtype_info->has_sticky_lb = dtp->has_sticky_lb;
-
-    MPIR_Assert(dataloop != NULL);
-    MPIR_Memcpy(dataloop, dtp->dataloop, dtp->dataloop_size);
-    /* The dataloop can have undefined padding sections, so we need to let
-     * valgrind know that it is OK to pass this data to writev later on. */
-    MPL_VG_MAKE_MEM_DEFINED(dataloop, dtp->dataloop_size);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_FILL_IN_DERIVED_DTP_INFO);
-}
-
 /* Set extended header for ACC operation and return its real size. */
 #undef FUNCNAME
 #define FUNCNAME init_accum_ext_pkt
@@ -105,71 +70,68 @@ static inline void fill_in_derived_dtp_info(MPIDI_RMA_dtype_info * dtype_info, v
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
                               MPIR_Datatype* target_dtp, intptr_t stream_offset,
-                              void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz)
+                              void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz, int *flattened_type_size)
 {
-    MPI_Aint _ext_hdr_sz = 0, _total_sz = 0;
-    void *dataloop_ptr = NULL;
+    MPI_Aint _total_sz = 0;
+    void *flattened_type;
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_INIT_ACCUM_EXT_PKT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_INIT_ACCUM_EXT_PKT);
 
     if ((flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) && target_dtp != NULL) {
-        MPIDI_CH3_Ext_pkt_accum_stream_derived_t *_ext_hdr_ptr = NULL;
+        void *total_hdr;
+        MPIDI_CH3_Ext_pkt_stream_t *_ext_hdr_ptr;
 
-        /* dataloop is behind of extended header on origin.
-         * TODO: support extended header array */
-        _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t);
-        _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
+        /* TODO: support extended header array */
+        MPIR_Type_flatten_size(target_dtp, flattened_type_size);
+        _total_sz = sizeof(MPIDI_CH3_Ext_pkt_stream_t) + *flattened_type_size;
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
-        if (_ext_hdr_ptr == NULL) {
+        total_hdr = MPL_malloc(_total_sz, MPL_MEM_RMA);
+        if (total_hdr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
-                                 "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_derived_t");
+                                 "**nomem %d", _total_sz);
         }
-        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
+        MPL_VG_MEM_INIT(total_hdr, _total_sz);
 
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_stream_t *) total_hdr;
         _ext_hdr_ptr->stream_offset = stream_offset;
 
-        dataloop_ptr = (void *) ((char *) _ext_hdr_ptr + _ext_hdr_sz);
-        fill_in_derived_dtp_info(&_ext_hdr_ptr->dtype_info, dataloop_ptr, target_dtp);
+        flattened_type = (void *) ((char *) total_hdr + sizeof(MPIDI_CH3_Ext_pkt_stream_t));
+        MPIR_Type_flatten(target_dtp, flattened_type);
 
         (*ext_hdr_ptr) = _ext_hdr_ptr;
     }
     else if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-        MPIDI_CH3_Ext_pkt_accum_stream_t *_ext_hdr_ptr = NULL;
+        MPIDI_CH3_Ext_pkt_stream_t *_ext_hdr_ptr = NULL;
 
-        _total_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
+        _total_sz = sizeof(MPIDI_CH3_Ext_pkt_stream_t);
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_stream_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
-                                 "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_stream_t");
+                                 "**nomem %s", "MPIDI_CH3_Ext_pkt_stream_t");
         }
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
 
         _ext_hdr_ptr->stream_offset = stream_offset;
         (*ext_hdr_ptr) = _ext_hdr_ptr;
+        *flattened_type_size = 0;
     }
     else if (target_dtp != NULL) {
-        MPIDI_CH3_Ext_pkt_accum_derived_t *_ext_hdr_ptr = NULL;
+        MPIR_Type_flatten_size(target_dtp, flattened_type_size);
 
-        /* dataloop is behind of extended header on origin.
-         * TODO: support extended header array */
-        _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t);
-        _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
-
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
-        if (_ext_hdr_ptr == NULL) {
+        flattened_type = MPL_malloc(*flattened_type_size, MPL_MEM_RMA);
+        if (flattened_type == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
-                                 "**nomem %s", "MPIDI_CH3_Ext_pkt_accum_derived_t");
+                                 "**nomem %d", *flattened_type_size);
         }
-        MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
+        MPL_VG_MEM_INIT(flattened_type, *flattened_type_size);
 
-        dataloop_ptr = (void *) ((char *) _ext_hdr_ptr + _ext_hdr_sz);
-        fill_in_derived_dtp_info(&_ext_hdr_ptr->dtype_info, dataloop_ptr, target_dtp);
+        MPIR_Type_flatten(target_dtp, flattened_type);
 
-        (*ext_hdr_ptr) = _ext_hdr_ptr;
+        _total_sz = *flattened_type_size;
+        (*ext_hdr_ptr) = flattened_type;
     }
 
     (*ext_hdr_sz) = _total_sz;
@@ -191,22 +153,14 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static int init_get_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
                                   MPIR_Datatype* target_dtp, intptr_t stream_offset,
-                                  void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz)
+                                  void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz, int *flattened_type_size)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_INIT_GET_ACCUM_EXT_PKT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_INIT_GET_ACCUM_EXT_PKT);
 
-    /* Check if get_accum still reuses accum' extended packet header. */
-    MPIR_Assert(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t) ==
-                sizeof(MPIDI_CH3_Ext_pkt_get_accum_stream_derived_t));
-    MPIR_Assert(sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t) ==
-                sizeof(MPIDI_CH3_Ext_pkt_get_accum_derived_t));
-    MPIR_Assert(sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t) ==
-                sizeof(MPIDI_CH3_Ext_pkt_get_accum_stream_t));
-
-    mpi_errno = init_accum_ext_pkt(flags, target_dtp, stream_offset, ext_hdr_ptr, ext_hdr_sz);
+    mpi_errno = init_accum_ext_pkt(flags, target_dtp, stream_offset, ext_hdr_ptr, ext_hdr_sz, flattened_type_size);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_INIT_GET_ACCUM_EXT_PKT);
     return mpi_errno;
@@ -254,9 +208,6 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     MPIDI_CH3_PKT_RMA_GET_TARGET_DATATYPE(rma_op->pkt, target_datatype, mpi_errno);
     if (!MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
         MPIR_Datatype_get_ptr(target_datatype, target_dtp);
-
-        /* Set dataloop size in pkt header */
-        MPIDI_CH3_PKT_RMA_SET_DATALOOP_SIZE(rma_op->pkt, target_dtp->dataloop_size, mpi_errno);
     }
 
     if (is_empty_origin == FALSE) {
@@ -327,6 +278,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     if (ext_hdr_sz > 0) {
         req->dev.ext_hdr_sz = ext_hdr_sz;
         req->dev.ext_hdr_ptr = ext_hdr_ptr;
+        req->dev.flattened_type = NULL;
     }
 
     if (origin_dtp != NULL) {
@@ -423,7 +375,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     }
     else {
         MPI_Aint origin_type_size;
-        MPIDI_CH3_Ext_pkt_put_derived_t *ext_hdr_ptr = NULL;
+        void *ext_hdr_ptr = NULL;
         MPI_Aint ext_hdr_sz = 0;
         MPIR_Datatype_get_size_macro(rma_op->origin_datatype, origin_type_size);
 
@@ -431,22 +383,17 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         MPIDI_CH3_PKT_RMA_GET_TARGET_DATATYPE(rma_op->pkt, target_datatype, mpi_errno);
         if (!MPIR_DATATYPE_IS_PREDEFINED(target_datatype)) {
             MPIR_Datatype_get_ptr(target_datatype, target_dtp_ptr);
+            MPIR_Type_flatten_size(target_dtp_ptr, &put_pkt->info.flattened_type_size);
 
-            void *dataloop_ptr = NULL;
-
-            /* dataloop is behind of extended header on origin.
-             * TODO: support extended header array */
-            ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t) + target_dtp_ptr->dataloop_size;
-            ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
-            if (!ext_hdr_ptr) {
+            ext_hdr_ptr = MPL_malloc(put_pkt->info.flattened_type_size, MPL_MEM_RMA);
+            if (ext_hdr_ptr == NULL) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
-                                     "**nomem %s", "MPIDI_CH3_Ext_pkt_put_derived_t");
+                                     "**nomem %d", put_pkt->info.flattened_type_size);
             }
-            MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
+            MPL_VG_MEM_INIT(ext_hdr_ptr, put_pkt->info.flattened_type_size);
 
-            dataloop_ptr = (void *) ((char *) ext_hdr_ptr +
-                                     sizeof(MPIDI_CH3_Ext_pkt_put_derived_t));
-            fill_in_derived_dtp_info(&ext_hdr_ptr->dtype_info, dataloop_ptr, target_dtp_ptr);
+            MPIR_Type_flatten(target_dtp_ptr, ext_hdr_ptr);
+            ext_hdr_sz = put_pkt->info.flattened_type_size;
         }
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
@@ -581,7 +528,8 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz);
+        init_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+                           &accum_pkt->info.flattened_type_size);
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
                                              stream_offset, stream_size, &curr_req);
@@ -801,14 +749,19 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_get_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz);
+        init_get_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+                               &get_accum_pkt->info.flattened_type_size);
 
         /* Note: here we need to allocate an extended packet header in response request,
          * in order to store the stream_offset locally and use it in PktHandler_Get_AccumResp.
          * This extended packet header only contains stream_offset and does not contain any
          * other information. */
-        init_get_accum_ext_pkt(flags, NULL /* target_dtp_ptr */ , stream_offset,
-                               &(resp_req->dev.ext_hdr_ptr), &(resp_req->dev.ext_hdr_sz));
+        {
+            int dummy;
+            init_get_accum_ext_pkt(flags, NULL /* target_dtp_ptr */ , stream_offset,
+                                   &(resp_req->dev.ext_hdr_ptr), &(resp_req->dev.ext_hdr_sz),
+                                   &dummy);
+        }
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
                                              stream_offset, stream_size, &curr_req);
@@ -888,8 +841,6 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     MPI_Datatype target_datatype;
     MPIR_Request *req = NULL;
     MPIR_Request *curr_req = NULL;
-    MPIDI_CH3_Ext_pkt_get_derived_t *ext_hdr_ptr = NULL;
-    MPI_Aint ext_hdr_sz = 0;
     MPL_IOV iov[MPL_IOV_LIMIT];
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_ISSUE_GET_OP);
 
@@ -936,25 +887,21 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     }
     else {
         /* derived datatype on target. */
+        void *ext_hdr_ptr = NULL;
+        MPI_Aint ext_hdr_sz = 0;
+
         MPIR_Datatype_get_ptr(target_datatype, dtp);
-        void *dataloop_ptr = NULL;
+        MPIR_Type_flatten_size(dtp, &get_pkt->info.flattened_type_size);
 
-        /* set extended packet header.
-         * dataloop is behind of extended header on origin.
-         * TODO: support extended header array */
-        ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t) + dtp->dataloop_size;
-        ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
-        if (!ext_hdr_ptr) {
+        ext_hdr_ptr = MPL_malloc(get_pkt->info.flattened_type_size, MPL_MEM_RMA);
+        if (ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
-                                 "**nomem %s", "MPIDI_CH3_Ext_pkt_get_derived_t");
+                                 "**nomem %d", get_pkt->info.flattened_type_size);
         }
-        MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
+        MPL_VG_MEM_INIT(ext_hdr_ptr, get_pkt->info.flattened_type_size);
 
-        dataloop_ptr = (void *) ((char *) ext_hdr_ptr + sizeof(MPIDI_CH3_Ext_pkt_get_derived_t));
-        fill_in_derived_dtp_info(&ext_hdr_ptr->dtype_info, dataloop_ptr, dtp);
-
-        /* Set dataloop size in pkt header */
-        MPIDI_CH3_PKT_RMA_SET_DATALOOP_SIZE(rma_op->pkt, dtp->dataloop_size, mpi_errno);
+        MPIR_Type_flatten(dtp, ext_hdr_ptr);
+        ext_hdr_sz = get_pkt->info.flattened_type_size;
 
         iov[0].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) get_pkt;
         iov[0].MPL_IOV_LEN = sizeof(*get_pkt);

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -65,10 +65,10 @@ static inline int immed_copy(void *src, void *dest, size_t len)
 
 /* Set extended header for ACC operation and return its real size. */
 #undef FUNCNAME
-#define FUNCNAME init_accum_ext_pkt
+#define FUNCNAME init_stream_dtype_ext_pkt
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
+static int init_stream_dtype_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
                               MPIR_Datatype* target_dtp, intptr_t stream_offset,
                               void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz, int *flattened_type_size)
 {
@@ -495,7 +495,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+        init_stream_dtype_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
                            &accum_pkt->info.flattened_type_size);
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
@@ -716,7 +716,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_accum_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+        init_stream_dtype_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
                            &get_accum_pkt->info.flattened_type_size);
 
         /* Note: here we need to allocate an extended packet header in response request,
@@ -725,9 +725,9 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
          * other information. */
         {
             int dummy;
-            init_accum_ext_pkt(flags, NULL /* target_dtp_ptr */ , stream_offset,
-                               &(resp_req->dev.ext_hdr_ptr), &(resp_req->dev.ext_hdr_sz),
-                               &dummy);
+            init_stream_dtype_ext_pkt(flags, NULL /* target_dtp_ptr */ , stream_offset,
+                                      &(resp_req->dev.ext_hdr_ptr), &(resp_req->dev.ext_hdr_sz),
+                                      &dummy);
         }
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -405,8 +405,6 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     MPIR_Request *curr_req = NULL;
     MPI_Datatype target_datatype;
     MPIR_Datatype*target_dtp_ptr = NULL;
-    MPIDI_CH3_Ext_pkt_put_derived_t *ext_hdr_ptr = NULL;
-    MPI_Aint ext_hdr_sz = 0;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_ISSUE_PUT_OP);
 
@@ -425,6 +423,8 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     }
     else {
         MPI_Aint origin_type_size;
+        MPIDI_CH3_Ext_pkt_put_derived_t *ext_hdr_ptr = NULL;
+        MPI_Aint ext_hdr_sz = 0;
         MPIR_Datatype_get_size_macro(rma_op->origin_datatype, origin_type_size);
 
         /* If derived datatype on target, add extended packet header. */

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -126,8 +126,7 @@ static int init_stream_dtype_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_INIT_ACCUM_EXT_PKT);
     return mpi_errno;
   fn_fail:
-    if ((*ext_hdr_ptr))
-        MPL_free((*ext_hdr_ptr));
+    MPL_free((*ext_hdr_ptr));
     (*ext_hdr_ptr) = NULL;
     (*ext_hdr_sz) = 0;
     goto fn_exit;
@@ -300,8 +299,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     if (req) {
         if (req->dev.datatype_ptr)
             MPIR_Datatype_ptr_release(req->dev.datatype_ptr);
-        if (req->dev.ext_hdr_ptr)
-            MPL_free(req->dev.ext_hdr_ptr);
+        MPL_free(req->dev.ext_hdr_ptr);
         MPIR_Request_free(req);
     }
 
@@ -546,10 +544,8 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rma_op->single_req = NULL;
     }
     else if (rma_op->reqs_size > 1) {
-        if (rma_op->multi_reqs != NULL) {
-            MPL_free(rma_op->multi_reqs);
-            rma_op->multi_reqs = NULL;
-        }
+        MPL_free(rma_op->multi_reqs);
+        rma_op->multi_reqs = NULL;
     }
     rma_op->reqs_size = 0;
     goto fn_exit;

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -122,7 +122,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_derived_t);
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -141,7 +141,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
 
         _total_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_stream_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -159,7 +159,7 @@ static int init_accum_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         _ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_derived_t);
         _total_sz = _ext_hdr_sz + target_dtp->dataloop_size;
 
-        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz, MPL_MEM_BUFFER);
+        _ext_hdr_ptr = (MPIDI_CH3_Ext_pkt_accum_derived_t *) MPL_malloc(_total_sz, MPL_MEM_RMA);
         MPL_VG_MEM_INIT(_ext_hdr_ptr, _total_sz);
         if (_ext_hdr_ptr == NULL) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -437,7 +437,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
             /* dataloop is behind of extended header on origin.
              * TODO: support extended header array */
             ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_put_derived_t) + target_dtp_ptr->dataloop_size;
-            ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_BUFFER);
+            ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
             MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
             if (!ext_hdr_ptr) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",
@@ -595,7 +595,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
                 if (stream_unit_count > 1) {
                     rma_op->multi_reqs =
-                        (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_BUFFER);
+                        (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_RMA);
                     for (i = 0; i < rma_op->reqs_size; i++)
                         rma_op->multi_reqs[i] = NULL;
                 }
@@ -743,7 +743,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
     if (rma_op->reqs_size > 1) {
         rma_op->multi_reqs =
-            (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_BUFFER);
+            (MPIR_Request **) MPL_malloc(sizeof(MPIR_Request *) * rma_op->reqs_size, MPL_MEM_RMA);
         for (i = 0; i < rma_op->reqs_size; i++)
             rma_op->multi_reqs[i] = NULL;
     }
@@ -943,7 +943,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
          * dataloop is behind of extended header on origin.
          * TODO: support extended header array */
         ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_derived_t) + dtp->dataloop_size;
-        ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_BUFFER);
+        ext_hdr_ptr = MPL_malloc(ext_hdr_sz, MPL_MEM_RMA);
         MPL_VG_MEM_INIT(ext_hdr_ptr, ext_hdr_sz);
         if (!ext_hdr_ptr) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem",

--- a/src/mpid/ch3/include/mpid_rma_oplist.h
+++ b/src/mpid/ch3/include/mpid_rma_oplist.h
@@ -209,9 +209,7 @@ static inline int MPIDI_CH3I_Win_op_free(MPIR_Win * win_ptr, MPIDI_RMA_Op_t * e)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (e->multi_reqs != NULL) {
-        MPL_free(e->multi_reqs);
-    }
+    MPL_free(e->multi_reqs);
 
     /* We enqueue elements to the right pool, so when they get freed
      * at window free time, they won't conflict with the global pool

--- a/src/mpid/ch3/include/mpidpkt.h
+++ b/src/mpid/ch3/include/mpidpkt.h
@@ -558,29 +558,6 @@ MPIDI_CH3_PKT_DEFS
         }                                                               \
     }
 
-#define MPIDI_CH3_PKT_RMA_SET_DATALOOP_SIZE(pkt_, dataloop_size_, err_) \
-    {                                                                   \
-        /* This macro sets dataloop_size in RMA operation packets       \
-           (PUT, GET, ACC, GACC) */                                     \
-        err_ = MPI_SUCCESS;                                             \
-        switch((pkt_).type) {                                           \
-        case (MPIDI_CH3_PKT_PUT):                                       \
-            (pkt_).put.info.dataloop_size = (dataloop_size_);           \
-            break;                                                      \
-        case (MPIDI_CH3_PKT_GET):                                       \
-            (pkt_).get.info.dataloop_size = (dataloop_size_);           \
-            break;                                                      \
-        case (MPIDI_CH3_PKT_ACCUMULATE):                                \
-            (pkt_).accum.info.dataloop_size = (dataloop_size_);         \
-            break;                                                      \
-        case (MPIDI_CH3_PKT_GET_ACCUM):                                 \
-            (pkt_).get_accum.info.dataloop_size = (dataloop_size_);     \
-            break;                                                      \
-        default:                                                        \
-            MPIR_ERR_SETANDJUMP1(err_, MPI_ERR_OTHER, "**invalidpkt", "**invalidpkt %d", (pkt_).type); \
-        }                                                               \
-    }
-
 #define MPIDI_CH3_PKT_RMA_GET_REQUEST_HANDLE(pkt_, request_hdl_, err_)  \
     {                                                                   \
         err_ = MPI_SUCCESS;                                             \
@@ -657,7 +634,7 @@ typedef struct MPIDI_CH3_Pkt_put {
     MPI_Win target_win_handle;
     MPI_Win source_win_handle;
     union {
-        int dataloop_size;
+        int flattened_type_size;
         MPIDI_CH3_RMA_Immed_u data;
     } info;
 } MPIDI_CH3_Pkt_put_t;
@@ -669,7 +646,7 @@ typedef struct MPIDI_CH3_Pkt_get {
     int count;
     MPI_Datatype datatype;
     struct {
-        int dataloop_size;      /* for derived datatypes */
+        int flattened_type_size;
     } info;
     MPI_Request request_handle;
     MPI_Win target_win_handle;
@@ -700,7 +677,7 @@ typedef struct MPIDI_CH3_Pkt_accum {
     MPI_Win target_win_handle;
     MPI_Win source_win_handle;
     union {
-        int dataloop_size;
+        int flattened_type_size;
         MPIDI_CH3_RMA_Immed_u data;
     } info;
 } MPIDI_CH3_Pkt_accum_t;
@@ -715,7 +692,7 @@ typedef struct MPIDI_CH3_Pkt_get_accum {
     MPI_Op op;
     MPI_Win target_win_handle;
     union {
-        int dataloop_size;
+        int flattened_type_size;
         MPIDI_CH3_RMA_Immed_u data;
     } info;
 } MPIDI_CH3_Pkt_get_accum_t;
@@ -918,57 +895,9 @@ typedef union MPIDI_CH3_Pkt {
 
 /* Extended header packet types */
 
-/* to send derived datatype across in RMA ops */
-typedef struct MPIDI_RMA_dtype_info {   /* for derived datatypes */
-    int is_contig;
-    MPI_Aint max_contig_blocks;
-    MPI_Aint size;
-    MPI_Aint extent;
-    MPI_Aint dataloop_size;     /* not needed because this info is sent in
-                                 * packet header. remove it after lock/unlock
-                                 * is implemented in the device */
-    void *dataloop;             /* pointer needed to update pointers
-                                 * within dataloop on remote side */
-    int basic_type;
-    MPI_Aint ub, lb, true_ub, true_lb;
-    int has_sticky_ub, has_sticky_lb;
-} MPIDI_RMA_dtype_info;
-
 typedef struct MPIDI_CH3_Ext_pkt_stream {
     MPI_Aint stream_offset;
 } MPIDI_CH3_Ext_pkt_stream_t;
-
-typedef struct MPIDI_CH3_Ext_pkt_derived {
-    MPIDI_RMA_dtype_info dtype_info;
-    /* Follow with variable-length dataloop.
-     * On origin we allocate a large buffer including
-     * this header and the dataloop; on target we use
-     * separate buffer to receive dataloop in order
-     * to avoid extra copy.*/
-} MPIDI_CH3_Ext_pkt_derived_t;
-
-typedef struct MPIDI_CH3_Ext_pkt_stream_derived {
-    MPI_Aint stream_offset;
-    MPIDI_RMA_dtype_info dtype_info;
-    /* follow with variable-length dataloop. */
-} MPIDI_CH3_Ext_pkt_stream_derived_t;
-
-/* Note that since ACC and GET_ACC contain the same extended attributes,
- * we use generic routines for them in some places (see below).
- * If we add OP-specific attribute in future, we should handle them separately.
- *  1. origin issuing function
- *  2. target packet handler
- *  3. target data receive complete handler. */
-typedef MPIDI_CH3_Ext_pkt_stream_t MPIDI_CH3_Ext_pkt_accum_stream_t;
-typedef MPIDI_CH3_Ext_pkt_derived_t MPIDI_CH3_Ext_pkt_accum_derived_t;
-typedef MPIDI_CH3_Ext_pkt_stream_derived_t MPIDI_CH3_Ext_pkt_accum_stream_derived_t;
-
-typedef MPIDI_CH3_Ext_pkt_stream_t MPIDI_CH3_Ext_pkt_get_accum_stream_t;
-typedef MPIDI_CH3_Ext_pkt_derived_t MPIDI_CH3_Ext_pkt_get_accum_derived_t;
-typedef MPIDI_CH3_Ext_pkt_stream_derived_t MPIDI_CH3_Ext_pkt_get_accum_stream_derived_t;
-
-typedef MPIDI_CH3_Ext_pkt_derived_t MPIDI_CH3_Ext_pkt_put_derived_t;
-typedef MPIDI_CH3_Ext_pkt_derived_t MPIDI_CH3_Ext_pkt_get_derived_t;
 
 #if defined(MPID_USE_SEQUENCE_NUMBERS)
 typedef struct MPIDI_CH3_Pkt_send_container {

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -444,7 +444,7 @@ typedef struct MPIDI_Request {
     /* For accumulate, since data is first read into a tmp_buf */
     void *real_user_buf;
     /* For derived datatypes at target. */
-    void *dataloop;
+    void *flattened_type;
     /* req. handle needed to implement derived datatype gets.
      * It also used for remembering user request of request-based RMA operations. */
     MPI_Request request_handle;

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -395,16 +395,8 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
             MPIR_Assert(pkt->type == MPIDI_CH3_PKT_ACCUMULATE ||
                         pkt->type == MPIDI_CH3_PKT_GET_ACCUM);
 
-            /* Only basic datatype may contain piggyback lock.
-             * Thus we do not check extended header type for derived case.*/
-            if (pkt->type == MPIDI_CH3_PKT_ACCUMULATE) {
-                recv_data_sz += sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
-                buf_size += sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
-            }
-            else {
-                recv_data_sz += sizeof(MPIDI_CH3_Ext_pkt_get_accum_stream_t);
-                buf_size += sizeof(MPIDI_CH3_Ext_pkt_get_accum_stream_t);
-            }
+            recv_data_sz += sizeof(MPIDI_CH3_Ext_pkt_stream_t);
+            buf_size += sizeof(MPIDI_CH3_Ext_pkt_stream_t);
         }
 
         if (new_ptr != NULL) {
@@ -1234,14 +1226,9 @@ static inline void MPIDI_CH3_ExtPkt_Accum_get_stream(MPIDI_CH3_Pkt_flags_t flags
                                                      int is_derived_dt, void *ext_hdr_ptr,
                                                      MPI_Aint * stream_offset)
 {
-    if ((flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) && is_derived_dt) {
+    if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
         MPIR_Assert(ext_hdr_ptr != NULL);
-        (*stream_offset) =
-            ((MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) ext_hdr_ptr)->stream_offset;
-    }
-    else if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-        MPIR_Assert(ext_hdr_ptr != NULL);
-        (*stream_offset) = ((MPIDI_CH3_Ext_pkt_accum_stream_t *) ext_hdr_ptr)->stream_offset;
+        (*stream_offset) = ((MPIDI_CH3_Ext_pkt_stream_t *) ext_hdr_ptr)->stream_offset;
     }
 }
 

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -83,15 +83,10 @@ static void free_pmi_keyvals(PMI_keyval_t **kv, int size, int *counts)
     {
 	for (j=0; j<counts[i]; j++)
 	{
-	    if (kv[i][j].key != NULL)
-		MPL_free((char *)kv[i][j].key);
-	    if (kv[i][j].val != NULL)
-		MPL_free(kv[i][j].val);
+            MPL_free((char *)kv[i][j].key);
+            MPL_free(kv[i][j].val);
 	}
-	if (kv[i] != NULL)
-	{
-	    MPL_free(kv[i]);
-	}
+        MPL_free(kv[i]);
     }
 }
 
@@ -294,9 +289,7 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 	MPL_free(info_keyval_sizes);
 	MPL_free(info_keyval_vectors);
     }
-    if (pmi_errcodes) {
-	MPL_free(pmi_errcodes);
-    }
+    MPL_free(pmi_errcodes);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMM_SPAWN_MULTIPLE);
     return mpi_errno;
  fn_fail:
@@ -369,9 +362,7 @@ int MPIDI_CH3_GetParentPort(char ** parent_port)
 }
 void MPIDI_CH3_FreeParentPort(void)
 {
-    if (parent_port_name) {
-	MPL_free( parent_port_name );
-	parent_port_name = 0;
-    }
+    MPL_free( parent_port_name );
+    parent_port_name = 0;
 }
 #endif

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -7,9 +7,6 @@
 #include "mpidimpl.h"
 #include "mpidrma.h"
 
-static int create_derived_datatype(MPIR_Request * req, MPIDI_RMA_dtype_info * dtype_info,
-                                   MPIR_Datatype** dtp);
-
 #undef FUNCNAME
 #define FUNCNAME MPIDI_CH3U_Handle_recv_req
 #undef FCNAME
@@ -564,15 +561,19 @@ int MPIDI_CH3_ReqHandler_PutDerivedDTRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((unu
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype*new_dtp = NULL;
-    MPIDI_RMA_dtype_info *dtype_info = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_REQHANDLER_PUTDERIVEDDTRECVCOMPLETE);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_REQHANDLER_PUTDERIVEDDTRECVCOMPLETE);
 
     /* get data from extended header */
-    dtype_info = &((MPIDI_CH3_Ext_pkt_put_derived_t *) rreq->dev.ext_hdr_ptr)->dtype_info;
-    /* create derived datatype */
-    create_derived_datatype(rreq, dtype_info, &new_dtp);
+    new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+    if (!new_dtp) {
+        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
+                             "MPIR_Datatype_mem");
+    }
+    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
+    MPIR_Object_set_ref(new_dtp, 1);
+    MPIR_Type_unflatten(new_dtp, rreq->dev.flattened_type);
 
     /* update request to get the data */
     MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_PUT_RECV);
@@ -611,7 +612,6 @@ int MPIDI_CH3_ReqHandler_AccumMetadataRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((un
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype*new_dtp = NULL;
-    MPIDI_RMA_dtype_info *dtype_info = NULL;
     MPI_Aint basic_type_extent, basic_type_size;
     MPI_Aint total_len, rest_len, stream_elem_count;
     MPI_Aint stream_offset;
@@ -622,24 +622,24 @@ int MPIDI_CH3_ReqHandler_AccumMetadataRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((un
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_REQHANDLER_ACCUMMETADATARECVCOMPLETE);
 
     stream_offset = 0;
-    MPIR_Assert(rreq->dev.ext_hdr_ptr != NULL);
+
+    /* get stream offset */
+    if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+        MPIDI_CH3_Ext_pkt_stream_t *ext_hdr = NULL;
+        MPIR_Assert(rreq->dev.ext_hdr_ptr != NULL);
+        ext_hdr = ((MPIDI_CH3_Ext_pkt_stream_t *) rreq->dev.ext_hdr_ptr);
+        stream_offset = ext_hdr->stream_offset;
+    }
 
     if (MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_ACCUM_RECV_DERIVED_DT) {
-        /* get data from extended header */
-        if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-            MPIDI_CH3_Ext_pkt_accum_stream_derived_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_accum_stream_derived_t *) rreq->dev.ext_hdr_ptr);
-            stream_offset = ext_hdr->stream_offset;
-            dtype_info = &ext_hdr->dtype_info;
+        new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+        if (!new_dtp) {
+            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
+                                 "MPIR_Datatype_mem");
         }
-        else {
-            MPIDI_CH3_Ext_pkt_accum_derived_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_accum_derived_t *) rreq->dev.ext_hdr_ptr);
-            dtype_info = &ext_hdr->dtype_info;
-        }
-
-        /* create derived datatype */
-        create_derived_datatype(rreq, dtype_info, &new_dtp);
+        /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
+        MPIR_Object_set_ref(new_dtp, 1);
+        MPIR_Type_unflatten(new_dtp, rreq->dev.flattened_type);
 
         /* update new request to get the data */
         MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_ACCUM_RECV);
@@ -655,13 +655,6 @@ int MPIDI_CH3_ReqHandler_AccumMetadataRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((un
     else {
         MPIR_Assert(MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_ACCUM_RECV);
         MPIR_Assert(rreq->dev.datatype != MPI_DATATYPE_NULL);
-
-        /* get data from extended header */
-        if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-            MPIDI_CH3_Ext_pkt_accum_stream_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_accum_stream_t *) rreq->dev.ext_hdr_ptr);
-            stream_offset = ext_hdr->stream_offset;
-        }
 
         MPIR_Datatype_get_size_macro(rreq->dev.datatype, type_size);
 
@@ -725,7 +718,6 @@ int MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete(MPIDI_VC_t * vc,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype*new_dtp = NULL;
-    MPIDI_RMA_dtype_info *dtype_info = NULL;
     MPI_Aint basic_type_extent, basic_type_size;
     MPI_Aint total_len, rest_len, stream_elem_count;
     MPI_Aint stream_offset;
@@ -742,24 +734,24 @@ int MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete(MPIDI_VC_t * vc,
     }
 
     stream_offset = 0;
-    MPIR_Assert(rreq->dev.ext_hdr_ptr != NULL);
+
+    /* get stream offset */
+    if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+        MPIDI_CH3_Ext_pkt_stream_t *ext_hdr = NULL;
+        MPIR_Assert(rreq->dev.ext_hdr_ptr != NULL);
+        ext_hdr = ((MPIDI_CH3_Ext_pkt_stream_t *) rreq->dev.ext_hdr_ptr);
+        stream_offset = ext_hdr->stream_offset;
+    }
 
     if (MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_GET_ACCUM_RECV_DERIVED_DT) {
-        /* get data from extended header */
-        if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-            MPIDI_CH3_Ext_pkt_get_accum_stream_derived_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_get_accum_stream_derived_t *) rreq->dev.ext_hdr_ptr);
-            stream_offset = ext_hdr->stream_offset;
-            dtype_info = &ext_hdr->dtype_info;
+        new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+        if (!new_dtp) {
+            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
+                                 "MPIR_Datatype_mem");
         }
-        else {
-            MPIDI_CH3_Ext_pkt_get_accum_derived_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_get_accum_derived_t *) rreq->dev.ext_hdr_ptr);
-            dtype_info = &ext_hdr->dtype_info;
-        }
-
-        /* create derived datatype */
-        create_derived_datatype(rreq, dtype_info, &new_dtp);
+        /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
+        MPIR_Object_set_ref(new_dtp, 1);
+        MPIR_Type_unflatten(new_dtp, rreq->dev.flattened_type);
 
         /* update new request to get the data */
         MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_GET_ACCUM_RECV);
@@ -775,13 +767,6 @@ int MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete(MPIDI_VC_t * vc,
     else {
         MPIR_Assert(MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_GET_ACCUM_RECV);
         MPIR_Assert(rreq->dev.datatype != MPI_DATATYPE_NULL);
-
-        /* get data from extended header */
-        if (rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
-            MPIDI_CH3_Ext_pkt_get_accum_stream_t *ext_hdr = NULL;
-            ext_hdr = ((MPIDI_CH3_Ext_pkt_get_accum_stream_t *) rreq->dev.ext_hdr_ptr);
-            stream_offset = ext_hdr->stream_offset;
-        }
 
         MPIR_Datatype_get_size_macro(rreq->dev.datatype, type_size);
 
@@ -857,7 +842,6 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype*new_dtp = NULL;
-    MPIDI_RMA_dtype_info *dtype_info = NULL;
     MPIDI_CH3_Pkt_t upkt;
     MPIDI_CH3_Pkt_get_resp_t *get_resp_pkt = &upkt.get_resp;
     MPIR_Request *sreq;
@@ -871,9 +855,14 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
     MPIR_Assert(!(rreq->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP));
 
     /* get data from extended header */
-    dtype_info = &((MPIDI_CH3_Ext_pkt_get_derived_t *) rreq->dev.ext_hdr_ptr)->dtype_info;
-    /* create derived datatype */
-    create_derived_datatype(rreq, dtype_info, &new_dtp);
+    new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+    if (!new_dtp) {
+        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
+                             "MPIR_Datatype_mem");
+    }
+    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
+    MPIR_Object_set_ref(new_dtp, 1);
+    MPIR_Type_unflatten(new_dtp, rreq->dev.flattened_type);
 
     /* create request for sending data */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
@@ -1068,64 +1057,6 @@ int MPIDI_CH3_ReqHandler_ReloadIOV(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 
 /* ----------------------------------------------------------------------- */
 /* ----------------------------------------------------------------------- */
-
-#undef FUNCNAME
-#define FUNCNAME create_derived_datatype
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static int create_derived_datatype(MPIR_Request * req, MPIDI_RMA_dtype_info * dtype_info,
-                                   MPIR_Datatype** dtp)
-{
-    MPIR_Datatype*new_dtp;
-    int mpi_errno = MPI_SUCCESS;
-    MPI_Aint ptrdiff;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CREATE_DERIVED_DATATYPE);
-
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_DERIVED_DATATYPE);
-
-    /* allocate new datatype object and handle */
-    new_dtp = (MPIR_Datatype*) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-    if (!new_dtp) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "MPIR_Datatype_mem");
-    }
-
-    *dtp = new_dtp;
-
-    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-    MPIR_Object_set_ref(new_dtp, 1);
-    new_dtp->is_committed = 1;
-    new_dtp->attributes = 0;
-    new_dtp->name[0] = 0;
-    new_dtp->is_contig = dtype_info->is_contig;
-    new_dtp->max_contig_blocks = dtype_info->max_contig_blocks;
-    new_dtp->size = dtype_info->size;
-    new_dtp->extent = dtype_info->extent;
-    new_dtp->dataloop_size = dtype_info->dataloop_size;
-    new_dtp->basic_type = dtype_info->basic_type;
-    /* set dataloop pointer */
-    new_dtp->dataloop = req->dev.dataloop;
-
-    new_dtp->ub = dtype_info->ub;
-    new_dtp->lb = dtype_info->lb;
-    new_dtp->true_ub = dtype_info->true_ub;
-    new_dtp->true_lb = dtype_info->true_lb;
-    new_dtp->has_sticky_ub = dtype_info->has_sticky_ub;
-    new_dtp->has_sticky_lb = dtype_info->has_sticky_lb;
-    /* update pointers in dataloop */
-    ptrdiff = (MPI_Aint) ((char *) (new_dtp->dataloop) - (char *)
-                          (dtype_info->dataloop));
-
-    MPIR_Dataloop_update(new_dtp->dataloop, ptrdiff);
-
-    new_dtp->contents = NULL;
-
-  fn_fail:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_CREATE_DERIVED_DATATYPE);
-
-    return mpi_errno;
-}
-
 
 static inline int perform_put_in_lock_queue(MPIR_Win * win_ptr,
                                             MPIDI_RMA_Target_lock_entry_t * target_lock_entry)
@@ -2014,14 +1945,7 @@ int MPIDI_CH3_ReqHandler_PiggybackLockOpRecvComplete(MPIDI_VC_t * vc,
             MPIR_Assert(target_lock_queue_entry->pkt.type == MPIDI_CH3_PKT_ACCUMULATE ||
                         target_lock_queue_entry->pkt.type == MPIDI_CH3_PKT_GET_ACCUM);
 
-            int ext_hdr_sz;
-
-            /* only basic datatype may contain piggyback lock.
-             * Thus we do not check extended header type for derived case.*/
-            if (target_lock_queue_entry->pkt.type == MPIDI_CH3_PKT_ACCUMULATE)
-                ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_accum_stream_t);
-            else
-                ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_get_accum_stream_t);
+            int ext_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_stream_t);
 
             /* here we drop the stream_offset received, because the stream unit that piggybacked with
              * LOCK must be the first stream unit, with stream_offset equals to 0. */

--- a/src/mpid/ch3/src/ch3u_handle_send_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_send_req.c
@@ -137,8 +137,7 @@ int MPIDI_CH3_ReqHandler_GaccumSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     /* This function is triggered when sending back process of GACC/FOP/CAS
      * is finished. Only GACC used user_buf. FOP and CAS can fit all data
      * in response packet. */
-    if (rreq->dev.user_buf != NULL)
-        MPL_free(rreq->dev.user_buf);
+    MPL_free(rreq->dev.user_buf);
 
     MPIR_Win_get_ptr(rreq->dev.target_win_handle, win_ptr);
 
@@ -206,8 +205,7 @@ int MPIDI_CH3_ReqHandler_CASSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     /* This function is triggered when sending back process of GACC/FOP/CAS
      * is finished. Only GACC used user_buf. FOP and CAS can fit all data
      * in response packet. */
-    if (rreq->dev.user_buf != NULL)
-        MPL_free(rreq->dev.user_buf);
+    MPL_free(rreq->dev.user_buf);
 
     MPIR_Win_get_ptr(rreq->dev.target_win_handle, win_ptr);
 
@@ -274,8 +272,7 @@ int MPIDI_CH3_ReqHandler_FOPSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     /* This function is triggered when sending back process of GACC/FOP/CAS
      * is finished. Only GACC used user_buf. FOP and CAS can fit all data
      * in response packet. */
-    if (rreq->dev.user_buf != NULL)
-        MPL_free(rreq->dev.user_buf);
+    MPL_free(rreq->dev.user_buf);
 
     MPIR_Win_get_ptr(rreq->dev.target_win_handle, win_ptr);
 

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -1138,9 +1138,7 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
     while (pg_list) {
 	pg_next = pg_list->next;
 	MPL_free( pg_list->str );
-	if (pg_list->pg_id ) {
-	    MPL_free( pg_list->pg_id );
-	}
+        MPL_free( pg_list->pg_id );
 	MPL_free( pg_list );
 	pg_list = pg_next;
     }

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -44,7 +44,7 @@ void MPID_Request_create_hook(MPIR_Request *req)
     req->dev.target_win_handle = MPI_WIN_NULL;
     req->dev.source_win_handle = MPI_WIN_NULL;
     req->dev.target_lock_queue_entry = NULL;
-    req->dev.dataloop	   = NULL;
+    req->dev.flattened_type = NULL;
     req->dev.iov_offset        = 0;
     req->dev.flags             = MPIDI_CH3_PKT_FLAG_NONE;
     req->dev.resp_request_handle = MPI_REQUEST_NULL;
@@ -617,5 +617,9 @@ void MPID_Request_destroy_hook(MPIR_Request *req)
 
     if (req->dev.ext_hdr_ptr != NULL) {
         MPL_free(req->dev.ext_hdr_ptr);
+    }
+
+    if (req->dev.flattened_type != NULL) {
+        MPL_free(req->dev.flattened_type);
     }
 }

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -615,11 +615,6 @@ void MPID_Request_destroy_hook(MPIR_Request *req)
         MPIDI_CH3U_SRBuf_free(req);
     }
 
-    if (req->dev.ext_hdr_ptr != NULL) {
-        MPL_free(req->dev.ext_hdr_ptr);
-    }
-
-    if (req->dev.flattened_type != NULL) {
-        MPL_free(req->dev.flattened_type);
-    }
+    MPL_free(req->dev.ext_hdr_ptr);
+    MPL_free(req->dev.flattened_type);
 }

--- a/src/mpid/ch3/src/ch3u_rma_ops.c
+++ b/src/mpid/ch3/src/ch3u_rma_ops.c
@@ -170,7 +170,7 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
             win_ptr->basic_info_table[target_rank].disp_unit * target_disp;
         put_pkt->count = target_count;
         put_pkt->datatype = target_datatype;
-        put_pkt->info.dataloop_size = 0;
+        put_pkt->info.flattened_type_size = 0;
         put_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         put_pkt->source_win_handle = win_ptr->handle;
         put_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
@@ -344,7 +344,7 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
             win_ptr->basic_info_table[target_rank].disp_unit * target_disp;
         get_pkt->count = target_count;
         get_pkt->datatype = target_datatype;
-        get_pkt->info.dataloop_size = 0;
+        get_pkt->info.flattened_type_size = 0;
         get_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         get_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_resp_pkt)
@@ -549,7 +549,7 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
             win_ptr->basic_info_table[target_rank].disp_unit * target_disp;
         accum_pkt->count = target_count;
         accum_pkt->datatype = target_datatype;
-        accum_pkt->info.dataloop_size = 0;
+        accum_pkt->info.flattened_type_size = 0;
         accum_pkt->op = op;
         accum_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         accum_pkt->source_win_handle = win_ptr->handle;
@@ -802,7 +802,7 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
             win_ptr->basic_info_table[target_rank].disp_unit * target_disp;
         get_accum_pkt->count = target_count;
         get_accum_pkt->datatype = target_datatype;
-        get_accum_pkt->info.dataloop_size = 0;
+        get_accum_pkt->info.flattened_type_size = 0;
         get_accum_pkt->op = op;
         get_accum_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         get_accum_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -1460,7 +1460,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
             MPIR_Datatype_get_extent_macro(fop_pkt->datatype, extent);
 
-            req->dev.user_buf = MPL_malloc(extent, MPL_MEM_BUFFER);
+            req->dev.user_buf = MPL_malloc(extent, MPL_MEM_RMA);
             if (!req->dev.user_buf) {
                 MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %d", extent);
             }

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -208,8 +208,7 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3_EXTPKTHANDLER_ACCUMULATE);
     return mpi_errno;
   fn_fail:
-    if ((*ext_hdr_ptr) != NULL)
-        MPL_free((*ext_hdr_ptr));
+    MPL_free((*ext_hdr_ptr));
     (*ext_hdr_ptr) = NULL;
     (*ext_hdr_sz) = 0;
     goto fn_exit;

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -615,9 +615,7 @@ int MPIDI_CH3I_BCInit( char **bc_val_p, int *val_max_sz_p )
 int MPIDI_CH3I_BCFree( char *bc_val )
 {
     /* */
-    if (bc_val) {
-	MPL_free( bc_val );
-    }
+    MPL_free( bc_val );
     
     return 0;
 }
@@ -632,10 +630,7 @@ static int pg_compare_ids(void * id1, void * id2)
 
 static int pg_destroy(MPIDI_PG_t * pg)
 {
-    if (pg->id != NULL)
-    { 
-	MPL_free(pg->id);
-    }
+    MPL_free(pg->id);
     
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -803,7 +803,7 @@ static int connToStringKVS( char **buf_p, int *slen, MPIDI_PG_t *pg )
  fn_exit:
     return mpi_errno;
  fn_fail:
-    if (string) MPL_free(string);
+    MPL_free(string);
     goto fn_exit;
 }
 static int connFromStringKVS( const char *buf ATTRIBUTE((unused)), 
@@ -814,9 +814,7 @@ static int connFromStringKVS( const char *buf ATTRIBUTE((unused)),
 }
 static int connFreeKVS( MPIDI_PG_t *pg )
 {
-    if (pg->connData) {
-	MPL_free( pg->connData );
-    }
+    MPL_free( pg->connData );
     return MPI_SUCCESS;
 }
 
@@ -868,7 +866,7 @@ int MPIDI_PG_InitConnKVS( MPIDI_PG_t *pg )
  fn_exit:
     return mpi_errno;
  fn_fail:
-    if (pg->connData) { MPL_free(pg->connData); }
+    MPL_free(pg->connData);
     goto fn_exit;
 }
 

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -206,8 +206,7 @@ int MPID_Win_free(MPIR_Win ** win_ptr)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if ((*win_ptr)->basic_info_table != NULL)
-        MPL_free((*win_ptr)->basic_info_table);
+    MPL_free((*win_ptr)->basic_info_table);
     MPL_free((*win_ptr)->op_pool_start);
     MPL_free((*win_ptr)->target_pool_start);
     MPL_free((*win_ptr)->slots);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -15,7 +15,6 @@
 #include <sys/types.h>
 #endif
 
-#include "mpir_dataloop.h"
 #ifdef HAVE_LIBHCOLL
 #include "hcoll/api/hcoll_dte.h"
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -340,9 +340,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
     MPIDI_OFI_CALL_NOLOCK(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
     OPA_decr_int(&MPIDI_Global.am_inflight_rma_send_mrs);
 
-    if (MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer)) {
-        MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
-    }
+    MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
 
     handler_id = MPIDI_OFI_AMREQUEST_HDR(sreq, msg_hdr).handler_id;
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -279,8 +279,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(struct fi_cq_tagged_entry *wc,
         if ((event_id == MPIDI_OFI_EVENT_SEND_PACK) && (MPIDI_OFI_REQUEST(sreq, noncontig.pack))) {
             MPIR_Segment_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack->segment));
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack));
-        } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK) &&
-                   MPIDI_OFI_REQUEST(sreq, noncontig.nopack))
+        } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK))
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack));
 
         MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(sreq, datatype));
@@ -556,10 +555,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_event(struct fi_cq_tagged_entry 
             break;
     }
 
-    if (MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer)) {
-        MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
-        MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
-    }
+    MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
+    MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer) = NULL;
 
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -915,10 +915,8 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* -------------------------------- */
     /* Free temporary resources         */
     /* -------------------------------- */
-    if (provname) {
-        MPL_free((char *) provname);
-        hints->fabric_attr->prov_name = NULL;
-    }
+    MPL_free((char *) provname);
+    hints->fabric_attr->prov_name = NULL;
 
     if (prov)
         fi_freeinfo(prov);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -220,8 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_PUT_GET);
     return mpi_errno;
   fn_fail:
-    if (req)
-        MPL_free(req);
+    MPL_free(req);
     req = NULL;
     goto fn_exit;
 }
@@ -277,8 +276,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_ACCUMULATE);
     return mpi_errno;
   fn_fail:
-    if (req)
-        MPL_free(req);
+    MPL_free(req);
     req = NULL;
     goto fn_exit;
 }
@@ -348,8 +346,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_GET_ACCUMULATE);
     return mpi_errno;
   fn_fail:
-    if (req)
-        MPL_free(req);
+    MPL_free(req);
     req = NULL;
     goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -1225,10 +1225,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free_hook(MPIR_Win * win)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).cmpl_cntr->fid), cntrclose);
         if (MPIDI_OFI_WIN(win).mr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).mr->fid), mr_unreg);
-        if (MPIDI_OFI_WIN(win).winfo) {
-            MPL_free(MPIDI_OFI_WIN(win).winfo);
-            MPIDI_OFI_WIN(win).winfo = NULL;
-        }
+        MPL_free(MPIDI_OFI_WIN(win).winfo);
+        MPIDI_OFI_WIN(win).winfo = NULL;
         MPL_free(MPIDI_OFI_WIN(win).acc_hint);
         MPIDI_OFI_WIN(win).acc_hint = NULL;
     }

--- a/src/mpid/ch4/netmod/portals4/ptl_request.h
+++ b/src/mpid/ch4/netmod/portals4/ptl_request.h
@@ -21,9 +21,7 @@ static inline void MPIDI_NM_am_request_init(MPIR_Request * req)
 
 static inline void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    if ((req)->dev.ch4.am.netmod_am.portals4.pack_buffer) {
-        MPL_free((req)->dev.ch4.am.netmod_am.portals4.pack_buffer);
-    }
+    MPL_free((req)->dev.ch4.am.netmod_am.portals4.pack_buffer);
     if ((req)->dev.ch4.am.netmod_am.portals4.md != PTL_INVALID_HANDLE) {
         PtlMDRelease((req)->dev.ch4.am.netmod_am.portals4.md);
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_request.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_request.h
@@ -26,9 +26,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    if ((req)->dev.ch4.am.netmod_am.ucx.pack_buffer) {
-        MPL_free((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    }
+    MPL_free((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
     /* MPIR_Request_free(req); */
 }
 

--- a/src/mpid/ch4/src/ch4_spawn.h
+++ b/src/mpid/ch4/src/ch4_spawn.h
@@ -99,15 +99,10 @@ static inline void MPIDI_free_pmi_keyvals(PMI_keyval_t ** kv, int size, int *cou
 
     for (i = 0; i < size; i++) {
         for (j = 0; j < counts[i]; j++) {
-            if (kv[i][j].key != NULL)
-                MPL_free((char *) kv[i][j].key);
-
-            if (kv[i][j].val != NULL)
-                MPL_free(kv[i][j].val);
+            MPL_free((char *) kv[i][j].key);
+            MPL_free(kv[i][j].val);
         }
-
-        if (kv[i] != NULL)
-            MPL_free(kv[i]);
+        MPL_free(kv[i]);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FREE_PMI_KEYVALS);
@@ -238,11 +233,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Comm_spawn_multiple(int count,
         MPL_free(info_keyval_vectors);
     }
 
-    if (info_keyval_sizes)
-        MPL_free(info_keyval_sizes);
-
-    if (pmi_errcodes)
-        MPL_free(pmi_errcodes);
+    MPL_free(info_keyval_sizes);
+    MPL_free(pmi_errcodes);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COMM_SPAWN_MULTIPLE);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4r_rma_origin_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_origin_callbacks.h
@@ -90,9 +90,7 @@ static inline int MPIDIG_get_ack_origin_cb(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACK_ORIGIN_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACK_ORIGIN_CB);
 
-    if (MPIDIG_REQUEST(req, req->greq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(req, req->greq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(req, req->greq.dt_iov));
 
     MPID_Request_complete(req);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACK_ORIGIN_CB);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -699,8 +699,7 @@ static inline int MPIDIG_handle_acc_cmpl(MPIR_Request * rreq)
 #endif
 
     /* MPIDI_CS_EXIT(); */
-    if (MPIDIG_REQUEST(rreq, req->areq.data))
-        MPL_free(MPIDIG_REQUEST(rreq, req->areq.data));
+    MPL_free(MPIDIG_REQUEST(rreq, req->areq.data));
 
     MPIDIG_REQUEST(rreq, req->areq.data) = NULL;
     mpi_errno = MPIDIG_ack_acc(rreq);
@@ -806,8 +805,7 @@ static inline int MPIDIG_handle_get_acc_cmpl(MPIR_Request * rreq)
 #endif
 
     /* MPIDI_CS_EXIT(); */
-    if (MPIDIG_REQUEST(rreq, req->areq.data))
-        MPL_free(MPIDIG_REQUEST(rreq, req->areq.data));
+    MPL_free(MPIDIG_REQUEST(rreq, req->areq.data));
 
     MPIDIG_REQUEST(rreq, req->areq.data) = original;
     mpi_errno = MPIDIG_ack_get_acc(rreq);
@@ -974,9 +972,7 @@ static inline int MPIDIG_put_target_cmpl_cb(MPIR_Request * rreq)
         MPL_free(MPIDIG_REQUEST(rreq, req->iov));
     }
 
-    if (MPIDIG_REQUEST(rreq, req->preq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(rreq, req->preq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(rreq, req->preq.dt_iov));
 
     mpi_errno = MPIDIG_ack_put(rreq);
     if (mpi_errno)
@@ -1330,9 +1326,7 @@ static inline int MPIDIG_put_ack_taget_msg_cb(int handler_id, void *am_hdr,
     preq = (MPIR_Request *) msg_hdr->preq_ptr;
     win = MPIDIG_REQUEST(preq, req->preq.win_ptr);
 
-    if (MPIDIG_REQUEST(preq, req->preq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(preq, req->preq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(preq, req->preq.dt_iov));
 
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(preq, rank));
 
@@ -1370,9 +1364,7 @@ static inline int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
     areq = (MPIR_Request *) msg_hdr->req_ptr;
     win = MPIDIG_REQUEST(areq, req->areq.win_ptr);
 
-    if (MPIDIG_REQUEST(areq, req->areq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
 
     MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
     MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
@@ -1415,9 +1407,7 @@ static inline int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr,
 
     areq = (MPIR_Request *) msg_hdr->req_ptr;
 
-    if (MPIDIG_REQUEST(areq, req->areq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
 
     MPIDI_Datatype_get_info(MPIDIG_REQUEST(areq, req->areq.result_count),
                             MPIDIG_REQUEST(areq, req->areq.result_datatype),
@@ -2418,9 +2408,7 @@ static inline int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr,
     MPIR_Assert(rreq->kind == MPIR_REQUEST_KIND__RMA);
     MPIDIG_REQUEST(greq, req->greq.greq_ptr) = (uint64_t) rreq;
 
-    if (MPIDIG_REQUEST(rreq, req->greq.dt_iov)) {
-        MPL_free(MPIDIG_REQUEST(rreq, req->greq.dt_iov));
-    }
+    MPL_free(MPIDIG_REQUEST(rreq, req->greq.dt_iov));
 
     *target_cmpl_cb = MPIDIG_get_ack_target_cmpl_cb;
 #ifndef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpl/include/mpl_thread_priv.h
+++ b/src/mpl/include/mpl_thread_priv.h
@@ -71,8 +71,7 @@ void MPLI_cleanup_tls(void *a);
         if (unlikely(*((int *) err_ptr_)))                 \
             break;                                      \
                                                         \
-        if (thread_ptr)                                 \
-            MPL_free(thread_ptr);                       \
+        MPL_free(thread_ptr);                           \
                                                         \
         MPL_thread_tls_set(&(key), NULL, err_ptr_);     \
         if (unlikely(*((int *) err_ptr_)))              \

--- a/src/mpl/src/thread/mpl_thread.c
+++ b/src/mpl/src/thread/mpl_thread.c
@@ -15,8 +15,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
  * allocated with MPL_calloc */
 void MPLI_cleanup_tls(void *a)
 {
-    if (a)
-        MPL_free(a);
+    MPL_free(a);
 }
 
 #endif

--- a/src/pm/hydra/pm/pmiserv/common.c
+++ b/src/pm/hydra/pm/pmiserv/common.c
@@ -59,8 +59,7 @@ HYD_status HYD_pmcd_pmi_parse_pmi_cmd(char *obuf, int pmi_version, char **pmi_cm
 
   fn_exit:
     MPL_free(buf);
-    if (str1)
-        MPL_free(str1);
+    MPL_free(str1);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/pm/pmiserv/pmip.c
+++ b/src/pm/hydra/pm/pmiserv/pmip.c
@@ -66,50 +66,28 @@ static void cleanup_params(void)
     HYDU_finalize_user_global(&HYD_pmcd_pmip.user_global);
 
     /* System global */
-    if (HYD_pmcd_pmip.system_global.pmi_fd)
-        MPL_free(HYD_pmcd_pmip.system_global.pmi_fd);
-
-    if (HYD_pmcd_pmip.system_global.pmi_process_mapping)
-        MPL_free(HYD_pmcd_pmip.system_global.pmi_process_mapping);
+    MPL_free(HYD_pmcd_pmip.system_global.pmi_fd);
+    MPL_free(HYD_pmcd_pmip.system_global.pmi_process_mapping);
 
 
     /* Upstream */
-    if (HYD_pmcd_pmip.upstream.server_name)
-        MPL_free(HYD_pmcd_pmip.upstream.server_name);
+    MPL_free(HYD_pmcd_pmip.upstream.server_name);
 
 
     /* Downstream */
-    if (HYD_pmcd_pmip.downstream.out)
-        MPL_free(HYD_pmcd_pmip.downstream.out);
-
-    if (HYD_pmcd_pmip.downstream.err)
-        MPL_free(HYD_pmcd_pmip.downstream.err);
-
-    if (HYD_pmcd_pmip.downstream.pid)
-        MPL_free(HYD_pmcd_pmip.downstream.pid);
-
-    if (HYD_pmcd_pmip.downstream.exit_status)
-        MPL_free(HYD_pmcd_pmip.downstream.exit_status);
-
-    if (HYD_pmcd_pmip.downstream.pmi_rank)
-        MPL_free(HYD_pmcd_pmip.downstream.pmi_rank);
-
-    if (HYD_pmcd_pmip.downstream.pmi_fd)
-        MPL_free(HYD_pmcd_pmip.downstream.pmi_fd);
-
-    if (HYD_pmcd_pmip.downstream.pmi_fd_active)
-        MPL_free(HYD_pmcd_pmip.downstream.pmi_fd_active);
+    MPL_free(HYD_pmcd_pmip.downstream.out);
+    MPL_free(HYD_pmcd_pmip.downstream.err);
+    MPL_free(HYD_pmcd_pmip.downstream.pid);
+    MPL_free(HYD_pmcd_pmip.downstream.exit_status);
+    MPL_free(HYD_pmcd_pmip.downstream.pmi_rank);
+    MPL_free(HYD_pmcd_pmip.downstream.pmi_fd);
+    MPL_free(HYD_pmcd_pmip.downstream.pmi_fd_active);
 
 
     /* Local */
-    if (HYD_pmcd_pmip.local.iface_ip_env_name)
-        MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
-
-    if (HYD_pmcd_pmip.local.hostname)
-        MPL_free(HYD_pmcd_pmip.local.hostname);
-
-    if (HYD_pmcd_pmip.local.spawner_kvsname)
-        MPL_free(HYD_pmcd_pmip.local.spawner_kvsname);
+    MPL_free(HYD_pmcd_pmip.local.iface_ip_env_name);
+    MPL_free(HYD_pmcd_pmip.local.hostname);
+    MPL_free(HYD_pmcd_pmip.local.spawner_kvsname);
 
     if (HYD_pmcd_pmip.local.ckpoint_prefix_list) {
         for (i = 0; HYD_pmcd_pmip.local.ckpoint_prefix_list[i]; i++)

--- a/src/pm/hydra/pm/pmiserv/pmip_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_cb.c
@@ -340,14 +340,12 @@ static HYD_status pmi_cb(int fd, HYD_event_t events, void *userp)
         goto check_cmd;
 
   fn_exit:
-    if (pmi_cmd)
-        MPL_free(pmi_cmd);
+    MPL_free(pmi_cmd);
     if (args) {
         HYDU_free_strlist(args);
         MPL_free(args);
     }
-    if (buf)
-        MPL_free(buf);
+    MPL_free(buf);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -403,14 +401,12 @@ static HYD_status handle_pmi_response(int fd, struct HYD_pmcd_hdr hdr)
     }
 
   fn_exit:
-    if (pmi_cmd)
-        MPL_free(pmi_cmd);
+    MPL_free(pmi_cmd);
     if (args) {
         HYDU_free_strlist(args);
         MPL_free(args);
     }
-    if (buf)
-        MPL_free(buf);
+    MPL_free(buf);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_pmi_v2.c
@@ -56,8 +56,7 @@ static HYD_status send_cmd_upstream(const char *start, int fd, char *args[])
     HYDU_ASSERT(!closed, status);
 
   fn_exit:
-    if (buf)
-        MPL_free(buf);
+    MPL_free(buf);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/pm/pmiserv/pmip_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmip_utils.c
@@ -50,8 +50,7 @@ static HYD_status control_port_fn(char *arg, char ***argv)
     (*argv)++;
 
   fn_exit:
-    if (port)
-        MPL_free(port);
+    MPL_free(port);
     return status;
 
   fn_fail:

--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -58,8 +58,7 @@ static HYD_status handle_pmi_cmd(int fd, int pgid, int pid, char *buf, int pmi_v
     }
 
   fn_exit:
-    if (cmd)
-        MPL_free(cmd);
+    MPL_free(cmd);
     if (args) {
         HYDU_free_strlist(args);
         MPL_free(args);

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmci.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmci.c
@@ -145,8 +145,7 @@ HYD_status HYD_pmci_launch_procs(void)
     MPL_free(control_fd);
 
   fn_exit:
-    if (control_port)
-        MPL_free(control_port);
+    MPL_free(control_port);
     HYD_STRING_STASH_FREE(proxy_stash);
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi.c
@@ -45,8 +45,7 @@ HYD_status HYD_pmcd_pmi_free_publish(struct HYD_pmcd_pmi_publish * publish)
         MPL_free(publish->info_keys[i].key);
         MPL_free(publish->info_keys[i].val);
     }
-    if (publish->info_keys)
-        MPL_free(publish->info_keys);
+    MPL_free(publish->info_keys);
 
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_pmi_v2.c
@@ -728,8 +728,7 @@ static HYD_status fn_spawn(int fd, int pid, int pgid, char *args[])
   fn_exit:
     HYD_pmcd_pmi_free_tokens(tokens, token_count);
     HYD_STRING_STASH_FREE(proxy_stash);
-    if (segment_list)
-        MPL_free(segment_list);
+    MPL_free(segment_list);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -787,10 +786,8 @@ static HYD_status fn_name_publish(int fd, int pid, int pgid, char *args[])
   fn_exit:
     if (tokens)
         HYD_pmcd_pmi_free_tokens(tokens, token_count);
-    if (name)
-        MPL_free(name);
-    if (port)
-        MPL_free(port);
+    MPL_free(name);
+    MPL_free(port);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_utils.c
@@ -495,8 +495,7 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
     }
 
   fn_exit:
-    if (mapping)
-        MPL_free(mapping);
+    MPL_free(mapping);
     MPL_free(filler_pmi_ids);
     MPL_free(nonfiller_pmi_ids);
     return status;
@@ -555,11 +554,8 @@ HYD_status HYD_pmcd_pmi_free_pg_scratch(struct HYD_pg *pg)
     if (pg->pg_scratch) {
         pg_scratch = pg->pg_scratch;
 
-        if (pg_scratch->ecount)
-            MPL_free(pg_scratch->ecount);
-
-        if (pg_scratch->dead_processes)
-            MPL_free(pg_scratch->dead_processes);
+        MPL_free(pg_scratch->ecount);
+        MPL_free(pg_scratch->dead_processes);
 
         HYD_pmcd_free_pmi_kvs_list(pg_scratch->kvs);
 

--- a/src/pm/hydra/tools/bootstrap/external/external_common_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/external_common_launch.c
@@ -202,8 +202,7 @@ HYD_status HYDT_bscd_common_launch_procs(char **args, struct HYD_proxy *proxy_li
     targs[idx] = NULL;
     for (proxy = proxy_list; proxy; proxy = proxy->next) {
 
-        if (targs[host_idx])
-            MPL_free(targs[host_idx]);
+        MPL_free(targs[host_idx]);
         if (proxy->node->user == NULL) {
             targs[host_idx] = MPL_strdup(proxy->node->hostname);
         } else {
@@ -214,8 +213,7 @@ HYD_status HYDT_bscd_common_launch_procs(char **args, struct HYD_proxy *proxy_li
         }
 
         /* append proxy ID */
-        if (targs[idx])
-            MPL_free(targs[idx]);
+        MPL_free(targs[idx]);
         targs[idx] = HYDU_int_to_str(proxy->proxy_id);
         targs[idx + 1] = NULL;
 
@@ -322,8 +320,7 @@ HYD_status HYDT_bscd_common_launch_procs(char **args, struct HYD_proxy *proxy_li
 
   fn_exit:
     HYDU_free_strlist(targs);
-    if (path)
-        MPL_free(path);
+    MPL_free(path);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/tools/bootstrap/external/ll_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/ll_launch.c
@@ -111,11 +111,9 @@ HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list, 
     HYDU_ERR_POP(status, "demux returned error registering fd\n");
 
   fn_exit:
-    if (node_list_str)
-        MPL_free(node_list_str);
+    MPL_free(node_list_str);
     HYDU_free_strlist(targs);
-    if (path)
-        MPL_free(path);
+    MPL_free(path);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/tools/bootstrap/external/lsf_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/lsf_query_node_list.c
@@ -45,8 +45,7 @@ HYD_status HYDT_bscd_lsf_query_node_list(struct HYD_node **node_list)
             hostname = strtok(NULL, " ");
         }
 
-        if (thosts)
-            MPL_free(thosts);
+        MPL_free(thosts);
     }
 
   fn_exit:

--- a/src/pm/hydra/tools/bootstrap/external/pbs_finalize.c
+++ b/src/pm/hydra/tools/bootstrap/external/pbs_finalize.c
@@ -21,10 +21,8 @@ HYD_status HYDT_bscd_pbs_launcher_finalize(void)
 #endif /* HAVE_TM_H */
 
     if (HYDT_bscd_pbs_sys) {
-        if (HYDT_bscd_pbs_sys->task_id)
-            MPL_free(HYDT_bscd_pbs_sys->task_id);
-        if (HYDT_bscd_pbs_sys->spawn_events)
-            MPL_free(HYDT_bscd_pbs_sys->spawn_events);
+        MPL_free(HYDT_bscd_pbs_sys->task_id);
+        MPL_free(HYDT_bscd_pbs_sys->spawn_events);
         MPL_free(HYDT_bscd_pbs_sys);
     }
 

--- a/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_launch.c
@@ -50,8 +50,7 @@ static HYD_status proxy_list_to_node_str(struct HYD_proxy *proxy_list, char **no
 
   fn_exit:
     HYDU_free_strlist(tmp);
-    if (foo)
-        MPL_free(foo);
+    MPL_free(foo);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -163,11 +162,9 @@ HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_lis
     HYDU_ERR_POP(status, "demux returned error registering fd\n");
 
   fn_exit:
-    if (node_list_str)
-        MPL_free(node_list_str);
+    MPL_free(node_list_str);
     HYDU_free_strlist(targs);
-    if (path)
-        MPL_free(path);
+    MPL_free(path);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/tools/bootstrap/utils/bscu_wait.c
+++ b/src/pm/hydra/tools/bootstrap/utils/bscu_wait.c
@@ -107,17 +107,13 @@ HYD_status HYDT_bscu_wait_for_completion(int timeout)
         }
     }
 
-    if (HYD_bscu_pid_list) {
-        MPL_free(HYD_bscu_pid_list);
-        HYD_bscu_pid_list = NULL;
-        HYD_bscu_pid_count = 0;
-    }
+    MPL_free(HYD_bscu_pid_list);
+    HYD_bscu_pid_list = NULL;
+    HYD_bscu_pid_count = 0;
 
-    if (HYD_bscu_fd_list) {
-        MPL_free(HYD_bscu_fd_list);
-        HYD_bscu_fd_list = NULL;
-        HYD_bscu_fd_count = 0;
-    }
+    MPL_free(HYD_bscu_fd_list);
+    HYD_bscu_fd_list = NULL;
+    HYD_bscu_fd_count = 0;
 
   fn_exit:
     HYDU_FUNC_EXIT();

--- a/src/pm/hydra/tools/demux/demux.c
+++ b/src/pm/hydra/tools/demux/demux.c
@@ -203,8 +203,7 @@ HYD_status HYDT_dmx_finalize(void)
     run1 = HYDT_dmxu_cb_list;
     while (run1) {
         run2 = run1->next;
-        if (run1->fd)
-            MPL_free(run1->fd);
+        MPL_free(run1->fd);
         MPL_free(run1);
         run1 = run2;
     }

--- a/src/pm/hydra/tools/demux/demux_poll.c
+++ b/src/pm/hydra/tools/demux/demux_poll.c
@@ -91,8 +91,7 @@ HYD_status HYDT_dmxu_poll_wait_for_event(int wtime)
         status = HYD_TIMED_OUT;
 
   fn_exit:
-    if (pollfds)
-        MPL_free(pollfds);
+    MPL_free(pollfds);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/tools/nameserver/hydra_nameserver.c
+++ b/src/pm/hydra/tools/nameserver/hydra_nameserver.c
@@ -84,12 +84,8 @@ static void free_publish_element(struct HYDT_ns_publish *publish)
     if (publish == NULL)
         return;
 
-    if (publish->name)
-        MPL_free(publish->name);
-
-    if (publish->info)
-        MPL_free(publish->info);
-
+    MPL_free(publish->name);
+    MPL_free(publish->info);
     MPL_free(publish);
 }
 

--- a/src/pm/hydra/tools/topo/topo.c
+++ b/src/pm/hydra/tools/topo/topo.c
@@ -112,8 +112,7 @@ HYD_status HYDT_topo_finalize(void)
     }
 #endif /* HAVE_HWLOC */
 
-    if (HYDT_topo_info.topolib)
-        MPL_free(HYDT_topo_info.topolib);
+    MPL_free(HYDT_topo_info.topolib);
 
   fn_exit:
     HYDU_FUNC_EXIT();

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -209,14 +209,10 @@ static HYD_status genv_fn(char *arg, char ***argv)
 
     HYDU_append_env_to_list(env_name, env_value, &HYD_server_info.user_global.global_env.user);
 
-    if (str[0])
-        MPL_free(str[0]);
-    if (str[1])
-        MPL_free(str[1]);
-    if (env_name)
-        MPL_free(env_name);
-    if (env_value)
-        MPL_free(env_value);
+    MPL_free(str[0]);
+    MPL_free(str[1]);
+    MPL_free(env_name);
+    MPL_free(env_value);
 
   fn_exit:
     return status;
@@ -653,14 +649,10 @@ static HYD_status env_fn(char *arg, char ***argv)
 
     HYDU_append_env_to_list(env_name, env_value, &exec->user_env);
 
-    if (str[0])
-        MPL_free(str[0]);
-    if (str[1])
-        MPL_free(str[1]);
-    if (env_name)
-        MPL_free(env_name);
-    if (env_value)
-        MPL_free(env_value);
+    MPL_free(str[0]);
+    MPL_free(str[1]);
+    MPL_free(env_name);
+    MPL_free(env_value);
 
   fn_exit:
     return status;

--- a/src/pm/hydra/ui/utils/uiu.c
+++ b/src/pm/hydra/ui/utils/uiu.c
@@ -55,38 +55,17 @@ void HYD_uiu_free_params(void)
 
     HYDU_finalize_user_global(&HYD_server_info.user_global);
 
-    if (HYD_server_info.base_path)
-        MPL_free(HYD_server_info.base_path);
-
-    if (HYD_server_info.port_range)
-        MPL_free(HYD_server_info.port_range);
-
-    if (HYD_server_info.iface_ip_env_name)
-        MPL_free(HYD_server_info.iface_ip_env_name);
-
-    if (HYD_server_info.nameserver)
-        MPL_free(HYD_server_info.nameserver);
-
-    if (HYD_server_info.localhost)
-        MPL_free(HYD_server_info.localhost);
-
-    if (HYD_server_info.node_list)
-        HYDU_free_node_list(HYD_server_info.node_list);
-
-    if (HYD_server_info.pg_list.proxy_list)
-        HYDU_free_proxy_list(HYD_server_info.pg_list.proxy_list);
-
-    if (HYD_server_info.pg_list.next)
-        HYDU_free_pg_list(HYD_server_info.pg_list.next);
-
-    if (HYD_ui_info.prepend_pattern)
-        MPL_free(HYD_ui_info.prepend_pattern);
-
-    if (HYD_ui_info.outfile_pattern)
-        MPL_free(HYD_ui_info.outfile_pattern);
-
-    if (HYD_ui_info.errfile_pattern)
-        MPL_free(HYD_ui_info.errfile_pattern);
+    MPL_free(HYD_server_info.base_path);
+    MPL_free(HYD_server_info.port_range);
+    MPL_free(HYD_server_info.iface_ip_env_name);
+    MPL_free(HYD_server_info.nameserver);
+    MPL_free(HYD_server_info.localhost);
+    HYDU_free_node_list(HYD_server_info.node_list);
+    HYDU_free_proxy_list(HYD_server_info.pg_list.proxy_list);
+    HYDU_free_pg_list(HYD_server_info.pg_list.next);
+    MPL_free(HYD_ui_info.prepend_pattern);
+    MPL_free(HYD_ui_info.outfile_pattern);
+    MPL_free(HYD_ui_info.errfile_pattern);
 
     for (run = stdoe_fd_list; run;) {
         close(run->fd);

--- a/src/pm/hydra/utils/alloc/alloc.c
+++ b/src/pm/hydra/utils/alloc/alloc.c
@@ -33,32 +33,15 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
 
 void HYDU_finalize_user_global(struct HYD_user_global *user_global)
 {
-    if (user_global->rmk)
-        MPL_free(user_global->rmk);
-
-    if (user_global->launcher)
-        MPL_free(user_global->launcher);
-
-    if (user_global->launcher_exec)
-        MPL_free(user_global->launcher_exec);
-
-    if (user_global->binding)
-        MPL_free(user_global->binding);
-
-    if (user_global->topolib)
-        MPL_free(user_global->topolib);
-
-    if (user_global->ckpointlib)
-        MPL_free(user_global->ckpointlib);
-
-    if (user_global->ckpoint_prefix)
-        MPL_free(user_global->ckpoint_prefix);
-
-    if (user_global->demux)
-        MPL_free(user_global->demux);
-
-    if (user_global->iface)
-        MPL_free(user_global->iface);
+    MPL_free(user_global->rmk);
+    MPL_free(user_global->launcher);
+    MPL_free(user_global->launcher_exec);
+    MPL_free(user_global->binding);
+    MPL_free(user_global->topolib);
+    MPL_free(user_global->ckpointlib);
+    MPL_free(user_global->ckpoint_prefix);
+    MPL_free(user_global->demux);
+    MPL_free(user_global->iface);
 
     HYDU_finalize_global_env(&user_global->global_env);
 }
@@ -82,8 +65,7 @@ void HYDU_finalize_global_env(struct HYD_env_global *global_env)
     if (global_env->inherited)
         HYDU_env_free_list(global_env->inherited);
 
-    if (global_env->prop)
-        MPL_free(global_env->prop);
+    MPL_free(global_env->prop);
 }
 
 HYD_status HYDU_alloc_node(struct HYD_node **node)
@@ -117,15 +99,9 @@ void HYDU_free_node_list(struct HYD_node *node_list)
     while (node) {
         tnode = node->next;
 
-        if (node->hostname)
-            MPL_free(node->hostname);
-
-        if (node->user)
-            MPL_free(node->user);
-
-        if (node->local_binding)
-            MPL_free(node->local_binding);
-
+        MPL_free(node->hostname);
+        MPL_free(node->user);
+        MPL_free(node->local_binding);
         MPL_free(node);
 
         node = tnode;
@@ -233,11 +209,8 @@ void HYDU_free_proxy_list(struct HYD_proxy *proxy_list)
             MPL_free(proxy->exec_launch_info);
         }
 
-        if (proxy->pid)
-            MPL_free(proxy->pid);
-
-        if (proxy->exit_status)
-            MPL_free(proxy->exit_status);
+        MPL_free(proxy->pid);
+        MPL_free(proxy->exit_status);
 
         HYDU_free_exec_list(proxy->exec_list);
 
@@ -282,11 +255,8 @@ void HYDU_free_exec_list(struct HYD_exec *exec_list)
         run = exec->next;
         HYDU_free_strlist(exec->exec);
 
-        if (exec->wdir)
-            MPL_free(exec->wdir);
-
-        if (exec->env_prop)
-            MPL_free(exec->env_prop);
+        MPL_free(exec->wdir);
+        MPL_free(exec->env_prop);
 
         HYDU_env_free_list(exec->user_env);
         exec->user_env = NULL;

--- a/src/pm/hydra/utils/args/args.c
+++ b/src/pm/hydra/utils/args/args.c
@@ -105,10 +105,8 @@ HYD_status HYDU_find_in_path(const char *execname, char **path)
     *path = MPL_strdup("");
 
   fn_exit:
-    if (user_path)
-        MPL_free(user_path);
-    if (path_loc)
-        MPL_free(path_loc);
+    MPL_free(user_path);
+    MPL_free(path_loc);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -381,8 +379,7 @@ char *HYDU_find_full_path(const char *execname)
 
   fn_exit:
     HYDU_free_strlist(tmp);
-    if (test_path)
-        MPL_free(test_path);
+    MPL_free(test_path);
     HYDU_FUNC_EXIT();
     return path;
 

--- a/src/pm/hydra/utils/env/env.c
+++ b/src/pm/hydra/utils/env/env.c
@@ -70,8 +70,7 @@ HYD_status HYDU_list_inherited_env(struct HYD_env **env_list)
     }
 
   fn_exit:
-    if (env_str)
-        MPL_free(env_str);
+    MPL_free(env_str);
     HYDU_FUNC_EXIT();
     return status;
 
@@ -131,10 +130,8 @@ HYD_status HYDU_env_free(struct HYD_env *env)
 
     HYDU_FUNC_ENTER();
 
-    if (env->env_name)
-        MPL_free(env->env_name);
-    if (env->env_value)
-        MPL_free(env->env_value);
+    MPL_free(env->env_name);
+    MPL_free(env->env_value);
     MPL_free(env);
 
     HYDU_FUNC_EXIT();
@@ -202,19 +199,15 @@ HYD_status HYDU_append_env_to_list(const char *env_name, const char *env_value,
         while (1) {
             if (!strcmp(run->env_name, env_name)) {
                 /* If we found an entry for this environment variable, just update it */
-                if (run->env_value != NULL && tenv->env_value != NULL) {
-                    MPL_free(run->env_value);
+                MPL_free(run->env_value);
+                if (tenv->env_value != NULL) {
                     run->env_value = MPL_strdup(tenv->env_value);
-                } else if (run->env_value != NULL) {
-                    MPL_free(run->env_value);
+                } else {
                     run->env_value = NULL;
-                } else if (env_value != NULL) {
-                    run->env_value = MPL_strdup(tenv->env_value);
                 }
 
                 MPL_free(tenv->env_name);
-                if (tenv->env_value)
-                    MPL_free(tenv->env_value);
+                MPL_free(tenv->env_value);
                 MPL_free(tenv);
 
                 break;
@@ -251,8 +244,7 @@ HYD_status HYDU_append_env_str_to_list(const char *str, struct HYD_env **env_lis
     HYDU_ERR_POP(status, "unable to append env to list\n");
 
   fn_exit:
-    if (my_str)
-        MPL_free(my_str);
+    MPL_free(my_str);
     HYDU_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra/utils/sock/sock.c
+++ b/src/pm/hydra/utils/sock/sock.c
@@ -568,8 +568,7 @@ HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_rang
     MPL_free(sport);
 
   fn_exit:
-    if (ip)
-        MPL_free(ip);
+    MPL_free(ip);
     return status;
 
   fn_fail:

--- a/src/pm/hydra/utils/string/string.c
+++ b/src/pm/hydra/utils/string/string.c
@@ -260,8 +260,7 @@ char **HYDU_str_to_strlist(char *str)
             argc++;
         }
     }
-    if (strlist[argc])
-        MPL_free(strlist[argc]);
+    MPL_free(strlist[argc]);
     strlist[argc] = NULL;
 
   fn_exit:

--- a/src/pm/hydra2/libhydra/bstrap/ll/ll_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/ll/ll_launch.c
@@ -49,8 +49,7 @@ HYD_status HYDI_bstrap_ll_launch(const char *hostname, const char *launch_exec, 
 
   fn_exit:
     HYD_str_free_list(targs);
-    if (lexec)
-        MPL_free(lexec);
+    MPL_free(lexec);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/bstrap/rsh/rsh_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/rsh/rsh_launch.c
@@ -54,8 +54,7 @@ HYD_status HYDI_bstrap_rsh_launch(const char *hostname, const char *launch_exec,
 
   fn_exit:
     HYD_str_free_list(targs);
-    if (lexec)
-        MPL_free(lexec);
+    MPL_free(lexec);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/bstrap/sge/sge_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/sge/sge_launch.c
@@ -55,8 +55,7 @@ HYD_status HYDI_bstrap_sge_launch(const char *hostname, const char *launch_exec,
 
   fn_exit:
     HYD_str_free_list(targs);
-    if (lexec)
-        MPL_free(lexec);
+    MPL_free(lexec);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/bstrap/slurm/slurm_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/slurm/slurm_launch.c
@@ -66,8 +66,7 @@ HYD_status HYDI_bstrap_slurm_launch(const char *hostname, const char *launch_exe
 
   fn_exit:
     HYD_str_free_list(targs);
-    if (lexec)
-        MPL_free(lexec);
+    MPL_free(lexec);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/bstrap/ssh/ssh_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/ssh/ssh_launch.c
@@ -64,8 +64,7 @@ HYD_status HYDI_bstrap_ssh_launch(const char *hostname, const char *launch_exec,
 
   fn_exit:
     HYD_str_free_list(targs);
-    if (lexec)
-        MPL_free(lexec);
+    MPL_free(lexec);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/demux/hydra_demux_poll.c
+++ b/src/pm/hydra2/libhydra/demux/hydra_demux_poll.c
@@ -82,8 +82,7 @@ HYD_status HYDI_dmx_poll_wait_for_event(int wtime)
         status = HYD_ERR_TIMED_OUT;
 
   fn_exit:
-    if (pollfds)
-        MPL_free(pollfds);
+    MPL_free(pollfds);
     HYD_FUNC_EXIT();
     return status;
 

--- a/src/pm/hydra2/libhydra/env/hydra_env.c
+++ b/src/pm/hydra2/libhydra/env/hydra_env.c
@@ -90,10 +90,8 @@ HYD_status HYD_env_free(struct HYD_env *env)
 
     HYD_FUNC_ENTER();
 
-    if (env->env_name)
-        MPL_free(env->env_name);
-    if (env->env_value)
-        MPL_free(env->env_value);
+    MPL_free(env->env_name);
+    MPL_free(env->env_value);
     MPL_free(env);
 
     HYD_FUNC_EXIT();
@@ -123,19 +121,15 @@ HYD_status HYD_env_append_to_list(const char *env_name, const char *env_value,
         while (1) {
             if (!strcmp(run->env_name, env_name)) {
                 /* If we found an entry for this environment variable, just update it */
-                if (run->env_value != NULL && tenv->env_value != NULL) {
-                    MPL_free(run->env_value);
+                MPL_free(run->env_value);
+                if (tenv->env_value != NULL) {
                     run->env_value = MPL_strdup(tenv->env_value);
-                } else if (run->env_value != NULL) {
-                    MPL_free(run->env_value);
+                } else {
                     run->env_value = NULL;
-                } else if (env_value != NULL) {
-                    run->env_value = MPL_strdup(tenv->env_value);
                 }
 
                 MPL_free(tenv->env_name);
-                if (tenv->env_value)
-                    MPL_free(tenv->env_value);
+                MPL_free(tenv->env_value);
                 MPL_free(tenv);
 
                 break;

--- a/src/pm/hydra2/libhydra/fs/hydra_fs.c
+++ b/src/pm/hydra2/libhydra/fs/hydra_fs.c
@@ -102,10 +102,8 @@ HYD_status HYD_find_in_path(const char *execname, char **path)
     *path = MPL_strdup("");
 
   fn_exit:
-    if (user_path)
-        MPL_free(user_path);
-    if (path_loc)
-        MPL_free(path_loc);
+    MPL_free(user_path);
+    MPL_free(path_loc);
     HYD_FUNC_EXIT();
     return status;
 
@@ -171,8 +169,7 @@ char *HYD_find_full_path(const char *execname)
 
   fn_exit:
     HYD_str_free_list(tmp);
-    if (test_path)
-        MPL_free(test_path);
+    MPL_free(test_path);
     HYD_FUNC_EXIT();
     return path;
 

--- a/src/pm/hydra2/libhydra/rmk/lsf/lsf_query_node_list.c
+++ b/src/pm/hydra2/libhydra/rmk/lsf/lsf_query_node_list.c
@@ -55,8 +55,7 @@ HYD_status HYDI_rmk_lsf_query_node_list(int *node_count, struct HYD_node **nodes
             hostname = strtok(NULL, " ");
         }
 
-        if (thosts)
-            MPL_free(thosts);
+        MPL_free(thosts);
     }
 
   fn_exit:

--- a/src/pm/hydra2/libhydra/str/hydra_str.c
+++ b/src/pm/hydra2/libhydra/str/hydra_str.c
@@ -180,8 +180,7 @@ char **HYD_str_to_strlist(char *str)
             argc++;
         }
     }
-    if (strlist[argc])
-        MPL_free(strlist[argc]);
+    MPL_free(strlist[argc]);
     strlist[argc] = NULL;
 
   fn_exit:

--- a/src/pm/hydra2/mpiexec/mpiexec.c
+++ b/src/pm/hydra2/mpiexec/mpiexec.c
@@ -999,15 +999,12 @@ int main(int argc, char **argv)
 
     HASH_DEL(mpiexec_pg_hash, pg);
 
-    if (pg->node_list)
-        MPL_free(pg->node_list);
+    MPL_free(pg->node_list);
     if (pg->exec_list)
         HYD_exec_free_list(pg->exec_list);
 
-    if (pg->downstream.proxy_id)
-        MPL_free(pg->downstream.proxy_id);
-    if (pg->downstream.pid)
-        MPL_free(pg->downstream.pid);
+    MPL_free(pg->downstream.proxy_id);
+    MPL_free(pg->downstream.pid);
 
     HASH_ITER(hh, pg->downstream.fd_control_hash, hash, thash) {
         HASH_DEL(pg->downstream.fd_control_hash, hash);
@@ -1015,73 +1012,48 @@ int main(int argc, char **argv)
     }
 
     for (i = 0; i < pg->num_downstream; i++)
-        if (pg->downstream.kvcache[i])
-            MPL_free(pg->downstream.kvcache[i]);
-    if (pg->downstream.kvcache)
-        MPL_free(pg->downstream.kvcache);
-    if (pg->downstream.kvcache_size)
-        MPL_free(pg->downstream.kvcache_size);
-    if (pg->downstream.kvcache_num_blocks)
-        MPL_free(pg->downstream.kvcache_num_blocks);
-
-    if (pg->pmi_process_mapping)
-        MPL_free(pg->pmi_process_mapping);
-
+        MPL_free(pg->downstream.kvcache[i]);
+    MPL_free(pg->downstream.kvcache);
+    MPL_free(pg->downstream.kvcache_size);
+    MPL_free(pg->downstream.kvcache_num_blocks);
+    MPL_free(pg->pmi_process_mapping);
     MPL_free(pg);
 
-    if (mpiexec_params.rmk)
-        MPL_free(mpiexec_params.rmk);
-    if (mpiexec_params.launcher)
-        MPL_free(mpiexec_params.launcher);
-    if (mpiexec_params.launcher_exec)
-        MPL_free(mpiexec_params.launcher_exec);
-    if (mpiexec_params.binding)
-        MPL_free(mpiexec_params.binding);
-    if (mpiexec_params.mapping)
-        MPL_free(mpiexec_params.mapping);
-    if (mpiexec_params.membind)
-        MPL_free(mpiexec_params.membind);
-    if (mpiexec_params.base_path)
-        MPL_free(mpiexec_params.base_path);
-    if (mpiexec_params.port_range)
-        MPL_free(mpiexec_params.port_range);
-    if (mpiexec_params.nameserver)
-        MPL_free(mpiexec_params.nameserver);
-    if (mpiexec_params.localhost)
-        MPL_free(mpiexec_params.localhost);
+    MPL_free(mpiexec_params.rmk);
+    MPL_free(mpiexec_params.launcher);
+    MPL_free(mpiexec_params.launcher_exec);
+    MPL_free(mpiexec_params.binding);
+    MPL_free(mpiexec_params.mapping);
+    MPL_free(mpiexec_params.membind);
+    MPL_free(mpiexec_params.base_path);
+    MPL_free(mpiexec_params.port_range);
+    MPL_free(mpiexec_params.nameserver);
+    MPL_free(mpiexec_params.localhost);
 
-    if (mpiexec_params.global_node_list)
-        MPL_free(mpiexec_params.global_node_list);
-    if (mpiexec_params.global_active_processes)
-        MPL_free(mpiexec_params.global_active_processes);
+    MPL_free(mpiexec_params.global_node_list);
+    MPL_free(mpiexec_params.global_active_processes);
 
     for (i = 0; i < mpiexec_params.envlist_count; i++)
         MPL_free(mpiexec_params.envlist[i]);
-    if (mpiexec_params.envlist)
-        MPL_free(mpiexec_params.envlist);
+    MPL_free(mpiexec_params.envlist);
 
     for (i = 0; i < mpiexec_params.primary.envcount; i++)
         MPL_free(mpiexec_params.primary.env[i]);
     if (mpiexec_params.primary.envcount)
         MPL_free(mpiexec_params.primary.env);
 
-    if (mpiexec_params.primary.serialized_buf)
-        MPL_free(mpiexec_params.primary.serialized_buf);
+    MPL_free(mpiexec_params.primary.serialized_buf);
 
     for (i = 0; i < mpiexec_params.secondary.envcount; i++)
         MPL_free(mpiexec_params.secondary.env[i]);
     if (mpiexec_params.secondary.envcount)
         MPL_free(mpiexec_params.secondary.env);
 
-    if (mpiexec_params.secondary.serialized_buf)
-        MPL_free(mpiexec_params.secondary.serialized_buf);
+    MPL_free(mpiexec_params.secondary.serialized_buf);
 
-    if (mpiexec_params.prepend_pattern)
-        MPL_free(mpiexec_params.prepend_pattern);
-    if (mpiexec_params.outfile_pattern)
-        MPL_free(mpiexec_params.outfile_pattern);
-    if (mpiexec_params.errfile_pattern)
-        MPL_free(mpiexec_params.errfile_pattern);
+    MPL_free(mpiexec_params.prepend_pattern);
+    MPL_free(mpiexec_params.outfile_pattern);
+    MPL_free(mpiexec_params.errfile_pattern);
 
   fn_exit:
     HYD_FUNC_EXIT();

--- a/src/pm/hydra2/mpiexec/mpiexec_params.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_params.c
@@ -172,14 +172,10 @@ static HYD_status genv_fn(char *arg, char ***argv)
     HYD_ERR_POP(status, "error converting env to string\n");
     mpiexec_params.primary.envcount++;
 
-    if (str[0])
-        MPL_free(str[0]);
-    if (str[1])
-        MPL_free(str[1]);
-    if (env_name)
-        MPL_free(env_name);
-    if (env_value)
-        MPL_free(env_value);
+    MPL_free(str[0]);
+    MPL_free(str[1]);
+    MPL_free(env_name);
+    MPL_free(env_value);
 
   fn_exit:
     return status;

--- a/src/pm/hydra2/mpiexec/mpiexec_utils.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_utils.c
@@ -58,26 +58,13 @@ void mpiexec_free_params(void)
 {
     struct stdoe_fd *tmp, *run;
 
-    if (mpiexec_params.base_path)
-        MPL_free(mpiexec_params.base_path);
-
-    if (mpiexec_params.port_range)
-        MPL_free(mpiexec_params.port_range);
-
-    if (mpiexec_params.nameserver)
-        MPL_free(mpiexec_params.nameserver);
-
-    if (mpiexec_params.localhost)
-        MPL_free(mpiexec_params.localhost);
-
-    if (mpiexec_params.prepend_pattern)
-        MPL_free(mpiexec_params.prepend_pattern);
-
-    if (mpiexec_params.outfile_pattern)
-        MPL_free(mpiexec_params.outfile_pattern);
-
-    if (mpiexec_params.errfile_pattern)
-        MPL_free(mpiexec_params.errfile_pattern);
+    MPL_free(mpiexec_params.base_path);
+    MPL_free(mpiexec_params.port_range);
+    MPL_free(mpiexec_params.nameserver);
+    MPL_free(mpiexec_params.localhost);
+    MPL_free(mpiexec_params.prepend_pattern);
+    MPL_free(mpiexec_params.outfile_pattern);
+    MPL_free(mpiexec_params.errfile_pattern);
 
     for (run = stdoe_fd_list; run;) {
         close(run->fd);
@@ -86,17 +73,10 @@ void mpiexec_free_params(void)
         run = tmp;
     }
 
-    if (mpiexec_params.rmk)
-        MPL_free(mpiexec_params.rmk);
-
-    if (mpiexec_params.launcher)
-        MPL_free(mpiexec_params.launcher);
-
-    if (mpiexec_params.launcher_exec)
-        MPL_free(mpiexec_params.launcher_exec);
-
-    if (mpiexec_params.binding)
-        MPL_free(mpiexec_params.binding);
+    MPL_free(mpiexec_params.rmk);
+    MPL_free(mpiexec_params.launcher);
+    MPL_free(mpiexec_params.launcher_exec);
+    MPL_free(mpiexec_params.binding);
 }
 
 void mpiexec_print_params(void)

--- a/src/pm/hydra2/nameserver/hydra_nameserver.c
+++ b/src/pm/hydra2/nameserver/hydra_nameserver.c
@@ -63,12 +63,8 @@ static void free_publish_element(struct nameserv_publish *publish)
     if (publish == NULL)
         return;
 
-    if (publish->name)
-        MPL_free(publish->name);
-
-    if (publish->info)
-        MPL_free(publish->info);
-
+    MPL_free(publish->name);
+    MPL_free(publish->info);
     MPL_free(publish);
 }
 

--- a/src/pm/hydra2/proxy/proxy.c
+++ b/src/pm/hydra2/proxy/proxy.c
@@ -806,11 +806,8 @@ int main(int argc, char **argv)
         MPL_free(hash);
     }
 
-    if (proxy_params.cwd)
-        MPL_free(proxy_params.cwd);
-
-    if (proxy_params.root.hostname)
-        MPL_free(proxy_params.root.hostname);
+    MPL_free(proxy_params.cwd);
+    MPL_free(proxy_params.root.hostname);
 
     HYD_ASSERT(proxy_params.immediate.proxy.fd_control_hash == NULL, status);
     HYD_ASSERT(proxy_params.immediate.proxy.fd_stdin_hash == NULL, status);
@@ -818,15 +815,12 @@ int main(int argc, char **argv)
     HYD_ASSERT(proxy_params.immediate.proxy.fd_stderr_hash == NULL, status);
     HYD_ASSERT(proxy_params.immediate.proxy.pid_hash == NULL, status);
 
-    if (proxy_params.immediate.proxy.block_start)
-        MPL_free(proxy_params.immediate.proxy.block_start);
-    if (proxy_params.immediate.proxy.block_size)
-        MPL_free(proxy_params.immediate.proxy.block_size);
+    MPL_free(proxy_params.immediate.proxy.block_start);
+    MPL_free(proxy_params.immediate.proxy.block_size);
 
     if (proxy_params.immediate.proxy.num_children) {
         for (i = 0; i < proxy_params.immediate.proxy.num_children; i++)
-            if (proxy_params.immediate.proxy.kvcache[i])
-                MPL_free(proxy_params.immediate.proxy.kvcache[i]);
+            MPL_free(proxy_params.immediate.proxy.kvcache[i]);
         MPL_free(proxy_params.immediate.proxy.kvcache);
         MPL_free(proxy_params.immediate.proxy.kvcache_size);
         MPL_free(proxy_params.immediate.proxy.kvcache_num_blocks);
@@ -837,32 +831,27 @@ int main(int argc, char **argv)
     HYD_ASSERT(proxy_params.immediate.process.fd_pmi_hash == NULL, status);
     HYD_ASSERT(proxy_params.immediate.process.pid_hash == NULL, status);
 
-    if (proxy_params.immediate.process.pmi_id)
-        MPL_free(proxy_params.immediate.process.pmi_id);
+    MPL_free(proxy_params.immediate.process.pmi_id);
 
-    if (proxy_params.all.kvsname)
-        MPL_free(proxy_params.all.kvsname);
+    MPL_free(proxy_params.all.kvsname);
     if (proxy_params.all.complete_exec_list)
         HYD_exec_free_list(proxy_params.all.complete_exec_list);
 
-    if (proxy_params.all.primary_env.serial_buf)
-        MPL_free(proxy_params.all.primary_env.serial_buf);
+    MPL_free(proxy_params.all.primary_env.serial_buf);
     if (proxy_params.all.primary_env.argc) {
         for (i = 0; i < proxy_params.all.primary_env.argc; i++)
             MPL_free(proxy_params.all.primary_env.argv[i]);
         MPL_free(proxy_params.all.primary_env.argv);
     }
 
-    if (proxy_params.all.secondary_env.serial_buf)
-        MPL_free(proxy_params.all.secondary_env.serial_buf);
+    MPL_free(proxy_params.all.secondary_env.serial_buf);
     if (proxy_params.all.secondary_env.argc) {
         for (i = 0; i < proxy_params.all.secondary_env.argc; i++)
             MPL_free(proxy_params.all.secondary_env.argv[i]);
         MPL_free(proxy_params.all.secondary_env.argv);
     }
 
-    if (proxy_params.all.pmi_process_mapping)
-        MPL_free(proxy_params.all.pmi_process_mapping);
+    MPL_free(proxy_params.all.pmi_process_mapping);
 
   fn_exit:
     return status;

--- a/src/pm/hydra2/proxy/proxy_pmi_cb.c
+++ b/src/pm/hydra2/proxy/proxy_pmi_cb.c
@@ -153,10 +153,8 @@ static HYD_status flush_put_cache(void)
         }
     }
 
-    if (lengths)
-        MPL_free(lengths);
-    if (buf)
-        MPL_free(buf);
+    MPL_free(lengths);
+    MPL_free(buf);
 
   fn_exit:
     return status;

--- a/src/pm/util/dbgiface.c
+++ b/src/pm/util/dbgiface.c
@@ -124,9 +124,7 @@ int MPIE_InitForDebugger(ProcessWorld * pWorld)
 /* This routine is provided to free memory allocated in this routine */
 int MPIE_FreeFromDebugger(void)
 {
-    if (MPIR_proctable) {
-        MPL_free(MPIR_proctable);
-    }
+    MPL_free(MPIR_proctable);
     return 0;
 }
 

--- a/src/pm/util/rm.c
+++ b/src/pm/util/rm.c
@@ -403,12 +403,8 @@ int MPIE_FreeMachineTable(MachineTable * mt)
     int i;
     for (i = 0; i < mt->nHosts; i++) {
         MPL_free(mt->desc[i].hostname);
-        if (mt->desc[i].login) {
-            MPL_free(mt->desc[i].login);
-        }
-        if (mt->desc[i].netname) {
-            MPL_free(mt->desc[i].netname);
-        }
+        MPL_free(mt->desc[i].login);
+        MPL_free(mt->desc[i].netname);
     }
     MPL_free(mt->desc);
     MPL_free(mt);

--- a/src/pmi/pmi2/simple/simple2pmi.c
+++ b/src/pmi/pmi2/simple/simple2pmi.c
@@ -1482,8 +1482,7 @@ int PMIi_ReadCommand(int fd, PMI2_Command * cmd)
   fn_exit:
     return pmi2_errno;
   fn_fail:
-    if (cmd_buf)
-        PMI2U_Free(cmd_buf);
+    PMI2U_Free(cmd_buf);
     goto fn_exit;
 }
 

--- a/src/util/logging/rlog/TraceInput/logformat_trace_InputLog.c
+++ b/src/util/logging/rlog/TraceInput/logformat_trace_InputLog.c
@@ -248,11 +248,11 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextCategory(JNIEnv *
     if (ierr != 0 || legend_pos <= 0) {
         fprintf(errfile, "%s\n", TRACE_Get_err_string(ierr));
         fflush(errfile);
-        if (legend_base != NULL && legend_base != slegend_base)
+        if (legend_base != slegend_base)
             MPL_free(legend_base);
-        if (label_base != NULL && label_base != slabel_base)
+        if (label_base != slabel_base)
             MPL_free(label_base);
-        if (methods_base != NULL && methods_base != smethods_base)
+        if (methods_base != smethods_base)
             MPL_free(methods_base);
         return NULL;
     }
@@ -296,17 +296,17 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextCategory(JNIEnv *
     /* Clean up the unused reference and free local memory */
     if (jlegend != NULL)
         (*env)->DeleteLocalRef(env, jlegend);
-    if (legend_base != NULL && legend_base != slegend_base)
+    if (legend_base != slegend_base)
         MPL_free(legend_base);
 
     if (jlabel != NULL)
         (*env)->DeleteLocalRef(env, jlabel);
-    if (label_base != NULL && label_base != slabel_base)
+    if (label_base != slabel_base)
         MPL_free(label_base);
 
     if (jmethods != NULL)
         (*env)->DeleteLocalRef(env, jmethods);
-    if (methods_base != NULL && methods_base != smethods_base)
+    if (methods_base != smethods_base)
         MPL_free(methods_base);
 
     return objdef;
@@ -381,18 +381,14 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextYCoordMap(JNIEnv 
     if (ierr != 0) {
         fprintf(errfile, "Error: %s\n", TRACE_Get_err_string(ierr));
         fflush(errfile);
-        if (coordmap_base != NULL)
-            MPL_free(coordmap_base);
-        if (title_name != NULL)
-            MPL_free(title_name);
+        MPL_free(coordmap_base);
+        MPL_free(title_name);
         if (column_names != NULL) {
             for (icol = 0; icol < ncolumns - 1; icol++)
-                if (column_names[icol] != NULL)
-                    MPL_free(column_names[icol]);
+                MPL_free(column_names[icol]);
             MPL_free(column_names);
         }
-        if (methods_base != NULL)
-            MPL_free(methods_base);
+        MPL_free(methods_base);
         return NULL;
     }
 
@@ -446,22 +442,18 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextYCoordMap(JNIEnv 
     /* Clean up the unused reference and free local memory */
     if (coordmap_pos > 0)
         (*env)->DeleteLocalRef(env, j_coordmap_elems);
-    if (coordmap_base != NULL)
-        MPL_free(coordmap_base);
+    MPL_free(coordmap_base);
 
-    if (title_name != NULL)
-        MPL_free(title_name);
+    MPL_free(title_name);
     if (column_names != NULL) {
         for (icol = 0; icol < ncolumns - 1; icol++)
-            if (column_names[icol] != NULL)
-                MPL_free(column_names[icol]);
+            MPL_free(column_names[icol]);
         MPL_free(column_names);
     }
 
     if (jmethods != NULL)
         (*env)->DeleteLocalRef(env, jmethods);
-    if (methods_base != NULL)
-        MPL_free(methods_base);
+    MPL_free(methods_base);
 
     return ycoordmap;
 }
@@ -534,11 +526,11 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextPrimitive(JNIEnv 
     if (ierr != 0 || (tcoord_pos <= 0 || ycoord_pos <= 0)) {
         fprintf(errfile, "%s\n", TRACE_Get_err_string(ierr));
         fflush(errfile);
-        if (tcoord_base != NULL && tcoord_base != stcoord_base)
+        if (tcoord_base != stcoord_base)
             MPL_free(tcoord_base);
-        if (ycoord_base != NULL && ycoord_base != sycoord_base)
+        if (ycoord_base != sycoord_base)
             MPL_free(ycoord_base);
-        if (info_base != NULL && info_base != sinfo_base)
+        if (info_base != sinfo_base)
             MPL_free(info_base);
         return NULL;
     }
@@ -578,17 +570,17 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextPrimitive(JNIEnv 
     /* Clean up the unused reference and free local memory */
     if (tcoord_pos > 0)
         (*env)->DeleteLocalRef(env, j_tcoords);
-    if (tcoord_base != NULL && tcoord_base != stcoord_base)
+    if (tcoord_base != stcoord_base)
         MPL_free(tcoord_base);
 
     if (ycoord_pos > 0)
         (*env)->DeleteLocalRef(env, j_ycoords);
-    if (ycoord_base != NULL && ycoord_base != sycoord_base)
+    if (ycoord_base != sycoord_base)
         MPL_free(ycoord_base);
 
     if (info_pos > 0)
         (*env)->DeleteLocalRef(env, j_infos);
-    if (info_base != NULL && info_base != sinfo_base)
+    if (info_base != sinfo_base)
         MPL_free(info_base);
 
     return prime;
@@ -690,8 +682,7 @@ JNIEXPORT jobject JNICALL Java_logformat_trace_InputLog_getNextComposite(JNIEnv 
     /* Clean up the unused reference and free local memory */
     if (cm_info_sz > 0 && cm_info_pos > 0)
         (*env)->DeleteLocalRef(env, j_cm_infos);
-    if (cm_info_base != NULL)
-        MPL_free(cm_info_base);
+    MPL_free(cm_info_base);
 
     return cmplx;
 }

--- a/src/util/logging/rlog/TraceInput/trace_input.c
+++ b/src/util/logging/rlog/TraceInput/trace_input.c
@@ -131,17 +131,13 @@ TRACE_EXPORT int TRACE_Close(TRACE_file * fp)
 
     if ((*fp)->pInput) {
         for (i = 0; i < (*fp)->pInput->nNumRanks; i++) {
-            if ((*fp)->ppEvent[i])
-                MPL_free((*fp)->ppEvent[i]);
-            if ((*fp)->ppEventAvail[i])
-                MPL_free((*fp)->ppEventAvail[i]);
+            MPL_free((*fp)->ppEvent[i]);
+            MPL_free((*fp)->ppEventAvail[i]);
         }
         RLOG_CloseInputStruct(&(*fp)->pInput);
     }
-    if ((*fp)->ppEvent)
-        MPL_free((*fp)->ppEvent);
-    if ((*fp)->ppEventAvail)
-        MPL_free((*fp)->ppEventAvail);
+    MPL_free((*fp)->ppEvent);
+    MPL_free((*fp)->ppEventAvail);
     MPL_free((*fp));
     *fp = NULL;
 

--- a/src/util/logging/rlog/rlogutil.c
+++ b/src/util/logging/rlog/rlogutil.c
@@ -503,31 +503,19 @@ int RLOG_CloseInputStruct(RLOG_IOStruct ** ppInput)
         return -1;
     fclose((*ppInput)->f);
     for (i = 0; i < (*ppInput)->nNumRanks; i++) {
-        if ((*ppInput)->ppCurEvent[i])
-            MPL_free((*ppInput)->ppCurEvent[i]);
-        if ((*ppInput)->ppCurGlobalEvent[i])
-            MPL_free((*ppInput)->ppCurGlobalEvent[i]);
-        if ((*ppInput)->gppCurEvent[i])
-            MPL_free((*ppInput)->gppCurEvent[i]);
-        if ((*ppInput)->gppPrevEvent[i])
-            MPL_free((*ppInput)->gppPrevEvent[i]);
-        if ((*ppInput)->ppEventOffset[i])
-            MPL_free((*ppInput)->ppEventOffset[i]);
-        if ((*ppInput)->ppNumEvents[i])
-            MPL_free((*ppInput)->ppNumEvents[i]);
+        MPL_free((*ppInput)->ppCurEvent[i]);
+        MPL_free((*ppInput)->ppCurGlobalEvent[i]);
+        MPL_free((*ppInput)->gppCurEvent[i]);
+        MPL_free((*ppInput)->gppPrevEvent[i]);
+        MPL_free((*ppInput)->ppEventOffset[i]);
+        MPL_free((*ppInput)->ppNumEvents[i]);
     }
-    if ((*ppInput)->ppCurEvent)
-        MPL_free((*ppInput)->ppCurEvent);
-    if ((*ppInput)->ppCurGlobalEvent)
-        MPL_free((*ppInput)->ppCurGlobalEvent);
-    if ((*ppInput)->gppCurEvent)
-        MPL_free((*ppInput)->gppCurEvent);
-    if ((*ppInput)->gppPrevEvent)
-        MPL_free((*ppInput)->gppPrevEvent);
-    if ((*ppInput)->ppEventOffset)
-        MPL_free((*ppInput)->ppEventOffset);
-    if ((*ppInput)->ppNumEvents)
-        MPL_free((*ppInput)->ppNumEvents);
+    MPL_free((*ppInput)->ppCurEvent);
+    MPL_free((*ppInput)->ppCurGlobalEvent);
+    MPL_free((*ppInput)->gppCurEvent);
+    MPL_free((*ppInput)->gppPrevEvent);
+    MPL_free((*ppInput)->ppEventOffset);
+    MPL_free((*ppInput)->ppNumEvents);
     MPL_free(*ppInput);
     *ppInput = NULL;
     return 0;

--- a/src/util/mem/handlemem.c
+++ b/src/util/mem/handlemem.c
@@ -132,9 +132,7 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr)
         }
     }
 
-    if (nIndirect) {
-        MPL_free(nIndirect);
-    }
+    MPL_free(nIndirect);
 
     if (leaked_handles && MPIR_CVAR_ABORT_ON_LEAKED_HANDLES) {
         /* comm_world has been (or should have been) destroyed by this point,


### PR DESCRIPTION
Current MPICH simply assumes that the dataloop structure is a contiguous block that can be simply copied and transferred to the target process (in RMA communication).  This happens to be true for the dataloop implementation of the internal datatype representation, but need not always be true (e.g., for other representations).

This patch abstracts the flattening infrastructure, so the core MPICH code can simply treat it as a `void *` buffer of a certain length.

This is a prereq PR for issue #1985.