### PR TITLE
ch4/ucx: Capture return code from bc table creation

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -72,9 +72,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
     MPIDI_UCX_CHK_STATUS(ucx_status);
     MPIR_Assert(MPIDI_UCX_global.addrname_len <= INT_MAX);
 
-    MPIDU_bc_table_create(rank, size, MPIDI_CH4_Global.node_map[0], MPIDI_UCX_global.if_address,
-                          (int) MPIDI_UCX_global.addrname_len, FALSE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI,
-                          (void **) &MPIDI_UCX_global.pmi_addr_table, &bc_indices);
+    mpi_errno =
+        MPIDU_bc_table_create(rank, size, MPIDI_CH4_Global.node_map[0], MPIDI_UCX_global.if_address,
+                              (int) MPIDI_UCX_global.addrname_len, FALSE,
+                              MPIR_CVAR_CH4_ROOTS_ONLY_PMI,
+                              (void **) &MPIDI_UCX_global.pmi_addr_table, &bc_indices);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 


### PR DESCRIPTION
Make sure to capture this error code, since the following line intends
to check it.

No reviewer.