### PR TITLE
ROMIO: set err to 0 for zero-length I/O requests

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -160,6 +160,10 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
     MPI_Type_size_x(datatype, &datatype_size);
     len = datatype_size * count;
 
+    /* zero-length request will make no calls to pwrite/pread below */
+    if (len == 0)
+        err = 0;
+
     if (file_ptr_type == ADIO_INDIVIDUAL) {
         offset = fd->fp_ind;
     }


### PR DESCRIPTION
Fix a bug of incorrectly using initial value -1 of `err` when the read/write request is of zero length.
I.e. for zero-length requests, `err` in `ADIOI_LUSTRE_IOContig()` will still be -1 when doing ERROR HANDLING at the end of the function.