### PR TITLE
ch4: use MPL_timer in symheap allocation.

### DIFF
--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -17,9 +17,6 @@
 #ifdef HAVE_SYS_MMAN_H
 #include <sys/mman.h>
 #endif /* HAVE_SYS_MMAN_H */
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#endif /* HAVE_SYS_TIME_H */
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif /* HAVE_SYS_STAT_H */
@@ -150,7 +147,8 @@ static inline void *MPIDIU_generate_random_addr(size_t size)
     size_t page_sz = 0;
     uint64_t random_unsigned;
     size_t mapsize = MPIDIU_get_mapsize(size, &page_sz);
-    struct timeval ts;
+    MPL_time_t ts;
+    unsigned int ts_32 = 0;
     int iter = MPIR_CVAR_CH4_RANDOM_ADDR_RETRY;
     int32_t rh, rl;
     struct random_data rbuf;
@@ -168,9 +166,10 @@ static inline void *MPIDIU_generate_random_addr(size_t size)
      * (http://stackoverflow.com/questions/4167034/c-initstate-r-crashing) */
     memset(&rbuf, 0, sizeof(rbuf));
 
-    gettimeofday(&ts, NULL);
+    MPL_wtime(&ts);
+    MPL_wtime_touint(&ts, &ts_32);
 
-    initstate_r(ts.tv_usec, random_state, sizeof(random_state), &rbuf);
+    initstate_r(ts_32, random_state, sizeof(random_state), &rbuf);
     random_r(&rbuf, &rh);
     random_r(&rbuf, &rl);
     random_unsigned = ((uint64_t) rh) << 32 | (uint64_t) rl;

--- a/src/mpl/include/mpl_timer.h.in
+++ b/src/mpl/include/mpl_timer.h.in
@@ -166,6 +166,22 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff);
 int MPL_wtime_acc(MPL_time_t * t1, MPL_time_t * t2, MPL_time_t * t3);
 
 /*@
+  MPL_wtime_touint - Converts a timestamp to an unsigned int.
+  Input Parameter:
+. timeval - 'MPL_time_t' time stamp
+
+  Output Parameter:
+. val - unsigned int generated from the timestamp.
+
+  Notes:
+  This routine may be used for initializing random seeds. The value is not
+  necessary a timestamp if 64-bit to 32-bit conversion happened.
+
+
+  @*/
+int MPL_wtime_touint(MPL_time_t * timeval, unsigned int *val);
+
+/*@
   MPL_wtime_todouble - Converts a timestamp to a double
 
   Input Parameter:

--- a/src/mpl/src/timer/mpl_timer_clock_gettime.c
+++ b/src/mpl/src/timer/mpl_timer_clock_gettime.c
@@ -25,6 +25,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) t->tv_nsec;
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = ((double) t->tv_sec + 1.0e-9 * (double) t->tv_nsec);

--- a/src/mpl/src/timer/mpl_timer_device.c
+++ b/src/mpl/src/timer/mpl_timer_device.c
@@ -13,6 +13,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 int (*MPL_wtime_fn) (MPL_time_t * timeval) = NULL;
 int (*MPL_wtime_diff_fn) (MPL_time_t * t1, MPL_time_t * t2, double *diff) = NULL;
 int (*MPL_wtime_acc_fn) (MPL_time_t * t1, MPL_time_t * t2, MPL_time_t * t3) = NULL;
+int (*MPL_wtime_touint_fn) (MPL_time_t * timeval, unsigned int *val) = NULL;
 int (*MPL_wtime_todouble_fn) (MPL_time_t * timeval, double *seconds) = NULL;
 int (*MPL_wtick_fn) (double *tick) = NULL;
 
@@ -28,6 +29,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     if (MPL_wtime_diff_fn == NULL)
         return MPL_TIMER_ERR_NOT_INITIALIZED;
     return MPL_wtime_diff_fn(t1, t2, diff);
+}
+
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    if (MPL_wtime_touint_fn == NULL)
+        return MPL_TIMER_ERR_NOT_INITIALIZED;
+    return MPL_wtime_touint_fn(t, val);
 }
 
 int MPL_wtime_todouble(MPL_time_t * t, double *val)

--- a/src/mpl/src/timer/mpl_timer_gcc_ia64_cycle.c
+++ b/src/mpl/src/timer/mpl_timer_gcc_ia64_cycle.c
@@ -49,6 +49,16 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    /* This returns the number of cycles as the "time".  This isn't correct
+     * for implementing MPI_Wtime, but it does allow us to insert cycle
+     * counters into test programs */
+    *val = (unsigned int) *t;
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     /* This returns the number of cycles as the "time".  This isn't correct

--- a/src/mpl/src/timer/mpl_timer_gethrtime.c
+++ b/src/mpl/src/timer/mpl_timer_gethrtime.c
@@ -38,6 +38,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) (*t & 0xffffffffUL);
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = 1.0e-9 * (*t);

--- a/src/mpl/src/timer/mpl_timer_gettimeofday.c
+++ b/src/mpl/src/timer/mpl_timer_gettimeofday.c
@@ -31,6 +31,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) t->tv_usec;
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = (double) t->tv_sec + .000001 * (double) t->tv_usec;

--- a/src/mpl/src/timer/mpl_timer_linux86_cycle.c
+++ b/src/mpl/src/timer/mpl_timer_linux86_cycle.c
@@ -49,6 +49,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) (*t & 0xffffffffUL);
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     /* This returns the number of cycles as the "time".  This isn't correct

--- a/src/mpl/src/timer/mpl_timer_mach_absolute_time.c
+++ b/src/mpl/src/timer/mpl_timer_mach_absolute_time.c
@@ -36,6 +36,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) (*t & 0xffffffffUL);
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = *t * MPIR_Wtime_mult;

--- a/src/mpl/src/timer/mpl_timer_ppc64_cycle.c
+++ b/src/mpl/src/timer/mpl_timer_ppc64_cycle.c
@@ -103,6 +103,13 @@ int MPL_wtime_diff(MPL_time_t * t1, MPL_time_t * t2, double *diff)
     return MPL_TIMER_SUCCESS;
 }
 
+int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) (*t & 0xffffffffUL);
+
+    return MPL_TIMER_SUCCESS;
+}
+
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = (double) *t * seconds_per_tick;

--- a/src/mpl/src/timer/mpl_timer_query_performance_counter.c
+++ b/src/mpl/src/timer/mpl_timer_query_performance_counter.c
@@ -25,6 +25,12 @@ double MPL_wtick(void)
     return seconds_per_tick;
 }
 
+void MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *val = (unsigned int) (t->QuadPart & 0xffffffffUL);
+}
+
+
 void MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
     *val = (double) t->QuadPart * seconds_per_tick;

--- a/src/mpl/src/timer/mpl_timer_win86_cycle.c
+++ b/src/mpl/src/timer/mpl_timer_win86_cycle.c
@@ -17,6 +17,11 @@ double MPL_wtick(void)
     return seconds_per_tick;
 }
 
+void MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
+{
+    *d = (unsigned int) (*t & 0xffffffffUL);
+}
+
 void MPL_wtime_todouble(MPL_time_t * t, double *d)
 {
     *d = (double) (__int64) * t * seconds_per_tick;


### PR DESCRIPTION
Symheap allocation should use MPL's timer rather than `gettimeofday` in
case it is not availble on the target platfrom.