### PR TITLE
ch4: misc. cleanup for work queue

### DIFF
--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -201,6 +201,9 @@ static int set_runtime_configurations(void)
                "unless --enable-ch4-mt=runtime is given at the configure time.\n");
 #endif /* #ifdef MPIDI_CH4_USE_MT_RUNTIME */
 
+#ifdef MPIDI_CH4_USE_MT_RUNTIME
+  fn_fail:
+#endif
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -45,7 +45,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
             } else {
                 MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
             }
-
         }
     }
     /* todo: progress unexp_list */

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -58,6 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     if (flags & MPIDI_PROGRESS_NM) {
         mpi_errno = MPIDI_NM_progress(0, 0);
         if (mpi_errno != MPI_SUCCESS) {
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
             MPIR_ERR_POP(mpi_errno);
         }
     }
@@ -65,12 +66,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     if (flags & MPIDI_PROGRESS_SHM) {
         mpi_errno = MPIDI_SHM_progress(0, 0);
         if (mpi_errno != MPI_SUCCESS) {
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
             MPIR_ERR_POP(mpi_errno);
         }
     }
 #endif
-  fn_exit:
     MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PROGRESS_TEST);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -168,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *buf,
                                                  MPI_Aint count, MPI_Datatype datatype,
-                                                 MPIR_Request * message, MPIR_Request ** rreqp)
+                                                 MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMRECV_UNSAFE);
@@ -292,7 +292,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
                                                MPI_Aint count, MPI_Datatype datatype,
-                                               MPIR_Request * message, MPIR_Request ** rreqp)
+                                               MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS, cs_acq = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMRECV_SAFE);
@@ -311,7 +311,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
                                   &message, NULL /*processed */);
     } else {
         MPIDI_workq_vci_progress_unsafe();
-        mpi_errno = MPIDI_imrecv_unsafe(buf, count, datatype, message, rreqp);
+        mpi_errno = MPIDI_imrecv_unsafe(buf, count, datatype, message);
     }
 
   fn_exit:
@@ -475,7 +475,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mrecv(void *buf,
     message->kind = MPIR_REQUEST_KIND__RECV;
     *rreq = message;
 
-    mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message, rreq);
+    mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }
@@ -504,7 +504,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
     message->kind = MPIR_REQUEST_KIND__RECV;
     *rreqp = message;
 
-    mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message, rreqp);
+    mpi_errno = MPIDI_imrecv_safe(buf, count, datatype, message);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -39,8 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *, MPI_Aint, MPI_Datatype, i
 MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *, MPI_Aint, MPI_Datatype, int, int,
                                                 MPIR_Comm *, int, MPIDI_av_entry_t *,
                                                 MPIR_Request **);
-MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *, MPI_Aint, MPI_Datatype, MPIR_Request *,
-                                                 MPIR_Request **);
+MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_unsafe(void *, MPI_Aint, MPI_Datatype, MPIR_Request *);
 MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *, int, MPI_Datatype, int, MPI_Aint, int,
                                               MPI_Datatype, MPIR_Win *);
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *, int, MPI_Datatype, int, MPI_Aint, int,
@@ -312,9 +311,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_dispatch(MPIDI_workq_elemt_t * workq_el
             }
         case IMRECV:{
                 struct MPIDI_workq_imrecv *wd = &workq_elemt->params.pt2pt.imrecv;
-                req = wd->request;
                 datatype = wd->datatype;
-                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, *wd->message, &req);
+                MPIDI_imrecv_unsafe(wd->buf, wd->count, wd->datatype, *wd->message);
                 MPIR_Datatype_release_if_not_builtin(datatype);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
                 if (!MPIDI_REQUEST(*wd->message, is_local))

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -135,8 +135,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
         case IPROBE:
             {
                 struct MPIDI_workq_iprobe *wd = &pt2pt_elemt->params.pt2pt.iprobe;
-                wd->count = count;
-                wd->datatype = datatype;
                 wd->rank = rank;
                 wd->tag = tag;
                 wd->comm_ptr = comm_ptr;
@@ -150,8 +148,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
         case IMPROBE:
             {
                 struct MPIDI_workq_improbe *wd = &pt2pt_elemt->params.pt2pt.improbe;
-                wd->count = count;
-                wd->datatype = datatype;
                 wd->rank = rank;
                 wd->tag = tag;
                 wd->comm_ptr = comm_ptr;
@@ -217,7 +213,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
                 wd->target_count = target_count;
                 wd->target_datatype = target_datatype;
                 wd->win_ptr = win_ptr;
-                wd->addr = addr;
                 break;
             }
         case GET:
@@ -231,7 +226,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
                 wd->target_count = target_count;
                 wd->target_datatype = target_datatype;
                 wd->win_ptr = win_ptr;
-                wd->addr = addr;
                 break;
             }
         default:

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -169,10 +169,4 @@ typedef struct MPIDI_workq_elemt {
     } params;
 } MPIDI_workq_elemt_t;
 
-/* List structure to implement per-object (e.g. per-communicator, per-window) work queues */
-struct MPIDI_workq_list {
-    MPIDI_workq_t pend_ops;
-    struct MPIDI_workq_list *next, *prev;
-};
-
 #endif /* CH4I_WORKQ_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -116,8 +116,6 @@ typedef struct MPIDI_workq_elemt {
                 MPIR_Request *request;
             } irecv;
             struct MPIDI_workq_iprobe {
-                MPI_Aint count;
-                MPI_Datatype datatype;
                 int rank;
                 int tag;
                 MPIR_Comm *comm_ptr;
@@ -128,8 +126,6 @@ typedef struct MPIDI_workq_elemt {
                 int *flag;
             } iprobe;
             struct MPIDI_workq_improbe {
-                MPI_Aint count;
-                MPI_Datatype datatype;
                 int rank;
                 int tag;
                 MPIR_Comm *comm_ptr;
@@ -158,7 +154,6 @@ typedef struct MPIDI_workq_elemt {
                 int target_count;
                 MPI_Datatype target_datatype;
                 MPIR_Win *win_ptr;
-                struct MPIDI_av_entry *addr;
             } put;
             struct MPIDI_workq_get {
                 void *origin_addr;
@@ -169,7 +164,6 @@ typedef struct MPIDI_workq_elemt {
                 int target_count;
                 MPI_Datatype target_datatype;
                 MPIR_Win *win_ptr;
-                struct MPIDI_av_entry *addr;
             } get;
         } rma;
     } params;

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -46,22 +46,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
         MPIR_STATUS_SET_COUNT(*status, MPIDIG_REQUEST(unexp_req, count));
     } else {
         *flag = 0;
-        /* FIXME: we do this because vci_lock is not a recursive lock that can
-         * be yielded easily. Recursive locking currently only works for the global
-         * lock. One way to improve this is to fix the lock yielding API to avoid this
-         * constraint.*/
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
-        MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
     }
     /* MPIDI_CS_EXIT(); */
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IPROBE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm * comm,
@@ -108,18 +98,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         MPIR_STATUS_SET_COUNT(*status, MPIDIG_REQUEST(unexp_req, count));
     } else {
         *flag = 0;
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
-        MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
     }
     /* MPIDI_CS_EXIT(); */
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_IMPROBE);
     return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_mprobe(int source, int tag, MPIR_Comm * comm,

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -106,18 +106,4 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_mprobe(int source, int tag, MPIR_Comm * comm,
-                                               int context_offset, MPIR_Request ** message,
-                                               MPI_Status * status)
-{
-    int mpi_errno, flag = 0;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_MPROBE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_MPROBE);
-    while (!flag) {
-        mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, &flag, message, status);
-    }
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_MPROBE);
-    return mpi_errno;
-}
-
 #endif /* CH4R_PROBE_H_INCLUDED */


### PR DESCRIPTION
This PR mostly cleans up the work queue-related code in CH4, except for the followings, which fix real build issue/bug.

* ch4: Guard unused label
    * fixes a build failure when CH4 runtime configuration is enabled
* ch4: Do not exit from CS if not entered
    * fixes an unlock-without-lock bug in case of an error in the progress engine
