### PR TITLE
test/maint: update xfail configuration.

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -37,13 +37,13 @@
 ch4 * * * * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
 ################################################################################
 # xfail known failures of UCX build for Hackathon
-ucx * * ch4:ucx * sed -i "s+\(^win_large_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ucx * * ch4:ucx * sed -i "s+\(^strided_putget_indexed_shared .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ucx * * ch4:ucx * sed -i "s+\(^bcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
+* * * ch4:ucx * sed -i "s+\(^win_large_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch4:ucx * sed -i "s+\(^strided_putget_indexed_shared .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch4:ucx * sed -i "s+\(^bcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
 # am-only failures
-ucx * am-only ch4:ucx * sed -i "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
-ucx * am-only ch4:ucx * sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
-ucx * am-only ch4:ucx * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
+* * am-only ch4:ucx * sed -i "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
+* * am-only ch4:ucx * sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
+* * am-only ch4:ucx * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 ################################################################################
 # xfail known failures of OFI build for Hackathon
 * * * ch4:ofi * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
@@ -64,15 +64,15 @@ ucx * am-only ch4:ucx * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mp
 * * debug ch4:ofi * sed -i "s+\(^c2f2cf .*\)+\1 xfail=ticket0+g" test/mpi/f77/ext/testlist
 * * debug ch4:ofi * sed -i "s+\(^c2f2cf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/ext/testlist
 # am-only failures
-ofi * am-only ch4:ofi * sed -i "s+\(^ssendf .*\)+\1 xfail=ticket0+g" test/mpi/f77/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^ssendf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^issendf .*\)+\1 xfail=ticket0+g" test/mpi/f77/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^issendf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^huge_anysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
-ofi * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
+* * am-only ch4:ofi * sed -i "s+\(^ssendf .*\)+\1 xfail=ticket0+g" test/mpi/f77/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^ssendf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^issendf .*\)+\1 xfail=ticket0+g" test/mpi/f77/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^issendf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^huge_anysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
+* * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
+* * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
 ################################################################################
 #ch3:ofi
 ofi * * ch3:ofi * sed -i  "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
@@ -135,18 +135,18 @@ ch3 * * * * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=MPI_FLOAT
 ch3 * * * * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket03079|g" test/mpi/rma/testlist
 ch3 * * * * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_INT .*\)|\1 xfail=ticket3079|g" test/mpi/rma/testlist
 ch3 * * * * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_SHORT_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_SHORT_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putpscw1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putpscw1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_SHORT_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_SHORT_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putpscw1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putpscw1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE_INT .*\)|\1 xfail=ticket3079" test/mpi/rma/testlist
 # xfail active message accumulates with short_int (only CH4 fails)
-ch4 * * * * sed -i "s+\(^atomic_get_short_int .*\)+\1 xfail=ticket3380+g" test/mpi/rma/testlist
+* * * * * sed -i "s+\(^atomic_get_short_int .*\)+\1 xfail=ticket3380+g" test/mpi/rma/testlist
 ################################################################################
 # xfail lock_contention_dt with >= 16 bytes datatypes and 262144 count (CH3 bug)
 ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI_LONG_DOUBLE arg=-count=262144 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
@@ -158,26 +158,26 @@ ch3 * * * * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=MPI
 * * * * ubuntu32 sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
 * * * * ubuntu32 sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket0|g" test/mpi/rma/testlist
 # xfail some basic datatypes that are causing a truncate message error to appear in UCX
-ucx * * ch4:ucx * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^sendrecv1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^sendrecv1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^sendself__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^sendself__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
-ucx * * ch4:ucx * sed -i "s|\(^bcast__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX arg=-count=[0-9]* .*\)|\1 xfail=ticket3078|g" test/mpi/coll/testlist
+* * * ch4:ucx * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^sendrecv1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^sendrecv1__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^sendself__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^sendself__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX .*\)|\1 xfail=ticket3078|g" test/mpi/pt2pt/testlist
+* * * ch4:ucx * sed -i "s|\(^bcast__BASIC__L[0-9]* [0-9]* arg=-type=MPI_C_LONG_DOUBLE_COMPLEX arg=-count=[0-9]* .*\)|\1 xfail=ticket3078|g" test/mpi/coll/testlist
 # xfail all the tests that are taking too long because of performance bug on OFI (not using SHM)
-ch4 * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lock_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lock_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^accfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^accpscw1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
-ch4 * * ch4:ofi * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-sendcnt=2048 .*\)|\1 xfail=ticket2965|g" test/mpi/pt2pt/testlist
+* * * ch4:ofi * sed -i "s|\(^getfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^putfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=16000000 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lock_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^epochtest__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lock_contention_dt__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lock_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^lockall_dt.*__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^accfence1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^accpscw1__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s|\(^pingping__BASIC__L[0-9]* [0-9]* arg=-type=.* arg=-sendcnt=2048 .*\)|\1 xfail=ticket2965|g" test/mpi/pt2pt/testlist
 # intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (includeing the aborted ones)
 * * * * * sed -i "s+\(^intercomm_abort .*\)+\1 xfail=ticket0+g" test/mpi/errors/comm/testlist
 # disable large datatype test for valgrind as it dies with valgrind running out of memory.


### PR DESCRIPTION
Remove the matching in jobname for ch4, ofi, ucx so that vci job can
correctly picking up these xfails.