### PR TITLE
Packed alignment

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -115,7 +115,7 @@ typedef struct {
     struct iovec iov[3];
 #else
     /* need bigger alignment */
-    struct iovec iov[3] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+    struct iovec iov[3] MPL_ATTR_ALIGNED_PACKED(MPIDI_OFI_IOVEC_ALIGN);
 #endif
 } MPIDI_OFI_am_request_header_t;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -370,7 +370,8 @@ typedef struct {
     struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
 #else
     /* need bigger alignment */
-    struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+    struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS]
+        MPL_ATTR_ALIGNED_PACKED(MPIDI_OFI_IOVEC_ALIGN);
 #endif
     struct fi_msg am_msg[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     void *am_bufs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1000,6 +1000,7 @@ dnl Check for ATTRIBUTE
 PAC_C_GNU_ATTRIBUTE
 AX_GCC_VAR_ATTRIBUTE(aligned)
 AX_GCC_VAR_ATTRIBUTE(used)
+AX_GCC_VAR_ATTRIBUTE(packed)
 
 dnl Check for fallthrough attribute
 PAC_PUSH_ALL_FLAGS

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -52,6 +52,12 @@
 #define MPL_FALLTHROUGH
 #endif
 
+#ifdef MPL_HAVE_VAR_ATTRIBUTE_PACKED
+#define MPL_ATTR_PACKED(x) ATTRIBUTE((packed(x)))
+#else
+#define MPL_ATTR_PACKED(x)
+#endif
+
 #ifdef MPL_HAVE_VAR_ATTRIBUTE_ALIGNED
 #define MPL_ATTR_ALIGNED(x) ATTRIBUTE((aligned(x)))
 #else

--- a/src/mpl/include/mpl_base.h
+++ b/src/mpl/include/mpl_base.h
@@ -52,15 +52,16 @@
 #define MPL_FALLTHROUGH
 #endif
 
-#ifdef MPL_HAVE_VAR_ATTRIBUTE_PACKED
-#define MPL_ATTR_PACKED(x) ATTRIBUTE((packed(x)))
-#else
-#define MPL_ATTR_PACKED(x)
-#endif
-
 #ifdef MPL_HAVE_VAR_ATTRIBUTE_ALIGNED
+#ifdef MPL_HAVE_VAR_ATTRIBUTE_PACKED
+#define MPL_ATTR_ALIGNED_PACKED(x) ATTRIBUTE((aligned(x), packed))
 #define MPL_ATTR_ALIGNED(x) ATTRIBUTE((aligned(x)))
 #else
+#define MPL_ATTR_ALIGNED_PACKED(x) ATTRIBUTE((aligned(x)))
+#define MPL_ATTR_ALIGNED(x) ATTRIBUTE((aligned(x)))
+#endif
+#else
+#define MPL_ATTR_ALIGNED_PACKED(x)
 #define MPL_ATTR_ALIGNED(x)
 #endif
 


### PR DESCRIPTION
The Intel compiler complains when using alignment that it must also be packed so start using the packed attribute when it's available. There needs to be a check because this is a GNU extension (that the Intel compiler also picks up).

This was migrated from #3605 to be a separate PR.