### PR TITLE
test/maint: Fix typo in xfail.conf

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -154,7 +154,7 @@ ch4 * * * * sed -i "s+\(^atomic_get_short_int .*\)+\1 xfail=ticket3380+g" test/m
 # xfail lock_contention_dt with >= 16 bytes datatypes and 262144 count (CH3 bug)
 ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE arg=-count=262144 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
 ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX arg=-count=262144 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
-ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX arg=-count=262144 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlisti
+ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX arg=-count=262144 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
 # xfail large count tests on 32 bit architectures
 * * * * freebsd32 sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
 * * * * freebsd32 sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist


### PR DESCRIPTION
Point to the right "testlist" file in order to skip test.

No reviewer.