### PR TITLE
Implement per-vci thread-safety for HCOLL

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -175,7 +175,7 @@ struct MPIR_Comm {
     MPIR_Info *info;            /* Hints to the communicator */
 
 #if defined HAVE_LIBHCOLL
-    hcoll_comm_priv_t hcoll_priv;
+    MPIDI_HCOLL_comm_priv_t hcoll_priv;
 #endif                          /* HAVE_LIBHCOLL */
 
     /* the mapper is temporarily filled out in order to allow the

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -21,7 +21,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_barrier(comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_barrier(comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -41,7 +41,7 @@ static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_bcast(buffer, count, datatype, root, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -62,7 +62,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -84,7 +84,7 @@ static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatyp
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
+    mpi_errno = MPIDI_HCOLL_coll_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -21,7 +21,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Barrier(comm, errflag);
+    mpi_errno = MPIDI_HCOLL_barrier(comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -41,7 +41,7 @@ static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -62,7 +62,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -84,7 +84,7 @@ static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatyp
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
+    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -97,9 +97,9 @@ int MPIDI_CH3I_Comm_init(void)
         }
 #endif
 
-        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_comm_create, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_mpi_comm_create, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_comm_destroy, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_mpi_comm_destroy, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
 #endif

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -97,9 +97,9 @@ int MPIDI_CH3I_Comm_init(void)
         }
 #endif
 
-        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(hcoll_comm_create, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_comm_create, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(hcoll_comm_destroy, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_comm_destroy, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BARRIER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_barrier(comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_barrier(comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BCAST);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_bcast(buffer, count, datatype, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -79,7 +79,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno =
+        MPIDI_HCOLL_coll_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -106,8 +107,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLGATHER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                      recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_allgather(sendbuf, sendcount, sendtype, recvbuf,
+                                           recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -248,8 +249,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int send
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALL);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_alltoall(sendbuf, sendcount, sendtype, recvbuf,
+                                          recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -278,8 +279,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALLV);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                      recvcounts, rdispls, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                           recvcounts, rdispls, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -330,7 +331,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_REDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno =
+        MPIDI_HCOLL_coll_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BARRIER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Barrier(comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_barrier(comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BCAST);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -79,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -106,8 +106,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLGATHER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
+                                      recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -248,8 +248,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int send
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALL);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                               recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_alltoall(sendbuf, sendcount, sendtype, recvbuf,
+                                     recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -278,8 +278,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALLV);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                recvcounts, rdispls, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                      recvcounts, rdispls, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -330,7 +330,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_REDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.h
@@ -56,7 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 #if defined HAVE_LIBHCOLL
-    hcoll_comm_create(comm, NULL);
+    MPIDI_HCOLL_comm_create(comm, NULL);
 #endif
 
   fn_exit:
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
 
     mpi_errno = MPIDIG_destroy_comm(comm);
 #ifdef HAVE_LIBHCOLL
-    hcoll_comm_destroy(comm, NULL);
+    MPIDI_HCOLL_comm_destroy(comm, NULL);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.h
@@ -56,7 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 #if defined HAVE_LIBHCOLL
-    MPIDI_HCOLL_comm_create(comm, NULL);
+    MPIDI_HCOLL_mpi_comm_create(comm, NULL);
 #endif
 
   fn_exit:
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
 
     mpi_errno = MPIDIG_destroy_comm(comm);
 #ifdef HAVE_LIBHCOLL
-    MPIDI_HCOLL_comm_destroy(comm, NULL);
+    MPIDI_HCOLL_mpi_comm_destroy(comm, NULL);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -136,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatyp
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
 #if HAVE_LIBHCOLL
-    MPIDI_HCOLL_type_free_hook(datatype_p);
+    MPIDI_HCOLL_dtype_free_hook(datatype_p);
 #endif
 
     return 0;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datat
 
     }
 #if HAVE_LIBHCOLL
-    MPIDI_HCOLL_type_commit_hook(datatype_p);
+    MPIDI_HCOLL_dtype_commit_hook(datatype_p);
 #endif
 
     return 0;

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -136,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatyp
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
 #if HAVE_LIBHCOLL
-    hcoll_type_free_hook(datatype_p);
+    MPIDI_HCOLL_type_free_hook(datatype_p);
 #endif
 
     return 0;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datat
 
     }
 #if HAVE_LIBHCOLL
-    hcoll_type_commit_hook(datatype_p);
+    MPIDI_HCOLL_type_commit_hook(datatype_p);
 #endif
 
     return 0;

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -326,6 +326,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+#ifdef HAVE_LIBHCOLL
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_HCOLL_MUTEX, &thr_err);
+#endif
 
     MPID_Thread_mutex_create(&MPIDI_CH4_Global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,11 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
+#ifdef HAVE_LIBHCOLL
+    MPID_Thread_mutex_t m[4];
+#else
     MPID_Thread_mutex_t m[3];
+#endif
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -324,5 +328,7 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_PROGRESS_MUTEX  MPIDI_CH4_Global.m[0]
 #define MPIDIU_THREAD_PROGRESS_HOOK_MUTEX  MPIDI_CH4_Global.m[1]
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_CH4_Global.m[2]
-
+#ifdef HAVE_LIBHCOLL
+#define MPIDIU_THREAD_HCOLL_MUTEX  MPIDI_CH4_Global.m[3]
+#endif
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -13,33 +13,32 @@
 #endif
 #include "hcoll_dtypes.h"
 
-extern int world_comm_destroying;
+extern int MPIDI_HCOLL_world_comm_destroying;
 
 #if defined(MPL_USE_DBG_LOGGING)
 extern MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-int hcoll_initialize(void);
+int MPIDI_HCOLL_initialize(void);
 
-int hcoll_comm_create(MPIR_Comm * comm, void *param);
-int hcoll_comm_destroy(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_comm_create(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm, void *param);
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                    void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err);
-int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype sdtype,
-                    void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rdtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
+                         MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
 
-int hcoll_do_progress(int *made_progress);
+int MPIDI_HCOLL_do_progress(int *made_progress);
 
 #endif /* HCOLL_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -13,32 +13,35 @@
 #endif
 #include "hcoll_dtypes.h"
 
-extern int MPIDI_HCOLL_world_comm_destroying;
+extern int MPIDI_HCOLL_state_world_comm_destroying;
 
 #if defined(MPL_USE_DBG_LOGGING)
 extern MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-int MPIDI_HCOLL_initialize(void);
+int MPIDI_HCOLL_state_initialize(void);
 
-int MPIDI_HCOLL_comm_create(MPIR_Comm * comm, void *param);
-int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_mpi_comm_create(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_mpi_comm_destroy(MPIR_Comm * comm, void *param);
 
-int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                         MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
-                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf,
+                               int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf,
+                              int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                               MPI_Datatype sdtype, void *rbuf, const int *rcounts,
+                               const int *rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err);
 
-int MPIDI_HCOLL_do_progress(int *made_progress);
+int MPIDI_HCOLL_state_progress(int *made_progress);
 
 #endif /* HCOLL_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -2,10 +2,10 @@
 #include "mpiimpl.h"
 #include "hcoll_dtypes.h"
 
-extern int MPIDI_HCOLL_initialized;
-extern int MPIDI_HCOLL_enable;
+extern int MPIDI_HCOLL_state_initialized;
+extern int MPIDI_HCOLL_state_enable;
 
-static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(MPI_Datatype
+static dte_data_representation_t MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(MPI_Datatype
                                                                                    datatype)
 {
     MPI_Aint size;
@@ -63,20 +63,20 @@ static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dty
     return DTE_ZERO;
 }
 
-dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_hcoll(MPI_Datatype datatype, int count,
                                                          const int mode)
 {
     dte_data_representation_t dte_data_rep = DTE_ZERO;
 
     if (HANDLE_GET_KIND((datatype)) == HANDLE_KIND_BUILTIN) {
         /* Built-in type */
-        dte_data_rep = MPIDI_HCOLL_mpi_to_dte_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_dtype_mpi_to_dte(datatype);
     }
 #if HCOLL_API >= HCOLL_VERSION(3,6)
     else if (TRY_FIND_DERIVED == mode) {
 
         /* Check for predefined derived types */
-        dte_data_rep = MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(datatype);
         if (HCOL_DTE_IS_ZERO(dte_data_rep)) {
             MPIR_Datatype *dt_ptr;
 
@@ -100,22 +100,22 @@ dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, 
 }
 
 /* This will only get called once */
-int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p)
 {
     int mpi_errno, ret;
 
-    if (0 == MPIDI_HCOLL_initialized) {
-        mpi_errno = MPIDI_HCOLL_initialize();
+    if (0 == MPIDI_HCOLL_state_initialized) {
+        mpi_errno = MPIDI_HCOLL_state_initialize();
         if (mpi_errno)
             return MPI_ERR_OTHER;
     }
 
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         return MPI_SUCCESS;
     }
 
     dtype_p->dev.hcoll_datatype =
-        MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(dtype_p->handle);
+        MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(dtype_p->handle);
     if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype)) {
         return MPI_SUCCESS;
     }
@@ -133,9 +133,9 @@ int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
     return MPI_SUCCESS;
 }
 
-int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p)
 {
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         return MPI_SUCCESS;
     }
 

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -122,7 +122,9 @@ int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p)
 
     dtype_p->dev.hcoll_datatype = DTE_ZERO;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     ret = hcoll_create_mpi_type((void *) (intptr_t) dtype_p->handle, &dtype_p->dev.hcoll_datatype);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     if (HCOLL_SUCCESS != ret) {
         return MPI_ERR_OTHER;
     }
@@ -142,7 +144,9 @@ int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p)
     if (HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
         MPIR_Datatype_release_if_not_builtin(dtype_p->handle);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     int rc = hcoll_dt_destroy(dtype_p->dev.hcoll_datatype);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     if (HCOLL_SUCCESS != rc) {
         return MPI_ERR_OTHER;
     }

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -2,10 +2,11 @@
 #include "mpiimpl.h"
 #include "hcoll_dtypes.h"
 
-extern int hcoll_initialized;
-extern int hcoll_enable;
+extern int MPIDI_HCOLL_initialized;
+extern int MPIDI_HCOLL_enable;
 
-static dte_data_representation_t mpi_predefined_derived_2_hcoll(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(MPI_Datatype
+                                                                                   datatype)
 {
     MPI_Aint size;
 
@@ -62,19 +63,20 @@ static dte_data_representation_t mpi_predefined_derived_2_hcoll(MPI_Datatype dat
     return DTE_ZERO;
 }
 
-dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int count, const int mode)
+dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+                                                         const int mode)
 {
     dte_data_representation_t dte_data_rep = DTE_ZERO;
 
     if (HANDLE_GET_KIND((datatype)) == HANDLE_KIND_BUILTIN) {
         /* Built-in type */
-        dte_data_rep = mpi_dtype_2_dte_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_mpi_to_dte_dtype(datatype);
     }
 #if HCOLL_API >= HCOLL_VERSION(3,6)
     else if (TRY_FIND_DERIVED == mode) {
 
         /* Check for predefined derived types */
-        dte_data_rep = mpi_predefined_derived_2_hcoll(datatype);
+        dte_data_rep = MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(datatype);
         if (HCOL_DTE_IS_ZERO(dte_data_rep)) {
             MPIR_Datatype *dt_ptr;
 
@@ -98,21 +100,22 @@ dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int cou
 }
 
 /* This will only get called once */
-int hcoll_type_commit_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
 {
     int mpi_errno, ret;
 
-    if (0 == hcoll_initialized) {
-        mpi_errno = hcoll_initialize();
+    if (0 == MPIDI_HCOLL_initialized) {
+        mpi_errno = MPIDI_HCOLL_initialize();
         if (mpi_errno)
             return MPI_ERR_OTHER;
     }
 
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         return MPI_SUCCESS;
     }
 
-    dtype_p->dev.hcoll_datatype = mpi_predefined_derived_2_hcoll(dtype_p->handle);
+    dtype_p->dev.hcoll_datatype =
+        MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(dtype_p->handle);
     if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype)) {
         return MPI_SUCCESS;
     }
@@ -130,9 +133,9 @@ int hcoll_type_commit_hook(MPIR_Datatype * dtype_p)
     return MPI_SUCCESS;
 }
 
-int hcoll_type_free_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p)
 {
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         return MPI_SUCCESS;
     }
 

--- a/src/mpid/common/hcoll/hcoll_dtypes.h
+++ b/src/mpid/common/hcoll/hcoll_dtypes.h
@@ -14,11 +14,12 @@ enum {
     NO_DERIVED
 };
 
-int hcoll_type_commit_hook(MPIR_Datatype * dtype_p);
-int hcoll_type_free_hook(MPIR_Datatype * dtype_p);
-dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int count, const int mode);
+int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p);
+int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p);
+dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+                                                         const int mode);
 
-static dte_data_representation_t mpi_dtype_2_dte_dtype(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datatype)
 {
     switch (datatype) {
         case MPI_CHAR:
@@ -54,7 +55,7 @@ static dte_data_representation_t mpi_dtype_2_dte_dtype(MPI_Datatype datatype)
     }
 }
 
-static hcoll_dte_op_t *mpi_op_2_dte_op(MPI_Op op)
+static hcoll_dte_op_t *MPIDI_HCOLL_mpi_to_dte_op(MPI_Op op)
 {
     switch (op) {
         case MPI_MAX:

--- a/src/mpid/common/hcoll/hcoll_dtypes.h
+++ b/src/mpid/common/hcoll/hcoll_dtypes.h
@@ -14,12 +14,12 @@ enum {
     NO_DERIVED
 };
 
-int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p);
-int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p);
-dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p);
+int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p);
+dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_hcoll(MPI_Datatype datatype, int count,
                                                          const int mode);
 
-static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_dte(MPI_Datatype datatype)
 {
     switch (datatype) {
         case MPI_CHAR:
@@ -55,7 +55,7 @@ static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datat
     }
 }
 
-static hcoll_dte_op_t *MPIDI_HCOLL_mpi_to_dte_op(MPI_Op op)
+static hcoll_dte_op_t *MPIDI_HCOLL_dtype_op_mpi_to_dte(MPI_Op op)
 {
     switch (op) {
         case MPI_MAX:

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -24,43 +24,43 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-static int hcoll_comm_world_initialized = 0;
-static int hcoll_progress_hook_id = 0;
+static int MPIDI_HCOLL_comm_world_initialized = 0;
+static int MPIDI_HCOLL_progress_hook_id = 0;
 
-int hcoll_initialized = 0;
-int hcoll_enable = -1;
-int hcoll_enable_barrier = 1;
-int hcoll_enable_bcast = 1;
-int hcoll_enable_reduce = 1;
-int hcoll_enable_allgather = 1;
-int hcoll_enable_allreduce = 1;
-int hcoll_enable_alltoall = 1;
-int hcoll_enable_alltoallv = 1;
-int hcoll_enable_ibarrier = 1;
-int hcoll_enable_ibcast = 1;
-int hcoll_enable_iallgather = 1;
-int hcoll_enable_iallreduce = 1;
-int world_comm_destroying = 0;
+int MPIDI_HCOLL_initialized = 0;
+int MPIDI_HCOLL_enable = -1;
+int MPIDI_HCOLL_enable_barrier = 1;
+int MPIDI_HCOLL_enable_bcast = 1;
+int MPIDI_HCOLL_enable_reduce = 1;
+int MPIDI_HCOLL_enable_allgather = 1;
+int MPIDI_HCOLL_enable_allreduce = 1;
+int MPIDI_HCOLL_enable_alltoall = 1;
+int MPIDI_HCOLL_enable_alltoallv = 1;
+int MPIDI_HCOLL_enable_ibarrier = 1;
+int MPIDI_HCOLL_enable_ibcast = 1;
+int MPIDI_HCOLL_enable_iallgather = 1;
+int MPIDI_HCOLL_enable_iallreduce = 1;
+int MPIDI_HCOLL_world_comm_destroying = 0;
 
 #if defined(MPL_USE_DBG_LOGGING)
 MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-void hcoll_rte_fns_setup(void);
+void MPIDI_HCOLL_rte_fns_setup(void);
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_destroy
+#define FUNCNAME MPIDI_HCOLL_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 
-int hcoll_destroy(void *param ATTRIBUTE((unused)))
+int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
 {
-    if (1 == hcoll_initialized) {
+    if (1 == MPIDI_HCOLL_initialized) {
         hcoll_finalize();
-        MPID_Progress_deactivate_hook(hcoll_progress_hook_id);
-        MPID_Progress_deregister_hook(hcoll_progress_hook_id);
+        MPID_Progress_deactivate_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_deregister_hook(MPIDI_HCOLL_progress_hook_id);
     }
-    hcoll_initialized = 0;
+    MPIDI_HCOLL_initialized = 0;
     return 0;
 }
 
@@ -68,32 +68,32 @@ int hcoll_destroy(void *param ATTRIBUTE((unused)))
     do { \
         envar = getenv("HCOLL_ENABLE_" #nameEnv); \
         if (NULL != envar) { \
-            hcoll_enable_##name = atoi(envar); \
-            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", hcoll_enable_##name); \
+            MPIDI_HCOLL_enable_##name = atoi(envar); \
+            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_enable_##name); \
         } \
     } while (0)
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_initialize
+#define FUNCNAME MPIDI_HCOLL_initialize
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_initialize(void)
+int MPIDI_HCOLL_initialize(void)
 {
     int mpi_errno;
     char *envar;
     hcoll_init_opts_t *init_opts;
     mpi_errno = MPI_SUCCESS;
 
-    hcoll_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
+    MPIDI_HCOLL_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
         !MPIR_ThreadInfo.isThreaded;
-    if (0 >= hcoll_enable) {
+    if (0 >= MPIDI_HCOLL_enable) {
         goto fn_exit;
     }
 #if defined(MPL_USE_DBG_LOGGING)
     MPIR_DBG_HCOLL = MPL_dbg_class_alloc("HCOLL", "hcoll");
 #endif /* MPL_USE_DBG_LOGGING */
 
-    hcoll_rte_fns_setup();
+    MPIDI_HCOLL_rte_fns_setup();
 
     hcoll_read_init_opts(&init_opts);
     init_opts->base_tag = MPIR_FIRST_HCOLL_TAG;
@@ -109,15 +109,16 @@ int hcoll_initialize(void)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (!hcoll_initialized) {
-        hcoll_initialized = 1;
-        mpi_errno = MPID_Progress_register_hook(hcoll_do_progress, &hcoll_progress_hook_id);
+    if (!MPIDI_HCOLL_initialized) {
+        MPIDI_HCOLL_initialized = 1;
+        mpi_errno =
+            MPID_Progress_register_hook(MPIDI_HCOLL_do_progress, &MPIDI_HCOLL_progress_hook_id);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        MPID_Progress_activate_hook(hcoll_progress_hook_id);
+        MPID_Progress_activate_hook(MPIDI_HCOLL_progress_hook_id);
     }
-    MPIR_Add_finalize(hcoll_destroy, 0, 0);
+    MPIR_Add_finalize(MPIDI_HCOLL_destroy, 0, 0);
 
     CHECK_ENABLE_ENV_VARS(BARRIER, barrier);
     CHECK_ENABLE_ENV_VARS(BCAST, bcast);
@@ -138,31 +139,31 @@ int hcoll_initialize(void)
 
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_comm_create
+#define FUNCNAME MPIDI_HCOLL_comm_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int num_ranks;
     int context_destroyed;
     mpi_errno = MPI_SUCCESS;
 
-    if (0 == hcoll_initialized) {
-        mpi_errno = hcoll_initialize();
+    if (0 == MPIDI_HCOLL_initialized) {
+        mpi_errno = MPIDI_HCOLL_initialize();
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
 
     if (MPIR_Process.comm_world == comm_ptr) {
-        hcoll_comm_world_initialized = 1;
+        MPIDI_HCOLL_comm_world_initialized = 1;
     }
-    if (!hcoll_comm_world_initialized) {
+    if (!MPIDI_HCOLL_comm_world_initialized) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
@@ -187,20 +188,20 @@ int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_comm_destroy
+#define FUNCNAME MPIDI_HCOLL_comm_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_comm_destroy(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int context_destroyed;
-    if (0 >= hcoll_enable) {
+    if (0 >= MPIDI_HCOLL_enable) {
         goto fn_exit;
     }
     mpi_errno = MPI_SUCCESS;
 
     if (comm_ptr->handle == MPI_COMM_WORLD)
-        world_comm_destroying = 1;
+        MPIDI_HCOLL_world_comm_destroying = 1;
 
     context_destroyed = 0;
     if ((NULL != comm_ptr) && (0 != comm_ptr->hcoll_priv.is_hcoll_init)) {
@@ -214,7 +215,7 @@ int hcoll_comm_destroy(MPIR_Comm * comm_ptr, void *param)
     goto fn_exit;
 }
 
-int hcoll_do_progress(int *made_progress)
+int MPIDI_HCOLL_do_progress(int *made_progress)
 {
     *made_progress = 1;
     hcoll_progress_fn();

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -24,23 +24,23 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-static int MPIDI_HCOLL_comm_world_initialized = 0;
-static int MPIDI_HCOLL_progress_hook_id = 0;
+static int MPIDI_HCOLL_state_comm_world_initialized = 0;
+static int MPIDI_HCOLL_state_progress_hook_id = 0;
 
-int MPIDI_HCOLL_initialized = 0;
-int MPIDI_HCOLL_enable = -1;
-int MPIDI_HCOLL_enable_barrier = 1;
-int MPIDI_HCOLL_enable_bcast = 1;
-int MPIDI_HCOLL_enable_reduce = 1;
-int MPIDI_HCOLL_enable_allgather = 1;
-int MPIDI_HCOLL_enable_allreduce = 1;
-int MPIDI_HCOLL_enable_alltoall = 1;
-int MPIDI_HCOLL_enable_alltoallv = 1;
-int MPIDI_HCOLL_enable_ibarrier = 1;
-int MPIDI_HCOLL_enable_ibcast = 1;
-int MPIDI_HCOLL_enable_iallgather = 1;
-int MPIDI_HCOLL_enable_iallreduce = 1;
-int MPIDI_HCOLL_world_comm_destroying = 0;
+int MPIDI_HCOLL_state_initialized = 0;
+int MPIDI_HCOLL_state_enable = -1;
+int MPIDI_HCOLL_state_enable_barrier = 1;
+int MPIDI_HCOLL_state_enable_bcast = 1;
+int MPIDI_HCOLL_state_enable_reduce = 1;
+int MPIDI_HCOLL_state_enable_allgather = 1;
+int MPIDI_HCOLL_state_enable_allreduce = 1;
+int MPIDI_HCOLL_state_enable_alltoall = 1;
+int MPIDI_HCOLL_state_enable_alltoallv = 1;
+int MPIDI_HCOLL_state_enable_ibarrier = 1;
+int MPIDI_HCOLL_state_enable_ibcast = 1;
+int MPIDI_HCOLL_state_enable_iallgather = 1;
+int MPIDI_HCOLL_state_enable_iallreduce = 1;
+int MPIDI_HCOLL_state_world_comm_destroying = 0;
 
 #if defined(MPL_USE_DBG_LOGGING)
 MPL_dbg_class MPIR_DBG_HCOLL;
@@ -49,18 +49,18 @@ MPL_dbg_class MPIR_DBG_HCOLL;
 void MPIDI_HCOLL_rte_fns_setup(void);
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_destroy
+#define FUNCNAME MPIDI_HCOLL_state_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 
-int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
+int MPIDI_HCOLL_state_destroy(void *param ATTRIBUTE((unused)))
 {
-    if (1 == MPIDI_HCOLL_initialized) {
+    if (1 == MPIDI_HCOLL_state_initialized) {
         hcoll_finalize();
-        MPID_Progress_deactivate_hook(MPIDI_HCOLL_progress_hook_id);
-        MPID_Progress_deregister_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_deactivate_hook(MPIDI_HCOLL_state_progress_hook_id);
+        MPID_Progress_deregister_hook(MPIDI_HCOLL_state_progress_hook_id);
     }
-    MPIDI_HCOLL_initialized = 0;
+    MPIDI_HCOLL_state_initialized = 0;
     return 0;
 }
 
@@ -68,25 +68,25 @@ int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
     do { \
         envar = getenv("HCOLL_ENABLE_" #nameEnv); \
         if (NULL != envar) { \
-            MPIDI_HCOLL_enable_##name = atoi(envar); \
-            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_enable_##name); \
+            MPIDI_HCOLL_state_enable_##name = atoi(envar); \
+            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_state_enable_##name); \
         } \
     } while (0)
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_initialize
+#define FUNCNAME MPIDI_HCOLL_state_initialize
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_initialize(void)
+int MPIDI_HCOLL_state_initialize(void)
 {
     int mpi_errno;
     char *envar;
     hcoll_init_opts_t *init_opts;
     mpi_errno = MPI_SUCCESS;
 
-    MPIDI_HCOLL_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
+    MPIDI_HCOLL_state_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
         !MPIR_ThreadInfo.isThreaded;
-    if (0 >= MPIDI_HCOLL_enable) {
+    if (0 >= MPIDI_HCOLL_state_enable) {
         goto fn_exit;
     }
 #if defined(MPL_USE_DBG_LOGGING)
@@ -109,16 +109,17 @@ int MPIDI_HCOLL_initialize(void)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (!MPIDI_HCOLL_initialized) {
-        MPIDI_HCOLL_initialized = 1;
+    if (!MPIDI_HCOLL_state_initialized) {
+        MPIDI_HCOLL_state_initialized = 1;
         mpi_errno =
-            MPID_Progress_register_hook(MPIDI_HCOLL_do_progress, &MPIDI_HCOLL_progress_hook_id);
+            MPID_Progress_register_hook(MPIDI_HCOLL_state_progress,
+                                        &MPIDI_HCOLL_state_progress_hook_id);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        MPID_Progress_activate_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_activate_hook(MPIDI_HCOLL_state_progress_hook_id);
     }
-    MPIR_Add_finalize(MPIDI_HCOLL_destroy, 0, 0);
+    MPIR_Add_finalize(MPIDI_HCOLL_state_destroy, 0, 0);
 
     CHECK_ENABLE_ENV_VARS(BARRIER, barrier);
     CHECK_ENABLE_ENV_VARS(BCAST, bcast);
@@ -139,31 +140,31 @@ int MPIDI_HCOLL_initialize(void)
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_comm_create
+#define FUNCNAME MPIDI_HCOLL_mpi_comm_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_mpi_comm_create(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int num_ranks;
     int context_destroyed;
     mpi_errno = MPI_SUCCESS;
 
-    if (0 == MPIDI_HCOLL_initialized) {
-        mpi_errno = MPIDI_HCOLL_initialize();
+    if (0 == MPIDI_HCOLL_state_initialized) {
+        mpi_errno = MPIDI_HCOLL_state_initialize();
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
 
     if (MPIR_Process.comm_world == comm_ptr) {
-        MPIDI_HCOLL_comm_world_initialized = 1;
+        MPIDI_HCOLL_state_comm_world_initialized = 1;
     }
-    if (!MPIDI_HCOLL_comm_world_initialized) {
+    if (!MPIDI_HCOLL_state_comm_world_initialized) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
@@ -188,20 +189,20 @@ int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_comm_destroy
+#define FUNCNAME MPIDI_HCOLL_mpi_comm_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_mpi_comm_destroy(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int context_destroyed;
-    if (0 >= MPIDI_HCOLL_enable) {
+    if (0 >= MPIDI_HCOLL_state_enable) {
         goto fn_exit;
     }
     mpi_errno = MPI_SUCCESS;
 
     if (comm_ptr->handle == MPI_COMM_WORLD)
-        MPIDI_HCOLL_world_comm_destroying = 1;
+        MPIDI_HCOLL_state_world_comm_destroying = 1;
 
     context_destroyed = 0;
     if ((NULL != comm_ptr) && (0 != comm_ptr->hcoll_priv.is_hcoll_init)) {
@@ -215,7 +216,7 @@ int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
     goto fn_exit;
 }
 
-int MPIDI_HCOLL_do_progress(int *made_progress)
+int MPIDI_HCOLL_state_progress(int *made_progress)
 {
     *made_progress = 1;
     hcoll_progress_fn();

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -52,7 +52,6 @@ void MPIDI_HCOLL_rte_fns_setup(void);
 #define FUNCNAME MPIDI_HCOLL_state_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-
 int MPIDI_HCOLL_state_destroy(void *param ATTRIBUTE((unused)))
 {
     if (1 == MPIDI_HCOLL_state_initialized) {

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -20,7 +20,9 @@ int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL BARRIER.");
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     rc = hcoll_collectives.coll_barrier(comm_ptr->hcoll_priv.hcoll_context);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     return rc;
 }
 
@@ -47,8 +49,10 @@ int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int r
         MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "unsupported data layout, calling fallback bcast.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_bcast(buffer, count, dtype, root,
                                           comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -80,8 +84,10 @@ int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_D
         MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "unsupported data layout, calling fallback bcast.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_reduce((void *) sendbuf, recvbuf, count, dtype, Op, root,
                                            comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -112,8 +118,10 @@ int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MP
                     "unsupported data layout, calling fallback allreduce.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_allreduce((void *) sendbuf, recvbuf, count, Dtype, Op,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -148,8 +156,10 @@ int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_allgather((void *) sbuf, scount, stype, rbuf, rcount, rtype,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -184,8 +194,10 @@ int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_alltoall((void *) sbuf, scount, stype, rbuf, rcount, rtype,
                                              comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -221,9 +233,11 @@ int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_alltoallv((void *) sbuf, (int *) scounts, (int *) sdispls,
                                               stype, rbuf, (int *) rcounts, (int *) rdispls, rtype,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -8,10 +8,10 @@
 #include "hcoll.h"
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Barrier
+#define FUNCNAME MPIDI_HCOLL_barrier
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -25,11 +25,11 @@ int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Bcast
+#define FUNCNAME MPIDI_HCOLL_bcast
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -38,7 +38,7 @@ int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL BCAST.");
-    dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
     MPI_Comm comm = comm_ptr->handle;
     if (HCOL_DTE_IS_COMPLEX(dtype) || HCOL_DTE_IS_ZERO(dtype)) {
         /*If we are here then datatype is not simple predefined datatype */
@@ -54,11 +54,11 @@ int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Reduce
+#define FUNCNAME MPIDI_HCOLL_reduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -68,8 +68,8 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL REDUCE.");
-    dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = mpi_op_2_dte_op(op);
+    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -87,11 +87,11 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Allreduce
+#define FUNCNAME MPIDI_HCOLL_allreduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -102,8 +102,8 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL ALLREDUCE.");
-    Dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = mpi_op_2_dte_op(op);
+    Dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -119,12 +119,12 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Allgather
+#define FUNCNAME MPIDI_HCOLL_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                    void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err)
+int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
+                          void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                          MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -135,12 +135,12 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -155,12 +155,12 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Alltoall
+#define FUNCNAME MPIDI_HCOLL_alltoall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
-                   void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * err)
+int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
+                         void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                         MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -171,12 +171,12 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -191,12 +191,12 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Alltoallv
+#define FUNCNAME MPIDI_HCOLL_alltoallv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype sdtype,
-                    void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rdtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -207,12 +207,12 @@ int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MP
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -8,10 +8,10 @@
 #include "hcoll.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_barrier
+#define FUNCNAME MPIDI_HCOLL_coll_barrier
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -25,11 +25,11 @@ int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_bcast
+#define FUNCNAME MPIDI_HCOLL_coll_bcast
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -38,7 +38,7 @@ int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL BCAST.");
-    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
     MPI_Comm comm = comm_ptr->handle;
     if (HCOL_DTE_IS_COMPLEX(dtype) || HCOL_DTE_IS_ZERO(dtype)) {
         /*If we are here then datatype is not simple predefined datatype */
@@ -54,11 +54,11 @@ int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_reduce
+#define FUNCNAME MPIDI_HCOLL_coll_reduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -68,8 +68,8 @@ int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL REDUCE.");
-    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
+    dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_dtype_op_mpi_to_dte(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -87,11 +87,11 @@ int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_allreduce
+#define FUNCNAME MPIDI_HCOLL_coll_allreduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -102,8 +102,8 @@ int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Dat
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL ALLREDUCE.");
-    Dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
+    Dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_dtype_op_mpi_to_dte(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -119,12 +119,12 @@ int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Dat
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_allgather
+#define FUNCNAME MPIDI_HCOLL_coll_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                          void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                          MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
+                               void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -135,12 +135,12 @@ int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -155,12 +155,12 @@ int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_alltoall
+#define FUNCNAME MPIDI_HCOLL_coll_alltoall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
-                         void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                         MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
+                              void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -171,12 +171,12 @@ int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -191,12 +191,13 @@ int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_alltoallv
+#define FUNCNAME MPIDI_HCOLL_coll_alltoallv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
-                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                               MPI_Datatype sdtype, void *rbuf, const int *rcounts,
+                               const int *rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -207,12 +208,12 @@ int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdisp
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, 0, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, 0, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -49,6 +49,8 @@ static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group);
 
 static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
 
+/* The current implementation of the function relies on its callees to be thread
+ * safe. */
 #undef FUNCNAME
 #define FUNCNAME MPIDI_HCOLL_rte_progress
 #undef FCNAME

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -10,108 +10,112 @@
 #include "hcoll/api/hcoll_dte.h"
 #include "hcoll_dtypes.h"
 
-static int MPIDI_HCOLL_recv_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t, rte_grp_handle_t, uint32_t tag,
-                               rte_request_handle_t * req);
+static int MPIDI_HCOLL_rte_recv_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t, rte_grp_handle_t, uint32_t tag,
+                                   rte_request_handle_t * req);
 
-static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req);
+static int MPIDI_HCOLL_rte_send_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag,
+                                   rte_request_handle_t * req);
 
-static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed);
+static int MPIDI_HCOLL_rte_test(rte_request_handle_t * request, int *completed);
 
-static int MPIDI_HCOLL_ec_handle_compare(rte_ec_handle_t handle_1,
-                                         rte_grp_handle_t
-                                         group_handle_1,
-                                         rte_ec_handle_t handle_2, rte_grp_handle_t group_handle_2);
+static int MPIDI_HCOLL_rte_ec_handle_compare(rte_ec_handle_t handle_1,
+                                             rte_grp_handle_t
+                                             group_handle_1,
+                                             rte_ec_handle_t handle_2,
+                                             rte_grp_handle_t group_handle_2);
 
-static int MPIDI_HCOLL_get_ec_handles(int num_ec,
-                                      int *ec_indexes, rte_grp_handle_t,
-                                      rte_ec_handle_t * ec_handles);
+static int MPIDI_HCOLL_rte_get_ec_handles(int num_ec,
+                                          int *ec_indexes, rte_grp_handle_t,
+                                          rte_ec_handle_t * ec_handles);
 
-static int MPIDI_HCOLL_group_size(rte_grp_handle_t group);
-static int MPIDI_HCOLL_my_rank(rte_grp_handle_t grp_h);
-static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group);
-static rte_grp_handle_t MPIDI_HCOLL_get_world_group_handle(void);
-static uint32_t MPIDI_HCOLL_jobid(void);
+static int MPIDI_HCOLL_rte_group_size(rte_grp_handle_t group);
+static int MPIDI_HCOLL_rte_my_rank(rte_grp_handle_t grp_h);
+static int MPIDI_HCOLL_rte_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group);
+static rte_grp_handle_t MPIDI_HCOLL_rte_get_world_group_handle(void);
+static uint32_t MPIDI_HCOLL_rte_jobid(void);
 
-static void *MPIDI_HCOLL_get_coll_handle(void);
-static int MPIDI_HCOLL_coll_handle_test(void *handle);
-static void MPIDI_HCOLL_coll_handle_free(void *handle);
-static void MPIDI_HCOLL_coll_handle_complete(void *handle);
-static int MPIDI_HCOLL_group_id(rte_grp_handle_t group);
+static void *MPIDI_HCOLL_rte_get_coll_handle(void);
+static int MPIDI_HCOLL_rte_coll_handle_test(void *handle);
+static void MPIDI_HCOLL_rte_coll_handle_free(void *handle);
+static void MPIDI_HCOLL_rte_coll_handle_complete(void *handle);
+static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group);
 
-static int MPIDI_HCOLL_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
+static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_progress
+#define FUNCNAME MPIDI_HCOLL_rte_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_progress(void)
+static void MPIDI_HCOLL_rte_progress(void)
 {
     int ret;
     int made_progress;
 
-    if (0 == MPIDI_HCOLL_world_comm_destroying) {
+    if (0 == MPIDI_HCOLL_state_world_comm_destroying) {
         MPID_Progress_test();
     } else {
         /* FIXME: The hcoll library needs to be updated to return
          * error codes.  The progress function pointer right now
          * expects that the function returns void. */
-        ret = MPIDI_HCOLL_do_progress(&made_progress);
+        ret = MPIDI_HCOLL_state_progress(&made_progress);
         MPIR_Assert(ret == MPI_SUCCESS);
     }
 }
 
 #if HCOLL_API >= HCOLL_VERSION(3,6)
-static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
-                                             int *num_addresses, int *num_datatypes,
-                                             hcoll_mpi_type_combiner_t * combiner);
-static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, int max_addresses,
-                                             int max_datatypes, int *array_of_integers,
-                                             void *array_of_addresses, void *array_of_datatypes);
-static int MPIDI_HCOLL_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type);
-static int MPIDI_HCOLL_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type);
-static int MPIDI_HCOLL_get_mpi_constants(size_t * mpi_datatype_size,
-                                         int *mpi_order_c, int *mpi_order_fortran,
-                                         int *mpi_distribute_block,
-                                         int *mpi_distribute_cyclic,
-                                         int *mpi_distribute_none, int *mpi_distribute_dflt_darg);
+static int MPIDI_HCOLL_rte_get_mpi_type_envelope(void *mpi_type, int *num_integers,
+                                                 int *num_addresses, int *num_datatypes,
+                                                 hcoll_mpi_type_combiner_t * combiner);
+static int MPIDI_HCOLL_rte_get_mpi_type_contents(void *mpi_type, int max_integers,
+                                                 int max_addresses, int max_datatypes,
+                                                 int *array_of_integers, void *array_of_addresses,
+                                                 void *array_of_datatypes);
+static int MPIDI_HCOLL_rte_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type);
+static int MPIDI_HCOLL_rte_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type);
+static int MPIDI_HCOLL_rte_get_mpi_constants(size_t * mpi_datatype_size,
+                                             int *mpi_order_c, int *mpi_order_fortran,
+                                             int *mpi_distribute_block,
+                                             int *mpi_distribute_cyclic,
+                                             int *mpi_distribute_none,
+                                             int *mpi_distribute_dflt_darg);
 #endif
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_init_module_fns
+#define FUNCNAME MPIDI_HCOLL_rte_init_module_fns
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_init_module_fns(void)
+static void MPIDI_HCOLL_rte_init_module_fns(void)
 {
-    hcoll_rte_functions.send_fn = MPIDI_HCOLL_send_nb;
-    hcoll_rte_functions.recv_fn = MPIDI_HCOLL_recv_nb;
-    hcoll_rte_functions.ec_cmp_fn = MPIDI_HCOLL_ec_handle_compare;
-    hcoll_rte_functions.get_ec_handles_fn = MPIDI_HCOLL_get_ec_handles;
-    hcoll_rte_functions.rte_group_size_fn = MPIDI_HCOLL_group_size;
-    hcoll_rte_functions.test_fn = MPIDI_HCOLL_test;
-    hcoll_rte_functions.rte_my_rank_fn = MPIDI_HCOLL_my_rank;
-    hcoll_rte_functions.rte_ec_on_local_node_fn = MPIDI_HCOLL_ec_on_local_node;
-    hcoll_rte_functions.rte_world_group_fn = MPIDI_HCOLL_get_world_group_handle;
-    hcoll_rte_functions.rte_jobid_fn = MPIDI_HCOLL_jobid;
-    hcoll_rte_functions.rte_progress_fn = MPIDI_HCOLL_progress;
-    hcoll_rte_functions.rte_get_coll_handle_fn = MPIDI_HCOLL_get_coll_handle;
-    hcoll_rte_functions.rte_coll_handle_test_fn = MPIDI_HCOLL_coll_handle_test;
-    hcoll_rte_functions.rte_coll_handle_free_fn = MPIDI_HCOLL_coll_handle_free;
-    hcoll_rte_functions.rte_coll_handle_complete_fn = MPIDI_HCOLL_coll_handle_complete;
-    hcoll_rte_functions.rte_group_id_fn = MPIDI_HCOLL_group_id;
-    hcoll_rte_functions.rte_world_rank_fn = MPIDI_HCOLL_world_rank;
+    hcoll_rte_functions.send_fn = MPIDI_HCOLL_rte_send_nb;
+    hcoll_rte_functions.recv_fn = MPIDI_HCOLL_rte_recv_nb;
+    hcoll_rte_functions.ec_cmp_fn = MPIDI_HCOLL_rte_ec_handle_compare;
+    hcoll_rte_functions.get_ec_handles_fn = MPIDI_HCOLL_rte_get_ec_handles;
+    hcoll_rte_functions.rte_group_size_fn = MPIDI_HCOLL_rte_group_size;
+    hcoll_rte_functions.test_fn = MPIDI_HCOLL_rte_test;
+    hcoll_rte_functions.rte_my_rank_fn = MPIDI_HCOLL_rte_my_rank;
+    hcoll_rte_functions.rte_ec_on_local_node_fn = MPIDI_HCOLL_rte_ec_on_local_node;
+    hcoll_rte_functions.rte_world_group_fn = MPIDI_HCOLL_rte_get_world_group_handle;
+    hcoll_rte_functions.rte_jobid_fn = MPIDI_HCOLL_rte_jobid;
+    hcoll_rte_functions.rte_progress_fn = MPIDI_HCOLL_rte_progress;
+    hcoll_rte_functions.rte_get_coll_handle_fn = MPIDI_HCOLL_rte_get_coll_handle;
+    hcoll_rte_functions.rte_coll_handle_test_fn = MPIDI_HCOLL_rte_coll_handle_test;
+    hcoll_rte_functions.rte_coll_handle_free_fn = MPIDI_HCOLL_rte_coll_handle_free;
+    hcoll_rte_functions.rte_coll_handle_complete_fn = MPIDI_HCOLL_rte_coll_handle_complete;
+    hcoll_rte_functions.rte_group_id_fn = MPIDI_HCOLL_rte_group_id;
+    hcoll_rte_functions.rte_world_rank_fn = MPIDI_HCOLL_rte_world_rank;
 #if HCOLL_API >= HCOLL_VERSION(3,6)
-    hcoll_rte_functions.rte_get_mpi_type_envelope_fn = MPIDI_HCOLL_get_mpi_type_envelope;
-    hcoll_rte_functions.rte_get_mpi_type_contents_fn = MPIDI_HCOLL_get_mpi_type_contents;
-    hcoll_rte_functions.rte_get_hcoll_type_fn = MPIDI_HCOLL_get_hcoll_type;
-    hcoll_rte_functions.rte_set_hcoll_type_fn = MPIDI_HCOLL_set_hcoll_type;
-    hcoll_rte_functions.rte_get_mpi_constants_fn = MPIDI_HCOLL_get_mpi_constants;
+    hcoll_rte_functions.rte_get_mpi_type_envelope_fn = MPIDI_HCOLL_rte_get_mpi_type_envelope;
+    hcoll_rte_functions.rte_get_mpi_type_contents_fn = MPIDI_HCOLL_rte_get_mpi_type_contents;
+    hcoll_rte_functions.rte_get_hcoll_type_fn = MPIDI_HCOLL_rte_get_hcoll_type;
+    hcoll_rte_functions.rte_set_hcoll_type_fn = MPIDI_HCOLL_rte_set_hcoll_type;
+    hcoll_rte_functions.rte_get_mpi_constants_fn = MPIDI_HCOLL_rte_get_mpi_constants;
 #endif
 }
 
@@ -121,18 +125,18 @@ static void MPIDI_HCOLL_init_module_fns(void)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 void MPIDI_HCOLL_rte_fns_setup(void)
 {
-    MPIDI_HCOLL_init_module_fns();
+    MPIDI_HCOLL_rte_init_module_fns();
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_recv_nb
+#define FUNCNAME MPIDI_HCOLL_rte_recv_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_recv_nb(struct dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
+static int MPIDI_HCOLL_rte_recv_nb(struct dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
 {
     int mpi_errno;
     MPI_Datatype dtype;
@@ -164,14 +168,14 @@ static int MPIDI_HCOLL_recv_nb(struct dte_data_representation_t data,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_send_nb
+#define FUNCNAME MPIDI_HCOLL_rte_send_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
+static int MPIDI_HCOLL_rte_send_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
 {
     int mpi_errno;
     MPI_Datatype dtype;
@@ -204,10 +208,10 @@ static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_test
+#define FUNCNAME MPIDI_HCOLL_rte_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed)
+static int MPIDI_HCOLL_rte_test(rte_request_handle_t * request, int *completed)
 {
     MPIR_Request *req;
     req = (MPIR_Request *) request->data;
@@ -226,24 +230,25 @@ static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_ec_handle_compare
+#define FUNCNAME MPIDI_HCOLL_rte_ec_handle_compare
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_ec_handle_compare(rte_ec_handle_t handle_1,
-                                         rte_grp_handle_t
-                                         group_handle_1,
-                                         rte_ec_handle_t handle_2, rte_grp_handle_t group_handle_2)
+static int MPIDI_HCOLL_rte_ec_handle_compare(rte_ec_handle_t handle_1,
+                                             rte_grp_handle_t
+                                             group_handle_1,
+                                             rte_ec_handle_t handle_2,
+                                             rte_grp_handle_t group_handle_2)
 {
     return handle_1.handle == handle_2.handle;
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_ec_handles
+#define FUNCNAME MPIDI_HCOLL_rte_get_ec_handles
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_get_ec_handles(int num_ec,
-                                      int *ec_indexes, rte_grp_handle_t grp_h,
-                                      rte_ec_handle_t * ec_handles)
+static int MPIDI_HCOLL_rte_get_ec_handles(int num_ec,
+                                          int *ec_indexes, rte_grp_handle_t grp_h,
+                                          rte_ec_handle_t * ec_handles)
 {
     int i;
     MPIR_Comm *comm;
@@ -260,28 +265,28 @@ static int MPIDI_HCOLL_get_ec_handles(int num_ec,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_group_size
+#define FUNCNAME MPIDI_HCOLL_rte_group_size
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_group_size(rte_grp_handle_t grp_h)
+static int MPIDI_HCOLL_rte_group_size(rte_grp_handle_t grp_h)
 {
     return MPIR_Comm_size((MPIR_Comm *) grp_h);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_my_rank
+#define FUNCNAME MPIDI_HCOLL_rte_my_rank
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_my_rank(rte_grp_handle_t grp_h)
+static int MPIDI_HCOLL_rte_my_rank(rte_grp_handle_t grp_h)
 {
     return MPIR_Comm_rank((MPIR_Comm *) grp_h);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_ec_on_local_node
+#define FUNCNAME MPIDI_HCOLL_rte_ec_on_local_node
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group)
+static int MPIDI_HCOLL_rte_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group)
 {
     MPIR_Comm *comm;
     int nodeid, my_nodeid;
@@ -295,29 +300,29 @@ static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t gro
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_world_group_handle
+#define FUNCNAME MPIDI_HCOLL_rte_get_world_group_handle
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static rte_grp_handle_t MPIDI_HCOLL_get_world_group_handle(void)
+static rte_grp_handle_t MPIDI_HCOLL_rte_get_world_group_handle(void)
 {
     return (rte_grp_handle_t) (MPIR_Process.comm_world);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_jobid
+#define FUNCNAME MPIDI_HCOLL_rte_jobid
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static uint32_t MPIDI_HCOLL_jobid(void)
+static uint32_t MPIDI_HCOLL_rte_jobid(void)
 {
     /* not used currently */
     return 0;
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_group_id
+#define FUNCNAME MPIDI_HCOLL_rte_group_id
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_group_id(rte_grp_handle_t group)
+static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group)
 {
     MPIR_Comm *comm;
     comm = (MPIR_Comm *) group;
@@ -325,10 +330,10 @@ static int MPIDI_HCOLL_group_id(rte_grp_handle_t group)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_coll_handle
+#define FUNCNAME MPIDI_HCOLL_rte_get_coll_handle
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void *MPIDI_HCOLL_get_coll_handle(void)
+static void *MPIDI_HCOLL_rte_get_coll_handle(void)
 {
     MPIR_Request *req;
     req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
@@ -337,10 +342,10 @@ static void *MPIDI_HCOLL_get_coll_handle(void)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_test
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_coll_handle_test(void *handle)
+static int MPIDI_HCOLL_rte_coll_handle_test(void *handle)
 {
     int completed;
     MPIR_Request *req;
@@ -350,10 +355,10 @@ static int MPIDI_HCOLL_coll_handle_test(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_free
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_free
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_coll_handle_free(void *handle)
+static void MPIDI_HCOLL_rte_coll_handle_free(void *handle)
 {
     MPIR_Request *req;
     if (NULL != handle) {
@@ -363,10 +368,10 @@ static void MPIDI_HCOLL_coll_handle_free(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_complete
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_complete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_coll_handle_complete(void *handle)
+static void MPIDI_HCOLL_rte_coll_handle_complete(void *handle)
 {
     MPIR_Request *req;
     if (NULL != handle) {
@@ -376,10 +381,10 @@ static void MPIDI_HCOLL_coll_handle_complete(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_world_rank
+#define FUNCNAME MPIDI_HCOLL_rte_world_rank
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec)
+static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec)
 {
 #ifdef MPIDCH4_H_INCLUDED
     return MPIDIU_rank_to_lpid(ec.rank, (MPIR_Comm *) grp_h);
@@ -430,9 +435,9 @@ hcoll_mpi_type_combiner_t MPIDI_HCOLL_combiner_mpi_to_hcoll(int combiner)
     return HCOLL_MPI_COMBINER_LAST;
 }
 
-static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
-                                             int *num_addresses, int *num_datatypes,
-                                             hcoll_mpi_type_combiner_t * combiner)
+static int MPIDI_HCOLL_rte_get_mpi_type_envelope(void *mpi_type, int *num_integers,
+                                                 int *num_addresses, int *num_datatypes,
+                                                 hcoll_mpi_type_combiner_t * combiner)
 {
     int mpi_combiner;
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
@@ -444,9 +449,10 @@ static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
     return HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, int max_addresses,
-                                             int max_datatypes, int *array_of_integers,
-                                             void *array_of_addresses, void *array_of_datatypes)
+static int MPIDI_HCOLL_rte_get_mpi_type_contents(void *mpi_type, int max_integers,
+                                                 int max_addresses, int max_datatypes,
+                                                 int *array_of_integers, void *array_of_addresses,
+                                                 void *array_of_datatypes)
 {
     int ret;
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
@@ -460,26 +466,27 @@ static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, i
     return ret == MPI_SUCCESS ? HCOLL_SUCCESS : HCOLL_ERROR;
 }
 
-static int MPIDI_HCOLL_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type)
+static int MPIDI_HCOLL_rte_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type)
 {
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
     MPIR_Datatype *dt_ptr;
 
-    *hcoll_type = MPIDI_HCOLL_mpi_to_hcoll_dtype(dt_handle, -1, TRY_FIND_DERIVED);
+    *hcoll_type = MPIDI_HCOLL_dtype_mpi_to_hcoll(dt_handle, -1, TRY_FIND_DERIVED);
 
     return HCOL_DTE_IS_ZERO((*hcoll_type)) ? HCOLL_ERR_NOT_FOUND : HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type)
+static int MPIDI_HCOLL_rte_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type)
 {
     return HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_get_mpi_constants(size_t * mpi_datatype_size,
-                                         int *mpi_order_c, int *mpi_order_fortran,
-                                         int *mpi_distribute_block,
-                                         int *mpi_distribute_cyclic,
-                                         int *mpi_distribute_none, int *mpi_distribute_dflt_darg)
+static int MPIDI_HCOLL_rte_get_mpi_constants(size_t * mpi_datatype_size,
+                                             int *mpi_order_c, int *mpi_order_fortran,
+                                             int *mpi_distribute_block,
+                                             int *mpi_distribute_cyclic,
+                                             int *mpi_distribute_none,
+                                             int *mpi_distribute_dflt_darg)
 {
     *mpi_datatype_size = sizeof(MPI_Datatype);
     *mpi_order_c = MPI_ORDER_C;

--- a/src/mpid/common/hcoll/hcollpre.h
+++ b/src/mpid/common/hcoll/hcollpre.h
@@ -10,6 +10,6 @@
 typedef struct {
     int is_hcoll_init;
     void *hcoll_context;
-} hcoll_comm_priv_t;
+} MPIDI_HCOLL_comm_priv_t;
 
 #endif /* HCOLLPRE_H_INCLUDED */


### PR DESCRIPTION
The `per-VCI` critical section model is essentially a subset of the `per-object` model. It needs thread safety for each VCI, and thread-safety for the other objects such as requests, hooks, etc.

This PR implements thread safety for code related to using the HCOLL library. Currently, the HCOLL library is not enabled if MPICH is threaded even if the HCOLL library is available.

The PR does the following:

(1) Currently, the HCOLL API and MPICH's HCOLL code share the same `hcoll_*` prefix. This PR gives the HCOLL code an MPICH-namespace: `MPIDI_HCOLL`. (1st commit)
(2) The PR applies new naming rules to differentiate between its various types of functions and objects. (2nd commit)
(3) The PR adds `per-vci` thread safety to the MPIDI_HCOLL class. (4th commit)

Testing:
- [x] HCOLL tests on Jenkins? (Only the simple `example/cpi.c` for now)
- [x] Test with #3659 with all the nbc code since they rely on each other for completeness (which also includes the global lock for collectives in per-vci critical section).