### PR TITLE
Fix regex version of list_to_nodes

### DIFF
--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_node_list.c
@@ -92,8 +92,8 @@ static HYD_status list_to_nodes(char *str)
     /* compile element regex for old format: "h14" */
     regcomp(&ematch_old, "([a-zA-Z]+[0-9]+)", REG_EXTENDED);
 
-    /* compile group-0 regex for new format: "h-[00-12,14] | h-14" */
-    regcomp(&gmatch_new[0], "(,|^)([a-zA-Z]+[0-9]*-)(\\[[-,0-9]+\\]|[0-9]+)(,|$)", REG_EXTENDED);
+    /* compile group-0 regex for new format: "h[00-12,14] | h14" */
+    regcomp(&gmatch_new[0], "(,|^)([a-zA-Z]+[0-9]*-?)(\\[[-,0-9]+\\]|[0-9]+)(,|$)", REG_EXTENDED);
 
     /* compile group-1 regex for new format: "00-12 | 14" */
     regcomp(&gmatch_new[1], "([[,]|^)([0-9]+-[0-9]+|[0-9]+)([],]|$)", REG_EXTENDED);


### PR DESCRIPTION
The group-0 regex required the base hostname and the host number to be separated with "-". If nodes are named h00 instead of h-00, Hydra misinterpreted the set of allocated nodes and tried to start processes on the wrong node.

I went for the minimal change that allowed Hydra to run successfully on our cluster.