### PR TITLE
get rid of MPI_Aint casting macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5020,16 +5020,6 @@ AC_SUBST(MPI_AINT_FMT_DEC_SPEC)
 AC_SUBST(MPI_AINT_FMT_HEX_SPEC)
 AC_DEFINE_UNQUOTED([MPIR_AINT_MAX],[$MPIR_AINT_MAX],[limits.h _MAX constant for MPI_Aint])
 
-# If sizeof(mpi_aint) = sizeof(int), set this value
-if test "$ac_cv_sizeof_int" = "$aint_size" ; then
-    AC_DEFINE(SIZEOF_INT_IS_AINT,1,[define if sizeof(int) = sizeof(MPI_Aint)])
-fi
-
-# If sizeof(mpi_aint) = sizeof(int), set this value
-if test "$ac_cv_sizeof_void_p" = "$aint_size" ; then
-    AC_DEFINE(SIZEOF_PTR_IS_AINT,1,[define if sizeof(void *) = sizeof(MPI_Aint)])
-fi
-
 # ----------------------------------------------------------------------------
 # MPI_AINT datatype
 # ----------------------------------------------------------------------------

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -4408,7 +4408,7 @@ MPII_Comm_copy_attr_f77_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)comm;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint *fextra = (MPI_Aint *)extra_state;
     MPI_Aint fnew = 0;
     MPI_Fint fflag = 0;
@@ -4416,7 +4416,7 @@ MPII_Comm_copy_attr_f77_proxy(
     ((F77_CopyFunction*)user_function)( &fhandle, &fkeyval, fextra, &fvalue, &fnew, &fflag, &ierr );
 
     *flag = MPII_FROM_FLOG(fflag);
-    *new_value = MPIR_AINT_CAST_TO_VOID_PTR ((MPI_Aint) fnew);
+    *new_value = (void *)fnew;
     return (int)ierr;
 }
 
@@ -4439,7 +4439,7 @@ MPIR_Comm_delete_attr_f77_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)comm;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint *fextra = (MPI_Aint *)extra_state;
 
     ((F77_DeleteFunction*)user_function)( &fhandle, &fkeyval, &fvalue, fextra, &ierr );
@@ -5421,7 +5421,7 @@ MPIR_Type_copy_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)datatype;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
     MPI_Aint fnew = 0;
     MPI_Fint fflag = 0;
@@ -5429,7 +5429,7 @@ MPIR_Type_copy_attr_f90_proxy(
     ((F90_CopyFunction*)user_function)( &fhandle, &fkeyval, fextra, &fvalue, &fnew, &fflag, &ierr );
 
     *flag = MPII_FROM_FLOG(fflag);
-    *new_value = MPIR_AINT_CAST_TO_VOID_PTR (fnew);
+    *new_value = (void *)fnew;
     return (int)ierr;
 }
 
@@ -5452,7 +5452,7 @@ MPIR_Type_delete_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)datatype;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
 
     ((F90_DeleteFunction*)user_function)( &fhandle, &fkeyval, &fvalue, fextra, &ierr );
@@ -5485,7 +5485,7 @@ MPII_Comm_copy_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)comm;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
     MPI_Aint fnew = 0;
     MPI_Fint fflag = 0;
@@ -5493,7 +5493,7 @@ MPII_Comm_copy_attr_f90_proxy(
     ((F90_CopyFunction*)user_function)( &fhandle, &fkeyval, fextra, &fvalue, &fnew, &fflag, &ierr );
 
     *flag = MPII_FROM_FLOG(fflag);
-    *new_value = MPIR_AINT_CAST_TO_VOID_PTR (fnew);
+    *new_value = (void *)fnew;
     return (int)ierr;
 }
 
@@ -5516,7 +5516,7 @@ MPIR_Comm_delete_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)comm;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
 
     ((F90_DeleteFunction*)user_function)( &fhandle, &fkeyval, &fvalue, fextra, &ierr );
@@ -5549,7 +5549,7 @@ MPIR_Win_copy_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)win;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
     MPI_Aint fnew = 0;
     MPI_Fint fflag = 0;
@@ -5557,7 +5557,7 @@ MPIR_Win_copy_attr_f90_proxy(
     ((F90_CopyFunction*)user_function)( &fhandle, &fkeyval, fextra, &fvalue, &fnew, &fflag, &ierr );
 
     *flag = MPII_FROM_FLOG(fflag);
-    *new_value = MPIR_AINT_CAST_TO_VOID_PTR (fnew);
+    *new_value = (void *)fnew;
     return (int)ierr;
 }
 
@@ -5580,7 +5580,7 @@ MPIR_Win_delete_attr_f90_proxy(
     MPI_Fint ierr = 0;
     MPI_Fint fhandle = (MPI_Fint)win;
     MPI_Fint fkeyval = (MPI_Fint)keyval;
-    MPI_Aint fvalue = MPIR_VOID_PTR_CAST_TO_MPI_AINT (value);
+    MPI_Aint fvalue = (MPI_Aint)value;
     MPI_Aint* fextra  = (MPI_Aint*)extra_state;
 
     ((F90_DeleteFunction*)user_function)( &fhandle, &fkeyval, &fvalue, fextra, &ierr );

--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -69,11 +69,6 @@ extern int MPIR_Ext_dbg_romio_terse_enabled;
 extern int MPIR_Ext_dbg_romio_typical_enabled;
 extern int MPIR_Ext_dbg_romio_verbose_enabled;
 
-/* a copy of MPIU_Ensure_Aint_fits_in_pointer for external use, slightly
- * modified to use ROMIO's version of the pointer-casting macro */
-#define MPIR_Ext_ensure_Aint_fits_in_pointer(aint) \
-  MPIR_Ext_assert((aint) == (MPI_Aint)(uintptr_t) ADIOI_AINT_CAST_TO_VOID_PTR(aint));
-
 /* to be called early by ROMIO's initialization process in order to setup init-time
  * glue code that cannot be initialized statically */
 int MPIR_Ext_init(void);

--- a/src/include/mpir_pointers.h
+++ b/src/include/mpir_pointers.h
@@ -73,17 +73,4 @@
 #define MPIR_Ensure_Aint_fits_in_int(aint) \
   MPIR_Assert((aint) == (MPI_Aint)(int)(aint));
 
-/*
- * Ensure an MPI_Aint value fits into a pointer.
- * Useful for detecting overflow when MPI_Aint is larger than a pointer.
- *
- * \param[in]  aint  Variable of type MPI_Aint
- */
-#ifndef SIZEOF_PTR_IS_AINT
-#define MPIR_Ensure_Aint_fits_in_pointer(aint) \
-  MPIR_Assert((aint) == (MPI_Aint)(uintptr_t) MPIR_AINT_CAST_TO_VOID_PTR(aint));
-#else
-#define MPIR_Ensure_Aint_fits_in_pointer(aint) do {} while (0)
-#endif
-
 #endif /* MPIR_POINTERS_H_INCLUDED */

--- a/src/include/mpir_type_defs.h
+++ b/src/include/mpir_type_defs.h
@@ -72,10 +72,4 @@
 #define MPIR_Aint_to_ptr(a) (void*)(a)
 #endif
 
-/* Adding the 32-bit compute/64-bit I/O related type-casts in here as
- * they are not a part of the MPI standard yet. */
-#define MPIR_AINT_CAST_TO_VOID_PTR (void *)(intptr_t)
-#define MPIR_VOID_PTR_CAST_TO_MPI_AINT (MPI_Aint)(uintptr_t)
-#define MPIR_PTR_DISP_CAST_TO_MPI_AINT (MPI_Aint)(intptr_t)
-
 #endif /* MPIR_TYPE_DEFS_H_INCLUDED */

--- a/src/mpi/attr/win_get_attr.c
+++ b/src/mpi/attr/win_get_attr.c
@@ -128,7 +128,7 @@ int MPII_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val,
             case MPII_ATTR_C_TO_FORTRAN(MPI_WIN_BASE):
                 /* The Fortran routine that matches this routine should
                  * provide an address-sized integer, not an MPI_Fint */
-                *attr_int = MPIR_VOID_PTR_CAST_TO_MPI_AINT(win_ptr->base);
+                *attr_int = (MPI_Aint) win_ptr->base;
                 break;
             case MPII_ATTR_C_TO_FORTRAN(MPI_WIN_SIZE):
                 /* We do not need to copy because we return the value,

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -43,7 +43,6 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int send
         MPIR_Datatype_get_extent_macro(sendtype, send_extent);
         extent = MPL_MAX(send_extent, true_extent);
 
-        MPIR_Ensure_Aint_fits_in_pointer(extent * sendcount * local_size);
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, extent * sendcount * local_size, mpi_errno, "tmp_buf",
                             MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -47,10 +47,6 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
     /* allocate a temporary buffer of the same size as recvbuf. */
 
     /* get true extent of recvtype */

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -56,11 +56,6 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
-
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) recvbuf +

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -48,10 +48,6 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
     /* First, load the "local" version in the recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -59,7 +59,6 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     /* get true extent of recvtype */
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &recvtype_true_extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(recvtype_true_extent, recvtype_extent));
     recvbuf_extent = total_count * (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -69,8 +69,6 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &recvtype_true_extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(total_count *
-                                     (MPL_MAX(recvtype_true_extent, recvtype_extent)));
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
                         total_count * (MPL_MAX(recvtype_true_extent, recvtype_extent)),
                         mpi_errno, "tmp_buf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -32,10 +32,6 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
     if (comm_ptr->rank == 0) {
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
-        /* I think this is the worse case, so we can avoid an assert()
-         * inside the for loop */
-        /* Should MPIR_CHKLMEM_MALLOC do this? */
-        MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                             "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -46,7 +46,6 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                         "temporary buffer", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -66,7 +66,6 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                         "temporary buffer", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -46,7 +46,6 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                         "temporary buffer", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -45,10 +45,6 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, int sendcount,
 
     /* Do the pairwise exchanges */
     max_size = MPL_MAX(local_size, remote_size);
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     max_size * recvcount * recvtype_extent);
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                     max_size * sendcount * sendtype_extent);
     for (i = 0; i < max_size; i++) {
         src = (rank - i + max_size) % max_size;
         dst = (rank + i) % max_size;

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -57,8 +57,6 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendc
             recvaddr = NULL;
             recvcount = 0;
         } else {
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                             rdispls[src] * recv_extent);
             recvaddr = (char *) recvbuf + rdispls[src] * recv_extent;
             recvcount = recvcounts[src];
         }
@@ -67,8 +65,6 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const int *sendc
             sendaddr = NULL;
             sendcount = 0;
         } else {
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                             sdispls[dst] * send_extent);
             sendaddr = (char *) sendbuf + sdispls[dst] * send_extent;
             sendcount = sendcounts[dst];
         }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -76,8 +76,6 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const int *sendcounts, c
             if (recvcounts[dst]) {
                 MPIR_Datatype_get_size_macro(recvtype, type_size);
                 if (type_size) {
-                    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                                     rdispls[dst] * recv_extent);
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
@@ -99,8 +97,6 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const int *sendcounts, c
             if (sendcounts[dst]) {
                 MPIR_Datatype_get_size_macro(sendtype, type_size);
                 if (type_size) {
-                    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                                     sdispls[dst] * send_extent);
                     mpi_errno = MPIC_Isend((char *) sendbuf + sdispls[dst] * send_extent,
                                            sendcounts[dst], sendtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr,

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -38,8 +38,6 @@ int MPIR_Gather_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype se
 
     if (root == MPI_ROOT) {
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (recvcount * remote_size * extent));
 
         for (i = 0; i < remote_size; i++) {
             mpi_errno =

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -64,8 +64,6 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcoun
             MPIR_Type_get_true_extent_impl(sendtype, &true_lb, &true_extent);
             MPIR_Datatype_get_extent_macro(sendtype, extent);
 
-            MPIR_Ensure_Aint_fits_in_pointer(sendcount * local_size *
-                                             (MPL_MAX(extent, true_extent)));
             MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
                                 sendcount * local_size * (MPL_MAX(extent, true_extent)), mpi_errno,
                                 "tmp_buf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -79,8 +79,6 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
 
     if (rank == root) {
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (extent * recvcount * comm_size));
     }
 
     if (rank == root) {
@@ -270,7 +268,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
                 }
             } else {
                 blocks[0] = sendcount;
-                struct_displs[0] = MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf;
+                struct_displs[0] = (MPI_Aint) sendbuf;
                 types[0] = sendtype;
                 /* check for overflow.  work around int limits if needed */
                 if (curr_cnt - nbytes != (int) (curr_cnt - nbytes)) {
@@ -280,7 +278,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype 
                     MPIR_Assign_trunc(blocks[1], curr_cnt - nbytes, int);
                     types[1] = MPI_BYTE;
                 }
-                struct_displs[1] = MPIR_VOID_PTR_CAST_TO_MPI_AINT tmp_buf;
+                struct_displs[1] = (MPI_Aint) tmp_buf;
                 mpi_errno =
                     MPIR_Type_create_struct_impl(2, blocks, struct_displs, types, &tmp_type);
                 if (mpi_errno)

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -71,9 +71,6 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        /* each node can make sure it is not going to overflow aint */
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         displs[rank] * extent);
 
         MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *),
                             mpi_errno, "reqarray", MPL_MEM_BUFFER);

--- a/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
@@ -40,7 +40,6 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
         MPIR_Datatype_get_extent_macro(sendtype, send_extent);
         extent = MPL_MAX(send_extent, true_extent);
 
-        MPIR_Ensure_Aint_fits_in_pointer(extent * sendcount * local_size);
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, extent * sendcount * local_size, mpi_errno,
                                   "tmp_buf", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/iallgather/iallgather_intra_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_brucks.c
@@ -36,10 +36,6 @@ int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_D
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &recvtype_true_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
     /* allocate a temporary buffer of the same size as recvbuf. */
     /* get true extent of recvtype */
 

--- a/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
@@ -78,10 +78,6 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
     /*  copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,

--- a/src/mpi/coll/iallgather/iallgather_intra_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_ring.c
@@ -39,10 +39,6 @@ int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Dat
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_size * recvcount * recvtype_extent));
-
     /* First, load the "local" version in the recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_brucks.c
@@ -39,7 +39,6 @@ int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     /* get true extent of recvtype */
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &recvtype_true_extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(recvtype_true_extent, recvtype_extent));
     recvbuf_extent = total_count * (MPL_MAX(recvtype_true_extent, recvtype_extent));
 
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, recvbuf_extent, mpi_errno, "tmp_buf",

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
@@ -45,8 +45,6 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
     if (total_count == 0)
         goto fn_exit;
 
-    MPIR_Ensure_Aint_fits_in_pointer(total_count *
-                                     (MPL_MAX(recvtype_true_extent, recvtype_extent)));
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *,
                               total_count * (MPL_MAX(recvtype_true_extent, recvtype_extent)),
                               mpi_errno, "tmp_buf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
@@ -30,7 +30,6 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                               "temporary buffer", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
@@ -38,7 +38,6 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                               "temporary buffer", MPL_MEM_BUFFER);
 

--- a/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
@@ -42,10 +42,6 @@ int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendco
 
     /* Do the pairwise exchanges */
     max_size = MPL_MAX(local_size, remote_size);
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     max_size * recvcount * recvtype_extent);
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                     max_size * sendcount * sendtype_extent);
     for (i = 0; i < max_size; i++) {
         src = (rank - i + max_size) % max_size;
         dst = (rank + i) % max_size;

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
@@ -53,8 +53,6 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
             recvaddr = NULL;
             recvcount = 0;
         } else {
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                             rdispls[src] * recv_extent);
             recvaddr = (char *) recvbuf + rdispls[src] * recv_extent;
             recvcount = recvcounts[src];
         }
@@ -63,8 +61,6 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
             sendaddr = NULL;
             sendcount = 0;
         } else {
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                             sdispls[dst] * send_extent);
             sendaddr = (char *) sendbuf + sdispls[dst] * send_extent;
             sendcount = sendcounts[dst];
         }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
@@ -49,8 +49,6 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
             if (recvcounts[dst] && recvtype_size) {
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                                 rdispls[dst] * recv_extent);
                 mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst] * recv_extent,
                                             recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
@@ -61,8 +59,6 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
             if (sendcounts[dst] && sendtype_size) {
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                                 sdispls[dst] * send_extent);
                 mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst] * send_extent,
                                             sendcounts[dst], sendtype, dst, comm_ptr, s);
                 if (mpi_errno)

--- a/src/mpi/coll/igather/igather_inter_long.c
+++ b/src/mpi/coll/igather/igather_inter_long.c
@@ -31,8 +31,6 @@ int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Dataty
     /* long message. use linear algorithm. */
     if (root == MPI_ROOT) {
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (recvcount * remote_size * extent));
 
         for (i = 0; i < remote_size; i++) {
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + recvcount * i * extent),

--- a/src/mpi/coll/igather/igather_inter_short.c
+++ b/src/mpi/coll/igather/igather_inter_short.c
@@ -49,8 +49,6 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
             MPIR_Type_get_true_extent_impl(sendtype, &true_lb, &true_extent);
             MPIR_Datatype_get_extent_macro(sendtype, extent);
 
-            MPIR_Ensure_Aint_fits_in_pointer(sendcount * local_size *
-                                             (MPL_MAX(extent, true_extent)));
             MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *,
                                       sendcount * local_size * (MPL_MAX(extent, true_extent)),
                                       mpi_errno, "tmp_buf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/igather/igather_intra_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_binomial.c
@@ -64,8 +64,6 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
 
     if (rank == root) {
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (extent * recvcount * comm_size));
     }
 
     if (rank == root) {
@@ -225,7 +223,7 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                     MPIR_ERR_POP(mpi_errno);
             } else {
                 blocks[0] = sendcount;
-                struct_displs[0] = MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf;
+                struct_displs[0] = (MPI_Aint) sendbuf;
                 types[0] = sendtype;
                 /* check for overflow.  work around int limits if needed */
                 if (curr_cnt - nbytes != (int) (curr_cnt - nbytes)) {
@@ -235,7 +233,7 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                     MPIR_Assign_trunc(blocks[1], curr_cnt - nbytes, int);
                     types[1] = MPI_BYTE;
                 }
-                struct_displs[1] = MPIR_VOID_PTR_CAST_TO_MPI_AINT tmp_buf;
+                struct_displs[1] = (MPI_Aint) tmp_buf;
 
                 mpi_errno =
                     MPIR_Type_create_struct_impl(2, blocks, struct_displs, types, &tmp_type);

--- a/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
@@ -38,9 +38,6 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(recvtype, extent);
-        /* each node can make sure it is not going to overflow aint */
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         displs[rank] * extent);
 
         for (i = 0; i < comm_size; i++) {
             if (recvcounts[i]) {

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
@@ -31,10 +31,6 @@ int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendc
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_ptr->local_size * recvcount * recvtype_extent));
-
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -42,10 +42,6 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int s
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_ptr->local_size * recvcount * recvtype_extent));
-
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
@@ -25,7 +25,7 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
     int comm_size;
     MPI_Aint recvtype_extent;
@@ -34,11 +34,6 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
     comm_size = comm_ptr->local_size;
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
-
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (displs[i] * recvtype_extent));
-    }
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -30,7 +30,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
     int comm_size;
     int tag;
@@ -43,11 +43,6 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
     comm_size = comm_ptr->local_size;
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
-
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (displs[i] * recvtype_extent));
-    }
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
@@ -32,13 +32,6 @@ int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendco
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to sendbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                     (comm_ptr->local_size * sendcount * sendtype_extent));
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_ptr->local_size * recvcount * recvtype_extent));
-
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -42,13 +42,6 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
-    /* This is the largest offset we add to sendbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                     (comm_ptr->local_size * sendcount * sendtype_extent));
-    /* This is the largest offset we add to recvbuf */
-    MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                     (comm_ptr->local_size * recvcount * recvtype_extent));
-
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
@@ -25,7 +25,7 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
     int comm_size;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -35,13 +35,6 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
-
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                         (sdispls[i] * sendtype_extent));
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (rdispls[i] * recvtype_extent));
-    }
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -31,7 +31,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
-    int i, k, l;
+    int k, l;
     int *srcs, *dsts;
     int comm_size;
     int tag;
@@ -46,13 +46,6 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
-
-    for (i = 0; i < comm_size; ++i) {
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                         (sdispls[i] * sendtype_extent));
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf +
-                                         (rdispls[i] * recvtype_extent));
-    }
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     if (mpi_errno)

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
@@ -43,7 +43,6 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
 
     for (k = 0; k < outdegree; ++k) {
         char *sb;
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + sdispls[k]);
 
         sb = ((char *) sendbuf) + sdispls[k];
         mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
@@ -53,7 +52,6 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
 
     for (l = 0; l < indegree; ++l) {
         char *rb;
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf + rdispls[l]);
 
         rb = ((char *) recvbuf) + rdispls[l];
         mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -61,7 +61,6 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
 
     for (k = 0; k < outdegree; ++k) {
         char *sb;
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + sdispls[k]);
 
         sb = ((char *) sendbuf) + sdispls[k];
         MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
@@ -70,7 +69,6 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
 
     for (l = 0; l < indegree; ++l) {
         char *rb;
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT recvbuf + rdispls[l]);
 
         rb = ((char *) recvbuf) + rdispls[l];
         MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,

--- a/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
@@ -51,10 +51,6 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
             MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
             MPIR_Datatype_get_extent_macro(datatype, extent);
-            /* I think this is the worse case, so we can avoid an assert()
-             * inside the for loop */
-            /* Should MPIR_SCHED_CHKPMEM_MALLOC do this? */
-            MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
             MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                                       mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/ireduce/ireduce_intra_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_binomial.c
@@ -47,11 +47,6 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
 
     is_commutative = MPIR_Op_is_commutative(op);
 
-    /* I think this is the worse case, so we can avoid an assert()
-     * inside the for loop */
-    /* should be buf+{this}? */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                               mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
@@ -65,13 +65,6 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-#ifdef HAVE_ERROR_CHECKING
-    /* I think this is the worse case, so we can avoid an assert()
-     * inside the for loop */
-    /* should be buf+{this}? */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-#endif /* HAVE_ERROR_CHECKING */
-
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                               mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/ireduce/ireduce_intra_smp.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_smp.c
@@ -43,8 +43,6 @@ int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                                   mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
@@ -54,9 +54,6 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
     if (total_count == 0) {
         goto fn_exit;
     }
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
 
     if (sendbuf != MPI_IN_PLACE) {
         /* copy local data into recvbuf */

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
@@ -60,11 +60,6 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
-
     /* need to allocate temporary buffer to receive incoming data */
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
                               mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
@@ -49,9 +49,6 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
     if (total_count == 0) {
         goto fn_exit;
     }
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
 
     if (sendbuf != MPI_IN_PLACE) {
         /* copy local data into recvbuf */

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_doubling.c
@@ -51,11 +51,6 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
-
     /* need to allocate temporary buffer to receive incoming data */
     MPIR_SCHED_CHKPMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
                               mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
@@ -37,10 +37,6 @@ int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf
     MPIR_SCHED_CHKPMEM_MALLOC(partial_scan, void *, count * (MPL_MAX(extent, true_extent)),
                               mpi_errno, "partial_scan", MPL_MEM_BUFFER);
 
-    /* This eventually gets malloc()ed as a temp buffer, not added to
-     * any user buffers */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *) ((char *) partial_scan - true_lb);
 

--- a/src/mpi/coll/iscan/iscan_intra_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_smp.c
@@ -42,8 +42,6 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     MPIR_SCHED_CHKPMEM_MALLOC(tempbuf, void *, count * (MPL_MAX(extent, true_extent)),
                               mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     tempbuf = (void *) ((char *) tempbuf - true_lb);

--- a/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
@@ -56,9 +56,6 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
             MPIR_Type_get_true_extent_impl(recvtype, &true_lb, &true_extent);
 
             MPIR_Datatype_get_extent_macro(recvtype, extent);
-            MPIR_Ensure_Aint_fits_in_pointer(extent * recvcount * local_size);
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                             sendcount * remote_size * extent);
 
             MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *,
                                       recvcount * local_size * (MPL_MAX(extent, true_extent)),

--- a/src/mpi/coll/iscatter/iscatter_intra_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_binomial.c
@@ -102,13 +102,9 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
          * in the event of recvbuf=MPI_IN_PLACE on the root,
          * recvcount and recvtype are not valid */
         MPIR_Datatype_get_size_macro(sendtype, sendtype_size);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                         extent * sendcount * comm_size);
-
         ss->nbytes = sendtype_size * sendcount;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
-        MPIR_Ensure_Aint_fits_in_pointer(extent * recvcount * comm_size);
         ss->nbytes = recvtype_size * recvcount;
     }
 

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
@@ -41,13 +41,6 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);
-        /* We need a check to ensure extent will fit in a
-         * pointer. That needs extent * (max count) but we can't get
-         * that without looping over the input data. This is at least
-         * a minimal sanity check. Maybe add a global var since we do
-         * loop over sendcount[] in MPI_Scatterv before calling
-         * this? */
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + extent);
 
         for (i = 0; i < comm_size; i++) {
             if (sendcounts[i]) {

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -63,10 +63,6 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
             MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
             MPIR_Datatype_get_extent_macro(datatype, extent);
-            /* I think this is the worse case, so we can avoid an assert()
-             * inside the for loop */
-            /* Should MPIR_CHKLMEM_MALLOC do this? */
-            MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
             MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                                 "temporary buffer", MPL_MEM_BUFFER);
             /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -43,11 +43,6 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
 
     is_commutative = MPIR_Op_is_commutative(op);
 
-    /* I think this is the worse case, so we can avoid an assert()
-     * inside the for loop */
-    /* should be buf+{this}? */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                         mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -76,11 +76,6 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    /* I think this is the worse case, so we can avoid an assert()
-     * inside the for loop */
-    /* should be buf+{this}? */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                         mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -35,8 +35,6 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, int count,
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                             mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -70,11 +70,6 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf, const
         goto fn_exit;
     }
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
-
     /* commutative and long message, or noncommutative and long message.
      * use (p-1) pairwise exchanges */
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -72,10 +72,6 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
         goto fn_exit;
     }
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
     /* slightly retask pof2 to mean pof2 equal or greater, not always greater as it is above */
     pof2 = 1;
     while (pof2 < comm_size)

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -94,10 +94,6 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         goto fn_exit;
     }
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
     /* commutative and short. use recursive halving algorithm */
 
     /* allocate temp. buffer to receive incoming data */

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -77,10 +77,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
         disps[i] = i * recvcount;
     }
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
     /* need to allocate temporary buffer to receive incoming data */
     MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
                         mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -97,10 +97,6 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         disps[i] = i * recvcount;
     }
 
-    /* total_count*extent eventually gets malloced. it isn't added to
-     * a user-passed in buffer */
-    MPIR_Ensure_Aint_fits_in_pointer(total_count * MPL_MAX(true_extent, extent));
-
     /* commutative and short. use recursive halving algorithm */
 
     /* allocate temp. buffer to receive incoming data */

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -87,10 +87,6 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     MPIR_CHKLMEM_MALLOC(partial_scan, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
                         "partial_scan", MPL_MEM_BUFFER);
 
-    /* This eventually gets malloc()ed as a temp buffer, not added to
-     * any user buffers */
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *) ((char *) partial_scan - true_lb);
 

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -30,8 +30,6 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, int count,
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
     MPIR_CHKLMEM_MALLOC(tempbuf, void *, count * (MPL_MAX(extent, true_extent)),
                         mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
     tempbuf = (void *) ((char *) tempbuf - true_lb);

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -64,9 +64,6 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendco
             MPIR_Type_get_true_extent_impl(recvtype, &true_lb, &true_extent);
 
             MPIR_Datatype_get_extent_macro(recvtype, extent);
-            MPIR_Ensure_Aint_fits_in_pointer(extent * recvcount * local_size);
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                             sendcount * remote_size * extent);
 
             MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
                                 recvcount * local_size * (MPL_MAX(extent, true_extent)), mpi_errno,

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -65,13 +65,9 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype
          * in the event of recvbuf=MPI_IN_PLACE on the root,
          * recvcount and recvtype are not valid */
         MPIR_Datatype_get_size_macro(sendtype, sendtype_size);
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf +
-                                         extent * sendcount * comm_size);
-
         nbytes = sendtype_size * sendcount;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
-        MPIR_Ensure_Aint_fits_in_pointer(extent * recvcount * comm_size);
         nbytes = recvtype_size * recvcount;
     }
 

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -47,13 +47,6 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const int *sendcounts, con
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);
-        /* We need a check to ensure extent will fit in a
-         * pointer. That needs extent * (max count) but we can't get
-         * that without looping over the input data. This is at least
-         * a minimal sanity check. Maybe add a global var since we do
-         * loop over sendcount[] in MPI_Scatterv before calling
-         * this? */
-        MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT sendbuf + extent);
 
         MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *),
                             mpi_errno, "reqarray", MPL_MEM_BUFFER);

--- a/src/mpi/datatype/address.c
+++ b/src/mpi/datatype/address.c
@@ -89,7 +89,7 @@ int MPI_Address(void *location, MPI_Aint * address)
      * standard, I can't tell if this is a compiler bug or a language bug.
      */
 #ifdef CHAR_PTR_IS_ADDRESS
-    *address = MPIR_VOID_PTR_CAST_TO_MPI_AINT((char *) location);
+    *address = (MPI_Aint) location;
 #else
     /* Note that this is the "portable" way to generate an address.
      * The difference of two pointers is the number of elements
@@ -98,7 +98,7 @@ int MPI_Address(void *location, MPI_Aint * address)
      * of bytes from 0 to location */
     /* To cover the case where a pointer is 32 bits and MPI_Aint is 64 bits,
      * add cast to unsigned so the high order address bit is not sign-extended. */
-    *address = MPIR_VOID_PTR_CAST_TO_MPI_AINT((char *) location - (char *) MPI_BOTTOM);
+    *address = (MPI_Aint) ((char *) location - (char *) MPI_BOTTOM);
 #endif
     /* The same code is used in MPI_Get_address */
 

--- a/src/mpi/datatype/dataloop/dataloop.c
+++ b/src/mpi/datatype/dataloop/dataloop.c
@@ -218,14 +218,8 @@ void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
             if (!(dataloop->kind & MPII_DATALOOP_FINAL_MASK)) {
                 MPIR_Assert(dataloop->loop_params.cm_t.dataloop);
 
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                 (char *)dataloop->loop_params.cm_t.dataloop +
-                                                 ptrdiff);
-
-                dataloop->loop_params.cm_t.dataloop =
-                    (MPIR_Dataloop *) MPIR_AINT_CAST_TO_VOID_PTR
-                    (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.cm_t.dataloop +
-                     ptrdiff);
+                dataloop->loop_params.cm_t.dataloop = (MPIR_Dataloop *) (void *)
+                    ((MPI_Aint) (char *) dataloop->loop_params.cm_t.dataloop + ptrdiff);
 
                 MPII_Dataloop_update(dataloop->loop_params.cm_t.dataloop, ptrdiff);
             }
@@ -234,26 +228,14 @@ void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
         case MPII_DATALOOP_KIND_BLOCKINDEXED:
             MPIR_Assert(dataloop->loop_params.bi_t.offset_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.bi_t.offset_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.bi_t.offset_array =
-                (MPI_Aint *) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.bi_t.offset_array +
-                 ptrdiff);
+            dataloop->loop_params.bi_t.offset_array = (MPI_Aint *) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.bi_t.offset_array + ptrdiff);
 
             if (!(dataloop->kind & MPII_DATALOOP_FINAL_MASK)) {
                 MPIR_Assert(dataloop->loop_params.bi_t.dataloop);
 
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                 (char *)dataloop->loop_params.bi_t.dataloop +
-                                                 ptrdiff);
-
-                dataloop->loop_params.bi_t.dataloop =
-                    (MPIR_Dataloop *) MPIR_AINT_CAST_TO_VOID_PTR
-                    (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.bi_t.dataloop +
-                     ptrdiff);
+                dataloop->loop_params.bi_t.dataloop = (MPIR_Dataloop *) (void *)
+                    ((MPI_Aint) (char *) dataloop->loop_params.bi_t.dataloop + ptrdiff);
 
                 MPII_Dataloop_update(dataloop->loop_params.bi_t.dataloop, ptrdiff);
             }
@@ -262,37 +244,19 @@ void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
         case MPII_DATALOOP_KIND_INDEXED:
             MPIR_Assert(dataloop->loop_params.i_t.blocksize_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.i_t.blocksize_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.i_t.blocksize_array =
-                (MPI_Aint *) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.i_t.blocksize_array +
-                 ptrdiff);
+            dataloop->loop_params.i_t.blocksize_array = (MPI_Aint *) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.i_t.blocksize_array + ptrdiff);
 
             MPIR_Assert(dataloop->loop_params.i_t.offset_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.i_t.offset_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.i_t.offset_array =
-                (MPI_Aint *) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.i_t.offset_array +
-                 ptrdiff);
+            dataloop->loop_params.i_t.offset_array = (MPI_Aint *) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.i_t.offset_array + ptrdiff);
 
             if (!(dataloop->kind & MPII_DATALOOP_FINAL_MASK)) {
                 MPIR_Assert(dataloop->loop_params.i_t.dataloop);
 
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                 (char *)dataloop->loop_params.i_t.dataloop +
-                                                 ptrdiff);
-
-                dataloop->loop_params.i_t.dataloop =
-                    (MPIR_Dataloop *) MPIR_AINT_CAST_TO_VOID_PTR
-                    (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.i_t.dataloop +
-                     ptrdiff);
+                dataloop->loop_params.i_t.dataloop = (MPIR_Dataloop *) (void *)
+                    ((MPI_Aint) (char *) dataloop->loop_params.i_t.dataloop + ptrdiff);
 
                 MPII_Dataloop_update(dataloop->loop_params.i_t.dataloop, ptrdiff);
             }
@@ -301,50 +265,29 @@ void MPII_Dataloop_update(MPIR_Dataloop * dataloop, MPI_Aint ptrdiff)
         case MPII_DATALOOP_KIND_STRUCT:
             MPIR_Assert(dataloop->loop_params.s_t.blocksize_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.s_t.blocksize_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.s_t.blocksize_array =
-                (MPI_Aint *) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.s_t.blocksize_array +
-                 ptrdiff);
+            dataloop->loop_params.s_t.blocksize_array = (MPI_Aint *) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.s_t.blocksize_array + ptrdiff);
 
             MPIR_Assert(dataloop->loop_params.s_t.offset_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.s_t.offset_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.s_t.offset_array =
-                (MPI_Aint *) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.s_t.offset_array +
-                 ptrdiff);
+            dataloop->loop_params.s_t.offset_array = (MPI_Aint *) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.s_t.offset_array + ptrdiff);
 
             if (dataloop->kind & MPII_DATALOOP_FINAL_MASK)
                 break;
 
             MPIR_Assert(dataloop->loop_params.s_t.dataloop_array);
 
-            MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                             (char *)dataloop->loop_params.s_t.dataloop_array +
-                                             ptrdiff);
-
-            dataloop->loop_params.s_t.dataloop_array =
-                (MPIR_Dataloop **) MPIR_AINT_CAST_TO_VOID_PTR
-                (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)dataloop->loop_params.s_t.dataloop_array +
-                 ptrdiff);
+            dataloop->loop_params.s_t.dataloop_array = (MPIR_Dataloop **) (void *)
+                ((MPI_Aint) (char *) dataloop->loop_params.s_t.dataloop_array + ptrdiff);
 
             /* fix the N dataloop pointers too */
             looparray = dataloop->loop_params.s_t.dataloop_array;
             for (i = 0; i < dataloop->loop_params.s_t.count; i++) {
                 MPIR_Assert(looparray[i]);
 
-                MPIR_Ensure_Aint_fits_in_pointer(MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)looparray
-                                                 [i] + ptrdiff);
-
-                looparray[i] = (MPIR_Dataloop *) MPIR_AINT_CAST_TO_VOID_PTR
-                    (MPIR_VOID_PTR_CAST_TO_MPI_AINT(char *)looparray[i] + ptrdiff);
+                looparray[i] = (MPIR_Dataloop *) (void *)
+                    ((MPI_Aint) (char *) looparray[i] + ptrdiff);
             }
 
             for (i = 0; i < dataloop->loop_params.s_t.count; i++) {

--- a/src/mpi/datatype/dataloop/dataloop_create.c
+++ b/src/mpi/datatype/dataloop/dataloop_create.c
@@ -15,7 +15,7 @@
     {                                                                   \
         struct { ut1_ a; ut2_ b; } foo;                                 \
         disps[0] = 0;                                                   \
-        disps[1] = MPIR_VOID_PTR_CAST_TO_MPI_AINT ((char *) &foo.b - (char *) &foo.a); \
+        disps[1] = (MPI_Aint) ((char *) &foo.b - (char *) &foo.a); \
         types[0] = mt1_;                                                \
         types[1] = mt2_;                                                \
     }

--- a/src/mpi/datatype/dataloop/dataloop_create_struct.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_struct.c
@@ -369,8 +369,7 @@ static int create_flattened_struct(MPI_Aint count,
          */
         if (oldtypes[i] != MPI_UB &&
             oldtypes[i] != MPI_LB && blklens[i] != 0 && (is_basic || sz > 0)) {
-            segp = MPIR_Segment_alloc((char *) MPIR_AINT_CAST_TO_VOID_PTR disps[i],
-                                      (MPI_Aint) blklens[i], oldtypes[i]);
+            segp = MPIR_Segment_alloc((char *) disps[i], (MPI_Aint) blklens[i], oldtypes[i]);
 
             last_ind = nr_blks - first_ind;
             bytes = MPIR_SEGMENT_IGNORE_LAST;

--- a/src/mpi/datatype/dataloop/looputil.c
+++ b/src/mpi/datatype/dataloop/looputil.c
@@ -437,22 +437,10 @@ static int contig_m2m(MPI_Aint * blocks_p,
 #endif
 
     if (paramp->direction == M2M_TO_USERBUF) {
-        /* Ensure that pointer increment fits in a pointer */
-        /* userbuf is a pointer (not a displacement) since it is being
-         * used on a memcpy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->userbuf)) +
-                                         rel_off);
         MPIR_Memcpy((char *) paramp->userbuf + rel_off, paramp->streambuf, size);
     } else {
-        /* Ensure that pointer increment fits in a pointer */
-        /* userbuf is a pointer (not a displacement) since it is being used on a memcpy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->userbuf)) +
-                                         rel_off);
         MPIR_Memcpy(paramp->streambuf, (char *) paramp->userbuf + rel_off, size);
     }
-    /* Ensure that pointer increment fits in a pointer */
-    /* streambuf is a pointer (not a displacement) since it was used on a memcpy */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->streambuf)) + size);
     paramp->streambuf += size;
     return 0;
 }
@@ -472,9 +460,6 @@ static int vector_m2m(MPI_Aint * blocks_p, MPI_Aint count ATTRIBUTE((unused)), M
     struct MPII_Dataloop_m2m_params *paramp = v_paramp;
     char *cbufp;
 
-    /* Ensure that pointer increment fits in a pointer */
-    /* userbuf is a pointer (not a displacement) since it is being used for a memory copy */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->userbuf)) + rel_off);
     cbufp = (char *) paramp->userbuf + rel_off;
     MPIR_Datatype_get_size_macro(el_type, el_size);
     DBG_SEGMENT(printf
@@ -499,26 +484,14 @@ static int vector_m2m(MPI_Aint * blocks_p, MPI_Aint count ATTRIBUTE((unused)), M
                 MPIR_Memcpy(cbufp, paramp->streambuf, ((MPI_Aint) blksz) * el_size);
                 DBG_SEGMENT(printf("vec: memcpy %p %p %d\n", cbufp,
                                    paramp->streambuf, (int) (blksz * el_size)));
-                /* Ensure that pointer increment fits in a pointer */
-                /* streambuf is a pointer (not a displacement) since it is being used for a memory copy */
-                MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                  (paramp->streambuf)) +
-                                                 ((MPI_Aint) blksz) * el_size);
                 paramp->streambuf += ((MPI_Aint) blksz) * el_size;
 
-                MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(cbufp)) + stride);
                 cbufp += stride;
             }
             if (blocks_left) {
                 MPIR_Memcpy(cbufp, paramp->streambuf, ((MPI_Aint) blocks_left) * el_size);
                 DBG_SEGMENT(printf("vec(left): memcpy %p %p %d\n", cbufp,
                                    paramp->streambuf, (int) (blocks_left * el_size)));
-                /* Ensure that pointer increment fits in a pointer */
-                /* streambuf is a pointer (not a displacement) since
-                 * it is being used for a memory copy */
-                MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                  (paramp->streambuf)) +
-                                                 ((MPI_Aint) blocks_left) * el_size);
                 paramp->streambuf += ((MPI_Aint) blocks_left) * el_size;
             }
         }
@@ -536,14 +509,8 @@ static int vector_m2m(MPI_Aint * blocks_p, MPI_Aint count ATTRIBUTE((unused)), M
         } else {
             for (i = 0; i < whole_count; i++) {
                 MPIR_Memcpy(paramp->streambuf, cbufp, (MPI_Aint) blksz * el_size);
-                /* Ensure that pointer increment fits in a pointer */
-                /* streambuf is a pointer (not a displacement) since
-                 * it is being used for a memory copy */
                 DBG_SEGMENT(printf("vec: memcpy %p %p %d\n",
                                    paramp->streambuf, cbufp, (int) (blksz * el_size)));
-                MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                  (paramp->streambuf)) +
-                                                 (MPI_Aint) blksz * el_size);
                 paramp->streambuf += (MPI_Aint) blksz *el_size;
                 cbufp += stride;
             }
@@ -551,12 +518,6 @@ static int vector_m2m(MPI_Aint * blocks_p, MPI_Aint count ATTRIBUTE((unused)), M
                 MPIR_Memcpy(paramp->streambuf, cbufp, (MPI_Aint) blocks_left * el_size);
                 DBG_SEGMENT(printf("vec(left): memcpy %p %p %d\n",
                                    paramp->streambuf, cbufp, (int) (blocks_left * el_size)));
-                /* Ensure that pointer increment fits in a pointer */
-                /* streambuf is a pointer (not a displacement) since
-                 * it is being used for a memory copy */
-                MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT
-                                                  (paramp->streambuf)) +
-                                                 (MPI_Aint) blocks_left * el_size);
                 paramp->streambuf += (MPI_Aint) blocks_left *el_size;
             }
         }
@@ -587,11 +548,6 @@ static int blkidx_m2m(MPI_Aint * blocks_p,
 
         MPIR_Assert(curblock < count);
 
-        /* Ensure that pointer increment fits in a pointer */
-        /* userbuf is a pointer (not a displacement) since it is being
-         * used for a memory copy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->userbuf)) +
-                                         rel_off + offsetarray[curblock]);
         cbufp = (char *) paramp->userbuf + rel_off + offsetarray[curblock];
 
         /* there was some casting going on here at one time but now all types
@@ -620,11 +576,6 @@ static int blkidx_m2m(MPI_Aint * blocks_p,
                         ("blkidx m3m:memcpy(%p,%p,%d)\n", dest, src, (int) (blocklen * el_size)));
         }
 
-        /* Ensure that pointer increment fits in a pointer */
-        /* streambuf is a pointer (not a displacement) since it is
-         * being used for a memory copy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->streambuf)) +
-                                         (MPI_Aint) blocklen * el_size);
         paramp->streambuf += (MPI_Aint) blocklen *el_size;
         blocks_left -= blocklen;
         curblock++;
@@ -655,11 +606,6 @@ static int index_m2m(MPI_Aint * blocks_p,
         MPIR_Assert(curblock < count);
         cur_block_sz = blockarray[curblock];
 
-        /* Ensure that pointer increment fits in a pointer */
-        /* userbuf is a pointer (not a displacement) since it is being
-         * used for a memory copy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->userbuf)) +
-                                         rel_off + offsetarray[curblock]);
         cbufp = (char *) paramp->userbuf + rel_off + offsetarray[curblock];
 
         if (cur_block_sz > blocks_left)
@@ -684,11 +630,6 @@ static int index_m2m(MPI_Aint * blocks_p,
             MPIR_Memcpy(dest, src, cur_block_sz * el_size);
         }
 
-        /* Ensure that pointer increment fits in a pointer */
-        /* streambuf is a pointer (not a displacement) since it is
-         * being used for a memory copy */
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(paramp->streambuf)) +
-                                         cur_block_sz * el_size);
         paramp->streambuf += cur_block_sz * el_size;
         blocks_left -= cur_block_sz;
         curblock++;
@@ -995,7 +936,6 @@ static int contig_pack_to_iov(MPI_Aint * blocks_p,
             paramp->u.pack_vector.vectorp[last_idx].MPL_IOV_LEN;
     }
 
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(bufp)) + rel_off);
     if ((last_idx == paramp->u.pack_vector.length - 1) && (last_end != ((char *) bufp + rel_off))) {
         /* we have used up all our entries, and this region doesn't fit on
          * the end of the last one.  setting blocks to 0 tells manipulation
@@ -1082,7 +1022,6 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blks
                 paramp->u.pack_vector.vectorp[last_idx].MPL_IOV_LEN;
         }
 
-        MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT(bufp)) + rel_off);
         if ((last_idx == paramp->u.pack_vector.length - 1) &&
             (last_end != ((char *) bufp + rel_off))) {
             /* we have used up all our entries, and this one doesn't fit on

--- a/src/mpi/datatype/dataloop/segment_flatten.c
+++ b/src/mpi/datatype/dataloop/segment_flatten.c
@@ -109,19 +109,10 @@ static int leaf_contig_mpi_flatten(MPI_Aint * blocks_p,
 
     last_idx = paramp->index - 1;
     if (last_idx >= 0) {
-        /* Since disps can be negative, we cannot use
-         * MPIR_Ensure_Aint_fits_in_pointer to verify that disps +
-         * blklens fits in a pointer.  Just let it truncate, if the
-         * sizeof a pointer is less than the sizeof an MPI_Aint.
-         */
-        last_end = (char *) MPIR_AINT_CAST_TO_VOID_PTR
+        last_end = (char *)
             (paramp->disps[last_idx] + ((MPI_Aint) paramp->blklens[last_idx]));
     }
 
-    /* Since bufp can be a displacement and can be negative, we cannot
-     * use MPIR_Ensure_Aint_fits_in_pointer to ensure the sum fits in
-     * a pointer.  Just let it truncate.
-     */
     if ((last_idx == paramp->length - 1) && (last_end != ((char *) bufp + rel_off))) {
         /* we have used up all our entries, and this region doesn't fit on
          * the end of the last one.  setting blocks to 0 tells manipulation
@@ -133,11 +124,7 @@ static int leaf_contig_mpi_flatten(MPI_Aint * blocks_p,
         /* add this size to the last vector rather than using up another one */
         paramp->blklens[last_idx] += size;
     } else {
-        /* Since bufp can be a displacement and can be negative, we cannot use
-         * MPIR_VOID_PTR_CAST_TO_MPI_AINT to cast the sum to a pointer.  Just let it
-         * sign extend.
-         */
-        paramp->disps[last_idx + 1] = MPIR_PTR_DISP_CAST_TO_MPI_AINT bufp + rel_off;
+        paramp->disps[last_idx + 1] = (MPI_Aint) bufp + rel_off;
         paramp->blklens[last_idx + 1] = size;
         paramp->index++;
     }
@@ -189,21 +176,10 @@ static int leaf_vector_mpi_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint
 
         last_idx = paramp->index - 1;
         if (last_idx >= 0) {
-            /* Since disps can be negative, we cannot use
-             * MPIR_Ensure_Aint_fits_in_pointer to verify that disps +
-             * blklens fits in a pointer.  Nor can we use
-             * MPIR_AINT_CAST_TO_VOID_PTR to cast the sum to a pointer.
-             * Just let it truncate, if the sizeof a pointer is less
-             * than the sizeof an MPI_Aint.
-             */
-            last_end = (char *) MPIR_AINT_CAST_TO_VOID_PTR
+            last_end = (char *)
                 (paramp->disps[last_idx] + (MPI_Aint) (paramp->blklens[last_idx]));
         }
 
-        /* Since bufp can be a displacement and can be negative, we cannot use
-         * MPIR_Ensure_Aint_fits_in_pointer to ensure the sum fits in a pointer.
-         * Just let it truncate.
-         */
         if ((last_idx == paramp->length - 1) && (last_end != ((char *) bufp + rel_off))) {
             /* we have used up all our entries, and this one doesn't fit on
              * the end of the last one.
@@ -221,11 +197,7 @@ static int leaf_vector_mpi_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint
             /* add this size to the last vector rather than using up new one */
             paramp->blklens[last_idx] += size;
         } else {
-            /* Since bufp can be a displacement and can be negative, we cannot use
-             * MPIR_VOID_PTR_CAST_TO_MPI_AINT to cast the sum to a pointer.  Just let it
-             * sign extend.
-             */
-            paramp->disps[last_idx + 1] = MPIR_PTR_DISP_CAST_TO_MPI_AINT bufp + rel_off;
+            paramp->disps[last_idx + 1] = (MPI_Aint) bufp + rel_off;
             paramp->blklens[last_idx + 1] = size;
             paramp->index++;
         }
@@ -280,21 +252,10 @@ static int leaf_blkidx_mpi_flatten(MPI_Aint * blocks_p,
 
         last_idx = paramp->index - 1;
         if (last_idx >= 0) {
-            /* Since disps can be negative, we cannot use
-             * MPIR_Ensure_Aint_fits_in_pointer to verify that disps +
-             * blklens fits in a pointer.  Nor can we use
-             * MPIR_AINT_CAST_TO_VOID_PTR to cast the sum to a pointer.
-             * Just let it truncate, if the sizeof a pointer is less
-             * than the sizeof an MPI_Aint.
-             */
-            last_end = (char *) MPIR_AINT_CAST_TO_VOID_PTR
+            last_end = (char *)
                 (paramp->disps[last_idx] + ((MPI_Aint) paramp->blklens[last_idx]));
         }
 
-        /* Since bufp can be a displacement and can be negative, we
-         * cannot use MPIR_Ensure_Aint_fits_in_pointer to ensure the
-         * sum fits in a pointer.  Just let it truncate.
-         */
         if ((last_idx == paramp->length - 1) &&
             (last_end != ((char *) bufp + rel_off + offsetarray[i]))) {
             /* we have used up all our entries, and this one doesn't fit on
@@ -306,12 +267,7 @@ static int leaf_blkidx_mpi_flatten(MPI_Aint * blocks_p,
             /* add this size to the last vector rather than using up new one */
             paramp->blklens[last_idx] += size;
         } else {
-            /* Since bufp can be a displacement and can be negative, we cannot
-             * use MPIR_VOID_PTR_CAST_TO_MPI_AINT to cast the sum to a pointer.
-             * Just let it sign extend.
-             */
-            paramp->disps[last_idx + 1] = MPIR_PTR_DISP_CAST_TO_MPI_AINT bufp +
-                rel_off + offsetarray[i];
+            paramp->disps[last_idx + 1] = (MPI_Aint) bufp + rel_off + offsetarray[i];
             paramp->blklens[last_idx + 1] = size;
             paramp->index++;
         }
@@ -356,21 +312,10 @@ static int leaf_index_mpi_flatten(MPI_Aint * blocks_p,
 
         last_idx = paramp->index - 1;
         if (last_idx >= 0) {
-            /* Since disps can be negative, we cannot use
-             * MPIR_Ensure_Aint_fits_in_pointer to verify that disps +
-             * blklens fits in a pointer.  Nor can we use
-             * MPIR_AINT_CAST_TO_VOID_PTR to cast the sum to a pointer.
-             * Just let it truncate, if the sizeof a pointer is less
-             * than the sizeof an MPI_Aint.
-             */
-            last_end = (char *) MPIR_AINT_CAST_TO_VOID_PTR
+            last_end = (char *)
                 (paramp->disps[last_idx] + (MPI_Aint) (paramp->blklens[last_idx]));
         }
 
-        /* Since bufp can be a displacement and can be negative, we
-         * cannot use MPIR_Ensure_Aint_fits_in_pointer to ensure the
-         * sum fits in a pointer.  Just let it truncate.
-         */
         if ((last_idx == paramp->length - 1) &&
             (last_end != ((char *) bufp + rel_off + offsetarray[i]))) {
             /* we have used up all our entries, and this one doesn't fit on
@@ -382,12 +327,7 @@ static int leaf_index_mpi_flatten(MPI_Aint * blocks_p,
             /* add this size to the last vector rather than using up new one */
             paramp->blklens[last_idx] += size;
         } else {
-            /* Since bufp can be a displacement and can be negative, we cannot
-             * use MPIR_VOID_PTR_CAST_TO_MPI_AINT to cast the sum to a pointer.
-             * Just let it sign extend.
-             */
-            paramp->disps[last_idx + 1] = MPIR_PTR_DISP_CAST_TO_MPI_AINT bufp +
-                rel_off + offsetarray[i];
+            paramp->disps[last_idx + 1] = (MPI_Aint) bufp + rel_off + offsetarray[i];
             paramp->blklens[last_idx + 1] = size;       /* these blocks are in bytes */
             paramp->index++;
         }

--- a/src/mpi/datatype/get_address.c
+++ b/src/mpi/datatype/get_address.c
@@ -100,14 +100,14 @@ int MPI_Get_address(const void *location, MPI_Aint * address)
      * standard, I can't tell if this is a compiler bug or a language bug.
      */
 #ifdef CHAR_PTR_IS_ADDRESS
-    *address = MPIR_VOID_PTR_CAST_TO_MPI_AINT((char *) location);
+    *address = (MPI_Aint) location;
 #else
     /* Note that this is the "portable" way to generate an address.
      * The difference of two pointers is the number of elements
      * between them, so this gives the number of chars between location
      * and ptr.  As long as sizeof(char) represents one byte,
      * of bytes from 0 to location */
-    *address = MPIR_VOID_PTR_CAST_TO_MPI_AINT((char *) location - (char *) MPI_BOTTOM);
+    *address = (MPI_Aint) ((char *) location - (char *) MPI_BOTTOM);
 #endif
     /* The same code is used in MPI_Address */
 

--- a/src/mpi/datatype/pack.c
+++ b/src/mpi/datatype/pack.c
@@ -79,10 +79,6 @@ int MPIR_Pack_impl(const void *inbuf,
     first = 0;
     last = MPIR_SEGMENT_IGNORE_LAST;
 
-    /* Ensure that pointer increment fits in a pointer */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT outbuf) +
-                                     (MPI_Aint) * position);
-
     MPIR_Segment_pack(segp, first, &last, (void *) ((char *) outbuf + *position));
 
     /* Ensure that calculation fits into an int datatype. */

--- a/src/mpi/datatype/pack_external.c
+++ b/src/mpi/datatype/pack_external.c
@@ -128,9 +128,6 @@ int MPI_Pack_external(const char datarep[],
     first = 0;
     last = MPIR_SEGMENT_IGNORE_LAST;
 
-    /* Ensure that pointer increment fits in a pointer */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT outbuf) + *position);
-
     MPIR_Segment_pack_external32(segp, first, &last, (void *) ((char *) outbuf + *position));
 
     *position += last;

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -19,9 +19,8 @@
         type_size_   = sizeof(foo.a) + sizeof(foo.b);                   \
         type_extent_ = (MPI_Aint) sizeof(foo);                          \
         el_size_ = (sizeof(foo.a) == sizeof(foo.b)) ? (int) sizeof(foo.a) : -1; \
-        true_ub_ = (MPIR_VOID_PTR_CAST_TO_MPI_AINT ((char *) &foo.b -     \
-                                                  (char *) &foo.a)) +   \
-                  (MPI_Aint) sizeof(foo.b);                             \
+        true_ub_ = ((MPI_Aint) ((char *) &foo.b - (char *) &foo.a)) +   \
+            (MPI_Aint) sizeof(foo.b);                                   \
         alignsize_ = MPL_MAX(MPIR_Datatype_get_basic_size(mt1_),        \
                              MPIR_Datatype_get_basic_size(mt2_));       \
     }

--- a/src/mpi/datatype/unpack.c
+++ b/src/mpi/datatype/unpack.c
@@ -74,10 +74,6 @@ int MPIR_Unpack_impl(const void *inbuf, MPI_Aint insize, MPI_Aint * position,
     first = 0;
     last = MPIR_SEGMENT_IGNORE_LAST;
 
-    /* Ensure that pointer increment fits in a pointer */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT inbuf) +
-                                     (MPI_Aint) * position);
-
     MPIR_Segment_unpack(segp, first, &last, (void *) ((char *) inbuf + *position));
 
     /* Ensure that calculation fits into an int datatype. */

--- a/src/mpi/datatype/unpack_external.c
+++ b/src/mpi/datatype/unpack_external.c
@@ -118,9 +118,6 @@ int MPI_Unpack_external(const char datarep[],
     first = 0;
     last = MPIR_SEGMENT_IGNORE_LAST;
 
-    /* Ensure that pointer increment fits in a pointer */
-    MPIR_Ensure_Aint_fits_in_pointer((MPIR_VOID_PTR_CAST_TO_MPI_AINT inbuf) + *position);
-
     MPIR_Segment_unpack_external32(segp, first, &last, (void *) ((char *) inbuf + *position));
 
     *position += last;

--- a/src/mpi/datatype/veccpy.h
+++ b/src/mpi/datatype/veccpy.h
@@ -11,21 +11,21 @@
 #ifdef HAVE_ANY_INT64_T_ALIGNEMENT
 #define MPIR_ALIGN8_TEST(p1,p2)
 #else
-#define MPIR_ALIGN8_TEST(p1,p2) && (((MPIR_VOID_PTR_CAST_TO_MPI_AINT p1 | MPIR_VOID_PTR_CAST_TO_MPI_AINT p2) & 0x7) == 0)
+#define MPIR_ALIGN8_TEST(p1,p2) && ((((MPI_Aint) p1 | (MPI_Aint) p2) & 0x7) == 0)
 #endif
 
 #ifdef HAVE_ANY_INT32_T_ALIGNEMENT
 #define MPIR_ALIGN4_TEST(p1,p2)
 #else
-#define MPIR_ALIGN4_TEST(p1,p2) && (((MPIR_VOID_PTR_CAST_TO_MPI_AINT p1 | MPIR_VOID_PTR_CAST_TO_MPI_AINT p2) & 0x3) == 0)
+#define MPIR_ALIGN4_TEST(p1,p2) && ((((MPI_Aint) p1 | (MPI_Aint) p2) & 0x3) == 0)
 #endif
 
 #define MPII_COPY_FROM_VEC(src,dest,stride,type,nelms,count)            \
     {                                                                   \
         if (!nelms) {                                                   \
-            src = (char*) MPIR_AINT_CAST_TO_VOID_PTR                 \
-            ((MPIR_VOID_PTR_CAST_TO_MPI_AINT (src)) +                    \
-             ((MPI_Aint) count * (MPI_Aint) stride));           \
+            src = (char*)                                               \
+                (((MPI_Aint) (src)) +                                   \
+                 ((MPI_Aint) count * (MPI_Aint) stride));               \
         }                                                               \
         else if (stride % sizeof(type)) {                               \
             MPII_COPY_FROM_VEC_UNALIGNED(src,dest,stride,type,nelms,count); \
@@ -38,11 +38,11 @@
 #define MPII_COPY_TO_VEC(src,dest,stride,type,nelms,count)              \
     {                                                                   \
         if (!nelms) {                                                   \
-            dest = (char*) MPIR_AINT_CAST_TO_VOID_PTR                \
-            ((MPIR_VOID_PTR_CAST_TO_MPI_AINT (dest)) +                   \
-             ((MPI_Aint) count * (MPI_Aint) stride));           \
+            dest = (char*)                                              \
+                (((MPI_Aint) (dest)) +                                  \
+                 ((MPI_Aint) count * (MPI_Aint) stride));               \
         }                                                               \
-        else if (stride % (MPI_Aint) sizeof(type)) {                \
+        else if (stride % (MPI_Aint) sizeof(type)) {                    \
             MPII_COPY_TO_VEC_UNALIGNED(src,dest,stride,type,nelms,count); \
         }                                                               \
         else {                                                          \

--- a/src/mpi/rma/alloc_mem.c
+++ b/src/mpi/rma/alloc_mem.c
@@ -90,7 +90,6 @@ int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr)
 
     /* ... body of routine ...  */
 
-    MPIR_Ensure_Aint_fits_in_pointer(size);
     ap = MPID_Alloc_mem(size, info_ptr);
 
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -1179,7 +1179,6 @@ static void ADIOI_R_Exchange_data_alltoallv(ADIO_File fd, void *buf, ADIOI_Flatl
             }
             sbuf_ptr = all_send_buf + sdispls[i];
             for (j = 0; j < count[i]; j++) {
-                ADIOI_ENSURE_AINT_FITS_IN_PTR(others_req[i].mem_ptrs[start_pos[i] + j]);
                 from_ptr =
                     (char *) ADIOI_AINT_CAST_TO_VOID_PTR(others_req[i].mem_ptrs[start_pos[i] + j]);
                 len = others_req[i].lens[start_pos[i] + j];

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -1651,7 +1651,6 @@ static void ADIOI_W_Exchange_data_alltoallv(ADIO_File fd, const void *buf, char 
 
             sbuf_ptr = all_recv_buf + rdispls[i];
             for (j = 0; j < count[i]; j++) {
-                ADIOI_ENSURE_AINT_FITS_IN_PTR(others_req[i].mem_ptrs[start_pos[i] + j]);
                 to_ptr =
                     (char *) ADIOI_AINT_CAST_TO_VOID_PTR(others_req[i].mem_ptrs[start_pos[i] + j]);
                 len = others_req[i].lens[start_pos[i] + j];

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -930,8 +930,6 @@ int ADIOI_MPE_iwrite_b;
    (no loss of (meaningful) high order bytes in 8 byte MPI_Aint
       to (possible) 4 byte ptr cast)                              */
 /* Should work even on 64bit or old 32bit configs                 */
-  /* Use MPIR_Ensure_Aint_fits_in_pointer and
-   * MPIR_AINT_CAST_TO_VOID_PTR from configure (mpi.h) */
 #include "mpir_ext.h"
 
 #define ADIOI_AINT_CAST_TO_VOID_PTR (void*)(intptr_t)
@@ -939,15 +937,12 @@ int ADIOI_MPE_iwrite_b;
    * when casting a (possible 4 byte) aint to a (8 byte) long long or offset */
 #define ADIOI_AINT_CAST_TO_LONG_LONG (long long)
 #define ADIOI_AINT_CAST_TO_OFFSET ADIOI_AINT_CAST_TO_LONG_LONG
-
-#define ADIOI_ENSURE_AINT_FITS_IN_PTR(aint_value) MPIR_Ext_ensure_Aint_fits_in_pointer(aint_value)
 #define ADIOI_Assert MPIR_Ext_assert
 #else
 #include <assert.h>
 #define ADIOI_AINT_CAST_TO_VOID_PTR (void*)
 #define ADIOI_AINT_CAST_TO_LONG_LONG (long long)
 #define ADIOI_AINT_CAST_TO_OFFSET ADIOI_AINT_CAST_TO_LONG_LONG
-#define ADIOI_ENSURE_AINT_FITS_IN_PTR(aint_value)
 #define ADIOI_Assert assert
 #endif
 

--- a/src/mpid/ch3/src/mpid_aint.c
+++ b/src/mpid/ch3/src/mpid_aint.c
@@ -27,7 +27,7 @@ MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_ADD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_AINT_ADD);
 
-    result =  MPIR_VOID_PTR_CAST_TO_MPI_AINT ((char*)MPIR_AINT_CAST_TO_VOID_PTR(base) + disp);
+    result = (MPI_Aint) ((char *) base + disp);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_AINT_ADD);
     return result;
@@ -54,7 +54,7 @@ MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_DIFF);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_AINT_DIFF);
 
-    result =  MPIR_PTR_DISP_CAST_TO_MPI_AINT ((char*)MPIR_AINT_CAST_TO_VOID_PTR(addr1) - (char*)MPIR_AINT_CAST_TO_VOID_PTR(addr2));
+    result = (MPI_Aint) ((char *) addr1 - (char *) addr2);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_AINT_DIFF);
     return result;

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -471,8 +471,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
-
         MPIR_CHKLMEM_MALLOC(recvbuf, void *, count * (MPL_MAX(extent, true_extent)),
                             mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
         /* adjust for potential negative lower bound in datatype */
@@ -569,8 +567,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
 
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
-
-        MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
                             mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
@@ -1505,8 +1501,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
-
-    MPIR_Ensure_Aint_fits_in_pointer(count * MPL_MAX(extent, true_extent));
 
     MPIR_CHKLMEM_MALLOC(tempbuf, void *, count * (MPL_MAX(extent, true_extent)),
                         mpi_errno, "temporary buffer", MPL_MEM_BUFFER);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -822,7 +822,7 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_add(MPI_Aint base, MPI_Aint disp)
     MPI_Aint result;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_ADD);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_AINT_ADD);
-    result = MPIR_VOID_PTR_CAST_TO_MPI_AINT((char *) MPIR_AINT_CAST_TO_VOID_PTR(base) + disp);
+    result = (MPI_Aint) ((char *) base + disp);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_AINT_ADD);
     return result;
 }
@@ -837,8 +837,7 @@ MPL_STATIC_INLINE_PREFIX MPI_Aint MPID_Aint_diff(MPI_Aint addr1, MPI_Aint addr2)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_AINT_DIFF);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_AINT_DIFF);
 
-    result = MPIR_PTR_DISP_CAST_TO_MPI_AINT((char *) MPIR_AINT_CAST_TO_VOID_PTR(addr1)
-                                            - (char *) MPIR_AINT_CAST_TO_VOID_PTR(addr2));
+    result = (MPI_Aint) ((char *) addr1 - (char *) addr2);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_AINT_DIFF);
     return result;
 }


### PR DESCRIPTION
We had added a bunch of MPI_Aint to/from (void *) macros, and macros
to make sure that one can fit inside the other, during the IBM BG/P
days.  This was done because BG/P was a 32-bit machine but IBM wanted
to support a 64-bit filesystem, so they created a version where
MPI_Aint could be upgraded to 64-bit even though "void *" was just
32-bit.

Luckily, such architectures are behind us.  We can now safely assume
that "void *" is large enough for our file systems for a while.