### PR TITLE
ch4/ofi: don't repost AM buffer until msgs are processed

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -157,12 +157,6 @@ static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
         goto fn_fail;
     }
 
-    /* If only FI_MULTI_RECV flag bit is provided, the provider is reporting that
-     * the multi-recv buffer has been released, and the completion entry is not
-     * associated with a received message. */
-    if (cq_entry.flags == FI_MULTI_RECV)
-        goto multi_recv;
-
     /* If the statically allocated buffered list is full or we've already
      * started using the dynamic list, continue using it. */
     if (((MPIDI_Global.cq_buffered_static_head + 1) %
@@ -179,15 +173,6 @@ static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
             cq_entry;
         MPIDI_Global.cq_buffered_static_head =
             (MPIDI_Global.cq_buffered_static_head + 1) % MPIDI_OFI_NUM_CQ_BUFFERED;
-    }
-
-    if (cq_entry.flags & FI_MULTI_RECV) {
-      multi_recv:
-        mpi_errno = MPIDI_OFI_repost_buffer(cq_entry.op_context,
-                                            MPIDI_OFI_context_to_request(cq_entry.op_context));
-
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -28,12 +28,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
-        mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1, 1);
+        mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
     else if (likely(1)) {
         ret = fi_cq_read(MPIDI_Global.ctx[vci].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
-            mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret, 0);
+            mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret);
         else if (ret == -FI_EAGAIN)
             mpi_errno = MPI_SUCCESS;
         else

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -193,7 +193,7 @@ int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
 
     switch (ctrlsend->type) {
         case MPIDI_OFI_CTRL_HUGEACK:{
-                mpi_errno = MPIDI_OFI_dispatch_function(NULL, ctrlsend->ackreq, 0);
+                mpi_errno = MPIDI_OFI_dispatch_function(NULL, ctrlsend->ackreq);
                 goto fn_exit;
             }
             break;


### PR DESCRIPTION
The AM implementation previously had a shortcut for handling
FI_MULTI_RECV CQ entries, immediately reposting the buffer. Other CQ
entries are stashed away to be handled later. This is a problem, since
as soon as the FI_MULTI_RECV buffer has been reposted, it can start
accepting messages into the same memory that the yet-to-be-handled CQ
entries reference, thereby corrupting recved messages.

Instead, treat the FI_MULTI_RECV completion like other completions, and
process it only after all FI_RECV completions associated with that
iteration of the buffer have been processed.