### PR TITLE
ch4: do not build shm in direct netmod mode

### DIFF
--- a/src/mpid/ch4/Makefile.mk
+++ b/src/mpid/ch4/Makefile.mk
@@ -16,6 +16,8 @@ include $(top_srcdir)/src/mpid/ch4/include/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/src/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/generic/Makefile.mk
 include $(top_srcdir)/src/mpid/ch4/netmod/Makefile.mk
+if BUILD_CH4_SHM
 include $(top_srcdir)/src/mpid/ch4/shm/Makefile.mk
+endif BUILD_CH4_SHM
 
 endif BUILD_CH4

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -245,7 +245,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 
 /* Include netmod prototypes */
 #include <netmod.h>
+#ifndef MPIDI_CH4_DIRECT_NETMOD
 #include "shm.h"
+#endif
 
 /* Declare request functions here so netmods can refer to
    them in the NETMOD_INLINE mode */
@@ -255,7 +257,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 /* Prototypes are split from impl to avoid */
 /* circular dependencies                   */
 #include <netmod_impl.h>
+#ifndef MPIDI_CH4_DIRECT_NETMOD
 #include "shm_impl.h"
+#endif
 
 #include "ch4i_workq.h"
 

--- a/src/mpid/ch4/src/ch4_coll_globals_default.c.in
+++ b/src/mpid/ch4/src/ch4_coll_globals_default.c.in
@@ -247,5 +247,7 @@ const MPIDI_coll_algo_container_t MPIDI_Exscan_intra_composition_alpha_cnt = {
 
 /* *INDENT-OFF* */
 @ch4_netmod_coll_globals_default@
+#ifndef MPIDI_CH4_DIRECT_NETMOD
 #include "../shm/posix/posix_coll_globals_default.c"
+#endif
 /* *INDENT-ON* */

--- a/src/mpid/ch4/src/ch4_coll_select.h
+++ b/src/mpid/ch4/src/ch4_coll_select.h
@@ -15,8 +15,9 @@
 #include "ch4r_proc.h"
 #include "ch4_coll_impl.h"
 
+#ifndef MPIDI_CH4_DIRECT_NETMOD
 #include "../shm/include/shm.h"
-
+#endif
 
 MPL_STATIC_INLINE_PREFIX const
 MPIDI_coll_algo_container_t *MPIDI_Barrier_select(MPIR_Comm * comm, MPIR_Errflag_t * errflag)

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -510,6 +510,8 @@ src/mpid/ch4/src/ch4_coll_globals_default.c
 ])
 ])dnl end AM_COND_IF(BUILD_CH4,...)
 
+# we have to define it here to cover ch3 build
+AM_CONDITIONAL([BUILD_CH4_SHM],[test "$enable_ch4_direct" = "auto"])
 AM_CONDITIONAL([BUILD_CH4_COLL_TUNING],[test -e "$srcdir/src/mpid/ch4/src/ch4_coll_globals.c"])
 
 ])dnl end _BODY


### PR DESCRIPTION
We originally kept shm build even when --enable-ch4-direct=netmod is
set because of two reasons: (1) the AM fallback may still use SHM based
on remote process's locality, and (2) the netmod might want to use SHM
routines to optimize communication when ppn is large.

The above thoughts no longer hold true in current master. In direct netmod
mode, all messages (including AM) are handled by netmod directly and all
SHM resource init/finalize hooks are disabled. Thus, there is no reason to
build shm.