### PR TITLE
coll: refactor src/include/mpir_coll.h

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -41,471 +41,476 @@ int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
                  MPIR_Errflag_t * errflag);
 
+/* temporary macros just to make this file reads better */
+#define _err   MPIR_Errflag_t *errflag
+#define _req   MPIR_Request **request
+#define _sched MPIR_Sched_t s
+
 /********** Barrier **********/
 #define PARAMS_BARRIER \
     MPIR_Comm *comm_ptr
-int MPIR_Barrier(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_impl(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_intra_auto(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_intra_dissemination(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_intra_smp(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_inter_auto(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_inter_bcast(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_allcomm_nb(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier(PARAMS_BARRIER, _err);
+int MPIR_Barrier_impl(PARAMS_BARRIER, _err);
+int MPIR_Barrier_intra_auto(PARAMS_BARRIER, _err);
+int MPIR_Barrier_intra_dissemination(PARAMS_BARRIER, _err);
+int MPIR_Barrier_intra_smp(PARAMS_BARRIER, _err);
+int MPIR_Barrier_inter_auto(PARAMS_BARRIER, _err);
+int MPIR_Barrier_inter_bcast(PARAMS_BARRIER, _err);
+int MPIR_Barrier_allcomm_nb(PARAMS_BARRIER, _err);
 
 /********** Ibarrier **********/
-int MPIR_Ibarrier(PARAMS_BARRIER, MPIR_Request ** request);
-int MPIR_Ibarrier_impl(PARAMS_BARRIER, MPIR_Request ** request);
-int MPIR_Ibarrier_intra_recexch(PARAMS_BARRIER, MPIR_Request ** request);
+int MPIR_Ibarrier(PARAMS_BARRIER, _req);
+int MPIR_Ibarrier_impl(PARAMS_BARRIER, _req);
+int MPIR_Ibarrier_intra_recexch(PARAMS_BARRIER, _req);
 
-int MPIR_Ibarrier_sched(PARAMS_BARRIER, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_impl(PARAMS_BARRIER, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_intra_auto(PARAMS_BARRIER, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_intra_recursive_doubling(PARAMS_BARRIER, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_inter_auto(PARAMS_BARRIER, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_inter_bcast(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched(PARAMS_BARRIER, _sched);
+int MPIR_Ibarrier_sched_impl(PARAMS_BARRIER, _sched);
+int MPIR_Ibarrier_sched_intra_auto(PARAMS_BARRIER, _sched);
+int MPIR_Ibarrier_sched_intra_recursive_doubling(PARAMS_BARRIER, _sched);
+int MPIR_Ibarrier_sched_inter_auto(PARAMS_BARRIER, _sched);
+int MPIR_Ibarrier_sched_inter_bcast(PARAMS_BARRIER, _sched);
 
 /********** Bcast **********/
 #define PARAMS_BCAST \
     void *buffer, int count, MPI_Datatype datatype, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Bcast(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_impl(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_auto(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_binomial(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_ring_allgather(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_smp(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_inter_auto(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_inter_remote_send_local_bcast(PARAMS_BCAST, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_allcomm_nb(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast(PARAMS_BCAST, _err);
+int MPIR_Bcast_impl(PARAMS_BCAST, _err);
+int MPIR_Bcast_intra_auto(PARAMS_BCAST, _err);
+int MPIR_Bcast_intra_binomial(PARAMS_BCAST, _err);
+int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, _err);
+int MPIR_Bcast_intra_scatter_ring_allgather(PARAMS_BCAST, _err);
+int MPIR_Bcast_intra_smp(PARAMS_BCAST, _err);
+int MPIR_Bcast_inter_auto(PARAMS_BCAST, _err);
+int MPIR_Bcast_inter_remote_send_local_bcast(PARAMS_BCAST, _err);
+int MPIR_Bcast_allcomm_nb(PARAMS_BCAST, _err);
 
 /********** Ibcast **********/
-int MPIR_Ibcast(PARAMS_BCAST, MPIR_Request ** request);
-int MPIR_Ibcast_impl(PARAMS_BCAST, MPIR_Request ** request);
-int MPIR_Ibcast_intra_tree(PARAMS_BCAST, MPIR_Request ** request);
-int MPIR_Ibcast_intra_scatter_recexch_allgather(PARAMS_BCAST, MPIR_Request ** request);
-int MPIR_Ibcast_intra_ring(PARAMS_BCAST, MPIR_Request ** request);
+int MPIR_Ibcast(PARAMS_BCAST, _req);
+int MPIR_Ibcast_impl(PARAMS_BCAST, _req);
+int MPIR_Ibcast_intra_tree(PARAMS_BCAST, _req);
+int MPIR_Ibcast_intra_scatter_recexch_allgather(PARAMS_BCAST, _req);
+int MPIR_Ibcast_intra_ring(PARAMS_BCAST, _req);
 
-int MPIR_Ibcast_sched(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_impl(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_auto(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_binomial(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_scatter_ring_allgather(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_smp(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_inter_auto(PARAMS_BCAST, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_inter_flat(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_impl(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_intra_auto(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_intra_binomial(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_intra_scatter_ring_allgather(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_intra_smp(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_inter_auto(PARAMS_BCAST, _sched);
+int MPIR_Ibcast_sched_inter_flat(PARAMS_BCAST, _sched);
 
 /********** Gather **********/
 #define PARAMS_GATHER \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Gather(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_impl(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_intra_auto(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_intra_binomial(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_auto(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_linear(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_local_gather_remote_send(PARAMS_GATHER, MPIR_Errflag_t * errflag);
-int MPIR_Gather_allcomm_nb(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather(PARAMS_GATHER, _err);
+int MPIR_Gather_impl(PARAMS_GATHER, _err);
+int MPIR_Gather_intra_auto(PARAMS_GATHER, _err);
+int MPIR_Gather_intra_binomial(PARAMS_GATHER, _err);
+int MPIR_Gather_inter_auto(PARAMS_GATHER, _err);
+int MPIR_Gather_inter_linear(PARAMS_GATHER, _err);
+int MPIR_Gather_inter_local_gather_remote_send(PARAMS_GATHER, _err);
+int MPIR_Gather_allcomm_nb(PARAMS_GATHER, _err);
 
 /********** Igather **********/
-int MPIR_Igather(PARAMS_GATHER, MPIR_Request ** request);
-int MPIR_Igather_impl(PARAMS_GATHER, MPIR_Request ** request);
-int MPIR_Igather_intra_tree(PARAMS_GATHER, MPIR_Request ** request);
+int MPIR_Igather(PARAMS_GATHER, _req);
+int MPIR_Igather_impl(PARAMS_GATHER, _req);
+int MPIR_Igather_intra_tree(PARAMS_GATHER, _req);
 
-int MPIR_Igather_sched(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_impl(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_intra_auto(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_intra_binomial(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_inter_auto(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_inter_long(PARAMS_GATHER, MPIR_Sched_t s);
-int MPIR_Igather_sched_inter_short(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_impl(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_intra_auto(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_intra_binomial(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_inter_auto(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_inter_long(PARAMS_GATHER, _sched);
+int MPIR_Igather_sched_inter_short(PARAMS_GATHER, _sched);
 
 /********** Gatherv **********/
 #define PARAMS_GATHERV \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Gatherv(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_impl(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_intra_auto(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_inter_auto(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_allcomm_linear(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_allcomm_nb(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv(PARAMS_GATHERV, _err);
+int MPIR_Gatherv_impl(PARAMS_GATHERV, _err);
+int MPIR_Gatherv_intra_auto(PARAMS_GATHERV, _err);
+int MPIR_Gatherv_inter_auto(PARAMS_GATHERV, _err);
+int MPIR_Gatherv_allcomm_linear(PARAMS_GATHERV, _err);
+int MPIR_Gatherv_allcomm_nb(PARAMS_GATHERV, _err);
 
 /********** Igatherv **********/
-int MPIR_Igatherv(PARAMS_GATHERV, MPIR_Request ** request);
-int MPIR_Igatherv_impl(PARAMS_GATHERV, MPIR_Request ** request);
+int MPIR_Igatherv(PARAMS_GATHERV, _req);
+int MPIR_Igatherv_impl(PARAMS_GATHERV, _req);
 
-int MPIR_Igatherv_sched(PARAMS_GATHERV, MPIR_Sched_t s);
-int MPIR_Igatherv_sched_impl(PARAMS_GATHERV, MPIR_Sched_t s);
-int MPIR_Igatherv_sched_intra_auto(PARAMS_GATHERV, MPIR_Sched_t s);
-int MPIR_Igatherv_sched_inter_auto(PARAMS_GATHERV, MPIR_Sched_t s);
-int MPIR_Igatherv_sched_allcomm_linear(PARAMS_GATHERV, MPIR_Sched_t s);
+int MPIR_Igatherv_sched(PARAMS_GATHERV, _sched);
+int MPIR_Igatherv_sched_impl(PARAMS_GATHERV, _sched);
+int MPIR_Igatherv_sched_intra_auto(PARAMS_GATHERV, _sched);
+int MPIR_Igatherv_sched_inter_auto(PARAMS_GATHERV, _sched);
+int MPIR_Igatherv_sched_allcomm_linear(PARAMS_GATHERV, _sched);
 
 /********** Scatter **********/
 #define PARAMS_SCATTER \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Scatter(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_impl(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_intra_auto(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_intra_binomial(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_auto(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_linear(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_remote_send_local_scatter(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_allcomm_nb(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter(PARAMS_SCATTER, _err);
+int MPIR_Scatter_impl(PARAMS_SCATTER, _err);
+int MPIR_Scatter_intra_auto(PARAMS_SCATTER, _err);
+int MPIR_Scatter_intra_binomial(PARAMS_SCATTER, _err);
+int MPIR_Scatter_inter_auto(PARAMS_SCATTER, _err);
+int MPIR_Scatter_inter_linear(PARAMS_SCATTER, _err);
+int MPIR_Scatter_inter_remote_send_local_scatter(PARAMS_SCATTER, _err);
+int MPIR_Scatter_allcomm_nb(PARAMS_SCATTER, _err);
 
 /********** Iscatter **********/
-int MPIR_Iscatter(PARAMS_SCATTER, MPIR_Request ** request);
-int MPIR_Iscatter_impl(PARAMS_SCATTER, MPIR_Request ** request);
-int MPIR_Iscatter_intra_tree(PARAMS_SCATTER, MPIR_Request ** request);
+int MPIR_Iscatter(PARAMS_SCATTER, _req);
+int MPIR_Iscatter_impl(PARAMS_SCATTER, _req);
+int MPIR_Iscatter_intra_tree(PARAMS_SCATTER, _req);
 
-int MPIR_Iscatter_sched(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_impl(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_intra_auto(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_intra_binomial(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_inter_auto(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_inter_linear(PARAMS_SCATTER, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_inter_remote_send_local_scatter(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_impl(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_intra_auto(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_intra_binomial(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_inter_auto(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_inter_linear(PARAMS_SCATTER, _sched);
+int MPIR_Iscatter_sched_inter_remote_send_local_scatter(PARAMS_SCATTER, _sched);
 
 /********** Scatterv **********/
 #define PARAMS_SCATTERV \
     const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype sendtype, \
     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Scatterv(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_impl(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_intra_auto(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_inter_auto(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_allcomm_linear(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_allcomm_nb(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv(PARAMS_SCATTERV, _err);
+int MPIR_Scatterv_impl(PARAMS_SCATTERV, _err);
+int MPIR_Scatterv_intra_auto(PARAMS_SCATTERV, _err);
+int MPIR_Scatterv_inter_auto(PARAMS_SCATTERV, _err);
+int MPIR_Scatterv_allcomm_linear(PARAMS_SCATTERV, _err);
+int MPIR_Scatterv_allcomm_nb(PARAMS_SCATTERV, _err);
 
 /********** Iscatterv **********/
-int MPIR_Iscatterv(PARAMS_SCATTERV, MPIR_Request ** request);
-int MPIR_Iscatterv_impl(PARAMS_SCATTERV, MPIR_Request ** request);
+int MPIR_Iscatterv(PARAMS_SCATTERV, _req);
+int MPIR_Iscatterv_impl(PARAMS_SCATTERV, _req);
 
-int MPIR_Iscatterv_sched(PARAMS_SCATTERV, MPIR_Sched_t s);
-int MPIR_Iscatterv_sched_impl(PARAMS_SCATTERV, MPIR_Sched_t s);
-int MPIR_Iscatterv_sched_intra_auto(PARAMS_SCATTERV, MPIR_Sched_t s);
-int MPIR_Iscatterv_sched_inter_auto(PARAMS_SCATTERV, MPIR_Sched_t s);
-int MPIR_Iscatterv_sched_allcomm_linear(PARAMS_SCATTERV, MPIR_Sched_t s);
+int MPIR_Iscatterv_sched(PARAMS_SCATTERV, _sched);
+int MPIR_Iscatterv_sched_impl(PARAMS_SCATTERV, _sched);
+int MPIR_Iscatterv_sched_intra_auto(PARAMS_SCATTERV, _sched);
+int MPIR_Iscatterv_sched_inter_auto(PARAMS_SCATTERV, _sched);
+int MPIR_Iscatterv_sched_allcomm_linear(PARAMS_SCATTERV, _sched);
 
 /********** Allgather **********/
 #define PARAMS_ALLGATHER \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, int recvcount, MPI_Datatype recvtype, \
     MPIR_Comm *comm_ptr
-int MPIR_Allgather(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_impl(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_auto(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_brucks(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_recursive_doubling(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_ring(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_inter_auto(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_allcomm_nb(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_impl(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_intra_auto(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_intra_brucks(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_intra_recursive_doubling(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_intra_ring(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_inter_auto(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, _err);
+int MPIR_Allgather_allcomm_nb(PARAMS_ALLGATHER, _err);
 
 /********** Iallgather **********/
-int MPIR_Iallgather(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Iallgather_impl(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Iallgather_intra_gentran_brucks(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Iallgather_intra_recexch_distance_doubling(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Iallgather_intra_recexch_distance_halving(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Iallgather_intra_gentran_ring(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather(PARAMS_ALLGATHER, _req);
+int MPIR_Iallgather_impl(PARAMS_ALLGATHER, _req);
+int MPIR_Iallgather_intra_gentran_brucks(PARAMS_ALLGATHER, _req);
+int MPIR_Iallgather_intra_recexch_distance_doubling(PARAMS_ALLGATHER, _req);
+int MPIR_Iallgather_intra_recexch_distance_halving(PARAMS_ALLGATHER, _req);
+int MPIR_Iallgather_intra_gentran_ring(PARAMS_ALLGATHER, _req);
 
-int MPIR_Iallgather_sched(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_impl(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_brucks(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_recursive_doubling(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_ring(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_inter_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_impl(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_intra_auto(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_intra_brucks(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_intra_recursive_doubling(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_intra_ring(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_inter_auto(PARAMS_ALLGATHER, _sched);
+int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, _sched);
 
 /********** Allgatherv **********/
 #define PARAMS_ALLGATHERV \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, \
     MPIR_Comm *comm_ptr
-int MPIR_Allgatherv(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_impl(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_auto(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_brucks(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_recursive_doubling(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_ring(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_inter_auto(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_allcomm_nb(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_impl(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_intra_auto(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_intra_brucks(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_intra_recursive_doubling(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_intra_ring(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_inter_auto(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, _err);
+int MPIR_Allgatherv_allcomm_nb(PARAMS_ALLGATHERV, _err);
 
 /********** Iallgatherv **********/
-int MPIR_Iallgatherv(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Iallgatherv_impl(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_gentran_brucks(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_recexch_distance_doubling(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_recexch_distance_halving(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_gentran_ring(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv(PARAMS_ALLGATHERV, _req);
+int MPIR_Iallgatherv_impl(PARAMS_ALLGATHERV, _req);
+int MPIR_Iallgatherv_intra_gentran_brucks(PARAMS_ALLGATHERV, _req);
+int MPIR_Iallgatherv_intra_recexch_distance_doubling(PARAMS_ALLGATHERV, _req);
+int MPIR_Iallgatherv_intra_recexch_distance_halving(PARAMS_ALLGATHERV, _req);
+int MPIR_Iallgatherv_intra_gentran_ring(PARAMS_ALLGATHERV, _req);
 
-int MPIR_Iallgatherv_sched(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_impl(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_brucks(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_recursive_doubling(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_ring(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_inter_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_impl(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_intra_auto(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_intra_brucks(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_intra_recursive_doubling(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_intra_ring(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_inter_auto(PARAMS_ALLGATHERV, _sched);
+int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, _sched);
 
 /********** Alltoall **********/
 #define PARAMS_ALLTOALL \
     const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
     void *recvbuf, int recvcount, MPI_Datatype recvtype, \
     MPIR_Comm *comm_ptr
-int MPIR_Alltoall(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_impl(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_auto(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_brucks(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_scattered(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_inter_auto(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_inter_pairwise_exchange(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_allcomm_nb(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_impl(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_intra_auto(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_intra_brucks(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_intra_pairwise(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_intra_scattered(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_inter_auto(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_inter_pairwise_exchange(PARAMS_ALLTOALL, _err);
+int MPIR_Alltoall_allcomm_nb(PARAMS_ALLTOALL, _err);
 
 /********** Ialltoall **********/
-int MPIR_Ialltoall(PARAMS_ALLTOALL, MPIR_Request ** request);
-int MPIR_Ialltoall_impl(PARAMS_ALLTOALL, MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_ring(PARAMS_ALLTOALL, MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_brucks(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ialltoall(PARAMS_ALLTOALL, _req);
+int MPIR_Ialltoall_impl(PARAMS_ALLTOALL, _req);
+int MPIR_Ialltoall_intra_gentran_ring(PARAMS_ALLTOALL, _req);
+int MPIR_Ialltoall_intra_gentran_brucks(PARAMS_ALLTOALL, _req);
 
-int MPIR_Ialltoall_sched(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_impl(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_brucks(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_inplace(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_pairwise(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_permuted_sendrecv(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_inter_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_inter_pairwise_exchange(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_impl(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_intra_auto(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_intra_brucks(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_intra_inplace(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_intra_pairwise(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_intra_permuted_sendrecv(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_inter_auto(PARAMS_ALLTOALL, _sched);
+int MPIR_Ialltoall_sched_inter_pairwise_exchange(PARAMS_ALLTOALL, _sched);
 
 /********** Alltoallv **********/
 #define PARAMS_ALLTOALLV \
     const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype sendtype, \
     void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, \
     MPIR_Comm *comm_ptr
-int MPIR_Alltoallv(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_impl(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_auto(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_scattered(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_inter_auto(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_inter_pairwise_exchange(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_allcomm_nb(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_impl(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_intra_auto(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_intra_scattered(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_inter_auto(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_inter_pairwise_exchange(PARAMS_ALLTOALLV, _err);
+int MPIR_Alltoallv_allcomm_nb(PARAMS_ALLTOALLV, _err);
 
 /********** Ialltoallv **********/
-int MPIR_Ialltoallv(PARAMS_ALLTOALLV, MPIR_Request ** request);
-int MPIR_Ialltoallv_impl(PARAMS_ALLTOALLV, MPIR_Request ** request);
-int MPIR_Ialltoallv_intra_gentran_scattered(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ialltoallv(PARAMS_ALLTOALLV, _req);
+int MPIR_Ialltoallv_impl(PARAMS_ALLTOALLV, _req);
+int MPIR_Ialltoallv_intra_gentran_scattered(PARAMS_ALLTOALLV, _req);
 
-int MPIR_Ialltoallv_sched(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_impl(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_intra_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_intra_blocked(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_intra_inplace(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_inter_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_inter_pairwise_exchange(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_impl(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_intra_auto(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_intra_blocked(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_intra_inplace(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_inter_auto(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ialltoallv_sched_inter_pairwise_exchange(PARAMS_ALLTOALLV, _sched);
 
 /********** Alltoallw **********/
 #define PARAMS_ALLTOALLW \
     const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype *sendtypes, \
     void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype *recvtypes, \
     MPIR_Comm *comm_ptr
-int MPIR_Alltoallw(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_impl(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_auto(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_scattered(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_inter_auto(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_inter_pairwise_exchange(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_allcomm_nb(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_impl(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_intra_auto(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_intra_scattered(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_inter_auto(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_inter_pairwise_exchange(PARAMS_ALLTOALLW, _err);
+int MPIR_Alltoallw_allcomm_nb(PARAMS_ALLTOALLW, _err);
 
 /********** Ialltoallw **********/
-int MPIR_Ialltoallw(PARAMS_ALLTOALLW, MPIR_Request ** request);
-int MPIR_Ialltoallw_impl(PARAMS_ALLTOALLW, MPIR_Request ** request);
+int MPIR_Ialltoallw(PARAMS_ALLTOALLW, _req);
+int MPIR_Ialltoallw_impl(PARAMS_ALLTOALLW, _req);
 
-int MPIR_Ialltoallw_sched(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_impl(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_intra_auto(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_intra_blocked(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_intra_inplace(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_inter_auto(PARAMS_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_inter_pairwise_exchange(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_impl(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_intra_auto(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_intra_blocked(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_intra_inplace(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_inter_auto(PARAMS_ALLTOALLW, _sched);
+int MPIR_Ialltoallw_sched_inter_pairwise_exchange(PARAMS_ALLTOALLW, _sched);
 
 /********** Reduce **********/
 #define PARAMS_REDUCE \
     const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, \
     MPI_Op op, int root, \
     MPIR_Comm *comm_ptr
-int MPIR_Reduce(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_impl(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_auto(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_binomial(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_reduce_scatter_gather(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_smp(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_inter_auto(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_inter_local_reduce_remote_send(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_allcomm_nb(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce(PARAMS_REDUCE, _err);
+int MPIR_Reduce_impl(PARAMS_REDUCE, _err);
+int MPIR_Reduce_intra_auto(PARAMS_REDUCE, _err);
+int MPIR_Reduce_intra_binomial(PARAMS_REDUCE, _err);
+int MPIR_Reduce_intra_reduce_scatter_gather(PARAMS_REDUCE, _err);
+int MPIR_Reduce_intra_smp(PARAMS_REDUCE, _err);
+int MPIR_Reduce_inter_auto(PARAMS_REDUCE, _err);
+int MPIR_Reduce_inter_local_reduce_remote_send(PARAMS_REDUCE, _err);
+int MPIR_Reduce_allcomm_nb(PARAMS_REDUCE, _err);
 
 /********** Ireduce **********/
-int MPIR_Ireduce(PARAMS_REDUCE, MPIR_Request ** request);
-int MPIR_Ireduce_impl(PARAMS_REDUCE, MPIR_Request ** request);
-int MPIR_Ireduce_intra_tree(PARAMS_REDUCE, MPIR_Request ** request);
-int MPIR_Ireduce_intra_ring(PARAMS_REDUCE, MPIR_Request ** request);
+int MPIR_Ireduce(PARAMS_REDUCE, _req);
+int MPIR_Ireduce_impl(PARAMS_REDUCE, _req);
+int MPIR_Ireduce_intra_tree(PARAMS_REDUCE, _req);
+int MPIR_Ireduce_intra_ring(PARAMS_REDUCE, _req);
 
-int MPIR_Ireduce_sched(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_impl(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_auto(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_binomial(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_reduce_scatter_gather(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_smp(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_inter_auto(PARAMS_REDUCE, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_inter_local_reduce_remote_send(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_impl(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_intra_auto(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_intra_binomial(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_intra_reduce_scatter_gather(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_intra_smp(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_inter_auto(PARAMS_REDUCE, _sched);
+int MPIR_Ireduce_sched_inter_local_reduce_remote_send(PARAMS_REDUCE, _sched);
 
 /********** Allreduce **********/
 #define PARAMS_ALLREDUCE \
     const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
     MPIR_Comm *comm_ptr
-int MPIR_Allreduce(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_impl(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_auto(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_recursive_doubling(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_smp(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_inter_auto(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_inter_reduce_exchange_bcast(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_allcomm_nb(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_impl(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_intra_auto(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_intra_recursive_doubling(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_intra_smp(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_inter_auto(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_inter_reduce_exchange_bcast(PARAMS_ALLREDUCE, _err);
+int MPIR_Allreduce_allcomm_nb(PARAMS_ALLREDUCE, _err);
 
 /********** Iallreduce **********/
-int MPIR_Iallreduce(PARAMS_ALLREDUCE, MPIR_Request ** request);
-int MPIR_Iallreduce_impl(PARAMS_ALLREDUCE, MPIR_Request ** request);
-int MPIR_Iallreduce_intra_recexch_single_buffer(PARAMS_ALLREDUCE, MPIR_Request ** request);
-int MPIR_Iallreduce_intra_recexch_multiple_buffer(PARAMS_ALLREDUCE, MPIR_Request ** request);
-int MPIR_Iallreduce_intra_tree(PARAMS_ALLREDUCE, MPIR_Request ** request);
-int MPIR_Iallreduce_intra_ring(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce(PARAMS_ALLREDUCE, _req);
+int MPIR_Iallreduce_impl(PARAMS_ALLREDUCE, _req);
+int MPIR_Iallreduce_intra_recexch_single_buffer(PARAMS_ALLREDUCE, _req);
+int MPIR_Iallreduce_intra_recexch_multiple_buffer(PARAMS_ALLREDUCE, _req);
+int MPIR_Iallreduce_intra_tree(PARAMS_ALLREDUCE, _req);
+int MPIR_Iallreduce_intra_ring(PARAMS_ALLREDUCE, _req);
 
-int MPIR_Iallreduce_sched(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_impl(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_auto(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_naive(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_recursive_doubling(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_smp(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_inter_auto(PARAMS_ALLREDUCE, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_impl(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_intra_auto(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_intra_naive(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_intra_recursive_doubling(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_intra_smp(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_inter_auto(PARAMS_ALLREDUCE, _sched);
+int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(PARAMS_ALLREDUCE, _sched);
 
 /********** Reduce_scatter **********/
 #define PARAMS_REDUCE_SCATTER \
     const void *sendbuf, void *recvbuf, const int *recvcnts, MPI_Datatype datatype, MPI_Op op, \
     MPIR_Comm *comm_ptr
-int MPIR_Reduce_scatter(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_impl(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_auto(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_noncommutative(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_pairwise(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_recursive_halving(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_inter_auto(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_allcomm_nb(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_impl(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_intra_auto(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_intra_noncommutative(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_intra_pairwise(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_intra_recursive_halving(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_inter_auto(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER, _err);
+int MPIR_Reduce_scatter_allcomm_nb(PARAMS_REDUCE_SCATTER, _err);
 
 /********** Ireduce_scatter **********/
-int MPIR_Ireduce_scatter(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
-int MPIR_Ireduce_scatter_impl(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
-int MPIR_Ireduce_scatter_intra_recexch(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
+int MPIR_Ireduce_scatter(PARAMS_REDUCE_SCATTER, _req);
+int MPIR_Ireduce_scatter_impl(PARAMS_REDUCE_SCATTER, _req);
+int MPIR_Ireduce_scatter_intra_recexch(PARAMS_REDUCE_SCATTER, _req);
 
-int MPIR_Ireduce_scatter_sched(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_impl(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_auto(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_pairwise(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_inter_auto(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_impl(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_intra_auto(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_intra_pairwise(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_inter_auto(PARAMS_REDUCE_SCATTER, _sched);
+int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER, _sched);
 
 /********** Reduce_scatter_block **********/
 #define PARAMS_REDUCE_SCATTER_BLOCK \
     const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
     MPIR_Comm *comm_ptr
-int MPIR_Reduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_allcomm_nb(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER_BLOCK, _err);
+int MPIR_Reduce_scatter_block_allcomm_nb(PARAMS_REDUCE_SCATTER_BLOCK, _err);
 
 /********** Ireduce_scatter_block **********/
-int MPIR_Ireduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
-int MPIR_Ireduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
-int MPIR_Ireduce_scatter_block_intra_recexch(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
+int MPIR_Ireduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, _req);
+int MPIR_Ireduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, _req);
+int MPIR_Ireduce_scatter_block_intra_recexch(PARAMS_REDUCE_SCATTER_BLOCK, _req);
 
-int MPIR_Ireduce_scatter_block_sched(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_impl(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
+int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER_BLOCK, _sched);
 
 /********** Scan **********/
 #define PARAMS_SCAN \
     const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
     MPIR_Comm *comm_ptr
-int MPIR_Scan(PARAMS_SCAN, MPIR_Errflag_t * errflag);
-int MPIR_Scan_impl(PARAMS_SCAN, MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_auto(PARAMS_SCAN, MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_recursive_doubling(PARAMS_SCAN, MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_smp(PARAMS_SCAN, MPIR_Errflag_t * errflag);
-int MPIR_Scan_allcomm_nb(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan(PARAMS_SCAN, _err);
+int MPIR_Scan_impl(PARAMS_SCAN, _err);
+int MPIR_Scan_intra_auto(PARAMS_SCAN, _err);
+int MPIR_Scan_intra_recursive_doubling(PARAMS_SCAN, _err);
+int MPIR_Scan_intra_smp(PARAMS_SCAN, _err);
+int MPIR_Scan_allcomm_nb(PARAMS_SCAN, _err);
 
 /********** Iscan **********/
-int MPIR_Iscan(PARAMS_SCAN, MPIR_Request ** request);
-int MPIR_Iscan_impl(PARAMS_SCAN, MPIR_Request ** request);
-int MPIR_Iscan_intra_gentran_recursive_doubling(PARAMS_SCAN, MPIR_Request ** request);
+int MPIR_Iscan(PARAMS_SCAN, _req);
+int MPIR_Iscan_impl(PARAMS_SCAN, _req);
+int MPIR_Iscan_intra_gentran_recursive_doubling(PARAMS_SCAN, _req);
 
-int MPIR_Iscan_sched(PARAMS_SCAN, MPIR_Sched_t s);
-int MPIR_Iscan_sched_impl(PARAMS_SCAN, MPIR_Sched_t s);
-int MPIR_Iscan_sched_intra_auto(PARAMS_SCAN, MPIR_Sched_t s);
-int MPIR_Iscan_sched_intra_recursive_doubling(PARAMS_SCAN, MPIR_Sched_t s);
-int MPIR_Iscan_sched_intra_smp(PARAMS_SCAN, MPIR_Sched_t s);
+int MPIR_Iscan_sched(PARAMS_SCAN, _sched);
+int MPIR_Iscan_sched_impl(PARAMS_SCAN, _sched);
+int MPIR_Iscan_sched_intra_auto(PARAMS_SCAN, _sched);
+int MPIR_Iscan_sched_intra_recursive_doubling(PARAMS_SCAN, _sched);
+int MPIR_Iscan_sched_intra_smp(PARAMS_SCAN, _sched);
 
 /********** Exscan **********/
 #define PARAMS_EXSCAN \
     const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
     MPIR_Comm *comm_ptr
-int MPIR_Exscan(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_impl(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_intra_auto(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_intra_recursive_doubling(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_allcomm_nb(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+int MPIR_Exscan(PARAMS_EXSCAN, _err);
+int MPIR_Exscan_impl(PARAMS_EXSCAN, _err);
+int MPIR_Exscan_intra_auto(PARAMS_EXSCAN, _err);
+int MPIR_Exscan_intra_recursive_doubling(PARAMS_EXSCAN, _err);
+int MPIR_Exscan_allcomm_nb(PARAMS_EXSCAN, _err);
 
 /********** Iexscan **********/
-int MPIR_Iexscan(PARAMS_EXSCAN, MPIR_Request ** request);
-int MPIR_Iexscan_impl(PARAMS_EXSCAN, MPIR_Request ** request);
+int MPIR_Iexscan(PARAMS_EXSCAN, _req);
+int MPIR_Iexscan_impl(PARAMS_EXSCAN, _req);
 
-int MPIR_Iexscan_sched(PARAMS_EXSCAN, MPIR_Sched_t s);
-int MPIR_Iexscan_sched_impl(PARAMS_EXSCAN, MPIR_Sched_t s);
-int MPIR_Iexscan_sched_intra_auto(PARAMS_EXSCAN, MPIR_Sched_t s);
-int MPIR_Iexscan_sched_intra_recursive_doubling(PARAMS_EXSCAN, MPIR_Sched_t s);
+int MPIR_Iexscan_sched(PARAMS_EXSCAN, _sched);
+int MPIR_Iexscan_sched_impl(PARAMS_EXSCAN, _sched);
+int MPIR_Iexscan_sched_intra_auto(PARAMS_EXSCAN, _sched);
+int MPIR_Iexscan_sched_intra_recursive_doubling(PARAMS_EXSCAN, _sched);
 
 /********** Neighbor_allgather **********/
 int MPIR_Neighbor_allgather(PARAMS_ALLGATHER);
@@ -514,15 +519,15 @@ int MPIR_Neighbor_allgather_intra_auto(PARAMS_ALLGATHER);
 int MPIR_Neighbor_allgather_inter_auto(PARAMS_ALLGATHER);
 int MPIR_Neighbor_allgather_allcomm_nb(PARAMS_ALLGATHER);
 
-int MPIR_Ineighbor_allgather(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_impl(PARAMS_ALLGATHER, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_allcomm_gentran_linear(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Ineighbor_allgather(PARAMS_ALLGATHER, _req);
+int MPIR_Ineighbor_allgather_impl(PARAMS_ALLGATHER, _req);
+int MPIR_Ineighbor_allgather_allcomm_gentran_linear(PARAMS_ALLGATHER, _req);
 
-int MPIR_Ineighbor_allgather_sched(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgather_sched_impl(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgather_sched_intra_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgather_sched_inter_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgather_sched_allcomm_linear(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched(PARAMS_ALLGATHER, _sched);
+int MPIR_Ineighbor_allgather_sched_impl(PARAMS_ALLGATHER, _sched);
+int MPIR_Ineighbor_allgather_sched_intra_auto(PARAMS_ALLGATHER, _sched);
+int MPIR_Ineighbor_allgather_sched_inter_auto(PARAMS_ALLGATHER, _sched);
+int MPIR_Ineighbor_allgather_sched_allcomm_linear(PARAMS_ALLGATHER, _sched);
 
 /********** Neighbor_allgatherv **********/
 int MPIR_Neighbor_allgatherv(PARAMS_ALLGATHERV);
@@ -531,15 +536,15 @@ int MPIR_Neighbor_allgatherv_intra_auto(PARAMS_ALLGATHERV);
 int MPIR_Neighbor_allgatherv_inter_auto(PARAMS_ALLGATHERV);
 int MPIR_Neighbor_allgatherv_allcomm_nb(PARAMS_ALLGATHERV);
 
-int MPIR_Ineighbor_allgatherv(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_impl(PARAMS_ALLGATHERV, MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Ineighbor_allgatherv(PARAMS_ALLGATHERV, _req);
+int MPIR_Ineighbor_allgatherv_impl(PARAMS_ALLGATHERV, _req);
+int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(PARAMS_ALLGATHERV, _req);
 
-int MPIR_Ineighbor_allgatherv_sched(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgatherv_sched_impl(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgatherv_sched_intra_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgatherv_sched_inter_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched(PARAMS_ALLGATHERV, _sched);
+int MPIR_Ineighbor_allgatherv_sched_impl(PARAMS_ALLGATHERV, _sched);
+int MPIR_Ineighbor_allgatherv_sched_intra_auto(PARAMS_ALLGATHERV, _sched);
+int MPIR_Ineighbor_allgatherv_sched_inter_auto(PARAMS_ALLGATHERV, _sched);
+int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(PARAMS_ALLGATHERV, _sched);
 
 /********** Neighbor_alltoall **********/
 int MPIR_Neighbor_alltoall(PARAMS_ALLTOALL);
@@ -548,15 +553,15 @@ int MPIR_Neighbor_alltoall_intra_auto(PARAMS_ALLTOALL);
 int MPIR_Neighbor_alltoall_inter_auto(PARAMS_ALLTOALL);
 int MPIR_Neighbor_alltoall_allcomm_nb(PARAMS_ALLTOALL);
 
-int MPIR_Ineighbor_alltoall(PARAMS_ALLTOALL, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_impl(PARAMS_ALLTOALL, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoall(PARAMS_ALLTOALL, _req);
+int MPIR_Ineighbor_alltoall_impl(PARAMS_ALLTOALL, _req);
+int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(PARAMS_ALLTOALL, _req);
 
-int MPIR_Ineighbor_alltoall_sched(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoall_sched_impl(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoall_sched_intra_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoall_sched_inter_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoall_sched_allcomm_linear(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched(PARAMS_ALLTOALL, _sched);
+int MPIR_Ineighbor_alltoall_sched_impl(PARAMS_ALLTOALL, _sched);
+int MPIR_Ineighbor_alltoall_sched_intra_auto(PARAMS_ALLTOALL, _sched);
+int MPIR_Ineighbor_alltoall_sched_inter_auto(PARAMS_ALLTOALL, _sched);
+int MPIR_Ineighbor_alltoall_sched_allcomm_linear(PARAMS_ALLTOALL, _sched);
 
 /********** Neighbor_alltoallv **********/
 int MPIR_Neighbor_alltoallv(PARAMS_ALLTOALLV);
@@ -565,15 +570,15 @@ int MPIR_Neighbor_alltoallv_intra_auto(PARAMS_ALLTOALLV);
 int MPIR_Neighbor_alltoallv_inter_auto(PARAMS_ALLTOALLV);
 int MPIR_Neighbor_alltoallv_allcomm_nb(PARAMS_ALLTOALLV);
 
-int MPIR_Ineighbor_alltoallv(PARAMS_ALLTOALLV, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_impl(PARAMS_ALLTOALLV, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallv(PARAMS_ALLTOALLV, _req);
+int MPIR_Ineighbor_alltoallv_impl(PARAMS_ALLTOALLV, _req);
+int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(PARAMS_ALLTOALLV, _req);
 
-int MPIR_Ineighbor_alltoallv_sched(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallv_sched_impl(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallv_sched_intra_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallv_sched_inter_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ineighbor_alltoallv_sched_impl(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ineighbor_alltoallv_sched_intra_auto(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ineighbor_alltoallv_sched_inter_auto(PARAMS_ALLTOALLV, _sched);
+int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(PARAMS_ALLTOALLV, _sched);
 
 /********** Neighbor_alltoallw **********/
 #define PARAMS_NEIGHBOR_ALLTOALLW \
@@ -586,16 +591,20 @@ int MPIR_Neighbor_alltoallw_intra_auto(PARAMS_NEIGHBOR_ALLTOALLW);
 int MPIR_Neighbor_alltoallw_inter_auto(PARAMS_NEIGHBOR_ALLTOALLW);
 int MPIR_Neighbor_alltoallw_allcomm_nb(PARAMS_NEIGHBOR_ALLTOALLW);
 
-int MPIR_Ineighbor_alltoallw(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_impl(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallw(PARAMS_NEIGHBOR_ALLTOALLW, _req);
+int MPIR_Ineighbor_alltoallw_impl(PARAMS_NEIGHBOR_ALLTOALLW, _req);
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(PARAMS_NEIGHBOR_ALLTOALLW, _req);
 
-int MPIR_Ineighbor_alltoallw_sched(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallw_sched_impl(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallw_sched_intra_auto(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallw_sched_inter_auto(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched(PARAMS_NEIGHBOR_ALLTOALLW, _sched);
+int MPIR_Ineighbor_alltoallw_sched_impl(PARAMS_NEIGHBOR_ALLTOALLW, _sched);
+int MPIR_Ineighbor_alltoallw_sched_intra_auto(PARAMS_NEIGHBOR_ALLTOALLW, _sched);
+int MPIR_Ineighbor_alltoallw_sched_inter_auto(PARAMS_NEIGHBOR_ALLTOALLW, _sched);
+int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(PARAMS_NEIGHBOR_ALLTOALLW, _sched);
 
+/* undef temporary macros */
+#undef _err
+#undef _req
+#undef _sched
 
 /******************************** Reduce_local ********************************/
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -41,1679 +41,565 @@ int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[],
                  MPIR_Errflag_t * errflag);
 
-
-/******************************** Allgather ********************************/
-int MPIR_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag);
-int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Allgather_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf, int sendcount,
-                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                            MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t * errflag);
-int MPIR_Allgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Allgather_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Allgatherv ********************************/
-int MPIR_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Allgatherv_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_pt,
-                               MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, const int *recvcounts, const int *displs,
-                                 MPI_Datatype recvtype, MPIR_Comm * comm_pt,
-                                 MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf,
-                                             const int *recvcounts, const int *displs,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm_pt,
-                                             MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_pt,
-                               MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Allgatherv_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Errflag_t * errflag);
-int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, const int *recvcounts, const int *displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Errflag_t * errflag);
-
-
-/******************************** Allreduce ********************************/
-int MPIR_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                        MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Allreduce_intra_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Allreduce_inter_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, int count,
-                                               MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Alltoall ********************************/
-int MPIR_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                  MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                       MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Alltoall_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_intra_scattered(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Alltoall_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Alltoallv ********************************/
-int MPIR_Alltoallv(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                   MPI_Datatype sendtype, void *recvbuf, const int *recvcnts, const int *rdispls,
-                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_impl(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                        MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
-                        const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Alltoallv_intra_auto(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const int *sendcnts,
-                                                   const int *sdispls, MPI_Datatype sendtype,
-                                                   void *recvbuf, const int *recvcnts,
-                                                   const int *rdispls, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                                   MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
-                                   const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Alltoallv_inter_auto(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag);
-int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendcnts,
-                                           const int *sdispls, MPI_Datatype sendtype, void *recvbuf,
-                                           const int *recvcnts, const int *rdispls,
-                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                           MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              MPI_Datatype sendtype, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag);
-
-
-/******************************** Alltoallw ********************************/
-int MPIR_Alltoallw(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                   const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                   const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_impl(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                        const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                        const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Alltoallw_intra_auto(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, const MPI_Datatype * recvtypes,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const int *sendcnts,
-                                                   const int *sdispls,
-                                                   const MPI_Datatype * sendtypes, void *recvbuf,
-                                                   const int *recvcnts, const int *rdispls,
-                                                   const MPI_Datatype * recvtypes,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                                   const MPI_Datatype * sendtypes, void *recvbuf,
-                                   const int *recvcnts, const int *rdispls,
-                                   const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Alltoallw_inter_auto(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, const MPI_Datatype * recvtypes,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const int *sendcnts,
-                                           const int *sdispls, const MPI_Datatype * sendtypes,
-                                           void *recvbuf, const int *recvcnts, const int *rdispls,
-                                           const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                           MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *sdispls,
-                              const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcnts,
-                              const int *rdispls, const MPI_Datatype * recvtypes,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Barrier ********************************/
-int MPIR_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_impl(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Barrier_intra_auto(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Barrier_inter_auto(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Bcast ********************************/
-int MPIR_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-               MPIR_Errflag_t * errflag);
-int MPIR_Bcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Bcast_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
-                                                          MPI_Datatype datatype, int root,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t * errflag);
-int MPIR_Bcast_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                         MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Bcast_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer, int count, MPI_Datatype datatype,
-                                             int root, MPIR_Comm * comm_ptr,
-                                             MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Bcast_allcomm_nb(void *buffer, int count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Exscan ********************************/
-int MPIR_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Exscan_intra_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Gather ********************************/
-int MPIR_Gather(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gather_impl(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                     int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                     MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Gather_intra_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag);
-int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcnt, MPI_Datatype recvtype, int root,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Gather_inter_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_linear(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                             int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
-int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcnt,
-                                               MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                                               MPI_Datatype recvtype, int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Gather_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t * errflag);
-
-
-/******************************** Gatherv ********************************/
-int MPIR_Gatherv(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                 const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_impl(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                      const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Gatherv_intra_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Gatherv_inter_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Gatherv_allcomm_linear(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
-                                void *recvbuf, const int *recvcnts, const int *displs,
-                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                MPIR_Errflag_t * errflag);
-int MPIR_Gatherv_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            const int *recvcnts, const int *displs, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Iallgather ********************************/
-/* request-based functions */
-int MPIR_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                    int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                    MPIR_Request ** request);
-int MPIR_Iallgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
-int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                          int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
-int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_intra_recexch_distance_doubling(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Request ** req);
-int MPIR_Iallgather_intra_recexch_distance_halving(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Request ** req);
-int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, int sendcount,
-                                       MPI_Datatype sendtype, void *recvbuf,
-                                       int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm, MPIR_Request ** req);
-/* sched-based intercomm-only functions */
-int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
-                                                          MPI_Datatype sendtype, void *recvbuf,
-                                                          int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Iallgatherv ********************************/
-/* request-based functions */
-int MPIR_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                     const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                     MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                          const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                          MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                          void *recvbuf, const int recvcounts[], const int displs[],
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                           const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, const int *recvcounts, const int *displs,
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int recvcounts[], const int displs[],
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_intra_recexch_distance_doubling(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     const int *recvcounts, const int *displs,
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Request ** req);
-int MPIR_Iallgatherv_intra_recexch_distance_halving(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    const int *recvcounts, const int *displs,
-                                                    MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                    MPIR_Request ** req);
-int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount,
-                                        MPI_Datatype sendtype, void *recvbuf,
-                                        const int *recvcounts, const int *displs,
-                                        MPI_Datatype recvtype, MPIR_Comm * comm,
-                                        MPIR_Request ** req);
-
-/* sched-based intercomm-only functions */
-int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
-                                                           MPI_Datatype sendtype, void *recvbuf,
-                                                           const int *recvcounts, const int *displs,
-                                                           MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Iallreduce ********************************/
-/* request-based functions */
-int MPIR_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
-                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int count,
-                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
-                                                         int count, MPI_Datatype datatype,
-                                                         MPI_Op op, MPIR_Comm * comm_ptr,
-                                                         MPIR_Sched_t s);
-int MPIR_Iallreduce_intra_recexch_single_buffer(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm, MPIR_Request ** req);
-int MPIR_Iallreduce_intra_recexch_multiple_buffer(const void *sendbuf, void *recvbuf, int count,
-                                                  MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Request ** req);
-int MPIR_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
-                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Request ** request);
-int MPIR_Iallreduce_intra_ring(const void *sendbuf, void *recvbuf, int count,
-                               MPI_Datatype datatype, MPI_Op op,
-                               MPIR_Comm * comm, MPIR_Request ** req);
-int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
-                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
-                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
-                                                          int count, MPI_Datatype datatype,
-                                                          MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
-
-
-/******************************** Ialltoall ********************************/
-/* request-based functions */
-int MPIR_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                   int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                   MPIR_Request ** request);
-int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                        MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ialltoallv ********************************/
-/* request-based functions */
-int MPIR_Ialltoallv(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                    MPI_Datatype sendtype, void *recvbuf, const int *recvcounts, const int *rdispls,
-                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ialltoallv_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                         MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                         const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ialltoallv_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                          MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                          const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                               MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                               const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                     const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendcnts[],
-                                            const int sdispls[], MPI_Datatype sendtype,
-                                            void *recvbuf, const int recvcnts[],
-                                            const int rdispls[], MPI_Datatype recvtype,
-                                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
-                                     const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ialltoallw ********************************/
-/* request-based functions */
-int MPIR_Ialltoallw(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                    const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                    const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                    MPIR_Request ** request);
-int MPIR_Ialltoallw_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                         const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                         const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ialltoallw_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                          const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                          const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                               const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
-                               const int *rdispls, const MPI_Datatype * recvtypes,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ialltoallw_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     const MPI_Datatype * sendtypes, void *recvbuf,
-                                     const int *recvcounts, const int *rdispls,
-                                     const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[], const int rdispls[],
-                                        const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
-                                     const MPI_Datatype * sendtypes, void *recvbuf,
-                                     const int *recvcounts, const int *rdispls,
-                                     const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[],
-                                                  const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const int rdispls[],
-                                                  const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ibarrier ********************************/
-/* request-based functions */
-int MPIR_Ibarrier(MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_intra_recexch(MPIR_Comm * comm, MPIR_Request ** req);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ibcast ********************************/
-/* request-based functions */
-int MPIR_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                MPIR_Request ** request);
-int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr,
-                     MPIR_Request ** request);
-int MPIR_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ibcast_intra_scatter_recexch_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Request ** request);
-int MPIR_Ibcast_intra_ring(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
-                                                                 MPI_Datatype datatype, int root,
-                                                                 MPIR_Comm * comm_ptr,
-                                                                 MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Iexscan ********************************/
-/* request-based functions */
-int MPIR_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iexscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
-                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
-int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Igather ********************************/
-/* request-based functions */
-int MPIR_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                 int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                 MPIR_Request ** request);
-int MPIR_Igather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                      MPIR_Request ** request);
-int MPIR_Igather_intra_tree(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                       MPIR_Sched_t s);
-int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Igatherv ********************************/
-/* request-based functions */
-int MPIR_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                       MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, const int *recvcounts, const int *displs,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                       MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s);
-
-
-/******************************** Ineighbor_allgather ********************************/
-/* request-based functions */
-int MPIR_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, int sendcount,
-                                                    MPI_Datatype sendtype, void *recvbuf,
-                                                    int recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ineighbor_allgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount,
-                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
-                                                  MPI_Datatype sendtype, void *recvbuf,
-                                                  int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ineighbor_allgatherv ********************************/
-/* request-based functions */
-int MPIR_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                              void *recvbuf, const int recvcounts[], const int displs[],
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, const int recvcounts[], const int displs[],
-                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Request ** request);
-int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, int sendcount,
-                                                     MPI_Datatype sendtype, void *recvbuf,
-                                                     const int recvcounts[], const int displs[],
-                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                    void *recvbuf, const int recvcounts[], const int displs[],
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                         void *recvbuf, const int recvcounts[], const int displs[],
-                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                         MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcount,
-                                               MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
-                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcount,
-                                               MPI_Datatype sendtype, void *recvbuf,
-                                               const int recvcounts[], const int displs[],
-                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   const int recvcounts[], const int displs[],
-                                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s);
-
-
-/******************************** Ineighbor_alltoall ********************************/
-/* request-based functions */
-int MPIR_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, int sendcount,
-                                                   MPI_Datatype sendtype, void *recvbuf,
-                                                   int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
-                                             MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
-                                                 MPI_Datatype sendtype, void *recvbuf,
-                                                 int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ineighbor_alltoallv ********************************/
-/* request-based functions */
-int MPIR_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                             MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                             const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                             MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                  MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                  const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
-                                                    const int sdispls[], MPI_Datatype sendtype,
-                                                    void *recvbuf, const int recvcounts[],
-                                                    const int rdispls[], MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ineighbor_alltoallv_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                   MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                   const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcounts[],
-                                        const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                        const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
-                                              const int sdispls[], MPI_Datatype sendtype,
-                                              void *recvbuf, const int recvcounts[],
-                                              const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                  const int sdispls[], MPI_Datatype sendtype,
-                                                  void *recvbuf, const int recvcounts[],
-                                                  const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ineighbor_alltoallw ********************************/
-/* request-based functions */
-int MPIR_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[],
-                             const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                             const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
-                                  const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                  void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                  MPIR_Request ** request);
-int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(const void *sendbuf, const int sendcounts[],
-                                                    const MPI_Aint sdispls[],
-                                                    const MPI_Datatype sendtypes[], void *recvbuf,
-                                                    const int recvcounts[],
-                                                    const MPI_Aint rdispls[],
-                                                    const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],
-                                   const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                   void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                                   const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
-int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcounts[],
-                                        const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                        void *recvbuf, const int recvcounts[],
-                                        const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sendcounts[],
-                                              const MPI_Aint sdispls[],
-                                              const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
-                                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[],
-                                              const MPI_Aint sdispls[],
-                                              const MPI_Datatype sendtypes[], void *recvbuf,
-                                              const int recvcounts[], const MPI_Aint rdispls[],
-                                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
-                                                  const MPI_Aint sdispls[],
-                                                  const MPI_Datatype sendtypes[], void *recvbuf,
-                                                  const int recvcounts[], const MPI_Aint rdispls[],
-                                                  const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ireduce ********************************/
-/* request-based functions */
-int MPIR_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                      MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
-                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Request ** request);
-int MPIR_Ireduce_intra_ring(const void *sendbuf, void *recvbuf, int count,
-                            MPI_Datatype datatype, MPI_Op op, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
-                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int count,
-                                      MPI_Datatype datatype, MPI_Op op, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
-                                                   MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
-                                 MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
-                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
-int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
-                                                      MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Ireduce_scatter ********************************/
-/* request-based functions */
-int MPIR_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Request ** request);
-int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
-                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                                    const int *recvcnts, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
-                                              const int *recvcnts, MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                        const int *recvcnts, MPI_Datatype datatype,
-                                                        MPI_Op op, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                       const int *recvcnts, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
-                                       const int *recvcounts, MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
-                                                                  void *recvbuf,
-                                                                  const int *recvcnts,
-                                                                  MPI_Datatype datatype, MPI_Op op,
-                                                                  MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s);
-
-
-/******************************** Ireduce_scatter_block ********************************/
-/* request-based functions */
-int MPIR_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
-                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Request ** request);
-int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf, int recvcount,
-                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Request ** request);
-int MPIR_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf,
-                                             int recvcount, MPI_Datatype datatype,
-                                             MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req);
-
-/* sched-based functions */
-int MPIR_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
-                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, int recvcount,
-                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                                          int recvcount, MPI_Datatype datatype,
-                                                          MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
-                                                    int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                              int recvcount, MPI_Datatype datatype,
-                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                             int recvcount, MPI_Datatype datatype,
-                                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
-                                                                        void *recvbuf,
-                                                                        int recvcount,
-                                                                        MPI_Datatype datatype,
-                                                                        MPI_Op op,
-                                                                        MPIR_Comm * comm_ptr,
-                                                                        MPIR_Sched_t s);
-
-
-/******************************** Iscan ********************************/
-/* request-based functions */
-int MPIR_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
-                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s);
-int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                              MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                                MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Request ** req);
-
-
-/******************************** Iscatter ********************************/
-/* request-based functions */
-int MPIR_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                  int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                  MPIR_Request ** request);
-int MPIR_Iscatter_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                       int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                       MPIR_Request ** request);
-int MPIR_Iscatter_intra_tree(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                        int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                        MPIR_Sched_t s);
-int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                     void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int sendcount,
-                                                        MPI_Datatype sendtype, void *recvbuf,
-                                                        int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
-
-
-/******************************** Iscatterv ********************************/
-/* request-based functions */
-int MPIR_Iscatterv(const void *sendbuf, const int *sendcounts, const int *displs,
-                   MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                   int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIR_Iscatterv_impl(const void *sendbuf, const int *sendcounts, const int *displs,
-                        MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                        int root, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-
-/* sched-based functions */
-int MPIR_Iscatterv_sched(const void *sendbuf, const int *sendcounts, const int *displs,
-                         MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int *sendcounts, const int *displs,
-                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                              MPIR_Sched_t s);
-
-/* sched-based intracomm-only functions */
-int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
-
-/* sched-based intercomm-only functions */
-int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *displs,
-                                    MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
-
-/* sched-based anycomm functions */
-int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int *sendcounts,
-                                        const int *displs, MPI_Datatype sendtype, void *recvbuf,
-                                        int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-
-
-/******************************** Neighbor_allgather ********************************/
-int MPIR_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                            void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr);
-
-/* intracomm-only functions */
-int MPIR_Neighbor_allgather_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr);
-
-/* intercomm-only functions */
-int MPIR_Neighbor_allgather_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr);
-
-/* anycomm functions */
-int MPIR_Neighbor_allgather_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr);
-
-
-/******************************** Neighbor_allgatherv ********************************/
-int MPIR_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                             void *recvbuf, const int recvcounts[], const int displs[],
-                             MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_allgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                  void *recvbuf, const int recvcounts[], const int displs[],
-                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* intracomm-only functions */
-int MPIR_Neighbor_allgatherv_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* intercomm-only functions */
-int MPIR_Neighbor_allgatherv_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* anycomm functions */
-int MPIR_Neighbor_allgatherv_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                        void *recvbuf, const int recvcounts[], const int displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-
-/******************************** Neighbor_alltoall ********************************/
-int MPIR_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoall_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm_ptr);
-
-/* intracomm-only functions */
-int MPIR_Neighbor_alltoall_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr);
-
-/* intercomm-only functions */
-int MPIR_Neighbor_alltoall_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr);
-
-/* anycomm functions */
-int MPIR_Neighbor_alltoall_allcomm_nb(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr);
-
-
-/******************************** Neighbor_alltoallv ********************************/
-int MPIR_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                            MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                            const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
-                                 MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
-                                 const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* intracomm-only functions */
-int MPIR_Neighbor_alltoallv_intra_auto(const void *sendbuf, const int sendcounts[],
-                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                       const int recvcounts[], const int rdispls[],
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* intercomm-only functions */
-int MPIR_Neighbor_alltoallv_inter_auto(const void *sendbuf, const int sendcounts[],
-                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                       const int recvcounts[], const int rdispls[],
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-/* anycomm functions */
-int MPIR_Neighbor_alltoallv_allcomm_nb(const void *sendbuf, const int sendcounts[],
-                                       const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
-                                       const int recvcounts[], const int rdispls[],
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr);
-
-
-/******************************** Neighbor_alltoallw ********************************/
-int MPIR_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[],
-                            const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
-                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                            MPIR_Comm * comm_ptr);
-int MPIR_Neighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
-                                 const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                 void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
-                                 const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr);
-
-/* intracomm-only functions */
-int MPIR_Neighbor_alltoallw_intra_auto(const void *sendbuf, const int sendcounts[],
-                                       const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                       void *recvbuf, const int recvcounts[],
-                                       const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                       MPIR_Comm * comm_ptr);
-
-/* intercomm-only functions */
-int MPIR_Neighbor_alltoallw_inter_auto(const void *sendbuf, const int sendcounts[],
-                                       const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                       void *recvbuf, const int recvcounts[],
-                                       const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                       MPIR_Comm * comm_ptr);
-
-/* anycomm functions */
-int MPIR_Neighbor_alltoallw_allcomm_nb(const void *sendbuf, const int sendcounts[],
-                                       const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
-                                       void *recvbuf, const int recvcounts[],
-                                       const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                       MPIR_Comm * comm_ptr);
-
-
-/******************************** Reduce ********************************/
-int MPIR_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Reduce_intra_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_binomial(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
-                                            MPI_Datatype datatype, MPI_Op op, int root,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Reduce_inter_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
-                                               MPI_Datatype datatype, MPI_Op op, int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                           MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
+/********** Barrier **********/
+#define PARAMS_BARRIER \
+    MPIR_Comm *comm_ptr
+int MPIR_Barrier(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_impl(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_intra_auto(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_intra_dissemination(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_intra_smp(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_inter_auto(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_inter_bcast(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+int MPIR_Barrier_allcomm_nb(PARAMS_BARRIER, MPIR_Errflag_t * errflag);
+
+/********** Ibarrier **********/
+int MPIR_Ibarrier(PARAMS_BARRIER, MPIR_Request ** request);
+int MPIR_Ibarrier_impl(PARAMS_BARRIER, MPIR_Request ** request);
+int MPIR_Ibarrier_intra_recexch(PARAMS_BARRIER, MPIR_Request ** request);
+
+int MPIR_Ibarrier_sched(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_impl(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_intra_auto(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_intra_recursive_doubling(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_inter_auto(PARAMS_BARRIER, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_inter_bcast(PARAMS_BARRIER, MPIR_Sched_t s);
+
+/********** Bcast **********/
+#define PARAMS_BCAST \
+    void *buffer, int count, MPI_Datatype datatype, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Bcast(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_impl(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_intra_auto(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_intra_binomial(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_intra_scatter_ring_allgather(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_intra_smp(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_inter_auto(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_inter_remote_send_local_bcast(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+int MPIR_Bcast_allcomm_nb(PARAMS_BCAST, MPIR_Errflag_t * errflag);
+
+/********** Ibcast **********/
+int MPIR_Ibcast(PARAMS_BCAST, MPIR_Request ** request);
+int MPIR_Ibcast_impl(PARAMS_BCAST, MPIR_Request ** request);
+int MPIR_Ibcast_intra_tree(PARAMS_BCAST, MPIR_Request ** request);
+int MPIR_Ibcast_intra_scatter_recexch_allgather(PARAMS_BCAST, MPIR_Request ** request);
+int MPIR_Ibcast_intra_ring(PARAMS_BCAST, MPIR_Request ** request);
+
+int MPIR_Ibcast_sched(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_impl(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_intra_auto(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_intra_binomial(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_intra_scatter_ring_allgather(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_intra_smp(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_inter_auto(PARAMS_BCAST, MPIR_Sched_t s);
+int MPIR_Ibcast_sched_inter_flat(PARAMS_BCAST, MPIR_Sched_t s);
+
+/********** Gather **********/
+#define PARAMS_GATHER \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Gather(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_impl(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_intra_auto(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_intra_binomial(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_inter_auto(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_inter_linear(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_inter_local_gather_remote_send(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+int MPIR_Gather_allcomm_nb(PARAMS_GATHER, MPIR_Errflag_t * errflag);
+
+/********** Igather **********/
+int MPIR_Igather(PARAMS_GATHER, MPIR_Request ** request);
+int MPIR_Igather_impl(PARAMS_GATHER, MPIR_Request ** request);
+int MPIR_Igather_intra_tree(PARAMS_GATHER, MPIR_Request ** request);
+
+int MPIR_Igather_sched(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_impl(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_intra_auto(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_intra_binomial(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_inter_auto(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_inter_long(PARAMS_GATHER, MPIR_Sched_t s);
+int MPIR_Igather_sched_inter_short(PARAMS_GATHER, MPIR_Sched_t s);
+
+/********** Gatherv **********/
+#define PARAMS_GATHERV \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Gatherv(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_impl(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_intra_auto(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_inter_auto(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_allcomm_linear(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Gatherv_allcomm_nb(PARAMS_GATHERV, MPIR_Errflag_t * errflag);
+
+/********** Igatherv **********/
+int MPIR_Igatherv(PARAMS_GATHERV, MPIR_Request ** request);
+int MPIR_Igatherv_impl(PARAMS_GATHERV, MPIR_Request ** request);
+
+int MPIR_Igatherv_sched(PARAMS_GATHERV, MPIR_Sched_t s);
+int MPIR_Igatherv_sched_impl(PARAMS_GATHERV, MPIR_Sched_t s);
+int MPIR_Igatherv_sched_intra_auto(PARAMS_GATHERV, MPIR_Sched_t s);
+int MPIR_Igatherv_sched_inter_auto(PARAMS_GATHERV, MPIR_Sched_t s);
+int MPIR_Igatherv_sched_allcomm_linear(PARAMS_GATHERV, MPIR_Sched_t s);
+
+/********** Scatter **********/
+#define PARAMS_SCATTER \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Scatter(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_impl(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_intra_auto(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_intra_binomial(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_inter_auto(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_inter_linear(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_inter_remote_send_local_scatter(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Scatter_allcomm_nb(PARAMS_SCATTER, MPIR_Errflag_t * errflag);
+
+/********** Iscatter **********/
+int MPIR_Iscatter(PARAMS_SCATTER, MPIR_Request ** request);
+int MPIR_Iscatter_impl(PARAMS_SCATTER, MPIR_Request ** request);
+int MPIR_Iscatter_intra_tree(PARAMS_SCATTER, MPIR_Request ** request);
+
+int MPIR_Iscatter_sched(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_impl(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_intra_auto(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_intra_binomial(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_inter_auto(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_inter_linear(PARAMS_SCATTER, MPIR_Sched_t s);
+int MPIR_Iscatter_sched_inter_remote_send_local_scatter(PARAMS_SCATTER, MPIR_Sched_t s);
+
+/********** Scatterv **********/
+#define PARAMS_SCATTERV \
+    const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype sendtype, \
+    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Scatterv(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_impl(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_intra_auto(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_inter_auto(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_linear(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+int MPIR_Scatterv_allcomm_nb(PARAMS_SCATTERV, MPIR_Errflag_t * errflag);
+
+/********** Iscatterv **********/
+int MPIR_Iscatterv(PARAMS_SCATTERV, MPIR_Request ** request);
+int MPIR_Iscatterv_impl(PARAMS_SCATTERV, MPIR_Request ** request);
+
+int MPIR_Iscatterv_sched(PARAMS_SCATTERV, MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_impl(PARAMS_SCATTERV, MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_intra_auto(PARAMS_SCATTERV, MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_inter_auto(PARAMS_SCATTERV, MPIR_Sched_t s);
+int MPIR_Iscatterv_sched_allcomm_linear(PARAMS_SCATTERV, MPIR_Sched_t s);
+
+/********** Allgather **********/
+#define PARAMS_ALLGATHER \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, int recvcount, MPI_Datatype recvtype, \
+    MPIR_Comm *comm_ptr
+int MPIR_Allgather(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_impl(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_intra_auto(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_intra_brucks(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_intra_recursive_doubling(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_intra_ring(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_inter_auto(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+int MPIR_Allgather_allcomm_nb(PARAMS_ALLGATHER, MPIR_Errflag_t * errflag);
+
+/********** Iallgather **********/
+int MPIR_Iallgather(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather_impl(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather_intra_gentran_brucks(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather_intra_recexch_distance_doubling(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather_intra_recexch_distance_halving(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Iallgather_intra_gentran_ring(PARAMS_ALLGATHER, MPIR_Request ** request);
+
+int MPIR_Iallgather_sched(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_impl(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_intra_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_intra_brucks(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_intra_recursive_doubling(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_intra_ring(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_inter_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(PARAMS_ALLGATHER, MPIR_Sched_t s);
+
+/********** Allgatherv **********/
+#define PARAMS_ALLGATHERV \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, \
+    MPIR_Comm *comm_ptr
+int MPIR_Allgatherv(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_impl(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_intra_auto(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_intra_brucks(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_intra_recursive_doubling(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_intra_ring(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_inter_auto(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+int MPIR_Allgatherv_allcomm_nb(PARAMS_ALLGATHERV, MPIR_Errflag_t * errflag);
+
+/********** Iallgatherv **********/
+int MPIR_Iallgatherv(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv_impl(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv_intra_gentran_brucks(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv_intra_recexch_distance_doubling(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv_intra_recexch_distance_halving(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Iallgatherv_intra_gentran_ring(PARAMS_ALLGATHERV, MPIR_Request ** request);
+
+int MPIR_Iallgatherv_sched(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_impl(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_intra_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_intra_brucks(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_intra_recursive_doubling(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_intra_ring(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_inter_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+
+/********** Alltoall **********/
+#define PARAMS_ALLTOALL \
+    const void *sendbuf, int sendcount, MPI_Datatype sendtype, \
+    void *recvbuf, int recvcount, MPI_Datatype recvtype, \
+    MPIR_Comm *comm_ptr
+int MPIR_Alltoall(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_impl(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_intra_auto(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_intra_brucks(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_intra_pairwise(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_intra_scattered(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_inter_auto(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_inter_pairwise_exchange(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+int MPIR_Alltoall_allcomm_nb(PARAMS_ALLTOALL, MPIR_Errflag_t * errflag);
+
+/********** Ialltoall **********/
+int MPIR_Ialltoall(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ialltoall_impl(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ialltoall_intra_gentran_ring(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ialltoall_intra_gentran_brucks(PARAMS_ALLTOALL, MPIR_Request ** request);
+
+int MPIR_Ialltoall_sched(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_impl(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_intra_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_intra_brucks(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_intra_inplace(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_intra_pairwise(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_intra_permuted_sendrecv(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_inter_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ialltoall_sched_inter_pairwise_exchange(PARAMS_ALLTOALL, MPIR_Sched_t s);
+
+/********** Alltoallv **********/
+#define PARAMS_ALLTOALLV \
+    const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype sendtype, \
+    void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype recvtype, \
+    MPIR_Comm *comm_ptr
+int MPIR_Alltoallv(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_impl(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_intra_auto(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_intra_scattered(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_inter_auto(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_inter_pairwise_exchange(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallv_allcomm_nb(PARAMS_ALLTOALLV, MPIR_Errflag_t * errflag);
+
+/********** Ialltoallv **********/
+int MPIR_Ialltoallv(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ialltoallv_impl(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ialltoallv_intra_gentran_scattered(PARAMS_ALLTOALLV, MPIR_Request ** request);
+
+int MPIR_Ialltoallv_sched(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_impl(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_intra_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_intra_blocked(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_intra_inplace(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_inter_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ialltoallv_sched_inter_pairwise_exchange(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+
+/********** Alltoallw **********/
+#define PARAMS_ALLTOALLW \
+    const void *sendbuf, const int *sendcnts, const int *sdispls, const MPI_Datatype *sendtypes, \
+    void *recvbuf, const int *recvcnts, const int *rdispls, const MPI_Datatype *recvtypes, \
+    MPIR_Comm *comm_ptr
+int MPIR_Alltoallw(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_impl(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_intra_auto(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_intra_scattered(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_inter_auto(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_inter_pairwise_exchange(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+int MPIR_Alltoallw_allcomm_nb(PARAMS_ALLTOALLW, MPIR_Errflag_t * errflag);
+
+/********** Ialltoallw **********/
+int MPIR_Ialltoallw(PARAMS_ALLTOALLW, MPIR_Request ** request);
+int MPIR_Ialltoallw_impl(PARAMS_ALLTOALLW, MPIR_Request ** request);
+
+int MPIR_Ialltoallw_sched(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_impl(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_intra_auto(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_intra_blocked(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_intra_inplace(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_inter_auto(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ialltoallw_sched_inter_pairwise_exchange(PARAMS_ALLTOALLW, MPIR_Sched_t s);
+
+/********** Reduce **********/
+#define PARAMS_REDUCE \
+    const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, \
+    MPI_Op op, int root, \
+    MPIR_Comm *comm_ptr
+int MPIR_Reduce(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_impl(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_auto(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_binomial(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_reduce_scatter_gather(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_intra_smp(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_inter_auto(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_inter_local_reduce_remote_send(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_allcomm_nb(PARAMS_REDUCE, MPIR_Errflag_t * errflag);
+
+/********** Ireduce **********/
+int MPIR_Ireduce(PARAMS_REDUCE, MPIR_Request ** request);
+int MPIR_Ireduce_impl(PARAMS_REDUCE, MPIR_Request ** request);
+int MPIR_Ireduce_intra_tree(PARAMS_REDUCE, MPIR_Request ** request);
+int MPIR_Ireduce_intra_ring(PARAMS_REDUCE, MPIR_Request ** request);
+
+int MPIR_Ireduce_sched(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_impl(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_intra_auto(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_intra_binomial(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_intra_reduce_scatter_gather(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_intra_smp(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_inter_auto(PARAMS_REDUCE, MPIR_Sched_t s);
+int MPIR_Ireduce_sched_inter_local_reduce_remote_send(PARAMS_REDUCE, MPIR_Sched_t s);
+
+/********** Allreduce **********/
+#define PARAMS_ALLREDUCE \
+    const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
+    MPIR_Comm *comm_ptr
+int MPIR_Allreduce(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_impl(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_intra_auto(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_intra_recursive_doubling(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_intra_smp(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_inter_auto(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_inter_reduce_exchange_bcast(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+int MPIR_Allreduce_allcomm_nb(PARAMS_ALLREDUCE, MPIR_Errflag_t * errflag);
+
+/********** Iallreduce **********/
+int MPIR_Iallreduce(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce_impl(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce_intra_recexch_single_buffer(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce_intra_recexch_multiple_buffer(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce_intra_tree(PARAMS_ALLREDUCE, MPIR_Request ** request);
+int MPIR_Iallreduce_intra_ring(PARAMS_ALLREDUCE, MPIR_Request ** request);
+
+int MPIR_Iallreduce_sched(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_impl(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_intra_auto(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_intra_naive(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_intra_recursive_doubling(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_intra_smp(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_inter_auto(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(PARAMS_ALLREDUCE, MPIR_Sched_t s);
+
+/********** Reduce_scatter **********/
+#define PARAMS_REDUCE_SCATTER \
+    const void *sendbuf, void *recvbuf, const int *recvcnts, MPI_Datatype datatype, MPI_Op op, \
+    MPIR_Comm *comm_ptr
+int MPIR_Reduce_scatter(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_impl(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_auto(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_noncommutative(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_pairwise(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_intra_recursive_halving(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_inter_auto(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_allcomm_nb(PARAMS_REDUCE_SCATTER, MPIR_Errflag_t * errflag);
+
+/********** Ireduce_scatter **********/
+int MPIR_Ireduce_scatter(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
+int MPIR_Ireduce_scatter_impl(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
+int MPIR_Ireduce_scatter_intra_recexch(PARAMS_REDUCE_SCATTER, MPIR_Request ** request);
+
+int MPIR_Ireduce_scatter_sched(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_impl(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_intra_auto(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_intra_pairwise(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_inter_auto(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER, MPIR_Sched_t s);
+
+/********** Reduce_scatter_block **********/
+#define PARAMS_REDUCE_SCATTER_BLOCK \
+    const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
+    MPIR_Comm *comm_ptr
+int MPIR_Reduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+int MPIR_Reduce_scatter_block_allcomm_nb(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Errflag_t * errflag);
+
+/********** Ireduce_scatter_block **********/
+int MPIR_Ireduce_scatter_block(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
+int MPIR_Ireduce_scatter_block_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
+int MPIR_Ireduce_scatter_block_intra_recexch(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Request ** request);
+
+int MPIR_Ireduce_scatter_block_sched(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_impl(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_intra_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_intra_pairwise(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_inter_auto(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(PARAMS_REDUCE_SCATTER_BLOCK, MPIR_Sched_t s);
+
+/********** Scan **********/
+#define PARAMS_SCAN \
+    const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
+    MPIR_Comm *comm_ptr
+int MPIR_Scan(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan_impl(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan_intra_auto(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan_intra_recursive_doubling(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan_intra_smp(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+int MPIR_Scan_allcomm_nb(PARAMS_SCAN, MPIR_Errflag_t * errflag);
+
+/********** Iscan **********/
+int MPIR_Iscan(PARAMS_SCAN, MPIR_Request ** request);
+int MPIR_Iscan_impl(PARAMS_SCAN, MPIR_Request ** request);
+int MPIR_Iscan_intra_gentran_recursive_doubling(PARAMS_SCAN, MPIR_Request ** request);
+
+int MPIR_Iscan_sched(PARAMS_SCAN, MPIR_Sched_t s);
+int MPIR_Iscan_sched_impl(PARAMS_SCAN, MPIR_Sched_t s);
+int MPIR_Iscan_sched_intra_auto(PARAMS_SCAN, MPIR_Sched_t s);
+int MPIR_Iscan_sched_intra_recursive_doubling(PARAMS_SCAN, MPIR_Sched_t s);
+int MPIR_Iscan_sched_intra_smp(PARAMS_SCAN, MPIR_Sched_t s);
+
+/********** Exscan **********/
+#define PARAMS_EXSCAN \
+    const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, \
+    MPIR_Comm *comm_ptr
+int MPIR_Exscan(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_impl(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_intra_auto(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_intra_recursive_doubling(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+int MPIR_Exscan_allcomm_nb(PARAMS_EXSCAN, MPIR_Errflag_t * errflag);
+
+/********** Iexscan **********/
+int MPIR_Iexscan(PARAMS_EXSCAN, MPIR_Request ** request);
+int MPIR_Iexscan_impl(PARAMS_EXSCAN, MPIR_Request ** request);
+
+int MPIR_Iexscan_sched(PARAMS_EXSCAN, MPIR_Sched_t s);
+int MPIR_Iexscan_sched_impl(PARAMS_EXSCAN, MPIR_Sched_t s);
+int MPIR_Iexscan_sched_intra_auto(PARAMS_EXSCAN, MPIR_Sched_t s);
+int MPIR_Iexscan_sched_intra_recursive_doubling(PARAMS_EXSCAN, MPIR_Sched_t s);
+
+/********** Neighbor_allgather **********/
+int MPIR_Neighbor_allgather(PARAMS_ALLGATHER);
+int MPIR_Neighbor_allgather_impl(PARAMS_ALLGATHER);
+int MPIR_Neighbor_allgather_intra_auto(PARAMS_ALLGATHER);
+int MPIR_Neighbor_allgather_inter_auto(PARAMS_ALLGATHER);
+int MPIR_Neighbor_allgather_allcomm_nb(PARAMS_ALLGATHER);
+
+int MPIR_Ineighbor_allgather(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Ineighbor_allgather_impl(PARAMS_ALLGATHER, MPIR_Request ** request);
+int MPIR_Ineighbor_allgather_allcomm_gentran_linear(PARAMS_ALLGATHER, MPIR_Request ** request);
+
+int MPIR_Ineighbor_allgather_sched(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_impl(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_intra_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_inter_auto(PARAMS_ALLGATHER, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgather_sched_allcomm_linear(PARAMS_ALLGATHER, MPIR_Sched_t s);
+
+/********** Neighbor_allgatherv **********/
+int MPIR_Neighbor_allgatherv(PARAMS_ALLGATHERV);
+int MPIR_Neighbor_allgatherv_impl(PARAMS_ALLGATHERV);
+int MPIR_Neighbor_allgatherv_intra_auto(PARAMS_ALLGATHERV);
+int MPIR_Neighbor_allgatherv_inter_auto(PARAMS_ALLGATHERV);
+int MPIR_Neighbor_allgatherv_allcomm_nb(PARAMS_ALLGATHERV);
+
+int MPIR_Ineighbor_allgatherv(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Ineighbor_allgatherv_impl(PARAMS_ALLGATHERV, MPIR_Request ** request);
+int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(PARAMS_ALLGATHERV, MPIR_Request ** request);
+
+int MPIR_Ineighbor_allgatherv_sched(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched_impl(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched_intra_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched_inter_auto(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(PARAMS_ALLGATHERV, MPIR_Sched_t s);
+
+/********** Neighbor_alltoall **********/
+int MPIR_Neighbor_alltoall(PARAMS_ALLTOALL);
+int MPIR_Neighbor_alltoall_impl(PARAMS_ALLTOALL);
+int MPIR_Neighbor_alltoall_intra_auto(PARAMS_ALLTOALL);
+int MPIR_Neighbor_alltoall_inter_auto(PARAMS_ALLTOALL);
+int MPIR_Neighbor_alltoall_allcomm_nb(PARAMS_ALLTOALL);
+
+int MPIR_Ineighbor_alltoall(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoall_impl(PARAMS_ALLTOALL, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(PARAMS_ALLTOALL, MPIR_Request ** request);
+
+int MPIR_Ineighbor_alltoall_sched(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_impl(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_intra_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_inter_auto(PARAMS_ALLTOALL, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoall_sched_allcomm_linear(PARAMS_ALLTOALL, MPIR_Sched_t s);
+
+/********** Neighbor_alltoallv **********/
+int MPIR_Neighbor_alltoallv(PARAMS_ALLTOALLV);
+int MPIR_Neighbor_alltoallv_impl(PARAMS_ALLTOALLV);
+int MPIR_Neighbor_alltoallv_intra_auto(PARAMS_ALLTOALLV);
+int MPIR_Neighbor_alltoallv_inter_auto(PARAMS_ALLTOALLV);
+int MPIR_Neighbor_alltoallv_allcomm_nb(PARAMS_ALLTOALLV);
+
+int MPIR_Ineighbor_alltoallv(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallv_impl(PARAMS_ALLTOALLV, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(PARAMS_ALLTOALLV, MPIR_Request ** request);
+
+int MPIR_Ineighbor_alltoallv_sched(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_impl(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_intra_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_inter_auto(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(PARAMS_ALLTOALLV, MPIR_Sched_t s);
+
+/********** Neighbor_alltoallw **********/
+#define PARAMS_NEIGHBOR_ALLTOALLW \
+    const void *sendbuf, const int *sendcnts, const MPI_Aint sdispls[], const MPI_Datatype *sendtypes, \
+    void *recvbuf, const int *recvcnts, const MPI_Aint rdispls[], const MPI_Datatype *recvtypes, \
+    MPIR_Comm *comm_ptr
+int MPIR_Neighbor_alltoallw(PARAMS_NEIGHBOR_ALLTOALLW);
+int MPIR_Neighbor_alltoallw_impl(PARAMS_NEIGHBOR_ALLTOALLW);
+int MPIR_Neighbor_alltoallw_intra_auto(PARAMS_NEIGHBOR_ALLTOALLW);
+int MPIR_Neighbor_alltoallw_inter_auto(PARAMS_NEIGHBOR_ALLTOALLW);
+int MPIR_Neighbor_alltoallw_allcomm_nb(PARAMS_NEIGHBOR_ALLTOALLW);
+
+int MPIR_Ineighbor_alltoallw(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallw_impl(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
+int MPIR_Ineighbor_alltoallw_allcomm_gentran_linear(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Request ** request);
+
+int MPIR_Ineighbor_alltoallw_sched(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched_impl(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched_intra_auto(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched_inter_auto(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
+int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(PARAMS_NEIGHBOR_ALLTOALLW, MPIR_Sched_t s);
 
 
 /******************************** Reduce_local ********************************/
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype,
                       MPI_Op op);
 
-
-/******************************** Reduce_scatter ********************************/
-int MPIR_Reduce_scatter(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Reduce_scatter_intra_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                             const int *recvcnts, MPI_Datatype datatype, MPI_Op op,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                       MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                 const int *recvcnts, MPI_Datatype datatype,
-                                                 MPI_Op op, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                const int *recvcnts, MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Reduce_scatter_inter_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
-                                                          const int *recvcnts,
-                                                          MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const int *recvcnts,
-                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-
-
-/******************************** Reduce_scatter_block ********************************/
-int MPIR_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_impl(const void *sendbuf, void *recvbuf, int recvcount,
-                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Reduce_scatter_block_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf, void *recvbuf,
-                                                   int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf, void *recvbuf, int recvcount,
-                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                             MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
-                                                       int recvcount, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf, void *recvbuf,
-                                                      int recvcount, MPI_Datatype datatype,
-                                                      MPI_Op op, MPIR_Comm * comm_ptr,
-                                                      MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Reduce_scatter_block_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
-                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t * errflag);
-int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
-                                                                int recvcount,
-                                                                MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, int recvcount,
-                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t * errflag);
-
-
-/******************************** Scan ********************************/
-int MPIR_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                   MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Scan_intra_auto(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
-                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                       MPIR_Errflag_t * errflag);
-int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                        MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-
-/******************************** Scatter ********************************/
-int MPIR_Scatter(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                 int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                 MPIR_Errflag_t * errflag);
-int MPIR_Scatter_impl(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                      int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                      MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Scatter_intra_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t * errflag);
-int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
-                                void *recvbuf, int recvcnt, MPI_Datatype recvtype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Scatter_inter_auto(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_linear(const void *sendbuf, int sendcnt, MPI_Datatype sendtype,
-                              void *recvbuf, int recvcnt, MPI_Datatype recvtype, int root,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendcnt,
-                                                 MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                                                 MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Scatter_allcomm_nb(const void *sendbuf, int sendcnt, MPI_Datatype sendtype, void *recvbuf,
-                            int recvcnt, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t * errflag);
-
-
-/******************************** Scatterv ********************************/
-int MPIR_Scatterv(const void *sendbuf, const int *sendcnts, const int *displs,
-                  MPI_Datatype sendtype, void *recvbuf, int recvcnt, MPI_Datatype recvtype,
-                  int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_impl(const void *sendbuf, const int *sendcnts, const int *displs,
-                       MPI_Datatype sendtype, void *recvbuf, int recvcnt, MPI_Datatype recvtype,
-                       int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag);
-
-/* intracomm-only functions */
-int MPIR_Scatterv_intra_auto(const void *sendbuf, const int *sendcnts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
-
-/* intercomm-only functions */
-int MPIR_Scatterv_inter_auto(const void *sendbuf, const int *sendcnts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
-
-/* anycomm functions */
-int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcnts, const int *displs,
-                                 MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t * errflag);
-int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const int *sendcnts, const int *displs,
-                             MPI_Datatype sendtype, void *recvbuf, int recvcnt,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t * errflag);
 
 #endif /* MPIR_COLL_H_INCLUDED */


### PR DESCRIPTION
This header declares all MPIR collective functions. It is a catalog of
all collective types and algorithms. The original files are cluttered
with parameter declarations, which are often long and repeats many
times and spans multiple lines. It is very difficult to read and
difficult to spot inconsistencies.

This refactor defines common parameters as macros (e.g. PARAMS_BCAST) --
one for each collective operation. These macros not only makes
parameters consistent and shortens code significantly in this file, it
also benefits many other files as the same parameter signature are often
needed in many internal functions. As the macro names are limited to the
list MPI public collective functions, it should be safe to be exposed to
global namespace.

The refactor also systematically orders all functions, first according
to the order in MPI standard, then follows `intra`, `inter` and
`allcomm` order, as well as `coll`, `icoll`, `icoll_sched` order.

Due to its regularity, such file is a potential target for script
generation -- infact, I generated this file using a template. This
refactoring provides foundation for further refactoring.