### PR TITLE
Improve per-vci thread-safety of Sched

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -70,7 +70,8 @@ noinst_HEADERS +=                   \
     src/include/nopackage.h         \
     src/include/rlog.h              \
     src/include/rlog_macros.h       \
-    src/include/mpir_op_util.h
+    src/include/mpir_op_util.h      \
+    src/include/mpir_sched.h
 
 src/include/mpir_cvars.h:
 	$(top_srcdir)/maint/extractcvars --dirs="`cat $(top_srcdir)/maint/cvardirs`"

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -232,6 +232,7 @@ typedef struct MPIR_Topology MPIR_Topology;
 #include "mpir_misc_post.h"
 #include "mpit.h"
 #include "mpir_handlemem.h"
+#include "mpir_sched.h"
 
 /*****************************************************************************/
 /******************** PART 6: DEVICE "POST" FUNCTIONALITY ********************/

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -426,25 +426,25 @@ int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI
 /* sched-based functions */
 int MPIR_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
@@ -460,11 +460,12 @@ int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, int sendcount,
 /* sched-based intercomm-only functions */
 int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                          MPIR_Comm * comm_ptr,
+                                                          MPIR_Sched_element_t s);
 
 
 /******************************** Iallgatherv ********************************/
@@ -483,27 +484,30 @@ int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MP
 /* sched-based functions */
 int MPIR_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                            const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int recvcounts[], const int displs[],
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_intra_gentran_recexch_doubling(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
@@ -514,21 +518,22 @@ int MPIR_Iallgatherv_intra_gentran_recexch_halving(const void *sendbuf, int send
                                                    const int *recvcounts, const int *displs,
                                                    MPI_Datatype recvtype, MPIR_Comm * comm,
                                                    MPIR_Request ** req);
-int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount,
-                                        MPI_Datatype sendtype, void *recvbuf,
-                                        const int *recvcounts, const int *displs,
+int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                        void *recvbuf, const int *recvcounts, const int *displs,
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                         MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            const int *recvcounts, const int *displs,
                                                            MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                           MPIR_Comm * comm_ptr,
+                                                           MPIR_Sched_element_t s);
 
 
 /******************************** Iallreduce ********************************/
@@ -540,24 +545,24 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Data
 
 /* sched-based functions */
 int MPIR_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s);
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
                                                          int count, MPI_Datatype datatype,
                                                          MPI_Op op, MPIR_Comm * comm_ptr,
-                                                         MPIR_Sched_t s);
+                                                         MPIR_Sched_element_t s);
 int MPIR_Iallreduce_intra_gentran_recexch_single_buffer(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm, MPIR_Request ** req);
@@ -570,16 +575,16 @@ int MPIR_Iallreduce_intra_gentran_tree(const void *sendbuf, void *recvbuf, int c
                                        MPIR_Request ** request);
 int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
                                                           int count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
+                                                          MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoall ********************************/
@@ -600,37 +605,37 @@ int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_
 /* sched-based functions */
 int MPIR_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                          int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Sched_t s);
+                         MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoallv ********************************/
@@ -647,27 +652,27 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int *sendcounts, const int *
 int MPIR_Ialltoallv_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
                           MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                           const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+                               MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                      const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendcnts[],
                                             const int sdispls[], MPI_Datatype sendtype,
                                             void *recvbuf, const int recvcnts[],
@@ -678,12 +683,12 @@ int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendc
 int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                      const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoallw ********************************/
@@ -701,41 +706,41 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int *sendcounts, const int *
 int MPIR_Ialltoallw_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
                           const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
                           const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
                                const int *rdispls, const MPI_Datatype * recvtypes,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoallw_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      const MPI_Datatype * sendtypes, void *recvbuf,
                                      const int *recvcounts, const int *rdispls,
                                      const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      const MPI_Datatype * sendtypes, void *recvbuf,
                                      const int *recvcounts, const int *rdispls,
                                      const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const int rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ibarrier ********************************/
@@ -744,17 +749,17 @@ int MPIR_Ibarrier(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibarrier_intra_gentran_recexch(MPIR_Comm * comm, MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ibcast ********************************/
@@ -774,29 +779,30 @@ int MPIR_Ibcast_intra_gentran_ring(void *buffer, int count, MPI_Datatype datatyp
 
 /* sched-based functions */
 int MPIR_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
                                                                  MPI_Datatype datatype, int root,
                                                                  MPIR_Comm * comm_ptr,
-                                                                 MPIR_Sched_t s);
+                                                                 MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Iexscan ********************************/
@@ -808,17 +814,17 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatyp
 
 /* sched-based functions */
 int MPIR_Iexscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Igather ********************************/
@@ -836,29 +842,29 @@ int MPIR_Igather_intra_gentran_tree(const void *sendbuf, int sendcount, MPI_Data
 /* sched-based functions */
 int MPIR_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                        int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                       MPIR_Sched_t s);
+                       MPIR_Sched_element_t s);
 int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Igatherv ********************************/
@@ -873,28 +879,29 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 /* sched-based functions */
 int MPIR_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int *recvcounts, const int *displs,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, const int *recvcounts, const int *displs,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s);
+                                       MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_allgather ********************************/
@@ -913,28 +920,28 @@ int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, int sen
 /* sched-based functions */
 int MPIR_Ineighbor_allgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_allgatherv ********************************/
@@ -955,32 +962,33 @@ int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, int se
 /* sched-based functions */
 int MPIR_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, const int recvcounts[], const int displs[],
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                    MPIR_Sched_element_t s);
 int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                          void *recvbuf, const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                         MPIR_Sched_t s);
+                                         MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s);
+                                                   MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoall ********************************/
@@ -999,28 +1007,28 @@ int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, int send
 /* sched-based functions */
 int MPIR_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoallv ********************************/
@@ -1043,33 +1051,33 @@ int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf, const i
 int MPIR_Ineighbor_alltoallv_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                    MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                                    const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoallw ********************************/
@@ -1096,12 +1104,12 @@ int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
                                    const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcounts[],
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sendcounts[],
@@ -1109,7 +1117,7 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[],
@@ -1117,7 +1125,7 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
@@ -1125,7 +1133,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce ********************************/
@@ -1143,31 +1151,31 @@ int MPIR_Ireduce_intra_gentran_ring(const void *sendbuf, void *recvbuf, int coun
 
 /* sched-based functions */
 int MPIR_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Sched_t s);
+                                 MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce_scatter ********************************/
@@ -1182,30 +1190,30 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *rec
 /* sched-based functions */
 int MPIR_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+                               MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                     const int *recvcnts, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                               const int *recvcnts, MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                         const int *recvcnts, MPI_Datatype datatype,
                                                         MPI_Op op, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
+                                                        MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                        const int *recvcnts, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Sched_t s);
+                                                       MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_intra_gentran_recexch(const void *sendbuf, void *recvbuf,
                                                const int *recvcounts, MPI_Datatype datatype,
                                                MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req);
@@ -1213,13 +1221,13 @@ int MPIR_Ireduce_scatter_intra_gentran_recexch(const void *sendbuf, void *recvbu
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
                                                                   void *recvbuf,
                                                                   const int *recvcnts,
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s);
+                                                                  MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce_scatter_block ********************************/
@@ -1238,42 +1246,42 @@ int MPIR_Ireduce_scatter_block_intra_gentran_recexch(const void *sendbuf, void *
 /* sched-based functions */
 int MPIR_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, int recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                           int recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
+                                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                                     int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                               int recvcount, MPI_Datatype datatype,
                                                               MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s);
+                                                              MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                              int recvcount, MPI_Datatype datatype,
                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s);
+                                                             MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
                                                                         void *recvbuf,
                                                                         int recvcount,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
-                                                                        MPIR_Sched_t s);
+                                                                        MPIR_Sched_element_t s);
 
 
 /******************************** Iscan ********************************/
@@ -1285,19 +1293,19 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
 
 /* sched-based functions */
 int MPIR_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s);
+                                MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                               MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req);
@@ -1318,31 +1326,31 @@ int MPIR_Iscatter_intra_gentran_tree(const void *sendbuf, int sendcount, MPI_Dat
 /* sched-based functions */
 int MPIR_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                        MPIR_Sched_t s);
+                        MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
+                                                        MPIR_Sched_element_t s);
 
 
 /******************************** Iscatterv ********************************/
@@ -1357,29 +1365,29 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int *sendcounts, const int *d
 /* sched-based functions */
 int MPIR_Iscatterv_sched(const void *sendbuf, const int *sendcounts, const int *displs,
                          MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int *sendcounts, const int *displs,
                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                              MPIR_Sched_t s);
+                              MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int *sendcounts,
                                         const int *displs, MPI_Datatype sendtype, void *recvbuf,
                                         int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Neighbor_allgather ********************************/

--- a/src/include/mpir_sched.h
+++ b/src/include/mpir_sched.h
@@ -1,0 +1,14 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *  See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPIR_SCHED_H_INCLUDED
+#define MPIR_SCHED_H_INCLUDED
+
+typedef struct MPIDU_Sched_list MPIR_Sched_list_t;
+
+extern MPIR_Sched_list_t MPIDU_all_schedules;
+
+#endif /* MPIR_SCHED_H_INCLUDED */

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -144,7 +144,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, vo
 
 int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, recvtype_size;
@@ -182,7 +182,8 @@ int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dat
 
 int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -196,7 +197,7 @@ int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount,
 int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount,
                                MPI_Datatype sendtype, void *recvbuf,
                                int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -250,7 +251,7 @@ int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount,
 
 int MPIR_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s)
+                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -271,7 +272,7 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
@@ -324,10 +325,10 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -337,7 +338,7 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
@@ -15,7 +15,8 @@
 int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm_ptr,
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size, root;

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -46,7 +46,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -228,7 +228,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -92,7 +92,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     /* Ranks pass around the data (size - 1) times */
     for (i = 0; i < size - 1; i++) {
         /* Get new tag for each cycle so that the send-recv pairs are matched correctly */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -137,7 +137,8 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 */
 int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, comm_size, total_count, recvtype_size;
@@ -188,7 +189,8 @@ int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Da
 
 int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -202,7 +204,7 @@ int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Da
 
 int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int recvcounts[], const int displs[],
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -258,7 +260,7 @@ int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype
 
 int MPIR_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                            void *recvbuf, const int recvcounts[], const int displs[],
-                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -279,7 +281,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     int comm_size = comm_ptr->local_size;
@@ -339,10 +341,10 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -352,7 +354,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
@@ -22,7 +22,8 @@ int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, 
                                                            const int recvcounts[],
                                                            const int displs[],
                                                            MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm_ptr,
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size, root, rank;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
@@ -8,7 +8,8 @@
 
 int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, const int recvcounts[], const int displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, j, i;
@@ -37,15 +38,15 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
 
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else {
-        mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
-                                    recvcounts[rank], recvtype,
-                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
+                                            recvcounts[rank], recvtype,
+                                            tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -71,12 +72,14 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
             incoming_count += recvcounts[(src + i) % comm_size];
         }
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier */
-        mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
-                                    incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(((char *) tmp_buf + curr_count * recvtype_sz),
+                                            incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr,
+                                            s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -96,13 +99,14 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
         for (i = 0; i < rem; i++)
             send_cnt += recvcounts[(rank + i) % comm_size];
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, send_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_send(tmp_buf, send_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier */
-        mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
-                                    (total_count - curr_count) * recvtype_sz, MPI_BYTE,
-                                    src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(((char *) tmp_buf + curr_count * recvtype_sz),
+                                            (total_count - curr_count) * recvtype_sz, MPI_BYTE,
+                                            src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -114,20 +118,20 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     send_cnt = 0;
     for (i = 0; i < (comm_size - rank); i++) {
         j = (rank + i) % comm_size;
-        mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
-                                    recvcounts[j] * recvtype_sz, MPI_BYTE,
-                                    ((char *) recvbuf + displs[j] * recvtype_extent),
-                                    recvcounts[j], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
+                                            recvcounts[j] * recvtype_sz, MPI_BYTE,
+                                            ((char *) recvbuf + displs[j] * recvtype_extent),
+                                            recvcounts[j], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         send_cnt += recvcounts[j];
     }
 
     for (i = 0; i < rank; i++) {
-        mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
-                                    recvcounts[i] * recvtype_sz, MPI_BYTE,
-                                    ((char *) recvbuf + displs[i] * recvtype_extent),
-                                    recvcounts[i], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
+                                            recvcounts[i] * recvtype_sz, MPI_BYTE,
+                                            ((char *) recvbuf + displs[i] * recvtype_extent),
+                                            recvcounts[i], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         send_cnt += recvcounts[i];

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
@@ -8,7 +8,8 @@
 
 int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_count;
@@ -35,9 +36,9 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
 
     if (sendbuf != MPI_IN_PLACE) {
         /* First, load the "local" version in the recvbuf. */
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    ((char *) recvbuf + displs[rank] * recvtype_extent),
-                                    recvcounts[rank], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            ((char *) recvbuf + displs[rank] * recvtype_extent),
+                                            recvcounts[rank], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -78,13 +79,13 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
 
         /* Communicate */
         if (recvnow) {  /* If there's no data to send, just do a recv call */
-            mpi_errno = MPIR_Sched_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             torecv -= recvnow;
         }
         if (sendnow) {  /* If there's no data to receive, just do a send call */
-            mpi_errno = MPIR_Sched_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             tosend -= sendnow;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -77,7 +77,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     int mpi_errno = MPI_SUCCESS;
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -253,7 +253,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -90,7 +90,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
         send_rank = (rank - i + nranks) % nranks;       /* Rank whose data you're sending */
 
         /* New tag for each send-recv pair. */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -137,7 +137,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
 
 int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, type_size;
@@ -183,7 +183,7 @@ int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int cou
 
 int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -195,7 +195,7 @@ int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int cou
 
 
 int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -252,7 +252,7 @@ int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MP
 }
 
 int MPIR_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -271,7 +271,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -314,10 +314,10 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -325,7 +325,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
+++ b/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
@@ -20,7 +20,7 @@
 int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
                                                           int count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;
@@ -63,7 +63,7 @@ int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, v
     }
 
     /* don't bcast until the reductions have finished */
-    mpi_errno = MPIR_Sched_barrier(s);
+    mpi_errno = MPIR_Sched_element_barrier(s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
@@ -9,7 +9,7 @@
 /* implements the naive intracomm allreduce, that is, reduce followed by bcast */
 int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s)
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
@@ -8,7 +8,7 @@
 
 int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, rem, comm_size, is_commutative, rank;
@@ -34,7 +34,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -53,7 +53,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -63,7 +63,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -71,7 +71,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -91,11 +91,11 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
             /* Send the most current data, which is in recvbuf. Recv
              * into tmp_buf */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -105,19 +105,20 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
             if (is_commutative || (dst < rank)) {
                 /* op is commutative OR the order is already right */
-                mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 /* op is noncommutative and the order is not right */
-                mpi_errno = MPIR_Sched_reduce(recvbuf, tmp_buf, count, datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(recvbuf, tmp_buf, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into recvbuf */
-                mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -131,11 +132,11 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
      * (rank-1), the ranks who didn't participate above. */
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
@@ -9,7 +9,7 @@
 
 int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -53,7 +53,8 @@ int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int coun
     } else {
         /* only one process on the node. copy sendbuf to recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -60,7 +60,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
 
     /* if there is only 1 rank, copy data from sendbuf
      * to recvbuf and exit */

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -123,7 +123,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -123,7 +123,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, voi
 */
 int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int nbytes, comm_size, sendtype_size;
@@ -162,7 +162,7 @@ int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Data
 
 int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype
                                     sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -175,7 +175,7 @@ int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Data
 
 int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -234,7 +234,8 @@ int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype s
 }
 
 int MPIR_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -255,7 +256,7 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
      * before going down to the MPIR_Sched-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
@@ -291,10 +292,10 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -304,7 +305,7 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
@@ -20,7 +20,7 @@
 int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int local_size, remote_size, max_size, i;
@@ -54,10 +54,10 @@ int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendco
             sendaddr = (char *) sendbuf + dst * sendcount * sendtype_extent;
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
@@ -20,7 +20,7 @@
  * scenario. */
 int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     void *tmp_buf = NULL;
@@ -58,17 +58,19 @@ int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_D
                     peer = i;
 
                 /* pack to tmp_buf */
-                mpi_errno = MPIR_Sched_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
+                mpi_errno =
+                    MPIR_Sched_element_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, tmp_buf, nbytes, MPI_BYTE, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* now simultaneously send from tmp_buf and recv to recvbuf */
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, peer, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
@@ -25,7 +25,7 @@
  */
 int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -44,10 +44,10 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     /* Make local copy first */
-    mpi_errno = MPIR_Sched_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
-                                sendcount, sendtype,
-                                ((char *) recvbuf + rank * recvcount * recvtype_extent),
-                                recvcount, recvtype, s);
+    mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
+                                        sendcount, sendtype,
+                                        ((char *) recvbuf + rank * recvcount * recvtype_extent),
+                                        recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -63,12 +63,12 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
             dst = (rank + i) % comm_size;
         }
 
-        mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
-                                    sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
+                                            sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
-                                    recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
+                                            recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
@@ -17,7 +17,7 @@
 int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -44,7 +44,8 @@ int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendco
         /* do the communication -- post ss sends and receives: */
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
-            mpi_errno = MPIR_Sched_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
+            mpi_errno =
+                MPIR_Sched_element_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
                                         recvcount, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
@@ -52,7 +53,8 @@ int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendco
 
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
-            mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
+            mpi_errno =
+                MPIR_Sched_element_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
                                         sendcount, sendtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -151,7 +151,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -123,7 +123,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
     for (i = 0; i < size - 1; i++) {
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -101,7 +101,8 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const int recvcounts[], const int rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -123,7 +124,8 @@ int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const int recvcounts[], const int rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -137,7 +139,7 @@ int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                                const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -187,7 +189,7 @@ int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int sendcounts[], cons
 int MPIR_Ialltoallv_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                           MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                           const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s)
+                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -209,7 +211,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
      * before going down to the MPIR_Sched-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
@@ -241,10 +243,10 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -254,7 +256,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
@@ -10,7 +10,7 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     /* Intercommunicator alltoallv. We use a pairwise exchange algorithm
      * similar to the one used in intracommunicator alltoallv. Since the
@@ -66,13 +66,13 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
         if (recvcount * recvtype_size == 0)
             src = MPI_PROC_NULL;
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
@@ -9,7 +9,8 @@
 int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -45,8 +46,8 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
             if (recvcounts[dst] && recvtype_size) {
-                mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst] * recv_extent,
-                                            recvcounts[dst], recvtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv((char *) recvbuf + rdispls[dst] * recv_extent,
+                                                    recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }
@@ -55,8 +56,8 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
             if (sendcounts[dst] && sendtype_size) {
-                mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst] * send_extent,
-                                            sendcounts[dst], sendtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send((char *) sendbuf + sdispls[dst] * send_extent,
+                                                    sendcounts[dst], sendtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
@@ -9,7 +9,8 @@
 int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_element_t s)
 {
     int max_count;
     void *tmp_buf = NULL;
@@ -58,17 +59,20 @@ int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcount
                 else
                     dst = i;
 
-                mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst] * recvtype_extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) recvbuf + rdispls[dst] * recvtype_extent),
                                             recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE, dst,
+                                            comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
                                             ((char *) recvbuf + rdispls[dst] * recvtype_extent),
                                             recvcounts[dst], recvtype, s);
                 if (mpi_errno)

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -66,7 +66,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_lb, &sendtype_true_extent);
     sendtype_extent = MPL_MAX(sendtype_extent, sendtype_true_extent);
 
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -77,7 +77,7 @@ int MPIR_Ialltoallw_sched_intra_auto(const void *sendbuf, const int sendcounts[]
                                      const int sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const int recvcounts[], const int rdispls[],
                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -98,7 +98,7 @@ int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[]
                                      const int sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const int recvcounts[], const int rdispls[],
                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -112,7 +112,8 @@ int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                const MPI_Datatype sendtypes[], void *recvbuf,
                                const int recvcounts[], const int rdispls[],
-                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -162,7 +163,7 @@ int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int sendcounts[], cons
 int MPIR_Ialltoallw_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                           const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
                           const int rdispls[], const MPI_Datatype recvtypes[],
-                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -184,14 +185,14 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -201,7 +202,7 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
@@ -11,7 +11,7 @@ int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const int rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
 /* Intercommunicator alltoallw. We use a pairwise exchange algorithm
    similar to the one used in intracommunicator alltoallw. Since the local and
@@ -58,11 +58,11 @@ int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int
             sendtype = sendtypes[dst];
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier here */
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
@@ -24,7 +24,7 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i;
@@ -53,8 +53,9 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (recvcounts[dst]) {
                 MPIR_Datatype_get_size_macro(recvtypes[dst], type_size);
                 if (type_size) {
-                    mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst],
-                                                recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv((char *) recvbuf + rdispls[dst],
+                                                        recvcounts[dst], recvtypes[dst], dst,
+                                                        comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -66,8 +67,9 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (sendcounts[dst]) {
                 MPIR_Datatype_get_size_macro(sendtypes[dst], type_size);
                 if (type_size) {
-                    mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst],
-                                                sendcounts[dst], sendtypes[dst], dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send((char *) sendbuf + sdispls[dst],
+                                                        sendcounts[dst], sendtypes[dst], dst,
+                                                        comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
@@ -22,7 +22,7 @@ int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcount
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i, j;
@@ -69,19 +69,22 @@ int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcount
                     dst = i;
 
                 MPIR_Datatype_get_size_macro(recvtypes[i], recvtype_sz);
-                mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + rdispls[dst]),
+                                                    recvcounts[dst], recvtypes[dst], dst, comm_ptr,
+                                                    s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE, dst,
+                                            comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            ((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], s);
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
+                                            ((char *) recvbuf + rdispls[dst]), recvcounts[dst],
+                                            recvtypes[dst], s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibarrier/ibarrier.c
+++ b/src/mpi/coll/ibarrier/ibarrier.c
@@ -83,7 +83,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request * request)
 
 /* any non-MPI functions go here, especially non-static ones */
 
-int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -94,7 +94,7 @@ int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 
 /* It will choose between several different algorithms based on the given
  * parameters. */
-int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -103,7 +103,7 @@ int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
     return mpi_errno;
 }
 
-int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -136,7 +136,7 @@ int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
     return mpi_errno;
 }
 
-int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -153,7 +153,7 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
@@ -178,10 +178,10 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
         }
     }
     if (comm_ptr->local_size != 1 || comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
-        mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_create(&s);
+        mpi_errno = MPIR_Sched_element_create(&s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -189,7 +189,7 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+        mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
+++ b/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
@@ -6,7 +6,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;

--- a/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
@@ -19,7 +19,7 @@
  * process i sends to process (i + 2^k) % p and receives from process
  * (i - 2^k + p) % p.
  */
-int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int size, rank, src, dst, mask;
@@ -38,15 +38,15 @@ int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
         dst = (rank + mask) % size;
         src = (rank - mask + size) % size;
 
-        mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -146,7 +146,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
  * hierarchy.  It will choose between several different algorithms
  * based on the given parameters. */
 int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -191,7 +191,7 @@ int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype,
  * know anything about hierarchy.  It will choose between several
  * different algorithms based on the given parameters. */
 int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -201,7 +201,7 @@ int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype,
 }
 
 int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -255,7 +255,7 @@ int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int r
 }
 
 int MPIR_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -273,7 +273,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     size_t type_size, nbytes;
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -322,10 +322,10 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -333,7 +333,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast.h
+++ b/src/mpi/coll/ibcast/ibcast.h
@@ -20,6 +20,6 @@ int MPII_Ibcast_sched_test_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_test_curr_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, int nbytes,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 
 #endif /* IBCAST_H_INCLUDED */

--- a/src/mpi/coll/ibcast/ibcast_inter_flat.c
+++ b/src/mpi/coll/ibcast/ibcast_inter_flat.c
@@ -8,7 +8,7 @@
 #include "ibcast.h"
 
 int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype,
-                                 int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -22,13 +22,13 @@ int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype,
         mpi_errno = MPI_SUCCESS;
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(buffer, count, datatype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
         /* remote group. rank 0 on remote group receives from root */
         if (comm_ptr->rank == 0) {
-            mpi_errno = MPIR_Sched_recv(buffer, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(buffer, count, datatype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibcast/ibcast_intra_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_binomial.c
@@ -14,7 +14,7 @@
  * to build up a larger hierarchical broadcast from multiple invocations of this
  * function. */
 int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int mask;
@@ -53,7 +53,8 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -94,16 +95,16 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
             if (src < 0)
                 src += comm_size;
             if (!is_contig)
-                mpi_errno = MPIR_Sched_recv_status(tmp_buf, nbytes, MPI_BYTE, src,
-                                                   comm_ptr, &ibcast_state->status, s);
+                mpi_errno = MPIR_Sched_element_recv_status(tmp_buf, nbytes, MPI_BYTE, src,
+                                                           comm_ptr, &ibcast_state->status, s);
             else
-                mpi_errno = MPIR_Sched_recv_status(buffer, count, datatype, src,
-                                                   comm_ptr, &ibcast_state->status, s);
+                mpi_errno = MPIR_Sched_element_recv_status(buffer, count, datatype, src,
+                                                           comm_ptr, &ibcast_state->status, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
             MPIR_SCHED_BARRIER(s);
-            mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, s);
+            mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_test_length, ibcast_state, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -130,14 +131,14 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
             if (dst >= comm_size)
                 dst -= comm_size;
             if (!is_contig)
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, s);
             else
-                mpi_errno = MPIR_Sched_send(buffer, count, datatype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(buffer, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
             /* NOTE: This is departure from MPIR_Bcast_intra_binomial.  A true analog
-             * would put an MPIR_Sched_barrier here after every send. */
+             * would put an MPIR_Sched_element_barrier here after every send. */
         }
         mask >>= 1;
     }
@@ -145,7 +146,8 @@ int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datat
     if (!is_contig) {
         if (rank != root) {
             MPIR_SCHED_BARRIER(s);
-            mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
@@ -26,7 +26,8 @@
  * Total Cost = (lgp+p-1).alpha + 2.n.((p-1)/p).beta
  */
 int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;
@@ -68,7 +69,8 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -111,18 +113,18 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
             right_count = 0;
         right_disp = rel_j * scatter_size;
 
-        mpi_errno = MPIR_Sched_send(((char *) tmp_buf + right_disp),
-                                    right_count, MPI_BYTE, right, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + right_disp),
+                                            right_count, MPI_BYTE, right, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier here */
-        mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + left_disp),
-                                           left_count, MPI_BYTE, left, comm_ptr,
-                                           &ibcast_state->status, s);
+        mpi_errno = MPIR_Sched_element_recv_status(((char *) tmp_buf + left_disp),
+                                                   left_count, MPI_BYTE, left, comm_ptr,
+                                                   &ibcast_state->status, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
-        mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
+        mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -130,12 +132,12 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }
-    mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
+    mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     if (!is_contig && rank != root) {
-        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ibcast/ibcast_intra_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_smp.c
@@ -27,7 +27,7 @@ static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
  * currently make any decision about which particular algorithm to use for any
  * subcommunicator. */
 int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -49,17 +49,17 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
     /* send to intranode-rank 0 on the root's node */
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) > 0) {   /* is not the node root (0) *//* and is on our node (!-1) */
         if (root == comm_ptr->rank) {
-            mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr->node_comm, s);
+            mpi_errno = MPIR_Sched_element_send(buffer, count, datatype, 0, comm_ptr->node_comm, s);
         } else if (0 == comm_ptr->node_comm->rank) {
             mpi_errno =
-                MPIR_Sched_recv_status(buffer, count, datatype,
-                                       MPIR_Get_intranode_rank(comm_ptr, root), comm_ptr->node_comm,
-                                       &ibcast_state->status, s);
+                MPIR_Sched_element_recv_status(buffer, count, datatype,
+                                               MPIR_Get_intranode_rank(comm_ptr, root),
+                                               comm_ptr->node_comm, &ibcast_state->status, s);
         }
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
-        mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
+        mpi_errno = MPIR_Sched_element_cb(&sched_test_length, ibcast_state, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -73,7 +73,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -64,7 +64,7 @@ int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state)
  * typical scatter arguments.  At the moment this function always
  * scatters a buffer of nbytes starting at tmp_buf address. */
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, int nbytes,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, src, dst;
@@ -104,7 +104,8 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
             curr_size = recv_size;
 
             if (recv_size > 0) {
-                mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + relative_rank * scatter_size),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) tmp_buf + relative_rank * scatter_size),
                                             recv_size, MPI_BYTE, src, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -130,8 +131,9 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
                 if (dst >= comm_size)
                     dst -= comm_size;
                 mpi_errno =
-                    MPIR_Sched_send(((char *) tmp_buf + scatter_size * (relative_rank + mask)),
-                                    send_size, MPI_BYTE, dst, comm_ptr, s);
+                    MPIR_Sched_element_send(((char *) tmp_buf +
+                                             scatter_size * (relative_rank + mask)), send_size,
+                                            MPI_BYTE, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -61,7 +61,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 
 int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -79,7 +79,7 @@ int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 }
 
 int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -102,7 +102,7 @@ int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_D
 }
 
 int MPIR_Iexscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -121,14 +121,14 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -136,7 +136,7 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -86,7 +86,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void 
 
 int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -104,7 +104,7 @@ int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dataty
 
 int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint local_size, remote_size;
@@ -143,7 +143,7 @@ int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Dataty
 
 int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -189,7 +189,7 @@ int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sen
 
 int MPIR_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -211,7 +211,7 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
@@ -238,10 +238,10 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -251,7 +251,7 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igather/igather_inter_long.c
+++ b/src/mpi/coll/igather/igather_inter_long.c
@@ -15,7 +15,7 @@
  */
 int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint remote_size;
@@ -29,13 +29,13 @@ int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Dataty
         MPIR_Datatype_get_extent_macro(recvtype, extent);
 
         for (i = 0; i < remote_size; i++) {
-            mpi_errno = MPIR_Sched_recv(((char *) recvbuf + recvcount * i * extent),
-                                        recvcount, recvtype, i, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + recvcount * i * extent),
+                                                recvcount, recvtype, i, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
     } else {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/igather/igather_inter_short.c
+++ b/src/mpi/coll/igather/igather_inter_short.c
@@ -16,7 +16,7 @@
  */
 int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -29,7 +29,8 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -68,7 +69,8 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
             MPIR_ERR_POP(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
+            mpi_errno =
+                MPIR_Sched_element_send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
                                         root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -55,7 +55,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -75,7 +75,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
 int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -95,7 +95,7 @@ int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
 int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -114,7 +114,8 @@ int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
 
 int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int recvcounts[], const int displs[],
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -157,7 +158,7 @@ int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
 
 int MPIR_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -178,14 +179,14 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -195,7 +196,7 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
@@ -15,7 +15,7 @@
 int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, const int recvcounts[], const int displs[],
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s)
+                                       MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -39,15 +39,16 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
             if (recvcounts[i]) {
                 if ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (i == rank)) {
                     if (sendbuf != MPI_IN_PLACE) {
-                        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                                    ((char *) recvbuf + displs[rank] * extent),
-                                                    recvcounts[rank], recvtype, s);
+                        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                                            ((char *) recvbuf +
+                                                             displs[rank] * extent),
+                                                            recvcounts[rank], recvtype, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                     }
                 } else {
-                    mpi_errno = MPIR_Sched_recv(((char *) recvbuf + displs[i] * extent),
-                                                recvcounts[i], recvtype, i, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + displs[i] * extent),
+                                                        recvcounts[i], recvtype, i, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -68,9 +69,11 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
                 MPIR_CVAR_GET_DEFAULT_INT(GATHERV_INTER_SSEND_MIN_PROCS, &min_procs);
 
             if (comm_size >= min_procs)
-                mpi_errno = MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             else
-                mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -77,7 +77,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
 int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -97,7 +97,7 @@ int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount
 int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -116,7 +116,7 @@ int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount
 
 int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -159,7 +159,7 @@ int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_
 
 int MPIR_Ineighbor_allgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -181,7 +181,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -226,10 +226,10 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgather_sched(sendbuf, sendcount, sendtype,
@@ -237,7 +237,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
@@ -16,7 +16,7 @@
 int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -39,14 +39,14 @@ int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendc
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -51,7 +51,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int s
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -78,7 +78,7 @@ int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcoun
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -99,7 +99,7 @@ int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcoun
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -120,7 +120,7 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
                                          const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                         MPIR_Sched_t s)
+                                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -164,7 +164,8 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount,
                                     MPI_Datatype sendtype, void *recvbuf,
                                     const int recvcounts[], const int displs[],
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -187,7 +188,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -232,10 +233,10 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgatherv_sched(sendbuf, sendcount, sendtype,
@@ -243,7 +244,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
@@ -17,7 +17,7 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s)
+                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -40,14 +40,14 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -50,7 +50,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -78,7 +78,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
 int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              int recvcount, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -98,7 +98,7 @@ int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              int recvcount, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -118,7 +118,7 @@ int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
                                        int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -162,7 +162,7 @@ int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                   MPI_Datatype sendtype, void *recvbuf,
                                   int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -184,7 +184,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -228,10 +228,10 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoall_sched(sendbuf, sendcount, sendtype,
@@ -239,7 +239,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
@@ -16,7 +16,7 @@
 int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -41,14 +41,14 @@ int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendco
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -51,7 +51,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -79,7 +79,7 @@ int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sen
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -101,7 +101,7 @@ int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sen
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -123,7 +123,7 @@ int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcount
                                         const int sdispls[], MPI_Datatype sendtype,
                                         void *recvbuf, const int recvcounts[],
                                         const int rdispls[], MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -169,7 +169,7 @@ int MPIR_Ineighbor_alltoallv_sched(const void *sendbuf, const int sendcounts[],
                                    const int sdispls[], MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[],
                                    const int rdispls[], MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -193,7 +193,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -239,10 +239,10 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallv_sched(sendbuf, sendcounts, sdispls, sendtype,
@@ -250,7 +250,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
@@ -17,7 +17,7 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -42,14 +42,14 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -53,7 +53,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -80,7 +80,7 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -103,7 +103,7 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -125,7 +125,7 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -172,7 +172,7 @@ int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const int recvcounts[],
                                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -198,7 +198,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -245,10 +245,10 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallw_sched(sendbuf, sendcounts, sdispls, sendtypes,
@@ -257,7 +257,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
@@ -18,7 +18,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -41,7 +41,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
         char *sb;
 
         sb = ((char *) sendbuf) + sdispls[k];
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -50,7 +50,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -51,7 +51,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -136,7 +136,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 
 int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, type_size;
@@ -173,7 +173,7 @@ int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 
 int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf,
                                   int count, MPI_Datatype datatype, MPI_Op op, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -184,7 +184,7 @@ int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf,
 }
 
 int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -236,7 +236,7 @@ int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_D
 }
 
 int MPIR_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -256,7 +256,7 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -291,10 +291,10 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -302,7 +302,7 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
@@ -14,7 +14,7 @@
 
 int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -31,10 +31,10 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -63,15 +63,15 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
             MPIR_Ireduce_sched(sendbuf, tmp_buf, count, datatype, op, 0, comm_ptr->local_comm, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(tmp_buf, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(tmp_buf, count, datatype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_barrier(s);
+            mpi_errno = MPIR_Sched_element_barrier(s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/ireduce/ireduce_intra_smp.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_smp.c
@@ -8,7 +8,7 @@
 
 int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Sched_t s)
+                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -158,7 +158,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -87,7 +87,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
 
 int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
                                           const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -156,7 +156,7 @@ int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
 
 int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf,
                                           const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -169,7 +169,7 @@ int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf,
 
 int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -229,7 +229,7 @@ int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const in
 
 int MPIR_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -250,7 +250,7 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     int is_commutative = MPIR_Op_is_commutative(op);
 
     *request = NULL;
@@ -279,10 +279,10 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -290,7 +290,7 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
@@ -18,7 +18,7 @@ int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *se
                                                                   const int recvcounts[],
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s)
+                                                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root, local_size, total_count, i;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
@@ -37,7 +37,7 @@
 int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                        const int recvcounts[],
                                                        MPI_Datatype datatype, MPI_Op op,
-                                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -90,11 +90,11 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
     /* copy sendbuf into tmp_results */
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(recvbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -111,7 +111,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -121,7 +122,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -129,7 +131,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -195,11 +198,13 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
                 int send_dst = (send_cnt ? dst : MPI_PROC_NULL);
                 int recv_dst = (recv_cnt ? dst : MPI_PROC_NULL);
 
-                mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) tmp_results + newdisps[send_idx] * extent),
                                             send_cnt, datatype, send_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                             recv_cnt, datatype, recv_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -209,7 +214,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
             if (recv_cnt) {
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                               ((char *) tmp_results + newdisps[recv_idx] * extent),
                                               recv_cnt, datatype, op, s);
                 MPIR_SCHED_BARRIER(s);
@@ -223,9 +229,9 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
         /* copy this process's result from tmp_results to recvbuf */
         if (recvcounts[rank]) {
-            mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
-                                        recvcounts[rank], datatype,
-                                        recvbuf, recvcounts[rank], datatype, s);
+            mpi_errno = MPIR_Sched_element_copy(((char *) tmp_results + disps[rank] * extent),
+                                                recvcounts[rank], datatype,
+                                                recvbuf, recvcounts[rank], datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -239,7 +245,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
             if (recvcounts[rank - 1]) {
-                mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) tmp_results + disps[rank - 1] * extent),
                                             recvcounts[rank - 1], datatype, rank - 1, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -248,7 +255,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno =
-                    MPIR_Sched_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr, s);
+                    MPIR_Sched_element_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr,
+                                            s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -45,7 +45,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
     nranks = MPIR_Comm_size(comm);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -88,7 +88,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
 
 int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -147,7 +147,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvb
 
 int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -161,7 +161,7 @@ int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvb
 
 int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, int recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s)
+                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -226,7 +226,7 @@ int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, in
 
 int MPIR_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -248,7 +248,7 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
     int is_commutative = MPIR_Op_is_commutative(op);
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
@@ -276,10 +276,10 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                 break;
         }
     }
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -288,7 +288,7 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
@@ -19,7 +19,7 @@ int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const vo
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
-                                                                        MPIR_Sched_t s)
+                                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root, local_size, total_count;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
@@ -13,7 +13,7 @@
 int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                           int recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;
@@ -61,12 +61,12 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
      * permute the blocks as we go according to the mirror permutation. */
     for (i = 0; i < comm_size; ++i) {
         mpi_errno =
-            MPIR_Sched_copy(((char *) (sendbuf ==
-                                       MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
-                             (i * true_extent * block_size)), block_size, datatype,
-                            ((char *) tmp_buf0 +
-                             (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
-                              block_size)), block_size, datatype, s);
+            MPIR_Sched_element_copy(((char *) (sendbuf ==
+                                               MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
+                                     (i * true_extent * block_size)), block_size, datatype,
+                                    ((char *) tmp_buf0 +
+                                     (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
+                                      block_size)), block_size, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -91,12 +91,12 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
             send_offset += size;
         }
 
-        mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send((outgoing_data + send_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv((incoming_data + recv_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -105,16 +105,16 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
          * is now our peer's responsibility */
         if (rank > peer) {
             /* higher ranked value so need to call op(received_data, my_data) */
-            mpi_errno = MPIR_Sched_reduce((incoming_data + recv_offset * true_extent),
-                                          (outgoing_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((incoming_data + recv_offset * true_extent),
+                                                  (outgoing_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
-            mpi_errno = MPIR_Sched_reduce((outgoing_data + recv_offset * true_extent),
-                                          (incoming_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((outgoing_data + recv_offset * true_extent),
+                                                  (incoming_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
@@ -130,7 +130,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
 
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
-    mpi_errno = MPIR_Sched_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
+    mpi_errno = MPIR_Sched_element_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
@@ -10,7 +10,7 @@
  * commutative op and is intended for use with large messages. */
 int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                                     int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -48,8 +48,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
 
     if (sendbuf != MPI_IN_PLACE) {
         /* copy local data into recvbuf */
-        mpi_errno = MPIR_Sched_copy(((char *) sendbuf + disps[rank] * extent),
-                                    recvcount, datatype, recvbuf, recvcount, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + disps[rank] * extent),
+                                            recvcount, datatype, recvbuf, recvcount, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -68,27 +68,28 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
         /* send the data that dst needs. recv data that this process
          * needs from src into tmp_recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + disps[dst] * extent),
+                                                recvcount, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[dst] * extent),
+                                                recvcount, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
-        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, recvbuf, recvcount, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_recvbuf, recvbuf, recvcount, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
                                           recvcount, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
@@ -103,8 +104,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
     /* if MPI_IN_PLACE, move output data to the beginning of
      * recvbuf. already done for rank 0. */
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
-        mpi_errno = MPIR_Sched_copy(((char *) recvbuf + disps[rank] * extent),
-                                    recvcount, datatype, recvbuf, recvcount, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) recvbuf + disps[rank] * extent),
+                                            recvcount, datatype, recvbuf, recvcount, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -48,7 +48,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
     nranks = MPIR_Comm_size(comm);

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -62,7 +62,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
 
 int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s)
+                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -78,7 +78,7 @@ int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 }
 
 int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -106,7 +106,7 @@ int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Dat
 }
 
 int MPIR_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -124,7 +124,7 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
@@ -150,10 +150,10 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -161,7 +161,7 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -38,7 +38,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -96,7 +96,7 @@ struct shared_state {
 /* any non-MPI functions go here, especially non-static ones */
 int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -115,7 +115,7 @@ int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
 
 int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int local_size, remote_size, sendtype_size, recvtype_size, nbytes;
     int mpi_errno = MPI_SUCCESS;
@@ -153,7 +153,7 @@ int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
 
 int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                             int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -203,7 +203,7 @@ int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
 
 int MPIR_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -225,7 +225,7 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
@@ -254,10 +254,10 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -267,7 +267,7 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter_inter_linear.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_linear.c
@@ -16,7 +16,7 @@
 
 int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size;
@@ -34,14 +34,14 @@ int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Dat
         MPIR_Datatype_get_extent_macro(sendtype, extent);
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
-                MPIR_Sched_send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
-                                comm_ptr, s);
+                MPIR_Sched_element_send(((char *) sendbuf + sendcount * i * extent), sendcount,
+                                        sendtype, i, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
-        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
@@ -19,7 +19,7 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s)
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size;
@@ -36,7 +36,8 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
 
     if (root == MPI_ROOT) {
         /* root sends all data to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -56,8 +57,8 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
                                       mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
             mpi_errno =
-                MPIR_Sched_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
-                                root, comm_ptr, s);
+                MPIR_Sched_element_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
+                                        root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -57,7 +57,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -77,7 +77,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
 int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[], const int displs[],
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -97,7 +97,7 @@ int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
 int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[], const int displs[],
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -116,7 +116,8 @@ int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
 
 int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const int displs[],
                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -164,7 +165,7 @@ int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const
 
 int MPIR_Iscatterv_sched(const void *sendbuf, const int sendcounts[], const int displs[],
                          MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -186,14 +187,14 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -203,7 +204,7 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
@@ -19,7 +19,7 @@
 int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                         const int displs[], MPI_Datatype sendtype, void *recvbuf,
                                         int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -42,15 +42,16 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
             if (sendcounts[i]) {
                 if ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (i == rank)) {
                     if (recvbuf != MPI_IN_PLACE) {
-                        mpi_errno = MPIR_Sched_copy(((char *) sendbuf + displs[rank] * extent),
-                                                    sendcounts[rank], sendtype,
-                                                    recvbuf, recvcount, recvtype, s);
+                        mpi_errno =
+                            MPIR_Sched_element_copy(((char *) sendbuf + displs[rank] * extent),
+                                                    sendcounts[rank], sendtype, recvbuf, recvcount,
+                                                    recvtype, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                     }
                 } else {
-                    mpi_errno = MPIR_Sched_send(((char *) sendbuf + displs[i] * extent),
-                                                sendcounts[i], sendtype, i, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + displs[i] * extent),
+                                                        sendcounts[i], sendtype, i, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -61,7 +62,7 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
     else if (root != MPI_PROC_NULL) {
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
-            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -6,7 +6,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Sched_cb_free_buf(MPIR_Comm * comm, int tag, void *state)
+int MPIR_Sched_element_cb_free_buf(MPIR_Comm * comm, int tag, void *state)
 {
     MPL_free(state);
     return MPI_SUCCESS;

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -71,7 +71,7 @@ int MPII_Coll_init(void)
         MPIR_Ireduce_tree_type = MPIR_TREE_TYPE_KARY;
 
     /* register non blocking collectives progress hook */
-    mpi_errno = MPID_Progress_register_hook(MPIDU_Sched_progress, &MPIR_Nbc_progress_hook_id);
+    mpi_errno = MPID_Progress_register_hook(MPIDU_Sched_list_progress, &MPIR_Nbc_progress_hook_id);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -87,7 +87,7 @@ cvars:
     (!MPID_nem_local_lmt_pending &&             \
      !MPIDI_CH3I_shm_active_send &&             \
      !MPIDI_CH3I_Sendq_head(MPIDI_CH3I_shm_sendq) &&       \
-     !MPIDU_Sched_are_pending() &&              \
+     !MPIDU_Sched_list_has_pending_sched() &&              \
      MPIR_Coll_safe_to_block() &&  \
      !MPIDI_RMA_Win_active_list_head)
 

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -601,7 +601,7 @@ static inline int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
 }
 
 
-static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -612,7 +612,7 @@ static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 
 
 static inline int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                              MPIR_Comm * comm, MPIR_Sched_t s)
+                              MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -624,7 +624,7 @@ static inline int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype dataty
 
 static inline int MPID_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -637,7 +637,7 @@ static inline int MPID_Iallgather_sched(const void *sendbuf, int sendcount, MPI_
 
 static inline int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Sched_t s)
+                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -650,7 +650,7 @@ static inline int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI
 
 static inline int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -662,7 +662,7 @@ static inline int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int 
 
 static inline int MPID_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Sched_t s)
+                                 MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -677,7 +677,7 @@ static inline int MPID_Ialltoallv_sched(const void *sendbuf, const int sendcount
                                   const int sdispls[], MPI_Datatype sendtype,
                                   void *recvbuf, const int recvcounts[],
                                   const int rdispls[], MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -692,7 +692,7 @@ static inline int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcount
                                   const int sdispls[], const MPI_Datatype sendtypes[],
                                   void *recvbuf, const int recvcounts[],
                                   const int rdispls[], const MPI_Datatype recvtypes[],
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -705,7 +705,7 @@ static inline int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcount
 
 static inline int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -717,7 +717,7 @@ static inline int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int cou
 
 static inline int MPID_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -731,7 +731,7 @@ static inline int MPID_Igather_sched(const void *sendbuf, int sendcount, MPI_Dat
 static inline int MPID_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Sched_t s)
+                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -744,7 +744,7 @@ static inline int MPID_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Da
 
 static inline int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -757,7 +757,7 @@ static inline int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *re
 
 static inline int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Sched_t s)
+                                       MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -769,7 +769,7 @@ static inline int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
 
 
 static inline int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                               MPI_Op op, int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -780,7 +780,7 @@ static inline int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int cou
 
 
 static inline int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                             MPI_Op op, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -792,7 +792,7 @@ static inline int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count
 
 static inline int MPID_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -806,7 +806,7 @@ static inline int MPID_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Da
 static inline int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                  const int *displs, MPI_Datatype sendtype,
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                 int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -820,7 +820,7 @@ static inline int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcount
 static inline int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -835,7 +835,7 @@ static inline int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendc
                                             MPI_Datatype sendtype, void *recvbuf,
                                             const int recvcounts[], const int displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Sched_t s)
+                                            MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -848,7 +848,7 @@ static inline int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendc
 
 static inline int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                           void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -863,7 +863,7 @@ static inline int MPID_Ineighbor_alltoallv_sched(const void *sendbuf, const int 
                                            const int sdispls[], MPI_Datatype sendtype,
                                            void *recvbuf, const int recvcounts[],
                                            const int rdispls[], MPI_Datatype recvtype,
-                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -878,7 +878,7 @@ static inline int MPID_Ineighbor_alltoallw_sched(const void *sendbuf, const int 
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                            void *recvbuf, const int recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch3/include/mpid_sched.h
+++ b/src/mpid/ch3/include/mpid_sched.h
@@ -8,19 +8,19 @@
 #define MPID_SCHED_H_INCLUDED
 #include "mpidu_sched.h"
 
-#define MPIR_Sched_cb MPIDU_Sched_cb
-#define MPIR_Sched_cb2 MPIDU_Sched_cb2
-#define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
-#define MPIR_Sched_create MPIDU_Sched_create
-#define MPIR_Sched_clone MPIDU_Sched_clone
-#define MPIR_Sched_start MPIDU_Sched_start
-#define MPIR_Sched_send MPIDU_Sched_send
-#define MPIR_Sched_send_defer MPIDU_Sched_send_defer
-#define MPIR_Sched_recv MPIDU_Sched_recv
-#define MPIR_Sched_recv_status MPIDU_Sched_recv_status
-#define MPIR_Sched_ssend MPIDU_Sched_ssend
-#define MPIR_Sched_reduce MPIDU_Sched_reduce
-#define MPIR_Sched_copy MPIDU_Sched_copy
-#define MPIR_Sched_barrier MPIDU_Sched_barrier
+#define MPIR_Sched_element_cb MPIDU_Sched_element_cb
+#define MPIR_Sched_element_cb2 MPIDU_Sched_element_cb2
+#define MPIR_Sched_list_get_next_tag  MPIDU_Sched_list_get_next_tag
+#define MPIR_Sched_element_create MPIDU_Sched_element_create
+#define MPIR_Sched_element_clone MPIDU_Sched_element_clone
+#define MPIR_Sched_list_enqueue_sched MPIDU_Sched_list_enqueue_sched
+#define MPIR_Sched_element_send MPIDU_Sched_element_send
+#define MPIR_Sched_element_send_defer MPIDU_Sched_element_send_defer
+#define MPIR_Sched_element_recv MPIDU_Sched_element_recv
+#define MPIR_Sched_element_recv_status MPIDU_Sched_element_recv_status
+#define MPIR_Sched_element_ssend MPIDU_Sched_element_ssend
+#define MPIR_Sched_element_reduce MPIDU_Sched_element_reduce
+#define MPIR_Sched_element_copy MPIDU_Sched_element_copy
+#define MPIR_Sched_element_barrier MPIDU_Sched_element_barrier
 
 #endif /* MPID_SCHED_H_INCLUDED */

--- a/src/mpid/ch4/include/mpid_sched.h
+++ b/src/mpid/ch4/include/mpid_sched.h
@@ -12,19 +12,19 @@
 #define MPID_SCHED_H_INCLUDED
 #include "mpidu_sched.h"
 
-#define MPIR_Sched_cb MPIDU_Sched_cb
-#define MPIR_Sched_cb2 MPIDU_Sched_cb2
-#define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
-#define MPIR_Sched_create MPIDU_Sched_create
-#define MPIR_Sched_clone MPIDU_Sched_clone
-#define MPIR_Sched_start MPIDU_Sched_start
-#define MPIR_Sched_send MPIDU_Sched_send
-#define MPIR_Sched_send_defer MPIDU_Sched_send_defer
-#define MPIR_Sched_recv MPIDU_Sched_recv
-#define MPIR_Sched_recv_status MPIDU_Sched_recv_status
-#define MPIR_Sched_ssend MPIDU_Sched_ssend
-#define MPIR_Sched_reduce MPIDU_Sched_reduce
-#define MPIR_Sched_copy MPIDU_Sched_copy
-#define MPIR_Sched_barrier MPIDU_Sched_barrier
+#define MPIR_Sched_element_cb MPIDU_Sched_element_cb
+#define MPIR_Sched_element_cb2 MPIDU_Sched_element_cb2
+#define MPIR_Sched_list_get_next_tag  MPIDU_Sched_list_get_next_tag
+#define MPIR_Sched_element_create MPIDU_Sched_element_create
+#define MPIR_Sched_element_clone MPIDU_Sched_element_clone
+#define MPIR_Sched_list_enqueue_sched MPIDU_Sched_list_enqueue_sched
+#define MPIR_Sched_element_send MPIDU_Sched_element_send
+#define MPIR_Sched_element_send_defer MPIDU_Sched_element_send_defer
+#define MPIR_Sched_element_recv MPIDU_Sched_element_recv
+#define MPIR_Sched_element_recv_status MPIDU_Sched_element_recv_status
+#define MPIR_Sched_element_ssend MPIDU_Sched_element_ssend
+#define MPIR_Sched_element_reduce MPIDU_Sched_element_reduce
+#define MPIR_Sched_element_copy MPIDU_Sched_element_copy
+#define MPIR_Sched_element_barrier MPIDU_Sched_element_barrier
 
 #endif /* MPID_SCHED_H_INCLUDED */

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -378,87 +378,88 @@ typedef int (*MPIDI_NM_mpi_iscatterv_t) (const void *sendbuf, const int *sendcou
                                          const int *displs, MPI_Datatype sendtype, void *recvbuf,
                                          int recvcount, MPI_Datatype recvtype, int root,
                                          MPIR_Comm * comm_ptr, MPIR_Request ** req);
-typedef int (*MPIDI_NM_mpi_ibarrier_sched_t) (MPIR_Comm * comm, MPIR_Sched_t s);
+typedef int (*MPIDI_NM_mpi_ibarrier_sched_t) (MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ibcast_sched_t) (void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s);
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallgather_sched_t) (const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s);
+                                                MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallgatherv_sched_t) (const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s);
+                                                 MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallreduce_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s);
+                                                MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoall_sched_t) (const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoallv_sched_t) (const void *sendbuf, const int sendcounts[],
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s);
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoallw_sched_t) (const void *sendbuf, const int sendcounts[],
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s);
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iexscan_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_igather_sched_t) (const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_igatherv_sched_t) (const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_scatter_block_sched_t) (const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s);
+                                                           MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_scatter_sched_t) (const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s);
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s);
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscan_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s);
+                                           MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscatter_sched_t) (const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscatterv_sched_t) (const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s);
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_allgather_sched_t) (const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_allgatherv_sched_t) (const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s);
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoall_sched_t) (const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s);
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoallv_sched_t) (const void *sendbuf,
                                                          const int sendcounts[],
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoallw_sched_t) (const void *sendbuf,
                                                          const int sendcounts[],
                                                          const MPI_Aint sdispls[],
@@ -466,7 +467,7 @@ typedef int (*MPIDI_NM_mpi_ineighbor_alltoallw_sched_t) (const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_type_commit_hook_t) (MPIR_Datatype * datatype_p);
 typedef int (*MPIDI_NM_mpi_type_free_hook_t) (MPIR_Datatype * datatype_p);
 typedef int (*MPIDI_NM_mpi_op_commit_hook_t) (MPIR_Op * op_p);
@@ -1173,32 +1174,37 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
                                                     MPIR_Comm * comm_ptr,
                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
                                                        MPIR_Comm * comm,
-                                                       MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
                                                            MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1206,7 +1212,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1215,60 +1222,68 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
                                                            MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
                                                          MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm,
-                                                                MPIR_Sched_t s)
+                                                                MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
                                                       MPIR_Comm * comm,
-                                                      MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
                                                          int root, MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           const int *sendcounts, const int *displs,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
                                                                     int sendcount,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
                                                                      int sendcount,
@@ -1278,7 +1293,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
                                                                    int sendcount,
@@ -1286,7 +1301,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm,
-                                                                   MPIR_Sched_t s)
+                                                                   MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                                     const int sendcounts[],
@@ -1297,7 +1312,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                                     const int sendcounts[],
@@ -1308,7 +1323,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
 int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p);

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -1748,7 +1748,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1763,7 +1763,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1779,7 +1779,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1798,7 +1798,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1815,7 +1815,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1832,7 +1832,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1853,7 +1853,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1875,7 +1875,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            void *recvbuf, const int recvcounts[],
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1892,7 +1892,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1908,7 +1908,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, voi
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1926,7 +1927,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, in
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1945,7 +1946,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1962,7 +1963,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                MPIR_Comm * comm,
+                                                                MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1978,7 +1980,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1995,7 +1998,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2011,7 +2014,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         int root, MPIR_Comm * comm,
+                                                         MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2030,7 +2034,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2050,7 +2054,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2072,7 +2076,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2092,7 +2096,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                   MPIR_Comm * comm,
+                                                                   MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2115,7 +2120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2139,7 +2144,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -1196,7 +1196,7 @@ static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcou
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1210,7 +1210,7 @@ static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 }
 
 static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1226,7 +1226,7 @@ static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatyp
 static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1244,7 +1244,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1260,7 +1260,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
 
 static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1276,7 +1276,7 @@ static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvb
 static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1294,7 +1294,7 @@ static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf, const int s
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1312,7 +1312,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1328,7 +1328,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
 
 static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1344,7 +1344,7 @@ static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
 static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1362,7 +1362,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1379,7 +1379,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1395,7 +1395,8 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, 
 
 static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1411,7 +1412,7 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *
 
 static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1426,7 +1427,7 @@ static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
 
 static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1442,7 +1443,7 @@ static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, i
 static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1459,7 +1460,7 @@ static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1476,7 +1477,7 @@ static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *s
 static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1494,7 +1495,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1512,7 +1513,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
 static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1531,7 +1532,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1553,7 +1554,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_coll.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_coll.h
@@ -721,7 +721,7 @@ static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcou
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -735,7 +735,7 @@ static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 }
 
 static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -751,7 +751,7 @@ static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatyp
 static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -769,7 +769,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -785,7 +785,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
 
 static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -801,7 +801,7 @@ static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvb
 static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -819,7 +819,7 @@ static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf, const int s
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -837,7 +837,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -853,7 +853,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
 
 static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -869,7 +869,7 @@ static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
 static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -887,7 +887,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -904,7 +904,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -920,7 +920,8 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, 
 
 static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -936,7 +937,7 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *
 
 static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -951,7 +952,7 @@ static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
 
 static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -967,7 +968,7 @@ static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, i
 static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -984,7 +985,7 @@ static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1001,7 +1002,7 @@ static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *s
 static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1019,7 +1020,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1036,7 +1037,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
 static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1055,7 +1056,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1076,7 +1077,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -814,7 +814,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -829,7 +829,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -845,7 +845,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -864,7 +864,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -881,7 +881,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -897,7 +897,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -918,7 +918,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -939,7 +939,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            void *recvbuf, const int recvcounts[],
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -955,7 +955,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -971,7 +971,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, voi
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -989,7 +990,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, in
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1007,7 +1008,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1024,7 +1025,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                MPIR_Comm * comm,
+                                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1040,7 +1042,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1055,7 +1058,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1071,7 +1074,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         int root, MPIR_Comm * comm,
+                                                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1090,7 +1094,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1110,7 +1114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1132,7 +1136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1151,7 +1155,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                   MPIR_Comm * comm,
+                                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1174,7 +1179,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1197,7 +1202,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -1132,7 +1132,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1146,7 +1146,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1162,7 +1162,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Data
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgather_sched(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1180,7 +1180,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sen
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                    MPIR_Sched_t s)
+                                                    MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1196,7 +1196,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sen
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1212,7 +1212,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *re
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall_sched(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1230,7 +1230,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv_sched(const void *sendbuf, const in
                                                    const int sdispls[], MPI_Datatype sendtype,
                                                    void *recvbuf, const int recvcounts[],
                                                    const int rdispls[], MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1249,7 +1249,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const in
                                                    const MPI_Datatype sendtypes[], void *recvbuf,
                                                    const int recvcounts[], const int rdispls[],
                                                    const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                                   MPIR_Sched_t s)
+                                                   MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1265,7 +1265,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const in
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1281,7 +1281,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvb
 MPL_STATIC_INLINE_PREFIX int MPID_Igather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1299,7 +1299,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1316,7 +1316,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendco
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                               int recvcount, MPI_Datatype datatype,
                                                               MPI_Op op, MPIR_Comm * comm,
-                                                              MPIR_Sched_t s)
+                                                              MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1333,7 +1333,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                         const int recvcounts[],
                                                         MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1348,7 +1348,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, int root,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1363,7 +1363,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvb
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1379,7 +1379,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatter_sched(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1397,7 +1397,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int
                                                   const int *displs, MPI_Datatype sendtype,
                                                   void *recvbuf, int recvcount,
                                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                  MPIR_Sched_t s)
+                                                  MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1414,7 +1414,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+                                                            MPIR_Comm * comm,
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1433,7 +1434,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf
                                                              const int recvcounts[],
                                                              const int displs[],
                                                              MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                                             MPIR_Comm * comm,
+                                                             MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1450,7 +1452,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1471,7 +1473,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv_sched(const void *sendbuf,
                                                             const int recvcounts[],
                                                             const int rdispls[],
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1493,7 +1495,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw_sched(const void *sendbuf,
                                                             void *recvbuf, const int recvcounts[],
                                                             const MPI_Aint rdispls[],
                                                             const MPI_Datatype recvtypes[],
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+                                                            MPIR_Comm * comm,
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -329,6 +329,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided, int *has_ar
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_SCHED_LIST_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[3];
+    MPID_Thread_mutex_t m[4];
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -324,5 +324,6 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_PROGRESS_MUTEX  MPIDI_global.m[0]
 #define MPIDIU_THREAD_PROGRESS_HOOK_MUTEX  MPIDI_global.m[1]
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_global.m[2]
+#define MPIDIU_THREAD_SCHED_LIST_MUTEX  MPIDI_global.m[3]
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -14,7 +14,7 @@
  */
 #include "mpidu_pre.h"
 
-enum MPIDU_Sched_entry_type {
+enum MPIDU_Sched_element_entry_type {
     MPIDU_SCHED_ENTRY_INVALID_LB = 0,
     MPIDU_SCHED_ENTRY_SEND,
     /* _SEND_DEFER is easily implemented via _SEND */
@@ -27,7 +27,7 @@ enum MPIDU_Sched_entry_type {
     MPIDU_SCHED_ENTRY_INVALID_UB
 };
 
-struct MPIDU_Sched_send {
+struct MPIDU_Sched_element_send {
     const void *buf;
     MPI_Aint count;
     const MPI_Aint *count_p;
@@ -38,7 +38,7 @@ struct MPIDU_Sched_send {
     int is_sync;                /* TRUE iff this send is an ssend */
 };
 
-struct MPIDU_Sched_recv {
+struct MPIDU_Sched_element_recv {
     void *buf;
     MPI_Aint count;
     MPI_Datatype datatype;
@@ -48,7 +48,7 @@ struct MPIDU_Sched_recv {
     MPI_Status *status;
 };
 
-struct MPIDU_Sched_reduce {
+struct MPIDU_Sched_element_reduce {
     const void *inbuf;
     void *inoutbuf;
     MPI_Aint count;
@@ -56,7 +56,7 @@ struct MPIDU_Sched_reduce {
     MPI_Op op;
 };
 
-struct MPIDU_Sched_copy {
+struct MPIDU_Sched_element_copy {
     const void *inbuf;
     MPI_Aint incount;
     MPI_Datatype intype;
@@ -67,22 +67,22 @@ struct MPIDU_Sched_copy {
 
 /* nop entries have no args, so no structure is needed */
 
-enum MPIDU_Sched_cb_type {
-    MPIDU_SCHED_CB_TYPE_1 = 0,  /* single state arg type --> MPIR_Sched_cb_t */
-    MPIDU_SCHED_CB_TYPE_2       /* double state arg type --> MPIR_Sched_cb2_t */
+enum MPIDU_Sched_element_cb_type {
+    MPIDU_SCHED_CB_TYPE_1 = 0,  /* single state arg type --> MPIR_Sched_element_cb_t */
+    MPIDU_SCHED_CB_TYPE_2       /* double state arg type --> MPIR_Sched_element_cb2_t */
 };
 
-struct MPIDU_Sched_cb {
-    enum MPIDU_Sched_cb_type cb_type;
+struct MPIDU_Sched_element_cb {
+    enum MPIDU_Sched_element_cb_type cb_type;
     union {
-        MPIR_Sched_cb_t *cb_p;
-        MPIR_Sched_cb2_t *cb2_p;
+        MPIR_Sched_element_cb_t *cb_p;
+        MPIR_Sched_element_cb2_t *cb2_p;
     } u;
     void *cb_state;
     void *cb_state2;            /* unused for single-param callbacks */
 };
 
-enum MPIDU_Sched_entry_status {
+enum MPIDU_Sched_element_entry_status {
     MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED = 0,
     MPIDU_SCHED_ENTRY_STATUS_STARTED,
     MPIDU_SCHED_ENTRY_STATUS_COMPLETE,
@@ -92,50 +92,50 @@ enum MPIDU_Sched_entry_status {
 
 /* Use a tagged union for schedule entries.  Not always space optimal, but saves
  * lots of error-prone pointer arithmetic and makes scanning the schedule easy. */
-struct MPIDU_Sched_entry {
-    enum MPIDU_Sched_entry_type type;
-    enum MPIDU_Sched_entry_status status;
+struct MPIDU_Sched_element_entry {
+    enum MPIDU_Sched_element_entry_type type;
+    enum MPIDU_Sched_element_entry_status status;
     int is_barrier;
     union {
-        struct MPIDU_Sched_send send;
-        struct MPIDU_Sched_recv recv;
-        struct MPIDU_Sched_reduce reduce;
-        struct MPIDU_Sched_copy copy;
+        struct MPIDU_Sched_element_send send;
+        struct MPIDU_Sched_element_recv recv;
+        struct MPIDU_Sched_element_reduce reduce;
+        struct MPIDU_Sched_element_copy copy;
         /* nop entries have no args */
-        struct MPIDU_Sched_cb cb;
+        struct MPIDU_Sched_element_cb cb;
     } u;
 };
 
-struct MPIDU_Sched {
+struct MPIDU_Sched_element {
     size_t size;                /* capacity (in entries) of the entries array */
     size_t idx;                 /* index into entries array of first yet-outstanding entry */
     int num_entries;            /* number of populated entries, num_entries <= size */
     int tag;
     struct MPIR_Request *req;   /* really needed? could cause MT problems... */
-    struct MPIDU_Sched_entry *entries;
+    struct MPIDU_Sched_element_entry *entries;
 
-    struct MPIDU_Sched *next;   /* linked-list next pointer */
-    struct MPIDU_Sched *prev;   /* linked-list next pointer */
+    struct MPIDU_Sched_element *next;   /* linked-list next pointer */
+    struct MPIDU_Sched_element *prev;   /* linked-list next pointer */
 };
 
 /* prototypes */
-int MPIDU_Sched_progress(int *made_progress);
-int MPIDU_Sched_are_pending(void);
-int MPIDU_Sched_next_tag(struct MPIR_Comm *comm_ptr, int *tag);
-int MPIDU_Sched_create(MPIR_Sched_t * sp);
-int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned);
-int MPIDU_Sched_start(MPIR_Sched_t * sp, struct MPIR_Comm *comm, int tag,
-                      struct MPIR_Request **req);
-int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIR_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIR_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Sched_t s);
-int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype, void *outbuf,
-                     MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_t s);
-int MPIDU_Sched_barrier(MPIR_Sched_t s);
+int MPIDU_Sched_list_progress(int *made_progress);
+int MPIDU_Sched_list_has_pending_sched(void);
+int MPIDU_Sched_list_get_next_tag(struct MPIR_Comm *comm_ptr, int *tag);
+int MPIDU_Sched_element_create(MPIR_Sched_element_t * sp);
+int MPIDU_Sched_element_clone(MPIR_Sched_element_t orig, MPIR_Sched_element_t * cloned);
+int MPIDU_Sched_list_enqueue_sched(MPIR_Sched_element_t * sp, struct MPIR_Comm *comm, int tag,
+                                   struct MPIR_Request **req);
+int MPIDU_Sched_element_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIR_Sched_element_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIR_Sched_element_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype, void *outbuf,
+                             MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_barrier(MPIR_Sched_element_t s);
 
 #endif /* MPIDU_SCHED_H_INCLUDED */

--- a/src/mpid/include/mpidu_pre.h
+++ b/src/mpid/include/mpidu_pre.h
@@ -16,10 +16,11 @@ struct MPIR_Comm;
 
 /* Scheduling forward declarations */
 
-struct MPIDU_Sched;
-typedef struct MPIDU_Sched *MPIR_Sched_t;
+struct MPIDU_Sched_element;
+typedef struct MPIDU_Sched_element *MPIR_Sched_element_t;
 
-typedef int (MPIR_Sched_cb_t) (struct MPIR_Comm * comm, int tag, void *state);
-typedef int (MPIR_Sched_cb2_t) (struct MPIR_Comm * comm, int tag, void *state, void *state2);
+typedef int (MPIR_Sched_element_cb_t) (struct MPIR_Comm * comm, int tag, void *state);
+typedef int (MPIR_Sched_element_cb2_t) (struct MPIR_Comm * comm, int tag, void *state,
+                                        void *state2);
 
 #endif /* MPIDU_PRE_H_INCLUDED */


### PR DESCRIPTION
The `per-VCI` critical section model is essentially a subset of the `per-object` model. It needs thread safety for each VCI, and thread-safety for the other objects such as requests, hooks, etc.

This PR improves the thread-safety of the `Nbc_progress_hook` which sits in `src/common/sched/mpidu_sched.c`. Currently, some of the operations are not thread-safe.

The PR first implements new naming rules for the existing functions so that it is easier to parse what kind of operations the functions do and what kind of objects they are acting upon. As a result, moving forward, it is straightforward to parse which functions need thread safety. 

Testing:
- [x] Rebase this on top of #3590 before running the tests.
- [x] Test with #3659 with all the nbc code since they rely on each other for completeness (which also includes the global lock for collectives in per-vci critical section).