### PR TITLE
comm_split_type: fix bug in node level split

### DIFF
--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -650,7 +650,7 @@ static int network_split_by_minsize(MPIR_Comm * comm_ptr, int key, int subcomm_m
                     for (i = 0; i < num_procs; i++) {
                         if (hwloc_bitmap_isincluded(parent_obj->cpuset, node_comm_bindset[i]) ||
                             hwloc_bitmap_isequal(parent_obj->cpuset, node_comm_bindset[i])) {
-                            processes_cpuset[hw_obj_index] = 1;
+                            processes_cpuset[hw_obj_index]++;
                             if (i == subcomm_rank) {
                                 current_proc_index = hw_obj_index;
                             }


### PR DESCRIPTION
When splitting communicator by `subcomm_min_size` or `min_memsize` the
current comm_split_type code does a first split at the network level and
then, if `subcomm_min_size` is still smaller than the number of processes
in the node, it further splits the `subcomm` at the node level.

This is done by grouping processes into fine grain subtrees and then
recursively merging them together until the desired comm size is
reached. The number of processes in each subtree is accounted for by an
array (`processes_cpuset[]`) which, right now, is statically set to `1`
in the code, thus assigning one process to every subtree.

This patch fixes this bug by properly incrementing the number of
processes.

Solves https://github.com/pmodels/mpich/issues/3625