### PR TITLE
ch4/ofi: Upgrade to libfabric 1.7.0

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -511,13 +511,25 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
         prov_use = MPIDI_OFI_pick_provider(hints, (char *) provname, prov);
 
         if (NULL == prov_use) {
+            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                            (MPL_DBG_FDEST, "1st trial of pick_provider() returned NULL\n"));
             MPIDI_OFI_init_global_settings(MPIDI_OFI_SET_NAME_DEFAULT);
             prov_use = MPIDI_OFI_pick_provider(hints, MPIDI_OFI_SET_NAME_DEFAULT, prov);
 
             if (NULL == prov_use) {
+                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                                (MPL_DBG_FDEST, "2nd trial of pick_provider() returned NULL\n"));
                 MPIDI_OFI_init_global_settings(MPIDI_OFI_SET_NAME_MINIMAL);
                 prov_use = MPIDI_OFI_pick_provider(hints, MPIDI_OFI_SET_NAME_MINIMAL, prov);
+            } else {
+                MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                                (MPL_DBG_FDEST, "2nd trial of pick_provider() returned %s\n",
+                                 prov_use->fabric_attr->prov_name));
             }
+        } else {
+            MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                            (MPL_DBG_FDEST, "1st trial of pick_provider() returned %s\n",
+                             prov_use->fabric_attr->prov_name));
         }
 
         /* If we did not find a provider, return an error */

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -79,6 +79,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_tcp="no"
         enable_shm="no"
         enable_mlx="no"
+        enable_perf="no"
+        enable_rstream="no"
+        enable_mrail="no"
     else
         enable_psm="yes"
         enable_psm2="yes"
@@ -93,6 +96,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         enable_tcp="yes"
         enable_shm="yes"
         enable_mlx="yes"
+        enable_perf="yes"
+        enable_rstream="yes"
+        enable_mrail="yes"
     fi
 
     for provider in $netmod_args ; do
@@ -235,6 +241,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
             prov_config+=" --enable-tcp=${enable_tcp}"
             prov_config+=" --enable-shm=${enable_shm}"
             prov_config+=" --enable-mlx=${enable_mlx}"
+            prov_config+=" --enable-perf=${enable_perf}"
+            prov_config+=" --enable-rstream=${enable_rstream}"
+            prov_config+=" --enable-mrail=${enable_mrail}"
         fi
 
         if test "x${ofi_direct_provider}" != "x" ; then


### PR DESCRIPTION
As libfabric 1.7.0 is out, this PR upgrades the embedded libfabric.

During the testing we found a few issues in the runtime capability set logic, which had been there for a long time but exposed by 1.7. This PR also contains a fix for that.
