### PR TITLE
ch4/ucx: Remove extra braces

### DIFF
--- a/src/mpid/ch4/netmod/ucx/globals.c
+++ b/src/mpid/ch4/netmod/ucx/globals.c
@@ -11,5 +11,5 @@
 #include "ucx_types.h"
 
 /* *INDENT-OFF* */
-MPIDI_UCX_global_t MPIDI_UCX_global = { {0} };
+MPIDI_UCX_global_t MPIDI_UCX_global = { 0 };
 /* *INDENT-ON* */


### PR DESCRIPTION
The intent is to zero initialize the entire struct. Using { 0 } will
do so. Squash a "braces around scalar initializer" warning.

No reviewer.