### PR TITLE
ch4/ucx: Remove packed attribute for win info struct

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -550,7 +550,6 @@ if test "$enable_strict_done" != "yes" ; then
         -Wold-style-definition
         -Wno-multichar
         -Wno-deprecated-declarations
-        -Wpacked
         -Wnested-externs
         -Winvalid-pch
         -Wno-pointer-sign

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -43,7 +43,7 @@ typedef struct MPIDI_UCX_win_info {
     ucp_rkey_h rkey;
     uint64_t addr;
     uint32_t disp;
-} __attribute__ ((packed)) MPIDI_UCX_win_info_t;
+} MPIDI_UCX_win_info_t;
 
 typedef enum {
     MPIDI_UCX_WIN_SYNC_UNSET = 0,


### PR DESCRIPTION
This struct is accessed in the communication critical path. The
compiler should not be forced to pack it, as it can result in
suboptimal unaligned accesses.