### PR TITLE
ch4/ofi: fix checking of libfabric.pc with external librabric.

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -285,7 +285,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     pcdir=""
     if test "${ofi_embedded}" = "yes" ; then
         pcdir="${use_top_srcdir}/src/mpid/ch4/netmod/ofi/libfabric"
-    elif [ -f ${with_libfabric}/lib/pkgconfig/libfabric.pc ] ; then
+    elif test -f ${with_libfabric}/lib/pkgconfig/libfabric.pc ; then
         pcdir="${with_libfabric}/lib/pkgconfig"
     fi
     PAC_LIB_DEPS(fabric, $pcdir)


### PR DESCRIPTION
The use of [ -f $path ] condition is invalid in m4 and cannot correctly
detect the presence of pkgconfig file of a external libfabric. It
causes the configure to either pick a system libfabric's pkgconfig or
missing library flags for libfabric when external libfabric is set in
./configure.