### PR TITLE
autogen.sh: patch ltmain.sh to recognize intel compiler option

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -931,6 +931,22 @@ if [ "$do_build_configure" = "yes" ] ; then
 	    echo "------------------------------------------------------------------------"
 	    echo "running $autoreconf in $amdir"
             (cd $amdir && $autoreconf $autoreconf_args) || exit 1
+            # Patching ltmain.sh
+            if [ -f $amdir/confdb/ltmain.sh ] ; then
+                echo_n "Patching ltmain.sh for compatibility with Intel compiler options... "
+                patch -N -s -l $amdir/confdb/ltmain.sh maint/patches/optional/confdb/intel-compiler.patch
+                if [ $? -eq 0 ] ; then
+                    # Remove possible leftovers, which don't imply a failure
+                    rm -f $amdir/confdb/ltmain.sh.orig
+                    echo "done"
+                else
+                    echo "failed"
+                fi
+                # Rebuild configure
+                (cd $amdir && $autoconf -f) || exit 1
+                # Reset ltmain.sh timestamps to avoid confusing make
+                touch -r $amdir/confdb/ltversion.m4 $amdir/confdb/ltmain.sh
+            fi
             # Patching libtool.m4
             # This works with libtool versions 2.4 - 2.4.2.
             # Older versions are not supported to build mpich.

--- a/maint/patches/optional/confdb/intel-compiler.patch
+++ b/maint/patches/optional/confdb/intel-compiler.patch
@@ -1,0 +1,14 @@
+--- ltmain.sh	2019-02-22 16:28:30.548803098 -0600
++++ ltmain.sh.new	2019-02-22 16:44:08.057521482 -0600
+@@ -7183,6 +7183,11 @@
+ 	continue
+ 	;;
+ 
++      -static-intel)
++        func_append compiler_flags " $arg"
++        continue
++        ;;
++
+       -thread-safe)
+ 	thread_safe=yes
+ 	continue


### PR DESCRIPTION
allows libtool to take intel compiler option "-static-intel" when
building dynamic shared libraries.