### PR TITLE
ch4: Fix enqueued receive (for trylock/handoff)

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -132,13 +132,6 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
     unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
-        if (*request != NULL) {
-            MPIDIG_request_copy(*request, unexp_req);
-            MPIR_Request_add_ref(*request);
-            MPIR_Object_set_ref(unexp_req, 0);
-            MPIR_Handle_obj_free(&MPIR_Request_mem, unexp_req);
-            unexp_req = *request;
-        }
         MPIR_Comm_release(root_comm);   /* -1 for removing from unexp_list */
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {
             MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
@@ -148,7 +141,20 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
             MPIDIG_REQUEST(unexp_req, datatype) = datatype;
             MPIDIG_REQUEST(unexp_req, buffer) = (char *) buf;
             MPIDIG_REQUEST(unexp_req, count) = count;
-            *request = unexp_req;
+            if (*request == NULL) {
+                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+                 * a request. Here we simply return `unexp_req` */
+                *request = unexp_req;
+                /* Mark `match_req` as NULL so that we know nothing else to complete when
+                 * `unexp_req` finally completes. (See below) */
+                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = NULL;
+            } else {
+                /* Enqueuing path: CH4 already allocated a request.
+                 * Record the passed `*request` to `match_req` so that we can complete it
+                 * later when `unexp_req` completes.
+                 * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
+                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
+            }
 #ifdef MPIDI_CH4_DIRECT_NETMOD
             mpi_errno = MPIDI_NM_am_recv(unexp_req);
 #else
@@ -160,10 +166,23 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
             MPIR_ERR_CHECK(mpi_errno);
             goto fn_exit;
         } else {
-            *request = unexp_req;
             mpi_errno =
                 MPIDIG_handle_unexpected(buf, count, datatype, root_comm, context_id, unexp_req);
             MPIR_ERR_CHECK(mpi_errno);
+            if (*request == NULL) {
+                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+                 * a request. Here we simply return `unexp_req`, which is already completed. */
+                *request = unexp_req;
+            } else {
+                /* Enqueuing path: CH4 already allocated request as `*request`.
+                 * Since the real operations has completed in `unexp_req`, here we
+                 * simply copy the status to `*request` and complete it. */
+                (*request)->status = unexp_req->status;
+                MPIR_Request_add_ref(*request);
+                MPID_Request_complete(*request);
+                /* Need to free here because we don't return this to user */
+                MPIR_Request_free(unexp_req);
+            }
             goto fn_exit;
         }
     }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -232,8 +232,15 @@ typedef struct {
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)
 #define MPIDI_REQUEST(req,field)       (((req)->dev).field)
 #define MPIDIG_REQUEST(req,field)       (((req)->dev.ch4.am).field)
-#define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS)
 #define MPIDI_PREQUEST(req,field)       (((req)->dev.ch4.preq).field)
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+/* `(r)->dev.ch4.am.req` might not be allocated right after SHM_mpi_recv when
+ * the operations are enqueued with trylock/handoff models. */
+#define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req && ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS))
+#else
+#define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS)
+#endif /* #ifdef MPIDI_CH4_USE_WORK_QUEUES */
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
 #define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  (((req)->dev).anysource_partner_request)

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -246,6 +246,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {
@@ -485,6 +486,8 @@ int MPID_CS_finalize(void)
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPIR_Assert(thr_err == 0);
+    MPID_Thread_mutex_destroy(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CS_FINALIZE);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -292,7 +292,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[3];
+    MPID_Thread_mutex_t m[4];
     MPIDIU_map_t *win_map;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDIG_rreq_t *posted_list;
@@ -325,5 +325,7 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_PROGRESS_MUTEX  MPIDI_global.m[0]
 #define MPIDIU_THREAD_PROGRESS_HOOK_MUTEX  MPIDI_global.m[1]
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_global.m[2]
+/* Protects MPIDIG global structures (e.g. global unexpected message queue) */
+#define MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX  MPIDI_global.m[3]
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -86,11 +86,17 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_HANDLE_UNEXP_CMPL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_HANDLE_UNEXP_CMPL);
 
-    /* Check if this message has already been claimed by a probe. */
+    /* Check if this message has already been claimed by mprobe. */
     /* MPIDI_CS_ENTER(); */
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_UNEXP_DQUED) {
+        /* This request has been claimed by mprobe */
         if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_UNEXP_CLAIMED) {
+            /* mrecv has been already called */
             MPIDIG_handle_unexp_mrecv(rreq);
+        } else {
+            /* mrecv has not been called yet -- just take out the busy flag so that
+             * mrecv in future knows this request is ready */
+            MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_BUSY;
         }
         /* MPIDI_CS_EXIT(); */
         goto fn_exit;

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -204,7 +204,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_posted(MPIR_Request * req, MPIDIG_r
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(MPIDI_global.posted_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
@@ -214,7 +214,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_unexp(MPIR_Request * req, MPIDIG_rr
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(MPIDI_global.unexp_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -79,31 +79,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_init(MPIR_Request * req,
     return req;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDIG_request_copy(MPIR_Request * dest, MPIR_Request * src)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_REQUEST_COPY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_REQUEST_COPY);
-
-    MPIR_Assert(dest != NULL && src != NULL);
-    MPIDI_NM_am_request_init(dest);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    MPIDI_SHM_am_request_init(dest);
-#endif
-
-    MPIDIG_REQUEST(dest, req) = MPIDIG_REQUEST(src, req);;
-    MPIDIG_REQUEST(dest, req->rreq.request) = dest;
-    MPIDIG_REQUEST(dest, datatype) = MPIDIG_REQUEST(src, datatype);
-    MPIDIG_REQUEST(dest, buffer) = MPIDIG_REQUEST(src, buffer);
-    MPIDIG_REQUEST(dest, count) = MPIDIG_REQUEST(src, count);
-    MPIDIG_REQUEST(dest, rank) = MPIDIG_REQUEST(src, rank);
-    MPIDIG_REQUEST(dest, tag) = MPIDIG_REQUEST(src, tag);
-    MPIDIG_REQUEST(dest, context_id) = MPIDIG_REQUEST(src, context_id);
-    MPIDIG_REQUEST(dest, req->status) = MPIDIG_REQUEST(src, req->status);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_REQUEST_COPY);
-    return;
-}
-
 /* This function should be called any time an anysource request is matched so
  * the upper layer will have a chance to arbitrate who wins the race between
  * the netmod and the shmod. This will cancel the request of the other side and


### PR DESCRIPTION
Trylock-enqueue and handoff have been partially broken since the active message shared memory was integrated (#3199), because #3199 was never tested with trylock/handoff before.

This PR fixes several critical issues when the POSIX shmmod is used with enqueued operations (trylock/handoff).

The key patches are as follows:
* ch4: Check pointer validity in REQUEST_IN_PROGRESS
    * avoids NULL pointer dereference
* ch4/generic: Correctly handle enqueued receive
    * if there is an unexpected message, let it complete first and complete the request pre-allocated by CH4 separately, in contrast to the current approach which simply tears down the unexpected message.
* ch4/generic: Protect global unexpected queue under per-vci
    * Under the per-vci critical section model, the global unexpected queue in MPIDIG can be accessed from multiple threads. Adds a necessary protection around the critical section.

Limitation:
Any source receive still has issues, which needs to be addressed separately.

Related: #3588 
