### PR TITLE
Implement per-vci thread-safety for TSP code

### DIFF
--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -202,7 +202,7 @@ int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Dat
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -332,7 +332,7 @@ int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Da
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -175,7 +175,7 @@ int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datat
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -346,7 +346,7 @@ int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -358,7 +358,7 @@ int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_D
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -172,7 +172,7 @@ int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Data
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -383,7 +383,7 @@ int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int co
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -255,7 +255,7 @@ int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -410,7 +410,7 @@ int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Data
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -209,7 +209,7 @@ int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, int sendcount, MPI_Dataty
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -142,7 +142,7 @@ int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const int sendcount
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -129,7 +129,7 @@ int MPIR_TSP_Ibcast_intra_scatter_recexch_allgather(void *buffer, int count, MPI
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -128,7 +128,7 @@ int MPIR_TSP_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, i
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -224,7 +224,7 @@ int MPIR_TSP_Igather_intra_tree(const void *sendbuf, int sendcount,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -16,6 +16,7 @@
 
 #include "stubtran_impl.h"
 #include "gentran_impl.h"
+#include "gentran_utils.h"
 
 #include "../algorithms/stubalgo/stubalgo.h"
 #include "../algorithms/treealgo/treealgo.h"

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -99,7 +99,7 @@ int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, int sendcou
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -99,7 +99,7 @@ int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, int sendco
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -101,7 +101,7 @@ int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, int sendcoun
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -104,7 +104,7 @@ int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const int s
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -109,7 +109,7 @@ int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int s
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -279,7 +279,7 @@ int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -246,7 +246,7 @@ int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -230,7 +230,7 @@ int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recv
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -149,7 +149,7 @@ int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, 
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -216,7 +216,7 @@ int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, int sendcount,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -124,7 +124,7 @@ int MPII_Coll_finalize(void)
  * block for a recv operation */
 int MPIR_Coll_safe_to_block(void)
 {
-    return MPII_Gentran_scheds_are_pending() == false;
+    return MPII_Genutil_queue_has_pending_scheds() == false;
 }
 
 /* Function to initialze communicators for collectives */

--- a/src/mpi/coll/transports/common/tsp_undef.h
+++ b/src/mpi/coll/transports/common/tsp_undef.h
@@ -36,4 +36,4 @@
 #undef MPIR_TSP_sched_isend
 #undef MPIR_TSP_sched_irecv
 #undef MPIR_TSP_sched_imcast
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue

--- a/src/mpi/coll/transports/gentran/gentran_impl.c
+++ b/src/mpi/coll/transports/gentran/gentran_impl.c
@@ -32,16 +32,17 @@ cvars:
 #include "tsp_gentran.h"
 #include "gentran_utils.h"
 
-MPII_Coll_queue_t coll_queue = { NULL };
+MPII_Coll_queue_t MPII_coll_queue = { NULL };
 
-int MPII_Genutil_progress_hook_id = 0;
+int MPII_Genutil_queue_progress_hook_id = 0;
 
 int MPII_Gentran_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPID_Progress_register_hook(MPII_Genutil_progress_hook, &MPII_Genutil_progress_hook_id);
+        MPID_Progress_register_hook(MPII_Genutil_queue_progress_hook,
+                                    &MPII_Genutil_queue_progress_hook_id);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -73,13 +74,7 @@ int MPII_Gentran_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_Progress_deregister_hook(MPII_Genutil_progress_hook_id);
+    MPID_Progress_deregister_hook(MPII_Genutil_queue_progress_hook_id);
 
     return mpi_errno;
-}
-
-
-int MPII_Gentran_scheds_are_pending(void)
-{
-    return coll_queue.head != NULL;
 }

--- a/src/mpi/coll/transports/gentran/gentran_impl.h
+++ b/src/mpi/coll/transports/gentran/gentran_impl.h
@@ -23,7 +23,4 @@ int MPII_Gentran_comm_init(MPIR_Comm * comm_ptr);
 /* communicator-specific cleanup */
 int MPII_Gentran_comm_cleanup(MPIR_Comm * comm_ptr);
 
-/* check if there are any pending schedules */
-int MPII_Gentran_scheds_are_pending(void);
-
 #endif /* GENTRAN_IMPL_H_INCLUDED */

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -201,7 +201,7 @@ static void vtx_record_completion(MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_
 }
 
 
-int MPII_Genutil_progress_hook(int *made_progress)
+int MPII_Genutil_queue_progress_hook(int *made_progress)
 {
     int count = 0;
     int mpi_errno = MPI_SUCCESS;
@@ -212,7 +212,7 @@ int MPII_Genutil_progress_hook(int *made_progress)
 
     /* Go over up to MPIR_COLL_PROGRESS_MAX_COLLS collecives in the
      * queue and make progress on them */
-    DL_FOREACH_SAFE(coll_queue.head, coll_req, coll_req_tmp) {
+    DL_FOREACH_SAFE(MPII_coll_queue.head, coll_req, coll_req_tmp) {
         /* make progress on the collective operation */
         int done;
         MPII_Genutil_sched_t *sched = (MPII_Genutil_sched_t *) (coll_req->sched);
@@ -226,15 +226,15 @@ int MPII_Genutil_progress_hook(int *made_progress)
             coll_req->sched = NULL;
 
             req = MPL_container_of(coll_req, MPIR_Request, u.nbc.coll);
-            DL_DELETE(coll_queue.head, coll_req);
+            DL_DELETE(MPII_coll_queue.head, coll_req);
             MPID_Request_complete(req);
         }
         if (++count >= MPIR_CVAR_PROGRESS_MAX_COLLS)
             break;
     }
 
-    if (coll_queue.head == NULL)
-        MPID_Progress_deactivate_hook(MPII_Genutil_progress_hook_id);
+    if (MPII_coll_queue.head == NULL)
+        MPID_Progress_deactivate_hook(MPII_Genutil_queue_progress_hook_id);
 
     return mpi_errno;
 }
@@ -495,4 +495,9 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_POKE);
     return mpi_errno;
+}
+
+int MPII_Genutil_queue_has_pending_scheds()
+{
+    return MPII_coll_queue.head != NULL;
 }

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -207,6 +207,8 @@ int MPII_Genutil_queue_progress_hook(int *made_progress)
     int mpi_errno = MPI_SUCCESS;
     MPII_Coll_req_t *coll_req, *coll_req_tmp;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
     if (made_progress)
         *made_progress = FALSE;
 
@@ -235,6 +237,8 @@ int MPII_Genutil_queue_progress_hook(int *made_progress)
 
     if (MPII_coll_queue.head == NULL)
         MPID_Progress_deactivate_hook(MPII_Genutil_queue_progress_hook_id);
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
 
     return mpi_errno;
 }
@@ -499,5 +503,11 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
 
 int MPII_Genutil_queue_has_pending_scheds()
 {
-    return MPII_coll_queue.head != NULL;
+    int ret;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+    ret = (MPII_coll_queue.head != NULL);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
+    return ret;
 }

--- a/src/mpi/coll/transports/gentran/gentran_utils.h
+++ b/src/mpi/coll/transports/gentran/gentran_utils.h
@@ -16,8 +16,8 @@
 #include "tsp_gentran.h"
 #include "utarray.h"
 
-extern MPII_Coll_queue_t coll_queue;
-extern int MPII_Genutil_progress_hook_id;
+extern MPII_Coll_queue_t MPII_coll_queue;
+extern int MPII_Genutil_queue_progress_hook_id;
 
 /* vertex copy function, required by utarray */
 void MPII_Genutil_vtx_copy(void *_dst, const void *_src);
@@ -39,6 +39,9 @@ int MPII_Genutil_vtx_create(MPII_Genutil_sched_t * sched, MPII_Genutil_vtx_t ** 
 int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int *made_progress);
 
 /* Hook to make progress on nonblocking collective operations  */
-int MPII_Genutil_progress_hook(int *);
+int MPII_Genutil_queue_progress_hook(int *);
+
+/* check if there are any pending schedules */
+int MPII_Genutil_queue_has_pending_scheds(void);
 
 #endif /* GENTRAN_UTILS_H_INCLUDED */

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -296,7 +296,7 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
     *req = reqp;
     MPIR_Request_add_ref(reqp);
 
-    /* Make some progress */
+    /* Kick start progress on this collective's schedule */
     mpi_errno = MPII_Genutil_sched_poke(sched, &is_complete, &made_progress);
     if (is_complete) {
         MPID_Request_complete(reqp);
@@ -309,9 +309,8 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
         MPID_Progress_activate_hook(MPII_Genutil_progress_hook_id);
     DL_APPEND(coll_queue.head, &(reqp->u.nbc.coll));
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);
-
   fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -279,7 +279,8 @@ void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched)
     return addr;
 }
 
-int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPIR_Request ** req)
+int MPII_Genutil_queue_sched_enqueue(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
+                                     MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_complete;
@@ -305,9 +306,9 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
 
     /* Enqueue schedule and activate progress hook if not already activated */
     reqp->u.nbc.coll.sched = (void *) sched;
-    if (coll_queue.head == NULL)
-        MPID_Progress_activate_hook(MPII_Genutil_progress_hook_id);
-    DL_APPEND(coll_queue.head, &(reqp->u.nbc.coll));
+    if (MPII_coll_queue.head == NULL)
+        MPID_Progress_activate_hook(MPII_Genutil_queue_progress_hook_id);
+    DL_APPEND(MPII_coll_queue.head, &(reqp->u.nbc.coll));
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -28,7 +28,7 @@
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
 #undef MPIR_TSP_sched_malloc
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue
 #undef MPIR_TSP_sched_free
 #undef MPIR_TSP_sched_optimize
 #undef MPIR_TSP_sched_reset
@@ -49,10 +49,10 @@
 #define MPIR_TSP_sched_sink                MPII_Genutil_sched_sink
 #define MPIR_TSP_sched_fence               MPII_Genutil_sched_fence
 #define MPIR_TSP_sched_malloc              MPII_Genutil_sched_malloc
-#define MPIR_TSP_sched_start               MPII_Genutil_sched_start
+#define MPIR_TSP_queue_sched_enqueue               MPII_Genutil_queue_sched_enqueue
 
-extern MPII_Coll_queue_t coll_queue;
-extern int MPII_Genutil_progress_hook_id;
+extern MPII_Coll_queue_t MPII_coll_queue;
+extern int MPII_Genutil_queue_progress_hook_id;
 
 /* Transport function to initialize a new schedule */
 int MPII_Genutil_sched_create(MPII_Genutil_sched_t * sched);
@@ -105,8 +105,8 @@ void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched);
 
 /* Transport function to enqueue and kick start a non-blocking
  * collective */
-int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
-                             MPIR_Request ** request);
+int MPII_Genutil_queue_sched_enqueue(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
+                                     MPIR_Request ** request);
 
 
 /* Transport function to schedule a sink */

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -57,7 +57,7 @@ extern int MPII_Genutil_progress_hook_id;
 /* Transport function to initialize a new schedule */
 int MPII_Genutil_sched_create(MPII_Genutil_sched_t * sched);
 
-/* Transport function to schedule a isend vertex */
+/* Transport function to schedule an isend vertex */
 int MPII_Genutil_sched_isend(const void *buf,
                              int count,
                              MPI_Datatype dt,
@@ -66,7 +66,7 @@ int MPII_Genutil_sched_isend(const void *buf,
                              MPIR_Comm * comm_ptr,
                              MPII_Genutil_sched_t * sched, int n_in_vtcs, int *in_vtcs);
 
-/* Transport function to schedule a irecv vertex */
+/* Transport function to schedule an irecv vertex */
 int MPII_Genutil_sched_irecv(void *buf,
                              int count,
                              MPI_Datatype dt,
@@ -75,7 +75,7 @@ int MPII_Genutil_sched_irecv(void *buf,
                              MPIR_Comm * comm_ptr,
                              MPII_Genutil_sched_t * sched, int n_in_vtcs, int *in_vtcs);
 
-/* Transport function to schedule a imcast vertex */
+/* Transport function to schedule an imcast vertex */
 int MPII_Genutil_sched_imcast(const void *buf,
                               int count,
                               MPI_Datatype dt,

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.c
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.c
@@ -62,8 +62,8 @@ void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched)
     return MPI_SUCCESS;
 }
 
-int MPII_Stubutil_sched_start(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
-                              MPII_Coll_req_t ** request)
+int MPII_Stubutil_queue_sched_enqueue(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
+                                      MPII_Coll_req_t ** request)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.h
@@ -25,7 +25,7 @@
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
 #undef MPIR_TSP_sched_malloc
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue
 #undef MPIR_TSP_sched_free
 #undef MPIR_TSP_sched_optimize
 #undef MPIR_TSP_sched_reset
@@ -46,7 +46,7 @@
 #define MPIR_TSP_sched_sink                 MPII_Stubutil_sched_sink
 #define MPIR_TSP_sched_fence                MPII_Stubutil_sched_fence
 #define MPIR_TSP_sched_malloc               MPII_Stubutil_sched_malloc
-#define MPIR_TSP_sched_start                MPII_Stubutil_sched_start
+#define MPIR_TSP_queue_sched_enqueue                MPII_Stubutil_queue_sched_enqueue
 
 int MPII_Stubutil_sched_create(MPII_Stubutil_sched_t * sched);
 int MPII_Stubutil_sched_isend(const void *buf, int count, MPI_Datatype dt, int dest, int tag,
@@ -68,7 +68,7 @@ int MPII_Stubutil_sched_selective_sink(MPII_Stubutil_sched_t * sched, int n_in_v
 int MPII_Genutil_sched_sink(MPII_Genutil_sched_t * sched);
 void MPII_Genutil_sched_fence(MPII_Genutil_sched_t * sched);
 void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched);
-int MPII_Stubutil_sched_start(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
-                              MPII_Coll_req_t ** request);
+int MPII_Stubutil_queue_sched_enqueue(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
+                                      MPII_Coll_req_t ** request);
 
 #endif /* TSP_STUBTRAN_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -329,6 +329,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided, int *has_ar
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_TSP_QUEUE_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[3];
+    MPID_Thread_mutex_t m[4];
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -324,5 +324,6 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_PROGRESS_MUTEX  MPIDI_global.m[0]
 #define MPIDIU_THREAD_PROGRESS_HOOK_MUTEX  MPIDI_global.m[1]
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_global.m[2]
+#define MPIDIU_THREAD_TSP_QUEUE_MUTEX  MPIDI_global.m[3]
 
 #endif /* CH4_TYPES_H_INCLUDED */


### PR DESCRIPTION
The `per-VCI` critical section model is essentially a subset of the `per-object` model. It needs thread safety for each VCI, and thread-safety for the other objects such as requests, hooks, etc.

This PR implements thread safety for code related to TSP. Currently, none of the contentious operations are thread safe in the `per-VCI` model.

The PR first implements new naming rules for the existing functions so that it is easier to parse what kind of operations the functions do and what kind of objects they are acting upon. As a result, moving forward, it is straightforward to parse which functions need thread safety.

Testing:
- [x] Are Jenkins tests configured to use TSP code for collectives? (Yes, they are)
- [x] Test with #3659 with all the nbc code since they rely on each other for completeness (which also includes the global lock for collectives in `per-vci` critical section).