### PR TITLE
PR to test changes to non-blocking collective code with per-VCI critical section

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -70,7 +70,8 @@ noinst_HEADERS +=                   \
     src/include/nopackage.h         \
     src/include/rlog.h              \
     src/include/rlog_macros.h       \
-    src/include/mpir_op_util.h
+    src/include/mpir_op_util.h      \
+    src/include/mpir_sched.h
 
 src/include/mpir_cvars.h:
 	$(top_srcdir)/maint/extractcvars --dirs="`cat $(top_srcdir)/maint/cvardirs`"

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -228,6 +228,7 @@ typedef struct MPIR_Topology MPIR_Topology;
 #include "mpir_misc_post.h"
 #include "mpit.h"
 #include "mpir_handlemem.h"
+#include "mpir_sched.h"
 
 /*****************************************************************************/
 /******************** PART 6: DEVICE "POST" FUNCTIONALITY ********************/

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -426,25 +426,25 @@ int MPIR_Iallgather_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI
 /* sched-based functions */
 int MPIR_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_intra_recexch_distance_doubling(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     int recvcount, MPI_Datatype recvtype,
@@ -460,11 +460,12 @@ int MPIR_Iallgather_intra_gentran_ring(const void *sendbuf, int sendcount,
 /* sched-based intercomm-only functions */
 int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                          MPIR_Comm * comm_ptr,
+                                                          MPIR_Sched_element_t s);
 
 
 /******************************** Iallgatherv ********************************/
@@ -483,27 +484,30 @@ int MPIR_Iallgatherv_intra_gentran_brucks(const void *sendbuf, int sendcount, MP
 /* sched-based functions */
 int MPIR_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                            const int *recvcounts, const int *displs, MPI_Datatype recvtype,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, const int recvcounts[], const int displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int recvcounts[], const int displs[],
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_intra_recexch_distance_doubling(const void *sendbuf, int sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const int *recvcounts, const int *displs,
@@ -514,21 +518,22 @@ int MPIR_Iallgatherv_intra_recexch_distance_halving(const void *sendbuf, int sen
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
                                                     MPIR_Request ** req);
-int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount,
-                                        MPI_Datatype sendtype, void *recvbuf,
-                                        const int *recvcounts, const int *displs,
+int MPIR_Iallgatherv_intra_gentran_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                                        void *recvbuf, const int *recvcounts, const int *displs,
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
                                         MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int *recvcounts, const int *displs,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            const int *recvcounts, const int *displs,
                                                            MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                           MPIR_Comm * comm_ptr,
+                                                           MPIR_Sched_element_t s);
 
 
 /******************************** Iallreduce ********************************/
@@ -540,24 +545,24 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count, MPI_Data
 
 /* sched-based functions */
 int MPIR_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s);
+                                      MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
                                                          int count, MPI_Datatype datatype,
                                                          MPI_Op op, MPIR_Comm * comm_ptr,
-                                                         MPIR_Sched_t s);
+                                                         MPIR_Sched_element_t s);
 int MPIR_Iallreduce_intra_recexch_single_buffer(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm, MPIR_Request ** req);
@@ -569,16 +574,16 @@ int MPIR_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
                                MPIR_Request ** request);
 int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
                                                           int count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
+                                                          MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoall ********************************/
@@ -599,37 +604,37 @@ int MPIR_Ialltoall_intra_gentran_brucks(const void *sendbuf, int sendcount, MPI_
 /* sched-based functions */
 int MPIR_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                          int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                         MPIR_Sched_t s);
+                         MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoallv ********************************/
@@ -646,27 +651,27 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int *sendcounts, const int *
 int MPIR_Ialltoallv_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
                           MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                           const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                const int *rdispls, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+                               MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                      const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendcnts[],
                                             const int sdispls[], MPI_Datatype sendtype,
                                             void *recvbuf, const int recvcnts[],
@@ -677,12 +682,12 @@ int MPIR_Ialltoallv_intra_gentran_scattered(const void *sendbuf, const int sendc
 int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                      const int *rdispls, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ialltoallw ********************************/
@@ -700,41 +705,41 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int *sendcounts, const int *
 int MPIR_Ialltoallw_sched(const void *sendbuf, const int *sendcounts, const int *sdispls,
                           const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
                           const int *rdispls, const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s);
+                          MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                const MPI_Datatype * sendtypes, void *recvbuf, const int *recvcounts,
                                const int *rdispls, const MPI_Datatype * recvtypes,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ialltoallw_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      const MPI_Datatype * sendtypes, void *recvbuf,
                                      const int *recvcounts, const int *rdispls,
                                      const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *sdispls,
                                      const MPI_Datatype * sendtypes, void *recvbuf,
                                      const int *recvcounts, const int *rdispls,
                                      const MPI_Datatype * recvtypes, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[],
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const int rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ibarrier ********************************/
@@ -743,17 +748,17 @@ int MPIR_Ibarrier(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /* sched-based functions */
-int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
-int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibarrier_intra_recexch(MPIR_Comm * comm, MPIR_Request ** req);
 
 /* sched-based intercomm-only functions */
-int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
-int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
+int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ibcast ********************************/
@@ -772,29 +777,30 @@ int MPIR_Ibcast_intra_ring(void *buffer, int count, MPI_Datatype datatype, int r
 
 /* sched-based functions */
 int MPIR_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_binomial(void *buffer, int count, MPI_Datatype datatype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
                                                                  MPI_Datatype datatype, int root,
                                                                  MPIR_Comm * comm_ptr,
-                                                                 MPIR_Sched_t s);
+                                                                 MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Iexscan ********************************/
@@ -806,17 +812,17 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatyp
 
 /* sched-based functions */
 int MPIR_Iexscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Igather ********************************/
@@ -834,29 +840,29 @@ int MPIR_Igather_intra_tree(const void *sendbuf, int sendcount, MPI_Datatype sen
 /* sched-based functions */
 int MPIR_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                        int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                       MPIR_Sched_t s);
+                       MPIR_Sched_element_t s);
 int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                             void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Igatherv ********************************/
@@ -871,28 +877,29 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 /* sched-based functions */
 int MPIR_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         const int *recvcounts, const int *displs, MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int *recvcounts, const int *displs,
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, const int *recvcounts, const int *displs,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s);
+                                       MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_allgather ********************************/
@@ -911,28 +918,28 @@ int MPIR_Ineighbor_allgather_allcomm_gentran_linear(const void *sendbuf, int sen
 /* sched-based functions */
 int MPIR_Ineighbor_allgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_allgatherv ********************************/
@@ -953,32 +960,33 @@ int MPIR_Ineighbor_allgatherv_allcomm_gentran_linear(const void *sendbuf, int se
 /* sched-based functions */
 int MPIR_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, const int recvcounts[], const int displs[],
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                    MPIR_Sched_element_t s);
 int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                          void *recvbuf, const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                         MPIR_Sched_t s);
+                                         MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s);
+                                                   MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoall ********************************/
@@ -997,28 +1005,28 @@ int MPIR_Ineighbor_alltoall_allcomm_gentran_linear(const void *sendbuf, int send
 /* sched-based functions */
 int MPIR_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoallv ********************************/
@@ -1041,33 +1049,33 @@ int MPIR_Ineighbor_alltoallv_allcomm_gentran_linear(const void *sendbuf, const i
 int MPIR_Ineighbor_alltoallv_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                    MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                                    const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s);
+                                        MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ineighbor_alltoallw ********************************/
@@ -1094,12 +1102,12 @@ int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[],
                                    const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s);
+                                   MPIR_Sched_element_t s);
 int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcounts[],
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sendcounts[],
@@ -1107,7 +1115,7 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[],
@@ -1115,7 +1123,7 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
@@ -1123,7 +1131,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce ********************************/
@@ -1141,31 +1149,31 @@ int MPIR_Ireduce_intra_ring(const void *sendbuf, void *recvbuf, int count,
 
 /* sched-based functions */
 int MPIR_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Sched_t s);
+                                 MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce_scatter ********************************/
@@ -1180,30 +1188,30 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int *rec
 /* sched-based functions */
 int MPIR_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s);
+                               MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const int *recvcounts,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                     const int *recvcnts, MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s);
+                                                    MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                               const int *recvcnts, MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                         const int *recvcnts, MPI_Datatype datatype,
                                                         MPI_Op op, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
+                                                        MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                        const int *recvcnts, MPI_Datatype datatype,
                                                        MPI_Op op, MPIR_Comm * comm_ptr,
-                                                       MPIR_Sched_t s);
+                                                       MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
                                        const int *recvcounts, MPI_Datatype datatype,
                                        MPI_Op op, MPIR_Comm * comm, MPIR_Request ** req);
@@ -1211,13 +1219,13 @@ int MPIR_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf, const int *recvcnts,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
                                                                   void *recvbuf,
                                                                   const int *recvcnts,
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s);
+                                                                  MPIR_Sched_element_t s);
 
 
 /******************************** Ireduce_scatter_block ********************************/
@@ -1235,42 +1243,42 @@ int MPIR_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recvbuf,
 /* sched-based functions */
 int MPIR_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s);
+                                     MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, int recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s);
+                                          MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                           int recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s);
+                                                          MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                                     int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                               int recvcount, MPI_Datatype datatype,
                                                               MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s);
+                                                              MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                              int recvcount, MPI_Datatype datatype,
                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s);
+                                                             MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const void *sendbuf,
                                                                         void *recvbuf,
                                                                         int recvcount,
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
-                                                                        MPIR_Sched_t s);
+                                                                        MPIR_Sched_element_t s);
 
 
 /******************************** Iscan ********************************/
@@ -1282,19 +1290,19 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
 
 /* sched-based functions */
 int MPIR_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s);
+                                MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                               MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscan_intra_gentran_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req);
@@ -1315,31 +1323,31 @@ int MPIR_Iscatter_intra_tree(const void *sendbuf, int sendcount, MPI_Datatype se
 /* sched-based functions */
 int MPIR_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         int recvcount, MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                        MPIR_Sched_t s);
+                        MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s);
+                                                        MPIR_Sched_element_t s);
 
 
 /******************************** Iscatterv ********************************/
@@ -1354,29 +1362,29 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int *sendcounts, const int *d
 /* sched-based functions */
 int MPIR_Iscatterv_sched(const void *sendbuf, const int *sendcounts, const int *displs,
                          MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int *sendcounts, const int *displs,
                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                               MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                              MPIR_Sched_t s);
+                              MPIR_Sched_element_t s);
 
 /* sched-based intracomm-only functions */
 int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based intercomm-only functions */
 int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int *sendcounts, const int *displs,
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s);
+                                    MPIR_Sched_element_t s);
 
 /* sched-based anycomm functions */
 int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int *sendcounts,
                                         const int *displs, MPI_Datatype sendtype, void *recvbuf,
                                         int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s);
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s);
 
 
 /******************************** Neighbor_allgather ********************************/

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -175,7 +175,7 @@ struct MPIR_Comm {
     MPIR_Info *info;            /* Hints to the communicator */
 
 #if defined HAVE_LIBHCOLL
-    hcoll_comm_priv_t hcoll_priv;
+    MPIDI_HCOLL_comm_priv_t hcoll_priv;
 #endif                          /* HAVE_LIBHCOLL */
 
     /* the mapper is temporarily filled out in order to allow the

--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -8,13 +8,13 @@
 #define MPIR_NBC_H_INCLUDED
 
 /* This specifies the interface that must be exposed by the ADI in order to
- * support MPI-3 non-blocking collectives.  MPIR_Sched_ routines are all
+ * support MPI-3 non-blocking collectives.  MPIR_Sched_element_ routines are all
  * permitted to be inlines.  They are not permitted to be macros.
  *
  * Most (currently all) devices will just use the default implementation that
  * lives in "src/mpid/common/sched" */
 
-/* The device must supply a typedef for MPIR_Sched_t.  MPIR_Sched_t is a handle
+/* The device must supply a typedef for MPIR_Sched_element_t.  MPIR_Sched_element_t is a handle
  * to the schedule (often a pointer under the hood), not the actual schedule.
  * This makes it easy to cheaply pass the schedule between functions.  Many
  *
@@ -43,51 +43,53 @@
 
 #define MPIR_SCHED_NULL (NULL)
 
-/* Open question: should tag allocation be rolled into Sched_start?  Keeping it
+/* Open question: should tag allocation be rolled into Sched_list_enqueue_sched?  Keeping it
  * separate potentially allows more parallelism in the future, but it also
  * pushes more work onto the clients of this interface. */
-int MPIR_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag);
+int MPIR_Sched_list_get_next_tag(MPIR_Comm * comm_ptr, int *tag);
 
-/* the device must provide a typedef for MPIR_Sched_t in mpidpre.h */
+/* the device must provide a typedef for MPIR_Sched_element_t in mpidpre.h */
 
 /* creates a new opaque schedule object and returns a handle to it in (*sp) */
-int MPIR_Sched_create(MPIR_Sched_t * sp);
+int MPIR_Sched_element_create(MPIR_Sched_element_t * sp);
 /* clones orig and returns a handle to the new schedule in (*cloned) */
-int MPIR_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned);
+int MPIR_Sched_element_clone(MPIR_Sched_element_t orig, MPIR_Sched_element_t * cloned);
 /* sets (*sp) to MPIR_SCHED_NULL and gives you back a request pointer in (*req).
  * The caller is giving up ownership of the opaque schedule object.
  *
  * comm should be the primary (user) communicator with which this collective is
  * associated, even if other hidden communicators are used for a subset of the
  * operations.  It will be used for error handling and similar operations. */
-int MPIR_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request ** req);
+int MPIR_Sched_list_enqueue_sched(MPIR_Sched_element_t * sp, MPIR_Comm * comm, int tag,
+                                  MPIR_Request ** req);
 
 /* send and recv take a comm ptr to enable hierarchical collectives */
-int MPIR_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                    MPIR_Comm * comm, MPIR_Sched_t s);
-int MPIR_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, MPIR_Comm * comm,
-                    MPIR_Sched_t s);
+int MPIR_Sched_element_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                            MPIR_Comm * comm, MPIR_Sched_element_t s);
+int MPIR_Sched_element_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                            MPIR_Comm * comm, MPIR_Sched_element_t s);
 
 /* just like MPI_Issend, can't complete until the matching recv is posted */
-int MPIR_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     MPIR_Comm * comm, MPIR_Sched_t s);
+int MPIR_Sched_element_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             MPIR_Comm * comm, MPIR_Sched_element_t s);
 
-int MPIR_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Sched_t s);
+int MPIR_Sched_element_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Sched_element_t s);
 /* packing/unpacking can be accomplished by passing MPI_PACKED as either intype
  * or outtype */
-int MPIR_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
-                    void *outbuf, MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_t s);
+int MPIR_Sched_element_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
+                            void *outbuf, MPI_Aint outcount, MPI_Datatype outtype,
+                            MPIR_Sched_element_t s);
 /* require that all previously added ops are complete before subsequent ops
  * may begin to execute */
-int MPIR_Sched_barrier(MPIR_Sched_t s);
+int MPIR_Sched_element_barrier(MPIR_Sched_element_t s);
 
 /* A convenience macro for the extremely common case that "mpi_errno" is the
  * variable used for tracking error state and MPIR_ERR_POP is needed.  This
  * declutters the NBC code substantially. */
 #define MPIR_SCHED_BARRIER(sched_)              \
     do {                                        \
-        mpi_errno = MPIR_Sched_barrier(sched_); \
+        mpi_errno = MPIR_Sched_element_barrier(sched_); \
         if (mpi_errno) MPIR_ERR_POP(mpi_errno); \
     } while (0)
 
@@ -98,23 +100,24 @@ int MPIR_Sched_barrier(MPIR_Sched_t s);
  * A corresponding _recv_defer function is not currently provided because there
  * is no known use case.  The recv count is just an upper bound, not an exact
  * amount to be received, so an oversized recv is used instead of deferral. */
-int MPIR_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype, int dest,
-                          MPIR_Comm * comm, MPIR_Sched_t s);
-/* Just like MPIR_Sched_recv except it populates the given status object with
+int MPIR_Sched_element_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype,
+                                  int dest, MPIR_Comm * comm, MPIR_Sched_element_t s);
+/* Just like MPIR_Sched_element_recv except it populates the given status object with
  * the received count and error information, much like a normal recv.  Often
- * useful in conjunction with MPIR_Sched_send_defer. */
-int MPIR_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                           MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_t s);
+ * useful in conjunction with MPIR_Sched_element_send_defer. */
+int MPIR_Sched_element_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                                   MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_element_t s);
 
 /* buffer management, fancy reductions, etc */
-int MPIR_Sched_cb(MPIR_Sched_cb_t * cb_p, void *cb_state, MPIR_Sched_t s);
-int MPIR_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MPIR_Sched_t s);
+int MPIR_Sched_element_cb(MPIR_Sched_element_cb_t * cb_p, void *cb_state, MPIR_Sched_element_t s);
+int MPIR_Sched_element_cb2(MPIR_Sched_element_cb2_t * cb_p, void *cb_state, void *cb_state2,
+                           MPIR_Sched_element_t s);
 
 /* TODO: develop a caching infrastructure for use by the upper level as well,
  * hopefully s.t. uthash can be used somehow */
 
 /* common callback utility functions */
-int MPIR_Sched_cb_free_buf(MPIR_Comm * comm, int tag, void *state);
+int MPIR_Sched_element_cb_free_buf(MPIR_Comm * comm, int tag, void *state);
 
 /* an upgraded version of MPIR_CHKPMEM_MALLOC/_DECL/_REAP/_COMMIT that adds
  * corresponding cleanup callbacks to the given schedule at _COMMIT time */
@@ -150,7 +153,7 @@ int MPIR_Sched_cb_free_buf(MPIR_Comm * comm, int tag, void *state);
     do {                                                                                       \
         MPIR_SCHED_BARRIER(s);                                                                 \
         while (mpir_sched_chkpmem_stk_sp_ > 0) {                                               \
-            mpi_errno = MPIR_Sched_cb(&MPIR_Sched_cb_free_buf,                                 \
+            mpi_errno = MPIR_Sched_element_cb(&MPIR_Sched_element_cb_free_buf,                                 \
                                       (mpir_sched_chkpmem_stk_[--mpir_sched_chkpmem_stk_sp_]), \
                                       (sched_));                                               \
             if (mpi_errno) MPIR_ERR_POP(mpi_errno);                                            \

--- a/src/include/mpir_sched.h
+++ b/src/include/mpir_sched.h
@@ -1,0 +1,15 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef MPIR_SCHED_H_INCLUDED
+#define MPIR_SCHED_H_INCLUDED
+
+typedef struct MPIDU_Sched_list MPIR_Sched_list_t;
+
+extern MPIR_Sched_list_t MPIDU_all_schedules;
+
+#endif /* MPIR_SCHED_H_INCLUDED */

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -148,7 +148,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, vo
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, recvtype_size;
@@ -190,7 +190,8 @@ int MPIR_Iallgather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dat
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                      MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -208,7 +209,7 @@ int MPIR_Iallgather_sched_inter_auto(const void *sendbuf, int sendcount,
 int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount,
                                MPI_Datatype sendtype, void *recvbuf,
                                int recvcount, MPI_Datatype recvtype,
-                               MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -266,7 +267,7 @@ int MPIR_Iallgather_sched_impl(const void *sendbuf, int sendcount,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                           int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s)
+                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -291,14 +292,14 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -339,15 +340,15 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -357,7 +358,7 @@ int MPIR_Iallgather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -426,7 +426,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLGATHER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLGATHER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -514,7 +514,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLGATHER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
@@ -19,7 +19,8 @@
 int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm_ptr,
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size, root;

--- a/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
@@ -49,7 +49,7 @@ static int dtp_release_ref(MPIR_Comm * comm, int tag, void *state)
 int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct shared_state *ss = NULL;
@@ -80,9 +80,9 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
 
     /*  copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    ((char *) recvbuf + rank * recvcount * recvtype_extent),
-                                    recvcount, recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            ((char *) recvbuf + rank * recvcount * recvtype_extent),
+                                            recvcount, recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -117,19 +117,19 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
         recv_offset = dst_tree_root * recvcount * recvtype_extent;
 
         if (dst < comm_size) {
-            mpi_errno = MPIR_Sched_send_defer(((char *) recvbuf + send_offset),
-                                              &ss->curr_count, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send_defer(((char *) recvbuf + send_offset),
+                                                      &ss->curr_count, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* send-recv, no sched barrier here */
-            mpi_errno = MPIR_Sched_recv_status(((char *) recvbuf + recv_offset),
-                                               ((comm_size - dst_tree_root) * recvcount),
-                                               recvtype, dst, comm_ptr, &ss->status, s);
+            mpi_errno = MPIR_Sched_element_recv_status(((char *) recvbuf + recv_offset),
+                                                       ((comm_size - dst_tree_root) * recvcount),
+                                                       recvtype, dst, comm_ptr, &ss->status, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
-            mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
+            mpi_errno = MPIR_Sched_element_cb(&get_count, ss, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -183,9 +183,9 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
                     /* last_recv_count was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    mpi_errno = MPIR_Sched_send_defer(((char *) recvbuf + offset),
-                                                      &ss->last_recv_count,
-                                                      recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send_defer(((char *) recvbuf + offset),
+                                                              &ss->last_recv_count,
+                                                              recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -197,12 +197,13 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
                          (rank >= tree_root + nprocs_completed)) {
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */
-                    mpi_errno = MPIR_Sched_recv_status(((char *) recvbuf + offset),
-                                                       ((comm_size -
-                                                         (my_tree_root + mask)) * recvcount),
-                                                       recvtype, dst, comm_ptr, &ss->status, s);
+                    mpi_errno = MPIR_Sched_element_recv_status(((char *) recvbuf + offset),
+                                                               ((comm_size -
+                                                                 (my_tree_root +
+                                                                  mask)) * recvcount), recvtype,
+                                                               dst, comm_ptr, &ss->status, s);
                     MPIR_SCHED_BARRIER(s);
-                    mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
+                    mpi_errno = MPIR_Sched_element_cb(&get_count, ss, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -219,7 +220,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
     }
 
     if (recv_dtp) {
-        mpi_errno = MPIR_Sched_cb(dtp_release_ref, recv_dtp, s);
+        mpi_errno = MPIR_Sched_element_cb(dtp_release_ref, recv_dtp, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/iallgather/iallgather_intra_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_ring.c
@@ -27,7 +27,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype
                                      sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -41,9 +41,9 @@ int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Dat
 
     /* First, load the "local" version in the recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    ((char *) recvbuf + rank * recvcount * recvtype_extent),
-                                    recvcount, recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            ((char *) recvbuf + rank * recvcount * recvtype_extent),
+                                            recvcount, recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -57,12 +57,13 @@ int MPIR_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Dat
     j = rank;
     jnext = left;
     for (i = 1; i < comm_size; i++) {
-        mpi_errno = MPIR_Sched_send(((char *) recvbuf + j * recvcount * recvtype_extent),
-                                    recvcount, recvtype, right, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + j * recvcount * recvtype_extent),
+                                            recvcount, recvtype, right, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* concurrent, no barrier here */
-        mpi_errno = MPIR_Sched_recv(((char *) recvbuf + jnext * recvcount * recvtype_extent),
+        mpi_errno =
+            MPIR_Sched_element_recv(((char *) recvbuf + jnext * recvcount * recvtype_extent),
                                     recvcount, recvtype, left, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -50,7 +50,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -212,7 +212,7 @@ int MPIR_TSP_Iallgather_intra_brucks(const void *sendbuf, int sendcount, MPI_Dat
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -356,7 +356,7 @@ int MPIR_TSP_Iallgather_intra_recexch(const void *sendbuf, int sendcount, MPI_Da
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -248,7 +248,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -183,7 +183,7 @@ int MPIR_TSP_Iallgather_intra_ring(const void *sendbuf, int sendcount, MPI_Datat
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -96,7 +96,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     /* Ranks pass around the data (size - 1) times */
     for (i = 0; i < size - 1; i++) {
         /* Get new tag for each cycle so that the send-recv pairs are matched correctly */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -141,7 +141,8 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, comm_size, total_count, recvtype_size;
@@ -196,7 +197,8 @@ int MPIR_Iallgatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Da
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -214,7 +216,7 @@ int MPIR_Iallgatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Da
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int recvcounts[], const int displs[],
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -274,7 +276,7 @@ int MPIR_Iallgatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                            void *recvbuf, const int recvcounts[], const int displs[],
-                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -299,14 +301,14 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     int comm_size = comm_ptr->local_size;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -354,15 +356,15 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -372,7 +374,7 @@ int MPIR_Iallgatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendt
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -443,7 +443,7 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLGATHERV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLGATHERV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -536,7 +536,7 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLGATHERV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_remote_gather_local_bcast.c
@@ -26,7 +26,8 @@ int MPIR_Iallgatherv_sched_inter_remote_gather_local_bcast(const void *sendbuf, 
                                                            const int recvcounts[],
                                                            const int displs[],
                                                            MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm_ptr,
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size, root, rank;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_recursive_doubling.c
@@ -14,7 +14,7 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int recvcounts[], const int displs[],
                                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                    MPIR_Sched_t s)
+                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, i, j, k;
@@ -57,17 +57,17 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
     for (i = 0; i < rank; i++)
         position += recvcounts[i];
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    ((char *) tmp_buf + position * recvtype_extent),
-                                    recvcounts[rank], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            ((char *) tmp_buf + position * recvtype_extent),
+                                            recvcounts[rank], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
         /* if in_place specified, local data is found in recvbuf */
-        mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
-                                    recvcounts[rank], recvtype,
-                                    ((char *) tmp_buf + position * recvtype_extent),
-                                    recvcounts[rank], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
+                                            recvcounts[rank], recvtype,
+                                            ((char *) tmp_buf + position * recvtype_extent),
+                                            recvcounts[rank], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -115,13 +115,13 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
             for (j = dst_tree_root; j < (dst_tree_root + mask) && j < comm_size; ++j)
                 incoming_count += recvcounts[j];
 
-            mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset * recvtype_extent),
-                                        curr_count, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + send_offset * recvtype_extent),
+                                                curr_count, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + recv_offset * recvtype_extent),
-                                        incoming_count, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) tmp_buf + recv_offset * recvtype_extent),
+                                                incoming_count, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -185,8 +185,8 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                     /* incoming_count was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
-                                                incoming_count, recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + offset),
+                                                        incoming_count, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -207,7 +207,8 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
                     for (j = dst_tree_root; j < (dst_tree_root + mask) && j < comm_size; ++j)
                         incoming_count += recvcounts[j];
 
-                    mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + offset * recvtype_extent),
+                    mpi_errno =
+                        MPIR_Sched_element_recv(((char *) tmp_buf + offset * recvtype_extent),
                                                 incoming_count, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
@@ -233,10 +234,10 @@ int MPIR_Iallgatherv_sched_intra_recursive_doubling(const void *sendbuf, int sen
         if ((sendbuf != MPI_IN_PLACE) || (j != rank)) {
             /* not necessary to copy if in_place and
              * j==rank. otherwise copy. */
-            mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + position * recvtype_extent),
-                                        recvcounts[j], recvtype,
-                                        ((char *) recvbuf + displs[j] * recvtype_extent),
-                                        recvcounts[j], recvtype, s);
+            mpi_errno = MPIR_Sched_element_copy(((char *) tmp_buf + position * recvtype_extent),
+                                                recvcounts[j], recvtype,
+                                                ((char *) recvbuf + displs[j] * recvtype_extent),
+                                                recvcounts[j], recvtype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_ring.c
@@ -12,7 +12,8 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, const int recvcounts[], const int displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_count;
@@ -39,9 +40,9 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
 
     if (sendbuf != MPI_IN_PLACE) {
         /* First, load the "local" version in the recvbuf. */
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    ((char *) recvbuf + displs[rank] * recvtype_extent),
-                                    recvcounts[rank], recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                            ((char *) recvbuf + displs[rank] * recvtype_extent),
+                                            recvcounts[rank], recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -82,13 +83,13 @@ int MPIR_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount, MPI_Da
 
         /* Communicate */
         if (recvnow) {  /* If there's no data to send, just do a recv call */
-            mpi_errno = MPIR_Sched_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             torecv -= recvnow;
         }
         if (sendnow) {  /* If there's no data to receive, just do a send call */
-            mpi_errno = MPIR_Sched_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             tosend -= sendnow;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -81,7 +81,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     int mpi_errno = MPI_SUCCESS;
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -354,7 +354,7 @@ int MPIR_TSP_Iallgatherv_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -380,7 +380,7 @@ int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_D
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -369,7 +369,7 @@ int MPIR_TSP_Iallgatherv_intra_recexch(const void *sendbuf, int sendcount, MPI_D
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -94,7 +94,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
         send_rank = (rank - i + nranks) % nranks;       /* Rank whose data you're sending */
 
         /* New tag for each send-recv pair. */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -180,7 +180,7 @@ int MPIR_TSP_Iallgatherv_intra_ring(const void *sendbuf, int sendcount, MPI_Data
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -406,7 +406,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLREDUCE);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLREDUCE);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -490,7 +490,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLREDUCE);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -141,7 +141,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype d
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, type_size;
@@ -191,7 +191,7 @@ int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int cou
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -207,7 +207,7 @@ int MPIR_Iallreduce_sched_inter_auto(const void *sendbuf, void *recvbuf, int cou
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -268,7 +268,7 @@ int MPIR_Iallreduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MP
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -291,13 +291,13 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -327,15 +327,15 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -343,7 +343,7 @@ int MPIR_Iallreduce_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
+++ b/src/mpi/coll/iallreduce/iallreduce_inter_remote_reduce_local_bcast.c
@@ -24,7 +24,7 @@
 int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
                                                           int count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;
@@ -67,7 +67,7 @@ int MPIR_Iallreduce_sched_inter_remote_reduce_local_bcast(const void *sendbuf, v
     }
 
     /* don't bcast until the reductions have finished */
-    mpi_errno = MPIR_Sched_barrier(s);
+    mpi_errno = MPIR_Sched_element_barrier(s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_naive.c
@@ -13,7 +13,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_intra_naive(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s)
+                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;

--- a/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_recursive_doubling.c
@@ -12,7 +12,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, rem, comm_size, is_commutative, rank;
@@ -38,7 +38,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -57,7 +57,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -67,7 +67,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -75,7 +75,7 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -95,11 +95,11 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
             /* Send the most current data, which is in recvbuf. Recv
              * into tmp_buf */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -109,19 +109,20 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
 
             if (is_commutative || (dst < rank)) {
                 /* op is commutative OR the order is already right */
-                mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 /* op is noncommutative and the order is not right */
-                mpi_errno = MPIR_Sched_reduce(recvbuf, tmp_buf, count, datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(recvbuf, tmp_buf, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into recvbuf */
-                mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -135,11 +136,11 @@ int MPIR_Iallreduce_sched_intra_recursive_doubling(const void *sendbuf, void *re
      * (rank-1), the ranks who didn't participate above. */
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
@@ -14,7 +14,7 @@
 int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, void *recvbuf,
                                                          int count, MPI_Datatype datatype,
                                                          MPI_Op op, MPIR_Comm * comm_ptr,
-                                                         MPIR_Sched_t s)
+                                                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, newrank, pof2, rem;
@@ -46,7 +46,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
 
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -65,7 +65,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -75,7 +75,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -83,7 +83,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -140,13 +140,13 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
             }
 
             /* Send data from recvbuf. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + disps[recv_idx] * extent),
-                                        recv_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) tmp_buf + disps[recv_idx] * extent),
+                                                recv_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                        send_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[send_idx] * extent),
+                                                send_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -156,9 +156,9 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
 
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
-            mpi_errno = MPIR_Sched_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
-                                          ((char *) recvbuf + disps[recv_idx] * extent),
-                                          recv_cnt, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
+                                                  ((char *) recvbuf + disps[recv_idx] * extent),
+                                                  recv_cnt, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -201,13 +201,13 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
                     recv_cnt += cnts[i];
             }
 
-            mpi_errno = MPIR_Sched_recv(((char *) recvbuf + disps[recv_idx] * extent),
-                                        recv_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + disps[recv_idx] * extent),
+                                                recv_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                        send_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[send_idx] * extent),
+                                                send_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -224,11 +224,11 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
      * (rank-1), the ranks who didn't participate above. */
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_smp.c
@@ -13,7 +13,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -57,7 +57,8 @@ int MPIR_Iallreduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int coun
     } else {
         /* only one process on the node. copy sendbuf to recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -382,7 +382,7 @@ int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int co
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -393,7 +393,7 @@ int MPIR_TSP_Iallreduce_intra_recexch(const void *sendbuf, void *recvbuf, int co
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -267,7 +267,7 @@ int MPIR_TSP_Iallreduce_intra_tree(const void *sendbuf, void *recvbuf, int count
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -131,7 +131,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -127,7 +127,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, voi
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int nbytes, comm_size, sendtype_size;
@@ -170,7 +170,7 @@ int MPIR_Ialltoall_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Data
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype
                                     sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -187,7 +187,7 @@ int MPIR_Ialltoall_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Data
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -250,7 +250,8 @@ int MPIR_Ialltoall_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype s
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
-                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                         int recvcount, MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -275,11 +276,11 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -301,7 +302,7 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -311,10 +312,10 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -324,7 +325,7 @@ int MPIR_Ialltoall_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -392,7 +392,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLTOALL);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLTOALL);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -478,7 +478,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLTOALL);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_pairwise_exchange.c
@@ -24,7 +24,7 @@
 int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int local_size, remote_size, max_size, i;
@@ -58,10 +58,10 @@ int MPIR_Ialltoall_sched_inter_pairwise_exchange(const void *sendbuf, int sendco
             sendaddr = (char *) sendbuf + dst * sendcount * sendtype_extent;
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_brucks.c
@@ -25,7 +25,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -58,15 +58,15 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 
     /* Do Phase 1 of the algorithim. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
-    mpi_errno = MPIR_Sched_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
-                                (comm_size - rank) * sendcount, sendtype,
-                                recvbuf, (comm_size - rank) * recvcount, recvtype, s);
+    mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
+                                        (comm_size - rank) * sendcount, sendtype,
+                                        recvbuf, (comm_size - rank) * recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_copy(sendbuf, rank * sendcount, sendtype,
-                                ((char *) recvbuf +
-                                 (comm_size - rank) * recvcount * recvtype_extent),
-                                rank * recvcount, recvtype, s);
+    mpi_errno = MPIR_Sched_element_copy(sendbuf, rank * sendcount, sendtype,
+                                        ((char *) recvbuf +
+                                         (comm_size - rank) * recvcount * recvtype_extent),
+                                        rank * recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -110,16 +110,17 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
         MPIR_Datatype_get_size_macro(newtype, newtype_size);
 
         /* we will usually copy much less than nbytes */
-        mpi_errno = MPIR_Sched_copy(recvbuf, 1, newtype, tmp_buf, newtype_size, MPI_BYTE, s);
+        mpi_errno =
+            MPIR_Sched_element_copy(recvbuf, 1, newtype, tmp_buf, newtype_size, MPI_BYTE, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* now send and recv in parallel */
-        mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvbuf, 1, newtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvbuf, 1, newtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -142,15 +143,16 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - recvtype_true_lb);
 
-    mpi_errno = MPIR_Sched_copy(((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent),
-                                (comm_size - rank - 1) * recvcount, recvtype,
-                                tmp_buf, (comm_size - rank - 1) * recvcount, recvtype, s);
+    mpi_errno =
+        MPIR_Sched_element_copy(((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent),
+                                (comm_size - rank - 1) * recvcount, recvtype, tmp_buf,
+                                (comm_size - rank - 1) * recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_copy(recvbuf, (rank + 1) * recvcount, recvtype,
-                                ((char *) tmp_buf +
-                                 (comm_size - rank - 1) * recvcount * recvtype_extent),
-                                (rank + 1) * recvcount, recvtype, s);
+    mpi_errno = MPIR_Sched_element_copy(recvbuf, (rank + 1) * recvcount, recvtype,
+                                        ((char *) tmp_buf +
+                                         (comm_size - rank - 1) * recvcount * recvtype_extent),
+                                        (rank + 1) * recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -159,11 +161,11 @@ int MPIR_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
      * Reorder them to (0 to comm_size-1) and store them in recvbuf. */
 
     for (i = 0; i < comm_size; i++) {
-        mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + i * recvcount * recvtype_extent),
-                                    recvcount, recvtype,
-                                    ((char *) recvbuf +
-                                     (comm_size - i - 1) * recvcount * recvtype_extent), recvcount,
-                                    recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) tmp_buf + i * recvcount * recvtype_extent),
+                                            recvcount, recvtype,
+                                            ((char *) recvbuf +
+                                             (comm_size - i - 1) * recvcount * recvtype_extent),
+                                            recvcount, recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_inplace.c
@@ -24,7 +24,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     void *tmp_buf = NULL;
@@ -62,17 +62,19 @@ int MPIR_Ialltoall_sched_intra_inplace(const void *sendbuf, int sendcount, MPI_D
                     peer = i;
 
                 /* pack to tmp_buf */
-                mpi_errno = MPIR_Sched_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
+                mpi_errno =
+                    MPIR_Sched_element_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, tmp_buf, nbytes, MPI_BYTE, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* now simultaneously send from tmp_buf and recv to recvbuf */
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, peer, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_pairwise.c
@@ -29,7 +29,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -48,10 +48,10 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     /* Make local copy first */
-    mpi_errno = MPIR_Sched_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
-                                sendcount, sendtype,
-                                ((char *) recvbuf + rank * recvcount * recvtype_extent),
-                                recvcount, recvtype, s);
+    mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
+                                        sendcount, sendtype,
+                                        ((char *) recvbuf + rank * recvcount * recvtype_extent),
+                                        recvcount, recvtype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -67,12 +67,12 @@ int MPIR_Ialltoall_sched_intra_pairwise(const void *sendbuf, int sendcount, MPI_
             dst = (rank + i) % comm_size;
         }
 
-        mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
-                                    sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
+                                            sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
-                                    recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
+                                            recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_permuted_sendrecv.c
@@ -21,7 +21,7 @@
 int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -48,7 +48,8 @@ int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendco
         /* do the communication -- post ss sends and receives: */
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
-            mpi_errno = MPIR_Sched_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
+            mpi_errno =
+                MPIR_Sched_element_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
                                         recvcount, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
@@ -56,7 +57,8 @@ int MPIR_Ialltoall_sched_intra_permuted_sendrecv(const void *sendbuf, int sendco
 
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
-            mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
+            mpi_errno =
+                MPIR_Sched_element_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
                                         sendcount, sendtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -418,7 +418,7 @@ int MPIR_TSP_Ialltoall_intra_brucks(const void *sendbuf, int sendcount, MPI_Data
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -155,7 +155,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -217,7 +217,7 @@ int MPIR_TSP_Ialltoall_intra_ring(const void *sendbuf, int sendcount, MPI_Dataty
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -127,7 +127,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
     for (i = 0; i < size - 1; i++) {
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -347,7 +347,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLTOALLV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLTOALLV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -434,7 +434,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLTOALLV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -104,7 +104,8 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const int recvcounts[], const int rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -130,7 +131,8 @@ int MPIR_Ialltoallv_sched_intra_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
                                      const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const int recvcounts[], const int rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -148,7 +150,7 @@ int MPIR_Ialltoallv_sched_inter_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                                const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -202,7 +204,7 @@ int MPIR_Ialltoallv_sched_impl(const void *sendbuf, const int sendcounts[], cons
 int MPIR_Ialltoallv_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                           MPI_Datatype sendtype, void *recvbuf, const int recvcounts[],
                           const int rdispls[], MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                          MPIR_Sched_t s)
+                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -228,11 +230,11 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -250,7 +252,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
                 }
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -260,10 +262,10 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -273,7 +275,7 @@ int MPIR_Ialltoallv_impl(const void *sendbuf, const int sendcounts[], const int 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_pairwise_exchange.c
@@ -14,7 +14,7 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     /* Intercommunicator alltoallv. We use a pairwise exchange algorithm
      * similar to the one used in intracommunicator alltoallv. Since the
@@ -70,13 +70,13 @@ int MPIR_Ialltoallv_sched_inter_pairwise_exchange(const void *sendbuf, const int
         if (recvcount * recvtype_size == 0)
             src = MPI_PROC_NULL;
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_blocked.c
@@ -13,7 +13,8 @@
 int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -49,8 +50,8 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
             if (recvcounts[dst] && recvtype_size) {
-                mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst] * recv_extent,
-                                            recvcounts[dst], recvtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv((char *) recvbuf + rdispls[dst] * recv_extent,
+                                                    recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }
@@ -59,8 +60,8 @@ int MPIR_Ialltoallv_sched_intra_blocked(const void *sendbuf, const int sendcount
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
             if (sendcounts[dst] && sendtype_size) {
-                mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst] * send_extent,
-                                            sendcounts[dst], sendtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send((char *) sendbuf + sdispls[dst] * send_extent,
+                                                    sendcounts[dst], sendtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_inplace.c
@@ -13,7 +13,8 @@
 int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcounts[],
                                         const int sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                         const int recvcounts[], const int rdispls[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                        MPIR_Sched_element_t s)
 {
     int max_count;
     void *tmp_buf = NULL;
@@ -61,18 +62,19 @@ int MPIR_Ialltoallv_sched_intra_inplace(const void *sendbuf, const int sendcount
                 else
                     dst = i;
 
-                mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst] * recv_extent),
-                                            recvcounts[dst], recvtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + rdispls[dst] * recv_extent),
+                                                    recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst], recvtype, dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_recv(tmp_buf, recvcounts[dst], recvtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst], recvtype,
-                                            ((char *) recvbuf + rdispls[dst] * recv_extent),
-                                            recvcounts[dst], recvtype, s);
+                mpi_errno = MPIR_Sched_element_copy(tmp_buf, recvcounts[dst], recvtype,
+                                                    ((char *) recvbuf + rdispls[dst] * recv_extent),
+                                                    recvcounts[dst], recvtype, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -70,7 +70,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_lb, &sendtype_true_extent);
     sendtype_extent = MPL_MAX(sendtype_extent, sendtype_true_extent);
 
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -150,7 +150,7 @@ int MPIR_TSP_Ialltoallv_intra_scattered(const void *sendbuf, const int sendcount
         MPIR_ERR_POP(mpi_errno);
 
     /* Start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -81,7 +81,7 @@ int MPIR_Ialltoallw_sched_intra_auto(const void *sendbuf, const int sendcounts[]
                                      const int sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const int recvcounts[], const int rdispls[],
                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -106,7 +106,7 @@ int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[]
                                      const int sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const int recvcounts[], const int rdispls[],
                                      const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -124,7 +124,8 @@ int MPIR_Ialltoallw_sched_inter_auto(const void *sendbuf, const int sendcounts[]
 int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int sendcounts[], const int sdispls[],
                                const MPI_Datatype sendtypes[], void *recvbuf,
                                const int recvcounts[], const int rdispls[],
-                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -178,7 +179,7 @@ int MPIR_Ialltoallw_sched_impl(const void *sendbuf, const int sendcounts[], cons
 int MPIR_Ialltoallw_sched(const void *sendbuf, const int sendcounts[], const int sdispls[],
                           const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[],
                           const int rdispls[], const MPI_Datatype recvtypes[],
-                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -204,14 +205,14 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -221,7 +222,7 @@ int MPIR_Ialltoallw_impl(const void *sendbuf, const int sendcounts[], const int 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ialltoallw/ialltoallw.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw.c
@@ -294,7 +294,7 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IALLTOALLW);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IALLTOALLW);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -361,7 +361,7 @@ int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispl
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IALLTOALLW);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_inter_pairwise_exchange.c
@@ -15,7 +15,7 @@ int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const int rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
 /* Intercommunicator alltoallw. We use a pairwise exchange algorithm
    similar to the one used in intracommunicator alltoallw. Since the local and
@@ -62,11 +62,11 @@ int MPIR_Ialltoallw_sched_inter_pairwise_exchange(const void *sendbuf, const int
             sendtype = sendtypes[dst];
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier here */
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_blocked.c
@@ -28,7 +28,7 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i;
@@ -57,8 +57,9 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (recvcounts[dst]) {
                 MPIR_Datatype_get_size_macro(recvtypes[dst], type_size);
                 if (type_size) {
-                    mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst],
-                                                recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv((char *) recvbuf + rdispls[dst],
+                                                        recvcounts[dst], recvtypes[dst], dst,
+                                                        comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -70,8 +71,9 @@ int MPIR_Ialltoallw_sched_intra_blocked(const void *sendbuf, const int sendcount
             if (sendcounts[dst]) {
                 MPIR_Datatype_get_size_macro(sendtypes[dst], type_size);
                 if (type_size) {
-                    mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst],
-                                                sendcounts[dst], sendtypes[dst], dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send((char *) sendbuf + sdispls[dst],
+                                                        sendcounts[dst], sendtypes[dst], dst,
+                                                        comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_inplace.c
@@ -26,7 +26,7 @@ int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcount
                                         const int sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[], const int rdispls[],
                                         const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                        MPIR_Sched_t s)
+                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i, j;
@@ -77,19 +77,21 @@ int MPIR_Ialltoallw_sched_intra_inplace(const void *sendbuf, const int sendcount
                 MPIR_Type_get_true_extent_impl(recvtypes[i], &true_lb, &true_extent);
                 adj_tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
-                mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + rdispls[dst]),
+                                                    recvcounts[dst], recvtypes[dst], dst, comm_ptr,
+                                                    s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 mpi_errno =
-                    MPIR_Sched_recv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                    MPIR_Sched_element_recv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst,
+                                            comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
-                                            ((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], s);
+                mpi_errno = MPIR_Sched_element_copy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
+                                                    ((char *) recvbuf + rdispls[dst]),
+                                                    recvcounts[dst], recvtypes[dst], s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibarrier/ibarrier.c
+++ b/src/mpi/coll/ibarrier/ibarrier.c
@@ -276,7 +276,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request * request)
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IBARRIER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IBARRIER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -326,7 +326,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request * request)
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IBARRIER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ibarrier/ibarrier.c
+++ b/src/mpi/coll/ibarrier/ibarrier.c
@@ -87,7 +87,7 @@ int MPI_Ibarrier(MPI_Comm comm, MPI_Request * request)
 #define FUNCNAME MPIR_Ibarrier_sched_intra_auto
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -102,7 +102,7 @@ int MPIR_Ibarrier_sched_intra_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 #define FUNCNAME MPIR_Ibarrier_sched_inter_auto
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -115,7 +115,7 @@ int MPIR_Ibarrier_sched_inter_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 #define FUNCNAME MPIR_Ibarrier_sched_impl
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -152,7 +152,7 @@ int MPIR_Ibarrier_sched_impl(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 #define FUNCNAME MPIR_Ibarrier_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -173,14 +173,14 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -193,15 +193,15 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
     if (comm_ptr->local_size != 1 || comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
-        mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_create(&s);
+        mpi_errno = MPIR_Sched_element_create(&s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -209,7 +209,7 @@ int MPIR_Ibarrier_impl(MPIR_Comm * comm_ptr, MPIR_Request ** request)
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+        mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
+++ b/src/mpi/coll/ibarrier/ibarrier_inter_bcast.c
@@ -10,7 +10,7 @@
 #define FUNCNAME MPIR_Ibarrier_sched_inter_bcast
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;

--- a/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_recursive_doubling.c
@@ -23,7 +23,7 @@
 #define FUNCNAME MPIR_Ibarrier_sched_intra_recursive_doubling
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int size, rank, src, dst, mask;
@@ -42,15 +42,15 @@ int MPIR_Ibarrier_sched_intra_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
         dst = (rank + mask) % size;
         src = (rank - mask + size) % size;
 
-        mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -415,7 +415,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IBCAST);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IBCAST);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -479,7 +479,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IBCAST);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -150,7 +150,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -199,7 +199,7 @@ int MPIR_Ibcast_sched_intra_auto(void *buffer, int count, MPI_Datatype datatype,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -213,7 +213,7 @@ int MPIR_Ibcast_sched_inter_auto(void *buffer, int count, MPI_Datatype datatype,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                           MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -271,7 +271,7 @@ int MPIR_Ibcast_sched_impl(void *buffer, int count, MPI_Datatype datatype, int r
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -293,7 +293,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     size_t type_size, nbytes;
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -301,9 +301,9 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -333,17 +333,17 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -351,7 +351,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast.h
+++ b/src/mpi/coll/ibcast/ibcast.h
@@ -20,6 +20,6 @@ int MPII_Ibcast_sched_test_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_test_curr_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, int nbytes,
-                                  MPIR_Sched_t s);
+                                  MPIR_Sched_element_t s);
 
 #endif /* IBCAST_H_INCLUDED */

--- a/src/mpi/coll/ibcast/ibcast_inter_flat.c
+++ b/src/mpi/coll/ibcast/ibcast_inter_flat.c
@@ -12,7 +12,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype,
-                                 int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -26,13 +26,13 @@ int MPIR_Ibcast_sched_inter_flat(void *buffer, int count, MPI_Datatype datatype,
         mpi_errno = MPI_SUCCESS;
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(buffer, count, datatype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
         /* remote group. rank 0 on remote group receives from root */
         if (comm_ptr->rank == 0) {
-            mpi_errno = MPIR_Sched_recv(buffer, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(buffer, count, datatype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
@@ -54,7 +54,7 @@
 int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, int count,
                                                                  MPI_Datatype datatype, int root,
                                                                  MPIR_Comm * comm_ptr,
-                                                                 MPIR_Sched_t s)
+                                                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, dst;
@@ -106,7 +106,8 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -162,18 +163,19 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
             else
                 incoming_count = 0;
 
-            mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset),
-                                        curr_size, MPI_BYTE, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + send_offset),
+                                                curr_size, MPI_BYTE, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier */
-            mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + recv_offset),
-                                               incoming_count,
-                                               MPI_BYTE, dst, comm_ptr, &ibcast_state->status, s);
+            mpi_errno = MPIR_Sched_element_recv_status(((char *) tmp_buf + recv_offset),
+                                                       incoming_count,
+                                                       MPI_BYTE, dst, comm_ptr,
+                                                       &ibcast_state->status, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
-            mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
+            mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -230,8 +232,8 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
                     /* incoming_count was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
-                                                incoming_count, MPI_BYTE, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + offset),
+                                                        incoming_count, MPI_BYTE, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -250,13 +252,14 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
 
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
-                    mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + offset),
-                                                       incoming_count, MPI_BYTE, dst, comm_ptr,
-                                                       &ibcast_state->status, s);
+                    mpi_errno = MPIR_Sched_element_recv_status(((char *) tmp_buf + offset),
+                                                               incoming_count, MPI_BYTE, dst,
+                                                               comm_ptr, &ibcast_state->status, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
-                    mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
+                    mpi_errno =
+                        MPIR_Sched_element_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -272,12 +275,13 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
         mask <<= 1;
         i++;
     }
-    mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
+    mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     if (!is_contig) {
         if (rank != root) {
-            mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
@@ -30,7 +30,8 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_Datatype datatype,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;
@@ -72,7 +73,8 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_element_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -115,18 +117,18 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
             right_count = 0;
         right_disp = rel_j * scatter_size;
 
-        mpi_errno = MPIR_Sched_send(((char *) tmp_buf + right_disp),
-                                    right_count, MPI_BYTE, right, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(((char *) tmp_buf + right_disp),
+                                            right_count, MPI_BYTE, right, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         /* sendrecv, no barrier here */
-        mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + left_disp),
-                                           left_count, MPI_BYTE, left, comm_ptr,
-                                           &ibcast_state->status, s);
+        mpi_errno = MPIR_Sched_element_recv_status(((char *) tmp_buf + left_disp),
+                                                   left_count, MPI_BYTE, left, comm_ptr,
+                                                   &ibcast_state->status, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
-        mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
+        mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -134,12 +136,12 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }
-    mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
+    mpi_errno = MPIR_Sched_element_cb(&MPII_Ibcast_sched_test_curr_length, ibcast_state, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     if (!is_contig && rank != root) {
-        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ibcast/ibcast_intra_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_smp.c
@@ -31,7 +31,7 @@ static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
  * currently make any decision about which particular algorithm to use for any
  * subcommunicator. */
 int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -53,17 +53,17 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
     /* send to intranode-rank 0 on the root's node */
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) > 0) {   /* is not the node root (0) *//* and is on our node (!-1) */
         if (root == comm_ptr->rank) {
-            mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr->node_comm, s);
+            mpi_errno = MPIR_Sched_element_send(buffer, count, datatype, 0, comm_ptr->node_comm, s);
         } else if (0 == comm_ptr->node_comm->rank) {
             mpi_errno =
-                MPIR_Sched_recv_status(buffer, count, datatype,
-                                       MPIR_Get_intranode_rank(comm_ptr, root), comm_ptr->node_comm,
-                                       &ibcast_state->status, s);
+                MPIR_Sched_element_recv_status(buffer, count, datatype,
+                                               MPIR_Get_intranode_rank(comm_ptr, root),
+                                               comm_ptr->node_comm, &ibcast_state->status, s);
         }
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
-        mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
+        mpi_errno = MPIR_Sched_element_cb(&sched_test_length, ibcast_state, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -137,7 +137,7 @@ int MPIR_TSP_Ibcast_intra_scatter_recexch_allgather(void *buffer, int count, MPI
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -77,7 +77,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -136,7 +136,7 @@ int MPIR_TSP_Ibcast_intra_tree(void *buffer, int count, MPI_Datatype datatype, i
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -80,7 +80,7 @@ int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, int nbytes,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, src, dst;
@@ -120,7 +120,8 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
             curr_size = recv_size;
 
             if (recv_size > 0) {
-                mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + relative_rank * scatter_size),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) tmp_buf + relative_rank * scatter_size),
                                             recv_size, MPI_BYTE, src, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -146,8 +147,9 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
                 if (dst >= comm_size)
                     dst -= comm_size;
                 mpi_errno =
-                    MPIR_Sched_send(((char *) tmp_buf + scatter_size * (relative_rank + mask)),
-                                    send_size, MPI_BYTE, dst, comm_ptr, s);
+                    MPIR_Sched_element_send(((char *) tmp_buf +
+                                             scatter_size * (relative_rank + mask)), send_size,
+                                            MPI_BYTE, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -216,7 +216,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IEXSCAN);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IEXSCAN);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -292,7 +292,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IEXSCAN);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -65,7 +65,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -87,7 +87,7 @@ int MPIR_Iexscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -114,7 +114,7 @@ int MPIR_Iexscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_D
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iexscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -137,14 +137,14 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -152,7 +152,7 @@ int MPIR_Iexscan_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iexscan/iexscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_recursive_doubling.c
@@ -55,7 +55,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -88,8 +88,8 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
     mpi_errno =
-        MPIR_Sched_copy((sendbuf == MPI_IN_PLACE ? (const void *) recvbuf : sendbuf), count,
-                        datatype, partial_scan, count, datatype, s);
+        MPIR_Sched_element_copy((sendbuf == MPI_IN_PLACE ? (const void *) recvbuf : sendbuf), count,
+                                datatype, partial_scan, count, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -99,17 +99,18 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
         dst = rank ^ mask;
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(partial_scan, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             if (rank > dst) {
-                mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
+                mpi_errno =
+                    MPIR_Sched_element_reduce(tmp_buf, partial_scan, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -123,15 +124,16 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
                 if (rank != 0) {
                     if (flag == 0) {
                         /* simply copy data recd from rank 0 into recvbuf */
-                        mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
-                                                    recvbuf, count, datatype, s);
+                        mpi_errno = MPIR_Sched_element_copy(tmp_buf, count, datatype,
+                                                            recvbuf, count, datatype, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                         MPIR_SCHED_BARRIER(s);
 
                         flag = 1;
                     } else {
-                        mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+                        mpi_errno =
+                            MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                         MPIR_SCHED_BARRIER(s);
@@ -139,18 +141,20 @@ int MPIR_Iexscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvb
                 }
             } else {
                 if (is_commutative) {
-                    mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
+                    mpi_errno =
+                        MPIR_Sched_element_reduce(tmp_buf, partial_scan, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 } else {
-                    mpi_errno = MPIR_Sched_reduce(partial_scan, tmp_buf, count, datatype, op, s);
+                    mpi_errno =
+                        MPIR_Sched_element_reduce(partial_scan, tmp_buf, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
 
-                    mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
-                                                partial_scan, count, datatype, s);
+                    mpi_errno = MPIR_Sched_element_copy(tmp_buf, count, datatype,
+                                                        partial_scan, count, datatype, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -90,7 +90,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void 
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -112,7 +112,7 @@ int MPIR_Igather_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Dataty
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint local_size, remote_size;
@@ -155,7 +155,7 @@ int MPIR_Igather_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Dataty
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                             void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                            int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -205,7 +205,7 @@ int MPIR_Igather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sen
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -231,14 +231,14 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -252,15 +252,15 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -270,7 +270,7 @@ int MPIR_Igather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -339,7 +339,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IGATHER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IGATHER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -473,7 +473,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IGATHER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/igather/igather_inter_long.c
+++ b/src/mpi/coll/igather/igather_inter_long.c
@@ -19,7 +19,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint remote_size;
@@ -33,13 +33,13 @@ int MPIR_Igather_sched_inter_long(const void *sendbuf, int sendcount, MPI_Dataty
         MPIR_Datatype_get_extent_macro(recvtype, extent);
 
         for (i = 0; i < remote_size; i++) {
-            mpi_errno = MPIR_Sched_recv(((char *) recvbuf + recvcount * i * extent),
-                                        recvcount, recvtype, i, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + recvcount * i * extent),
+                                                recvcount, recvtype, i, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
     } else {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/igather/igather_inter_short.c
+++ b/src/mpi/coll/igather/igather_inter_short.c
@@ -20,7 +20,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -35,7 +35,8 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_recv(recvbuf, recvcount * remote_size, recvtype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -73,7 +74,8 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
 
         if (rank == 0) {
             mpi_errno =
-                MPIR_Sched_send(tmp_buf, sendcount * local_size, sendtype, root, comm_ptr, s);
+                MPIR_Sched_element_send(tmp_buf, sendcount * local_size, sendtype, root, comm_ptr,
+                                        s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/igather/igather_intra_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_binomial.c
@@ -32,7 +32,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                       void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;
@@ -138,19 +138,20 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                         char *rp =
                             (char *) recvbuf + (((rank + mask) % comm_size) * recvcount * extent);
                         mpi_errno =
-                            MPIR_Sched_recv(rp, (recvblks * recvcount), recvtype, src, comm_ptr, s);
+                            MPIR_Sched_element_recv(rp, (recvblks * recvcount), recvtype, src,
+                                                    comm_ptr, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
-                        mpi_errno = MPIR_Sched_barrier(s);
+                        mpi_errno = MPIR_Sched_element_barrier(s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         mpi_errno =
-                            MPIR_Sched_recv(tmp_buf, (recvblks * nbytes), MPI_BYTE, src,
-                                            comm_ptr, s);
+                            MPIR_Sched_element_recv(tmp_buf, (recvblks * nbytes), MPI_BYTE, src,
+                                                    comm_ptr, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
-                        mpi_errno = MPIR_Sched_barrier(s);
+                        mpi_errno = MPIR_Sched_element_barrier(s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                         copy_offset = rank + mask;
@@ -168,10 +169,10 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
 
-                        mpi_errno = MPIR_Sched_recv(recvbuf, 1, tmp_type, src, comm_ptr, s);
+                        mpi_errno = MPIR_Sched_element_recv(recvbuf, 1, tmp_type, src, comm_ptr, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
-                        mpi_errno = MPIR_Sched_barrier(s);
+                        mpi_errno = MPIR_Sched_element_barrier(s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
 
@@ -192,11 +193,11 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                     else
                         offset = (mask - 1) * nbytes;
                     mpi_errno =
-                        MPIR_Sched_recv(((char *) tmp_buf + offset), (recvblks * nbytes),
-                                        MPI_BYTE, src, comm_ptr, s);
+                        MPIR_Sched_element_recv(((char *) tmp_buf + offset), (recvblks * nbytes),
+                                                MPI_BYTE, src, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
-                    mpi_errno = MPIR_Sched_barrier(s);
+                    mpi_errno = MPIR_Sched_element_barrier(s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     curr_cnt += (recvblks * nbytes);
@@ -208,17 +209,17 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
 
             if (!tmp_buf_size) {
                 /* leaf nodes send directly from sendbuf */
-                mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_barrier(s);
+                mpi_errno = MPIR_Sched_element_barrier(s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
-                mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt, MPI_BYTE, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(tmp_buf, curr_cnt, MPI_BYTE, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_barrier(s);
+                mpi_errno = MPIR_Sched_element_barrier(s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             } else {
@@ -243,7 +244,7 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
 
-                mpi_errno = MPIR_Sched_send(MPI_BOTTOM, 1, tmp_type, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(MPI_BOTTOM, 1, tmp_type, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -260,15 +261,16 @@ int MPIR_Igather_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Da
     if ((rank == root) && root && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) && copy_blks) {
         /* reorder and copy from tmp_buf into recvbuf */
         /* FIXME why are there two copies here? */
-        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes * (comm_size - copy_offset), MPI_BYTE,
-                                    ((char *) recvbuf + extent * recvcount * copy_offset),
-                                    recvcount * (comm_size - copy_offset), recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy(tmp_buf, nbytes * (comm_size - copy_offset), MPI_BYTE,
+                                            ((char *) recvbuf + extent * recvcount * copy_offset),
+                                            recvcount * (comm_size - copy_offset), recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_copy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
-                                    nbytes * (copy_blks - comm_size + copy_offset), MPI_BYTE,
-                                    recvbuf, recvcount * (copy_blks - comm_size + copy_offset),
-                                    recvtype, s);
+        mpi_errno = MPIR_Sched_element_copy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
+                                            nbytes * (copy_blks - comm_size + copy_offset),
+                                            MPI_BYTE, recvbuf,
+                                            recvcount * (copy_blks - comm_size + copy_offset),
+                                            recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -59,7 +59,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -232,7 +232,7 @@ int MPIR_TSP_Igather_intra_tree(const void *sendbuf, int sendcount,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -79,7 +79,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
 int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -103,7 +103,7 @@ int MPIR_Igatherv_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
 int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[], const int displs[],
                                    MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                   MPIR_Sched_t s)
+                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -126,7 +126,8 @@ int MPIR_Igatherv_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, const int recvcounts[], const int displs[],
-                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -173,7 +174,7 @@ int MPIR_Igatherv_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf,
                         const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root,
-                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -198,14 +199,14 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -215,7 +216,7 @@ int MPIR_Igatherv_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -286,7 +286,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IGATHERV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IGATHERV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -437,7 +437,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IGATHERV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_linear.c
@@ -19,7 +19,7 @@
 int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, const int recvcounts[], const int displs[],
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s)
+                                       MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -43,15 +43,16 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
             if (recvcounts[i]) {
                 if ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (i == rank)) {
                     if (sendbuf != MPI_IN_PLACE) {
-                        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                                    ((char *) recvbuf + displs[rank] * extent),
-                                                    recvcounts[rank], recvtype, s);
+                        mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount, sendtype,
+                                                            ((char *) recvbuf +
+                                                             displs[rank] * extent),
+                                                            recvcounts[rank], recvtype, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                     }
                 } else {
-                    mpi_errno = MPIR_Sched_recv(((char *) recvbuf + displs[i] * extent),
-                                                recvcounts[i], recvtype, i, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + displs[i] * extent),
+                                                        recvcounts[i], recvtype, i, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -72,9 +73,11 @@ int MPIR_Igatherv_sched_allcomm_linear(const void *sendbuf, int sendcount, MPI_D
                 MPIR_CVAR_GET_DEFAULT_INT(GATHERV_INTER_SSEND_MIN_PROCS, &min_procs);
 
             if (comm_size >= min_procs)
-                mpi_errno = MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             else
-                mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_element_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -16,6 +16,7 @@
 
 #include "stubtran_impl.h"
 #include "gentran_impl.h"
+#include "gentran_utils.h"
 
 #include "../algorithms/stubalgo/stubalgo.h"
 #include "../algorithms/treealgo/treealgo.h"

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -81,7 +81,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
 int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -105,7 +105,7 @@ int MPIR_Ineighbor_allgather_sched_intra_auto(const void *sendbuf, int sendcount
 int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -128,7 +128,7 @@ int MPIR_Ineighbor_allgather_sched_inter_auto(const void *sendbuf, int sendcount
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -175,7 +175,7 @@ int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ineighbor_allgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -201,13 +201,13 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -222,7 +222,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     } else {
@@ -238,7 +238,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -246,10 +246,10 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgather_sched(sendbuf, sendcount, sendtype,
@@ -257,7 +257,7 @@ int MPIR_Ineighbor_allgather_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -325,7 +325,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_INEIGHBOR_ALLGATHER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_INEIGHBOR_ALLGATHER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -401,7 +401,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INEIGHBOR_ALLGATHER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c
@@ -20,7 +20,7 @@
 int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -43,14 +43,14 @@ int MPIR_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int sendc
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -55,7 +55,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, int s
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear_algos.h
@@ -107,7 +107,7 @@ int MPIR_TSP_Ineighbor_allgather_allcomm_linear(const void *sendbuf, int sendcou
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -82,7 +82,7 @@ int MPIR_Ineighbor_allgatherv_sched_intra_auto(const void *sendbuf, int sendcoun
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -107,7 +107,7 @@ int MPIR_Ineighbor_allgatherv_sched_inter_auto(const void *sendbuf, int sendcoun
                                                MPI_Datatype sendtype, void *recvbuf,
                                                const int recvcounts[], const int displs[],
                                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -132,7 +132,7 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
                                          const int recvcounts[], const int displs[],
                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                         MPIR_Sched_t s)
+                                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -180,7 +180,8 @@ int MPIR_Ineighbor_allgatherv_sched_impl(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_allgatherv_sched(const void *sendbuf, int sendcount,
                                     MPI_Datatype sendtype, void *recvbuf,
                                     const int recvcounts[], const int displs[],
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -207,13 +208,13 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -228,7 +229,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     } else {
@@ -244,7 +245,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -252,10 +253,10 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_allgatherv_sched(sendbuf, sendcount, sendtype,
@@ -263,7 +264,7 @@ int MPIR_Ineighbor_allgatherv_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -333,7 +333,7 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_INEIGHBOR_ALLGATHERV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_INEIGHBOR_ALLGATHERV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -410,7 +410,7 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INEIGHBOR_ALLGATHERV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_linear.c
@@ -21,7 +21,7 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const int recvcounts[], const int displs[],
                                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                   MPIR_Sched_t s)
+                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -47,14 +47,14 @@ int MPIR_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int send
         MPIR_ERR_POP(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -57,7 +57,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, int 
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear_algos.h
@@ -110,7 +110,7 @@ int MPIR_TSP_Ineighbor_allgatherv_allcomm_linear(const void *sendbuf, int sendco
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -328,7 +328,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_INEIGHBOR_ALLTOALL);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_INEIGHBOR_ALLTOALL);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -404,7 +404,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INEIGHBOR_ALLTOALL);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -82,7 +82,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
 int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              int recvcount, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -106,7 +106,7 @@ int MPIR_Ineighbor_alltoall_sched_intra_auto(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              int recvcount, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                             MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -130,7 +130,7 @@ int MPIR_Ineighbor_alltoall_sched_inter_auto(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
                                        int recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -178,7 +178,7 @@ int MPIR_Ineighbor_alltoall_sched_impl(const void *sendbuf, int sendcount,
 int MPIR_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                   MPI_Datatype sendtype, void *recvbuf,
                                   int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -204,13 +204,13 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -225,7 +225,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     } else {
@@ -241,17 +241,17 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoall_sched(sendbuf, sendcount, sendtype,
@@ -259,7 +259,7 @@ int MPIR_Ineighbor_alltoall_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_linear.c
@@ -20,7 +20,7 @@
 int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -45,14 +45,14 @@ int MPIR_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int sendco
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -109,7 +109,7 @@ int MPIR_TSP_Ineighbor_alltoall_allcomm_linear(const void *sendbuf, int sendcoun
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear_algos.h
@@ -55,7 +55,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, int se
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -83,7 +83,7 @@ int MPIR_Ineighbor_alltoallv_sched_intra_auto(const void *sendbuf, const int sen
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -109,7 +109,7 @@ int MPIR_Ineighbor_alltoallv_sched_inter_auto(const void *sendbuf, const int sen
                                               const int sdispls[], MPI_Datatype sendtype,
                                               void *recvbuf, const int recvcounts[],
                                               const int rdispls[], MPI_Datatype recvtype,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -135,7 +135,7 @@ int MPIR_Ineighbor_alltoallv_sched_impl(const void *sendbuf, const int sendcount
                                         const int sdispls[], MPI_Datatype sendtype,
                                         void *recvbuf, const int recvcounts[],
                                         const int rdispls[], MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -185,7 +185,7 @@ int MPIR_Ineighbor_alltoallv_sched(const void *sendbuf, const int sendcounts[],
                                    const int sdispls[], MPI_Datatype sendtype,
                                    void *recvbuf, const int recvcounts[],
                                    const int rdispls[], MPI_Datatype recvtype,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -213,13 +213,13 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -235,7 +235,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     } else {
@@ -252,17 +252,17 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallv_sched(sendbuf, sendcounts, sdispls, sendtype,
@@ -270,7 +270,7 @@ int MPIR_Ineighbor_alltoallv_impl(const void *sendbuf, const int sendcounts[],
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -342,7 +342,7 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_INEIGHBOR_ALLTOALLV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_INEIGHBOR_ALLTOALLV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -417,7 +417,7 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INEIGHBOR_ALLTOALLV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_linear.c
@@ -21,7 +21,7 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
                                                   const int sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const int recvcounts[],
                                                   const int rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -49,14 +49,14 @@ int MPIR_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const int
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -60,7 +60,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf, const
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear_algos.h
@@ -115,7 +115,7 @@ int MPIR_TSP_Ineighbor_alltoallv_allcomm_linear(const void *sendbuf, const int s
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -84,7 +84,7 @@ int MPIR_Ineighbor_alltoallw_sched_intra_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -111,7 +111,7 @@ int MPIR_Ineighbor_alltoallw_sched_inter_auto(const void *sendbuf, const int sen
                                               const MPI_Datatype sendtypes[], void *recvbuf,
                                               const int recvcounts[], const MPI_Aint rdispls[],
                                               const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -137,7 +137,7 @@ int MPIR_Ineighbor_alltoallw_sched_impl(const void *sendbuf, const int sendcount
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const int recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -188,7 +188,7 @@ int MPIR_Ineighbor_alltoallw_sched(const void *sendbuf, const int sendcounts[],
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const int recvcounts[],
                                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -218,13 +218,13 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -240,7 +240,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     } else {
@@ -257,7 +257,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -265,10 +265,10 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     mpi_errno = MPIR_Ineighbor_alltoallw_sched(sendbuf, sendcounts, sdispls, sendtypes,
@@ -277,7 +277,7 @@ int MPIR_Ineighbor_alltoallw_impl(const void *sendbuf, const int sendcounts[],
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw.c
@@ -351,7 +351,7 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_INEIGHBOR_ALLTOALLW);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_INEIGHBOR_ALLTOALLW);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -404,7 +404,7 @@ int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const M
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INEIGHBOR_ALLTOALLW);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_linear.c
@@ -22,7 +22,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
                                                   const MPI_Datatype sendtypes[], void *recvbuf,
                                                   const int recvcounts[], const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int indegree, outdegree, weighted;
@@ -45,7 +45,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
         char *sb;
 
         sb = ((char *) sendbuf) + sdispls[k];
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -54,7 +54,7 @@ int MPIR_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const int
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -55,7 +55,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf, const
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear_algos.h
@@ -117,7 +117,7 @@ int MPIR_TSP_Ineighbor_alltoallw_allcomm_linear(const void *sendbuf, const int s
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm_ptr, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm_ptr, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -140,7 +140,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, type_size;
@@ -181,7 +181,7 @@ int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf,
                                   int count, MPI_Datatype datatype, MPI_Op op, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -196,7 +196,7 @@ int MPIR_Ireduce_sched_inter_auto(const void *sendbuf, void *recvbuf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -252,7 +252,7 @@ int MPIR_Ireduce_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_D
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -276,13 +276,13 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -304,17 +304,17 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -322,7 +322,7 @@ int MPIR_Ireduce_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -388,7 +388,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IREDUCE);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IREDUCE);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -479,7 +479,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IREDUCE);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_local_reduce_remote_send.c
@@ -18,7 +18,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -35,10 +35,10 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else {
@@ -67,15 +67,15 @@ int MPIR_Ireduce_sched_inter_local_reduce_remote_send(const void *sendbuf, void 
             MPIR_Ireduce_sched(sendbuf, tmp_buf, count, datatype, op, 0, comm_ptr->local_comm, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(tmp_buf, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(tmp_buf, count, datatype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_barrier(s);
+            mpi_errno = MPIR_Sched_element_barrier(s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/ireduce/ireduce_intra_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_binomial.c
@@ -12,7 +12,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
-                                      MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, is_commutative;
@@ -64,10 +64,10 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
     if ((rank != root) || (sendbuf != MPI_IN_PLACE)) {
         /* could do this up front as an MPIR_Localcopy instead, but we'll defer
          * it to the progress engine */
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_barrier(s);
+        mpi_errno = MPIR_Sched_element_barrier(s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -116,32 +116,33 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
             source = (relrank | mask);
             if (source < comm_size) {
                 source = (source + lroot) % comm_size;
-                mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, source, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, source, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_barrier(s);
+                mpi_errno = MPIR_Sched_element_barrier(s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
 
                 /* The sender is above us, so the received buffer must be
                  * the second argument (in the noncommutative case). */
                 if (is_commutative) {
-                    mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+                    mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 } else {
-                    mpi_errno = MPIR_Sched_reduce(recvbuf, tmp_buf, count, datatype, op, s);
+                    mpi_errno = MPIR_Sched_element_reduce(recvbuf, tmp_buf, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
-                    mpi_errno = MPIR_Sched_barrier(s);
+                    mpi_errno = MPIR_Sched_element_barrier(s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     mpi_errno =
-                        MPIR_Sched_copy(tmp_buf, count, datatype, recvbuf, count, datatype, s);
+                        MPIR_Sched_element_copy(tmp_buf, count, datatype, recvbuf, count, datatype,
+                                                s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
-                mpi_errno = MPIR_Sched_barrier(s);
+                mpi_errno = MPIR_Sched_element_barrier(s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }
@@ -149,10 +150,10 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
             /* I've received all that I'm going to.  Send my result to
              * my parent */
             source = ((relrank & (~mask)) + lroot) % comm_size;
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, source, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, source, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_barrier(s);
+            mpi_errno = MPIR_Sched_element_barrier(s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
@@ -163,17 +164,17 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
 
     if (!is_commutative && (root != 0)) {
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_barrier(s);
+            mpi_errno = MPIR_Sched_element_barrier(s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else if (rank == root) {
-            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, count, datatype, 0, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_barrier(s);
+            mpi_errno = MPIR_Sched_element_barrier(s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
@@ -39,7 +39,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, j, comm_size, rank, pof2, is_commutative ATTRIBUTE((unused));
@@ -89,7 +89,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
     }
 
     if ((rank != root) || (sendbuf != MPI_IN_PLACE)) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -112,7 +112,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
 
     if (rank < 2 * rem) {
         if (rank % 2 != 0) {    /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -122,7 +122,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
              * doubling */
             newrank = -1;
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -130,7 +130,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             /* do the reduction on received data. */
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
-            mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -189,13 +189,13 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             }
 
             /* Send data from recvbuf. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                        send_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[send_idx] * extent),
+                                                send_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + disps[recv_idx] * extent),
-                                        recv_cnt, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(((char *) tmp_buf + disps[recv_idx] * extent),
+                                                recv_cnt, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -205,9 +205,9 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
 
             /* This algorithm is used only for predefined ops
              * and predefined ops are always commutative. */
-            mpi_errno = MPIR_Sched_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
-                                          ((char *) recvbuf + disps[recv_idx] * extent),
-                                          recv_cnt, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_buf + disps[recv_idx] * extent),
+                                                  ((char *) recvbuf + disps[recv_idx] * extent),
+                                                  recv_cnt, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -242,7 +242,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
                 for (i = 1; i < pof2; i++)
                     disps[i] = disps[i - 1] + cnts[i - 1];
 
-                mpi_errno = MPIR_Sched_recv(recvbuf, cnts[0], datatype, 0, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv(recvbuf, cnts[0], datatype, 0, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -251,7 +251,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
                 send_idx = 0;
                 last_idx = 2;
             } else if (newrank == 0) {  /* send */
-                mpi_errno = MPIR_Sched_send(recvbuf, cnts[0], datatype, root, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(recvbuf, cnts[0], datatype, root, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -315,16 +315,16 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
             if (newdst_tree_root == newroot_tree_root) {
                 /* send and exit */
                 /* Send data from recvbuf. Recv into tmp_buf */
-                mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                            send_cnt, datatype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[send_idx] * extent),
+                                                    send_cnt, datatype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 break;
             } else {
                 /* recv and continue */
-                mpi_errno = MPIR_Sched_recv(((char *) recvbuf + disps[recv_idx] * extent),
-                                            recv_cnt, datatype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv(((char *) recvbuf + disps[recv_idx] * extent),
+                                                    recv_cnt, datatype, dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce/ireduce_intra_smp.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_smp.c
@@ -12,7 +12,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_sched_intra_smp(const void *sendbuf, void *recvbuf, int count,
                                  MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                 MPIR_Sched_t s)
+                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -162,7 +162,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
 
         /* For correctness, transport based collectives need to get the
          * tag from the same pool as schedule based collectives */
-        mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+        mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -287,7 +287,7 @@ int MPIR_TSP_Ireduce_intra_tree(const void *sendbuf, void *recvbuf, int count,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -376,7 +376,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IREDUCE_SCATTER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IREDUCE_SCATTER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -462,7 +462,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IREDUCE_SCATTER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -91,7 +91,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
                                           const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -164,7 +164,7 @@ int MPIR_Ireduce_scatter_sched_intra_auto(const void *sendbuf, void *recvbuf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf,
                                           const int recvcounts[], MPI_Datatype datatype, MPI_Op op,
-                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -181,7 +181,7 @@ int MPIR_Ireduce_scatter_sched_inter_auto(const void *sendbuf, void *recvbuf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -245,7 +245,7 @@ int MPIR_Ireduce_scatter_sched_impl(const void *sendbuf, void *recvbuf, const in
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -270,15 +270,15 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
     int is_commutative = MPIR_Op_is_commutative(op);
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -294,15 +294,15 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
                 }
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -310,7 +310,7 @@ int MPIR_Ireduce_scatter_impl(const void *sendbuf, void *recvbuf, const int recv
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_remote_reduce_local_scatterv.c
@@ -22,7 +22,7 @@ int MPIR_Ireduce_scatter_sched_inter_remote_reduce_local_scatterv(const void *se
                                                                   const int recvcounts[],
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s)
+                                                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root, local_size, total_count, i;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_noncommutative.c
@@ -27,7 +27,8 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                     const int recvcounts[], MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr,
+                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;
@@ -79,12 +80,12 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
      * permute the blocks as we go according to the mirror permutation. */
     for (i = 0; i < comm_size; ++i) {
         mpi_errno =
-            MPIR_Sched_copy(((char *) (sendbuf ==
-                                       MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
-                             (i * true_extent * block_size)), block_size, datatype,
-                            ((char *) tmp_buf0 +
-                             (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
-                              block_size)), block_size, datatype, s);
+            MPIR_Sched_element_copy(((char *) (sendbuf ==
+                                               MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
+                                     (i * true_extent * block_size)), block_size, datatype,
+                                    ((char *) tmp_buf0 +
+                                     (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
+                                      block_size)), block_size, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -109,12 +110,12 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
             send_offset += size;
         }
 
-        mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send((outgoing_data + send_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv((incoming_data + recv_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -123,16 +124,16 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
          * is now our peer's responsibility */
         if (rank > peer) {
             /* higher ranked value so need to call op(received_data, my_data) */
-            mpi_errno = MPIR_Sched_reduce((incoming_data + recv_offset * true_extent),
-                                          (outgoing_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((incoming_data + recv_offset * true_extent),
+                                                  (outgoing_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
-            mpi_errno = MPIR_Sched_reduce((outgoing_data + recv_offset * true_extent),
-                                          (incoming_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((outgoing_data + recv_offset * true_extent),
+                                                  (incoming_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
@@ -148,7 +149,7 @@ int MPIR_Ireduce_scatter_sched_intra_noncommutative(const void *sendbuf, void *r
 
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
-    mpi_errno = MPIR_Sched_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
+    mpi_errno = MPIR_Sched_element_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_CHKPMEM_COMMIT(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_pairwise.c
@@ -19,7 +19,8 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                               const int recvcounts[], MPI_Datatype datatype,
-                                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPI_Op op, MPIR_Comm * comm_ptr,
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -57,9 +58,9 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
 
     if (sendbuf != MPI_IN_PLACE) {
         /* copy local data into recvbuf */
-        mpi_errno = MPIR_Sched_copy(((char *) sendbuf + disps[rank] * extent),
-                                    recvcounts[rank], datatype,
-                                    recvbuf, recvcounts[rank], datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + disps[rank] * extent),
+                                            recvcounts[rank], datatype,
+                                            recvbuf, recvcounts[rank], datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -79,27 +80,30 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
         /* send the data that dst needs. recv data that this process
          * needs from src into tmp_recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
-                                        recvcounts[dst], datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + disps[dst] * extent),
+                                                recvcounts[dst], datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
-                                        recvcounts[dst], datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[dst] * extent),
+                                                recvcounts[dst], datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
-        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcounts[rank], datatype, src, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_recv(tmp_recvbuf, recvcounts[rank], datatype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op, s);
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
                                           recvcounts[rank], datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
@@ -114,9 +118,9 @@ int MPIR_Ireduce_scatter_sched_intra_pairwise(const void *sendbuf, void *recvbuf
     /* if MPI_IN_PLACE, move output data to the beginning of
      * recvbuf. already done for rank 0. */
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
-        mpi_errno = MPIR_Sched_copy(((char *) recvbuf + disps[rank] * extent),
-                                    recvcounts[rank], datatype,
-                                    recvbuf, recvcounts[rank], datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) recvbuf + disps[rank] * extent),
+                                            recvcounts[rank], datatype,
+                                            recvbuf, recvcounts[rank], datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_doubling.c
@@ -24,7 +24,8 @@
 int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                         const int recvcounts[],
                                                         MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm_ptr,
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -75,11 +76,11 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
 
     /* copy sendbuf into tmp_results */
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(recvbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -151,10 +152,10 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
              * received in tmp_recvbuf and then accumulated into
              * tmp_results. accumulation is done later below.   */
 
-            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -196,7 +197,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
                 if ((dst > rank) && (rank < tree_root + nprocs_completed)
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
-                    mpi_errno = MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -206,7 +207,7 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
                 else if ((dst < rank) &&
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
-                    mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -232,29 +233,32 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
         if (received) {
             if (is_commutative || (dst_tree_root < my_tree_root)) {
                 mpi_errno =
-                    MPIR_Sched_reduce(tmp_recvbuf, tmp_results, blklens[0], datatype, op, s);
+                    MPIR_Sched_element_reduce(tmp_recvbuf, tmp_results, blklens[0], datatype, op,
+                                              s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + dis[1] * extent),
-                                              ((char *) tmp_results + dis[1] * extent),
-                                              blklens[1], datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_recvbuf + dis[1] * extent),
+                                                      ((char *) tmp_results + dis[1] * extent),
+                                                      blklens[1], datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 mpi_errno =
-                    MPIR_Sched_reduce(tmp_results, tmp_recvbuf, blklens[0], datatype, op, s);
+                    MPIR_Sched_element_reduce(tmp_results, tmp_recvbuf, blklens[0], datatype, op,
+                                              s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_results + dis[1] * extent),
-                                              ((char *) tmp_recvbuf + dis[1] * extent),
-                                              blklens[1], datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_results + dis[1] * extent),
+                                                      ((char *) tmp_recvbuf + dis[1] * extent),
+                                                      blklens[1], datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into tmp_results */
-                mpi_errno = MPIR_Sched_copy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype, s);
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -269,8 +273,9 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_doubling(const void *sendbuf, voi
     }
 
     /* now copy final results from tmp_results to recvbuf */
-    mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
-                                recvcounts[rank], datatype, recvbuf, recvcounts[rank], datatype, s);
+    mpi_errno = MPIR_Sched_element_copy(((char *) tmp_results + disps[rank] * extent),
+                                        recvcounts[rank], datatype, recvbuf, recvcounts[rank],
+                                        datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_recursive_halving.c
@@ -41,7 +41,7 @@
 int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                        const int recvcounts[],
                                                        MPI_Datatype datatype, MPI_Op op,
-                                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -94,11 +94,11 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
     /* copy sendbuf into tmp_results */
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(recvbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -115,7 +115,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -125,7 +126,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -133,7 +135,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -199,11 +202,13 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
                 int send_dst = (send_cnt ? dst : MPI_PROC_NULL);
                 int recv_dst = (recv_cnt ? dst : MPI_PROC_NULL);
 
-                mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) tmp_results + newdisps[send_idx] * extent),
                                             send_cnt, datatype, send_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                             recv_cnt, datatype, recv_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -213,7 +218,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
             if (recv_cnt) {
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                               ((char *) tmp_results + newdisps[recv_idx] * extent),
                                               recv_cnt, datatype, op, s);
                 MPIR_SCHED_BARRIER(s);
@@ -227,9 +233,9 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
 
         /* copy this process's result from tmp_results to recvbuf */
         if (recvcounts[rank]) {
-            mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
-                                        recvcounts[rank], datatype,
-                                        recvbuf, recvcounts[rank], datatype, s);
+            mpi_errno = MPIR_Sched_element_copy(((char *) tmp_results + disps[rank] * extent),
+                                                recvcounts[rank], datatype,
+                                                recvbuf, recvcounts[rank], datatype, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -243,7 +249,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
             if (recvcounts[rank - 1]) {
-                mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) tmp_results + disps[rank - 1] * extent),
                                             recvcounts[rank - 1], datatype, rank - 1, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -252,7 +259,8 @@ int MPIR_Ireduce_scatter_sched_intra_recursive_halving(const void *sendbuf, void
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno =
-                    MPIR_Sched_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr, s);
+                    MPIR_Sched_element_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr,
+                                            s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -245,7 +245,7 @@ int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -256,7 +256,7 @@ int MPIR_TSP_Ireduce_scatter_intra_recexch(const void *sendbuf, void *recvbuf,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -92,7 +92,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -155,7 +155,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_auto(const void *sendbuf, void *recvb
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvbuf, int recvcount,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -173,7 +173,7 @@ int MPIR_Ireduce_scatter_block_sched_inter_auto(const void *sendbuf, void *recvb
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, int recvcount,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                          MPIR_Sched_t s)
+                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -242,7 +242,7 @@ int MPIR_Ireduce_scatter_block_sched_impl(const void *sendbuf, void *recvbuf, in
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -268,14 +268,14 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
     int is_commutative = MPIR_Op_is_commutative(op);
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -291,14 +291,14 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
                 }
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -307,7 +307,7 @@ int MPIR_Ireduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -375,7 +375,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_IREDUCE_SCATTER_BLOCK);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_IREDUCE_SCATTER_BLOCK);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -453,7 +453,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_IREDUCE_SCATTER_BLOCK);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_remote_reduce_local_scatterv.c
@@ -23,7 +23,7 @@ int MPIR_Ireduce_scatter_block_sched_inter_remote_reduce_local_scatterv(const vo
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
-                                                                        MPIR_Sched_t s)
+                                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root, local_size, total_count;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_noncommutative.c
@@ -17,7 +17,7 @@
 int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                                           int recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;
@@ -65,12 +65,12 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
      * permute the blocks as we go according to the mirror permutation. */
     for (i = 0; i < comm_size; ++i) {
         mpi_errno =
-            MPIR_Sched_copy(((char *) (sendbuf ==
-                                       MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
-                             (i * true_extent * block_size)), block_size, datatype,
-                            ((char *) tmp_buf0 +
-                             (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
-                              block_size)), block_size, datatype, s);
+            MPIR_Sched_element_copy(((char *) (sendbuf ==
+                                               MPI_IN_PLACE ? (const void *) recvbuf : sendbuf) +
+                                     (i * true_extent * block_size)), block_size, datatype,
+                                    ((char *) tmp_buf0 +
+                                     (MPL_mirror_permutation(i, log2_comm_size) * true_extent *
+                                      block_size)), block_size, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -95,12 +95,12 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
             send_offset += size;
         }
 
-        mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_send((outgoing_data + send_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv((incoming_data + recv_offset * true_extent),
+                                            size, datatype, peer, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -109,16 +109,16 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
          * is now our peer's responsibility */
         if (rank > peer) {
             /* higher ranked value so need to call op(received_data, my_data) */
-            mpi_errno = MPIR_Sched_reduce((incoming_data + recv_offset * true_extent),
-                                          (outgoing_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((incoming_data + recv_offset * true_extent),
+                                                  (outgoing_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
             /* lower ranked value so need to call op(my_data, received_data) */
-            mpi_errno = MPIR_Sched_reduce((outgoing_data + recv_offset * true_extent),
-                                          (incoming_data + recv_offset * true_extent),
-                                          size, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce((outgoing_data + recv_offset * true_extent),
+                                                  (incoming_data + recv_offset * true_extent),
+                                                  size, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             buf0_was_inout = !buf0_was_inout;
@@ -134,7 +134,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_noncommutative(const void *sendbuf, v
 
     /* copy the reduced data to the recvbuf */
     result_ptr = (char *) (buf0_was_inout ? tmp_buf0 : tmp_buf1) + recv_offset * true_extent;
-    mpi_errno = MPIR_Sched_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
+    mpi_errno = MPIR_Sched_element_copy(result_ptr, size, datatype, recvbuf, size, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_pairwise.c
@@ -14,7 +14,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *recvbuf,
                                                     int recvcount, MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -52,8 +52,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
 
     if (sendbuf != MPI_IN_PLACE) {
         /* copy local data into recvbuf */
-        mpi_errno = MPIR_Sched_copy(((char *) sendbuf + disps[rank] * extent),
-                                    recvcount, datatype, recvbuf, recvcount, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + disps[rank] * extent),
+                                            recvcount, datatype, recvbuf, recvcount, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -72,27 +72,28 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
         /* send the data that dst needs. recv data that this process
          * needs from src into tmp_recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + disps[dst] * extent),
+                                                recvcount, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) recvbuf + disps[dst] * extent),
+                                                recvcount, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
-        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, recvbuf, recvcount, datatype, op, s);
+            mpi_errno = MPIR_Sched_element_reduce(tmp_recvbuf, recvbuf, recvcount, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         } else {
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, ((char *) recvbuf + disps[rank] * extent),
                                           recvcount, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
@@ -107,8 +108,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_pairwise(const void *sendbuf, void *r
     /* if MPI_IN_PLACE, move output data to the beginning of
      * recvbuf. already done for rank 0. */
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
-        mpi_errno = MPIR_Sched_copy(((char *) recvbuf + disps[rank] * extent),
-                                    recvcount, datatype, recvbuf, recvcount, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) recvbuf + disps[rank] * extent),
+                                            recvcount, datatype, recvbuf, recvcount, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_doubling.c
@@ -15,7 +15,7 @@
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                               int recvcount, MPI_Datatype datatype,
                                                               MPI_Op op, MPIR_Comm * comm_ptr,
-                                                              MPIR_Sched_t s)
+                                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -66,11 +66,11 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
 
     /* copy sendbuf into tmp_results */
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(recvbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -137,10 +137,10 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
             /* tmp_results contains data to be sent in each step. Data is
              * received in tmp_recvbuf and then accumulated into
              * tmp_results. accumulation is done later below.   */
-            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -182,7 +182,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
                 if ((dst > rank) && (rank < tree_root + nprocs_completed)
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
-                    mpi_errno = MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -192,7 +192,7 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
                 else if ((dst < rank) &&
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
-                    mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -218,29 +218,32 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
         if (received) {
             if (is_commutative || (dst_tree_root < my_tree_root)) {
                 mpi_errno =
-                    MPIR_Sched_reduce(tmp_recvbuf, tmp_results, blklens[0], datatype, op, s);
+                    MPIR_Sched_element_reduce(tmp_recvbuf, tmp_results, blklens[0], datatype, op,
+                                              s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + dis[1] * extent),
-                                              ((char *) tmp_results + dis[1] * extent),
-                                              blklens[1], datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_recvbuf + dis[1] * extent),
+                                                      ((char *) tmp_results + dis[1] * extent),
+                                                      blklens[1], datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 mpi_errno =
-                    MPIR_Sched_reduce(tmp_results, tmp_recvbuf, blklens[0], datatype, op, s);
+                    MPIR_Sched_element_reduce(tmp_results, tmp_recvbuf, blklens[0], datatype, op,
+                                              s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_results + dis[1] * extent),
-                                              ((char *) tmp_recvbuf + dis[1] * extent),
-                                              blklens[1], datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(((char *) tmp_results + dis[1] * extent),
+                                                      ((char *) tmp_recvbuf + dis[1] * extent),
+                                                      blklens[1], datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* copy result back into tmp_results */
-                mpi_errno = MPIR_Sched_copy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype, s);
+                mpi_errno =
+                    MPIR_Sched_element_copy(tmp_recvbuf, 1, recvtype, tmp_results, 1, recvtype, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -255,8 +258,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_doubling(const void *sendbu
     }
 
     /* now copy final results from tmp_results to recvbuf */
-    mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
-                                recvcount, datatype, recvbuf, recvcount, datatype, s);
+    mpi_errno = MPIR_Sched_element_copy(((char *) tmp_results + disps[rank] * extent),
+                                        recvcount, datatype, recvbuf, recvcount, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_recursive_halving.c
@@ -15,7 +15,7 @@
 int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                              int recvcount, MPI_Datatype datatype,
                                                              MPI_Op op, MPIR_Comm * comm_ptr,
-                                                             MPIR_Sched_t s)
+                                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -68,11 +68,11 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
 
     /* copy sendbuf into tmp_results */
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, total_count, datatype,
-                                    tmp_results, total_count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(recvbuf, total_count, datatype,
+                                            tmp_results, total_count, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -92,7 +92,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -102,7 +103,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -110,7 +112,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
              * the operation is commutative or not. */
-            mpi_errno = MPIR_Sched_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
+            mpi_errno =
+                MPIR_Sched_element_reduce(tmp_recvbuf, tmp_results, total_count, datatype, op, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -176,11 +179,13 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
                 int send_dst = (send_cnt ? dst : MPI_PROC_NULL);
                 int recv_dst = (recv_cnt ? dst : MPI_PROC_NULL);
 
-                mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_send(((char *) tmp_results + newdisps[send_idx] * extent),
                                             send_cnt, datatype, send_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                             recv_cnt, datatype, recv_dst, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
@@ -190,7 +195,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
             if (recv_cnt) {
-                mpi_errno = MPIR_Sched_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
+                mpi_errno =
+                    MPIR_Sched_element_reduce(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
                                               ((char *) tmp_results + newdisps[recv_idx] * extent),
                                               recv_cnt, datatype, op, s);
                 if (mpi_errno)
@@ -205,8 +211,8 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
         }
 
         /* copy this process's result from tmp_results to recvbuf */
-        mpi_errno = MPIR_Sched_copy(((char *) tmp_results + disps[rank] * extent),
-                                    recvcount, datatype, recvbuf, recvcount, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(((char *) tmp_results + disps[rank] * extent),
+                                            recvcount, datatype, recvbuf, recvcount, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -218,13 +224,14 @@ int MPIR_Ireduce_scatter_block_sched_intra_recursive_halving(const void *sendbuf
      * calculated for that process */
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
-            mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
-                                        recvcount, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(((char *) tmp_results + disps[rank - 1] * extent),
+                                                recvcount, datatype, rank - 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_element_recv(recvbuf, recvcount, datatype, rank + 1, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -240,7 +240,7 @@ int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recv
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -229,7 +229,7 @@ int MPIR_TSP_Ireduce_scatter_block_intra_recexch(const void *sendbuf, void *recv
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -240,7 +240,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_ISCAN);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_ISCAN);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -319,7 +319,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_ISCAN);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -66,7 +66,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s)
+                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -86,7 +86,7 @@ int MPIR_Iscan_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -118,7 +118,7 @@ int MPIR_Iscan_sched_impl(const void *sendbuf, void *recvbuf, int count, MPI_Dat
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                     MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -140,14 +140,14 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -161,15 +161,15 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -177,7 +177,7 @@ int MPIR_Iscan_impl(const void *sendbuf, void *recvbuf, int count,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_recursive_doubling.c
@@ -12,7 +12,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf, int count,
                                               MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint true_extent, true_lb, extent;
@@ -50,15 +50,17 @@ int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf
     /* Since this is an inclusive scan, copy local contribution into
      * recvbuf. */
     if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
     if (sendbuf != MPI_IN_PLACE)
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, partial_scan, count, datatype, s);
+        mpi_errno =
+            MPIR_Sched_element_copy(sendbuf, count, datatype, partial_scan, count, datatype, s);
     else
-        mpi_errno = MPIR_Sched_copy(recvbuf, count, datatype, partial_scan, count, datatype, s);
+        mpi_errno =
+            MPIR_Sched_element_copy(recvbuf, count, datatype, partial_scan, count, datatype, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -67,37 +69,40 @@ int MPIR_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf
         dst = rank ^ mask;
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_send(partial_scan, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
             if (rank > dst) {
-                mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
+                mpi_errno =
+                    MPIR_Sched_element_reduce(tmp_buf, partial_scan, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
-                mpi_errno = MPIR_Sched_reduce(tmp_buf, recvbuf, count, datatype, op, s);
+                mpi_errno = MPIR_Sched_element_reduce(tmp_buf, recvbuf, count, datatype, op, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 if (is_commutative) {
-                    mpi_errno = MPIR_Sched_reduce(tmp_buf, partial_scan, count, datatype, op, s);
+                    mpi_errno =
+                        MPIR_Sched_element_reduce(tmp_buf, partial_scan, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 } else {
-                    mpi_errno = MPIR_Sched_reduce(partial_scan, tmp_buf, count, datatype, op, s);
+                    mpi_errno =
+                        MPIR_Sched_element_reduce(partial_scan, tmp_buf, count, datatype, op, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
 
-                    mpi_errno = MPIR_Sched_copy(tmp_buf, count, datatype,
-                                                partial_scan, count, datatype, s);
+                    mpi_errno = MPIR_Sched_element_copy(tmp_buf, count, datatype,
+                                                        partial_scan, count, datatype, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                     MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscan/iscan_intra_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_smp.c
@@ -12,7 +12,7 @@
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank = comm_ptr->rank;
@@ -67,7 +67,7 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (sendbuf != MPI_IN_PLACE) {
-        mpi_errno = MPIR_Sched_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
+        mpi_errno = MPIR_Sched_element_copy(sendbuf, count, datatype, recvbuf, count, datatype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -78,14 +78,14 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
      * localfulldata. For example, localfulldata from node 1 contains
      * reduced data of rank 1,2,3. */
     if (roots_comm != NULL && node_comm != NULL) {
-        mpi_errno = MPIR_Sched_recv(localfulldata, count, datatype,
-                                    (node_comm->local_size - 1), node_comm, s);
+        mpi_errno = MPIR_Sched_element_recv(localfulldata, count, datatype,
+                                            (node_comm->local_size - 1), node_comm, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (roots_comm == NULL && node_comm != NULL &&
                node_comm->rank == node_comm->local_size - 1) {
-        mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, 0, node_comm, s);
+        mpi_errno = MPIR_Sched_element_send(recvbuf, count, datatype, 0, node_comm, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -110,13 +110,15 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
 
         if (roots_rank != roots_comm->local_size - 1) {
             mpi_errno =
-                MPIR_Sched_send(prefulldata, count, datatype, (roots_rank + 1), roots_comm, s);
+                MPIR_Sched_element_send(prefulldata, count, datatype, (roots_rank + 1), roots_comm,
+                                        s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
         if (roots_rank != 0) {
-            mpi_errno = MPIR_Sched_recv(tempbuf, count, datatype, (roots_rank - 1), roots_comm, s);
+            mpi_errno =
+                MPIR_Sched_element_recv(tempbuf, count, datatype, (roots_rank - 1), roots_comm, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -141,7 +143,7 @@ int MPIR_Iscan_sched_intra_smp(const void *sendbuf, void *recvbuf, int count, MP
         }
 
         /* do reduce on tempbuf and recvbuf, finish scan. */
-        mpi_errno = MPIR_Sched_reduce(tempbuf, recvbuf, count, datatype, op, s);
+        mpi_errno = MPIR_Sched_element_reduce(tempbuf, recvbuf, count, datatype, op, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -157,7 +157,7 @@ int MPIR_TSP_Iscan_intra_recursive_doubling(const void *sendbuf, void *recvbuf, 
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -42,7 +42,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -355,7 +355,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_ISCATTER);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_ISCATTER);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -484,7 +484,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_ISCATTER);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -100,7 +100,7 @@ struct shared_state {
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -123,7 +123,7 @@ int MPIR_Iscatter_sched_intra_auto(const void *sendbuf, int sendcount, MPI_Datat
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int local_size, remote_size, sendtype_size, recvtype_size, nbytes;
     int mpi_errno = MPI_SUCCESS;
@@ -165,7 +165,7 @@ int MPIR_Iscatter_sched_inter_auto(const void *sendbuf, int sendcount, MPI_Datat
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                              void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                             int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                             int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -219,7 +219,7 @@ int MPIR_Iscatter_sched_impl(const void *sendbuf, int sendcount, MPI_Datatype se
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -245,13 +245,13 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
     /* If the user picks one of the transport-enabled algorithms, branch there
-     * before going down to the MPIR_Sched-based algorithms. */
+     * before going down to the MPIR_Sched_element-based algorithms. */
     /* TODO - Eventually the intention is to replace all of the
-     * MPIR_Sched-based algorithms with transport-enabled algorithms, but that
+     * MPIR_Sched_element-based algorithms with transport-enabled algorithms, but that
      * will require sufficient performance testing and replacement algorithms. */
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         /* intracommunicator */
@@ -265,7 +265,7 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
                 goto fn_exit;
                 break;
             default:
-                /* go down to the MPIR_Sched-based algorithms */
+                /* go down to the MPIR_Sched_element-based algorithms */
                 break;
         }
     }
@@ -273,10 +273,10 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
     /* If the user doesn't pick a transport-enabled algorithm, go to the old
      * sched function. */
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -286,7 +286,7 @@ int MPIR_Iscatter_impl(const void *sendbuf, int sendcount,
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter_inter_linear.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_linear.c
@@ -20,7 +20,7 @@
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, int recvcount, MPI_Datatype recvtype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size;
@@ -38,14 +38,14 @@ int MPIR_Iscatter_sched_inter_linear(const void *sendbuf, int sendcount, MPI_Dat
         MPIR_Datatype_get_extent_macro(sendtype, extent);
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
-                MPIR_Sched_send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
-                                comm_ptr, s);
+                MPIR_Sched_element_send(((char *) sendbuf + sendcount * i * extent), sendcount,
+                                        sendtype, i, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
-        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_element_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
@@ -23,7 +23,7 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s)
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size;
@@ -42,7 +42,8 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
 
     if (root == MPI_ROOT) {
         /* root sends all data to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_element_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -65,7 +66,8 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
             tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
             mpi_errno =
-                MPIR_Sched_recv(tmp_buf, recvcount * local_size, recvtype, root, comm_ptr, s);
+                MPIR_Sched_element_recv(tmp_buf, recvcount * local_size, recvtype, root, comm_ptr,
+                                        s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscatter/iscatter_intra_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_binomial.c
@@ -70,7 +70,7 @@ static int calc_curr_count(MPIR_Comm * comm, int tag, void *state)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                        void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint extent = 0;
@@ -129,21 +129,23 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                                       MPL_MEM_BUFFER);
 
             if (recvbuf != MPI_IN_PLACE)
-                mpi_errno = MPIR_Sched_copy(((char *) sendbuf + extent * sendcount * rank),
-                                            sendcount * (comm_size - rank), sendtype,
-                                            tmp_buf, ss->nbytes * (comm_size - rank), MPI_BYTE, s);
+                mpi_errno = MPIR_Sched_element_copy(((char *) sendbuf + extent * sendcount * rank),
+                                                    sendcount * (comm_size - rank), sendtype,
+                                                    tmp_buf, ss->nbytes * (comm_size - rank),
+                                                    MPI_BYTE, s);
             else
                 mpi_errno =
-                    MPIR_Sched_copy(((char *) sendbuf + extent * sendcount * (rank + 1)),
-                                    sendcount * (comm_size - rank - 1), sendtype,
-                                    ((char *) tmp_buf + ss->nbytes),
-                                    ss->nbytes * (comm_size - rank - 1), MPI_BYTE, s);
+                    MPIR_Sched_element_copy(((char *) sendbuf + extent * sendcount * (rank + 1)),
+                                            sendcount * (comm_size - rank - 1), sendtype,
+                                            ((char *) tmp_buf + ss->nbytes),
+                                            ss->nbytes * (comm_size - rank - 1), MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
-            mpi_errno = MPIR_Sched_copy(sendbuf, sendcount * rank, sendtype,
-                                        ((char *) tmp_buf + ss->nbytes * (comm_size - rank)),
-                                        ss->nbytes * rank, MPI_BYTE, s);
+            mpi_errno = MPIR_Sched_element_copy(sendbuf, sendcount * rank, sendtype,
+                                                ((char *) tmp_buf +
+                                                 ss->nbytes * (comm_size - rank)),
+                                                ss->nbytes * rank, MPI_BYTE, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
@@ -166,7 +168,7 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
              * they don't have to forward data to anyone. Others
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
-                mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, src, comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_recv(recvbuf, recvcount, recvtype, src, comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -175,12 +177,12 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                 /* the recv size is larger than what may be sent in
                  * some cases. query amount of data actually received */
                 mpi_errno =
-                    MPIR_Sched_recv_status(tmp_buf, tmp_buf_size, MPI_BYTE, src, comm_ptr,
-                                           &ss->status, s);
+                    MPIR_Sched_element_recv_status(tmp_buf, tmp_buf_size, MPI_BYTE, src, comm_ptr,
+                                                   &ss->status, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
-                mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
+                mpi_errno = MPIR_Sched_element_cb(&get_count, ss, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -209,35 +211,38 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                  * is it always true the (curr_cnt/2==sendcount*mask)? */
                 send_subtree_cnt = curr_cnt - sendcount * mask;
 #endif
-                mpi_errno = MPIR_Sched_cb2(&calc_send_count_root, ss, ((void *) (size_t) mask), s);
+                mpi_errno =
+                    MPIR_Sched_element_cb2(&calc_send_count_root, ss, ((void *) (size_t) mask), s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* mask is also the size of this process's subtree */
                 mpi_errno =
-                    MPIR_Sched_send_defer(((char *) sendbuf + extent * sendcount * mask),
-                                          &ss->send_subtree_count, sendtype, dst, comm_ptr, s);
+                    MPIR_Sched_element_send_defer(((char *) sendbuf + extent * sendcount * mask),
+                                                  &ss->send_subtree_count, sendtype, dst, comm_ptr,
+                                                  s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
                 /* non-zero root and others */
                 mpi_errno =
-                    MPIR_Sched_cb2(&calc_send_count_non_root, ss, ((void *) (size_t) mask), s);
+                    MPIR_Sched_element_cb2(&calc_send_count_non_root, ss, ((void *) (size_t) mask),
+                                           s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* mask is also the size of this process's subtree */
-                mpi_errno = MPIR_Sched_send_defer(((char *) tmp_buf + ss->nbytes * mask),
-                                                  &ss->send_subtree_count, MPI_BYTE, dst,
-                                                  comm_ptr, s);
+                mpi_errno = MPIR_Sched_element_send_defer(((char *) tmp_buf + ss->nbytes * mask),
+                                                          &ss->send_subtree_count, MPI_BYTE, dst,
+                                                          comm_ptr, s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
-            mpi_errno = MPIR_Sched_cb(&calc_curr_count, ss, s);
+            mpi_errno = MPIR_Sched_element_cb(&calc_curr_count, ss, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -247,14 +252,16 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
 
     if ((rank == root) && (root == 0) && (recvbuf != MPI_IN_PLACE)) {
         /* for root=0, put root's data in recvbuf if not MPI_IN_PLACE */
-        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, s);
+        mpi_errno =
+            MPIR_Sched_element_copy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (!(relative_rank % 2) && (recvbuf != MPI_IN_PLACE)) {
         /* for non-zero root and non-leaf nodes, copy from tmp_buf
          * into recvbuf */
-        mpi_errno = MPIR_Sched_copy(tmp_buf, ss->nbytes, MPI_BYTE, recvbuf, recvcount, recvtype, s);
+        mpi_errno =
+            MPIR_Sched_element_copy(tmp_buf, ss->nbytes, MPI_BYTE, recvbuf, recvcount, recvtype, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -224,7 +224,7 @@ int MPIR_TSP_Iscatter_intra_tree(const void *sendbuf, int sendcount,
         MPIR_ERR_POP(mpi_errno);
 
     /* start and register the schedule */
-    mpi_errno = MPIR_TSP_sched_start(sched, comm, req);
+    mpi_errno = MPIR_TSP_queue_sched_enqueue(sched, comm, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -61,7 +61,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
-    mpi_errno = MPIR_Sched_next_tag(comm, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -81,7 +81,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
 int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[], const int displs[],
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -105,7 +105,7 @@ int MPIR_Iscatterv_sched_intra_auto(const void *sendbuf, const int sendcounts[],
 int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[], const int displs[],
                                     MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                     MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -128,7 +128,8 @@ int MPIR_Iscatterv_sched_inter_auto(const void *sendbuf, const int sendcounts[],
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const int displs[],
                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
-                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                              MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
+                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -180,7 +181,7 @@ int MPIR_Iscatterv_sched_impl(const void *sendbuf, const int sendcounts[], const
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Iscatterv_sched(const void *sendbuf, const int sendcounts[], const int displs[],
                          MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                         int root, MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -206,14 +207,14 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
 {
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
-    MPIR_Sched_t s = MPIR_SCHED_NULL;
+    MPIR_Sched_element_t s = MPIR_SCHED_NULL;
 
     *request = NULL;
 
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -223,7 +224,7 @@ int MPIR_Iscatterv_impl(const void *sendbuf, const int sendcounts[], const int d
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, request);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, request);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -294,7 +294,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_ISCATTERV);
 
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_ISCATTERV);
 
     /* Validate parameters, especially handles needing to be converted */
@@ -450,7 +450,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_ISCATTERV);
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI_GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_linear.c
@@ -23,7 +23,7 @@
 int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcounts[],
                                         const int displs[], MPI_Datatype sendtype, void *recvbuf,
                                         int recvcount, MPI_Datatype recvtype, int root,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -46,15 +46,16 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
             if (sendcounts[i]) {
                 if ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (i == rank)) {
                     if (recvbuf != MPI_IN_PLACE) {
-                        mpi_errno = MPIR_Sched_copy(((char *) sendbuf + displs[rank] * extent),
-                                                    sendcounts[rank], sendtype,
-                                                    recvbuf, recvcount, recvtype, s);
+                        mpi_errno =
+                            MPIR_Sched_element_copy(((char *) sendbuf + displs[rank] * extent),
+                                                    sendcounts[rank], sendtype, recvbuf, recvcount,
+                                                    recvtype, s);
                         if (mpi_errno)
                             MPIR_ERR_POP(mpi_errno);
                     }
                 } else {
-                    mpi_errno = MPIR_Sched_send(((char *) sendbuf + displs[i] * extent),
-                                                sendcounts[i], sendtype, i, comm_ptr, s);
+                    mpi_errno = MPIR_Sched_element_send(((char *) sendbuf + displs[i] * extent),
+                                                        sendcounts[i], sendtype, i, comm_ptr, s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -65,7 +66,7 @@ int MPIR_Iscatterv_sched_allcomm_linear(const void *sendbuf, const int sendcount
     else if (root != MPI_PROC_NULL) {
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
-            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_element_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpi/coll/nbcutil.c
+++ b/src/mpi/coll/nbcutil.c
@@ -7,10 +7,10 @@
 #include "mpiimpl.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIR_Sched_cb_free_buf
+#define FUNCNAME MPIR_Sched_element_cb_free_buf
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIR_Sched_cb_free_buf(MPIR_Comm * comm, int tag, void *state)
+int MPIR_Sched_element_cb_free_buf(MPIR_Comm * comm, int tag, void *state)
 {
     MPL_free(state);
     return MPI_SUCCESS;

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -1011,7 +1011,7 @@ int MPII_Coll_finalize(void)
  * block for a recv operation */
 int MPIR_Coll_safe_to_block()
 {
-    return MPII_Gentran_scheds_are_pending() == false;
+    return MPII_Genutil_queue_has_pending_scheds() == false;
 }
 
 /* Function to initialze communicators for collectives */

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -954,7 +954,7 @@ int MPII_Coll_init(void)
         MPIR_Scatterv_inter_algo_choice = MPIR_SCATTERV_INTER_ALGO_AUTO;
 
     /* register non blocking collectives progress hook */
-    mpi_errno = MPID_Progress_register_hook(MPIDU_Sched_progress, &MPIR_Nbc_progress_hook_id);
+    mpi_errno = MPID_Progress_register_hook(MPIDU_Sched_list_progress, &MPIR_Nbc_progress_hook_id);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/coll/transports/common/tsp_undef.h
+++ b/src/mpi/coll/transports/common/tsp_undef.h
@@ -36,4 +36,4 @@
 #undef MPIR_TSP_sched_isend
 #undef MPIR_TSP_sched_irecv
 #undef MPIR_TSP_sched_imcast
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue

--- a/src/mpi/coll/transports/gentran/gentran_impl.c
+++ b/src/mpi/coll/transports/gentran/gentran_impl.c
@@ -32,9 +32,9 @@ cvars:
 #include "tsp_gentran.h"
 #include "gentran_utils.h"
 
-MPII_Coll_queue_t coll_queue = { NULL };
+MPII_Coll_queue_t MPII_coll_queue = { NULL };
 
-int MPII_Genutil_progress_hook_id = 0;
+int MPII_Genutil_queue_progress_hook_id = 0;
 
 #undef FUNCNAME
 #define FUNCNAME MPII_Gentran_init
@@ -45,7 +45,8 @@ int MPII_Gentran_init()
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
-        MPID_Progress_register_hook(MPII_Genutil_progress_hook, &MPII_Genutil_progress_hook_id);
+        MPID_Progress_register_hook(MPII_Genutil_queue_progress_hook,
+                                    &MPII_Genutil_queue_progress_hook_id);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -89,17 +90,7 @@ int MPII_Gentran_finalize()
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_Progress_deregister_hook(MPII_Genutil_progress_hook_id);
+    MPID_Progress_deregister_hook(MPII_Genutil_queue_progress_hook_id);
 
     return mpi_errno;
-}
-
-
-#undef FUNCNAME
-#define FUNCNAME MPII_Gentran_scheds_are_pending
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-int MPII_Gentran_scheds_are_pending()
-{
-    return coll_queue.head != NULL;
 }

--- a/src/mpi/coll/transports/gentran/gentran_impl.h
+++ b/src/mpi/coll/transports/gentran/gentran_impl.h
@@ -23,7 +23,4 @@ int MPII_Gentran_comm_init(MPIR_Comm * comm_ptr);
 /* communicator-specific cleanup */
 int MPII_Gentran_comm_cleanup(MPIR_Comm * comm_ptr);
 
-/* check if there are any pending schedules */
-int MPII_Gentran_scheds_are_pending(void);
-
 #endif /* GENTRAN_IMPL_H_INCLUDED */

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -227,6 +227,8 @@ int MPII_Genutil_queue_progress_hook(int *made_progress)
     int mpi_errno = MPI_SUCCESS;
     MPII_Coll_req_t *coll_req, *coll_req_tmp;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
     if (made_progress)
         *made_progress = FALSE;
 
@@ -255,6 +257,8 @@ int MPII_Genutil_queue_progress_hook(int *made_progress)
 
     if (MPII_coll_queue.head == NULL)
         MPID_Progress_deactivate_hook(MPII_Genutil_queue_progress_hook_id);
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
 
     return mpi_errno;
 }
@@ -543,5 +547,13 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPII_Genutil_queue_has_pending_scheds()
 {
-    return MPII_coll_queue.head != NULL;
+    int retval;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
+    retval = (MPII_coll_queue.head != NULL);
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
+    return retval;
 }

--- a/src/mpi/coll/transports/gentran/gentran_utils.h
+++ b/src/mpi/coll/transports/gentran/gentran_utils.h
@@ -17,7 +17,7 @@
 #include "utarray.h"
 
 extern MPII_Coll_queue_t coll_queue;
-extern int MPII_Genutil_progress_hook_id;
+extern int MPII_Genutil_queue_progress_hook_id;
 
 /* vertex copy function, required by utarray */
 void MPII_Genutil_vtx_copy(void *_dst, const void *_src);
@@ -39,6 +39,9 @@ int MPII_Genutil_vtx_create(MPII_Genutil_sched_t * sched, MPII_Genutil_vtx_t ** 
 int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int *made_progress);
 
 /* Hook to make progress on nonblocking collective operations  */
-int MPII_Genutil_progress_hook(int *);
+int MPII_Genutil_queue_progress_hook(int *);
+
+/* check if there are any pending schedules */
+int MPII_Genutil_queue_has_pending_scheds(void);
 
 #endif /* GENTRAN_UTILS_H_INCLUDED */

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -350,9 +350,22 @@ int MPII_Genutil_queue_sched_enqueue(MPII_Genutil_sched_t * sched, MPIR_Comm * c
 
     /* Enqueue schedule and activate progress hook if not already activated */
     reqp->u.nbc.coll.sched = (void *) sched;
+    /* The check for head == NULL should happen inside the lock. Consider
+     * we have another thread that is executing the progress hook through the
+     * progress engine. The other thread holds the TSP_QUEUE lock and if it
+     * finishes progressing all the schedules, then it would deactivate the
+     * hook before releasing the lock. If the head == NULL check occurs outside
+     * the lock, then the hook will not be rightly activated until the user
+     * issues another non-blocking collective operation, which is incorrect since
+     * the user may not issue another non-blocking collective operation.
+     */
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
+
     if (MPII_coll_queue.head == NULL)
         MPID_Progress_activate_hook(MPII_Genutil_queue_progress_hook_id);
     DL_APPEND(MPII_coll_queue.head, &(reqp->u.nbc.coll));
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_TSP_QUEUE_MUTEX);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -320,10 +320,11 @@ void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPII_Genutil_sched_start
+#define FUNCNAME MPII_Genutil_queue_sched_enqueue
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPIR_Request ** req)
+int MPII_Genutil_queue_sched_enqueue(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
+                                     MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_complete;
@@ -349,9 +350,9 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
 
     /* Enqueue schedule and activate progress hook if not already activated */
     reqp->u.nbc.coll.sched = (void *) sched;
-    if (coll_queue.head == NULL)
-        MPID_Progress_activate_hook(MPII_Genutil_progress_hook_id);
-    DL_APPEND(coll_queue.head, &(reqp->u.nbc.coll));
+    if (MPII_coll_queue.head == NULL)
+        MPID_Progress_activate_hook(MPII_Genutil_queue_progress_hook_id);
+    DL_APPEND(MPII_coll_queue.head, &(reqp->u.nbc.coll));
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -340,7 +340,7 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
     *req = reqp;
     MPIR_Request_add_ref(reqp);
 
-    /* Make some progress */
+    /* Kick start progress on this collective's schedule */
     mpi_errno = MPII_Genutil_sched_poke(sched, &is_complete, &made_progress);
     if (is_complete) {
         MPID_Request_complete(reqp);
@@ -353,9 +353,8 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
         MPID_Progress_activate_hook(MPII_Genutil_progress_hook_id);
     DL_APPEND(coll_queue.head, &(reqp->u.nbc.coll));
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);
-
   fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPII_GENUTIL_SCHED_START);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -28,7 +28,7 @@
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
 #undef MPIR_TSP_sched_malloc
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue
 #undef MPIR_TSP_sched_free
 #undef MPIR_TSP_sched_optimize
 #undef MPIR_TSP_sched_reset
@@ -49,10 +49,10 @@
 #define MPIR_TSP_sched_sink                MPII_Genutil_sched_sink
 #define MPIR_TSP_sched_fence               MPII_Genutil_sched_fence
 #define MPIR_TSP_sched_malloc              MPII_Genutil_sched_malloc
-#define MPIR_TSP_sched_start               MPII_Genutil_sched_start
+#define MPIR_TSP_queue_sched_enqueue               MPII_Genutil_queue_sched_enqueue
 
-extern MPII_Coll_queue_t coll_queue;
-extern int MPII_Genutil_progress_hook_id;
+extern MPII_Coll_queue_t MPII_coll_queue;
+extern int MPII_Genutil_queue_progress_hook_id;
 
 /* Transport function to initialize a new schedule */
 int MPII_Genutil_sched_create(MPII_Genutil_sched_t * sched);
@@ -105,8 +105,8 @@ void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched);
 
 /* Transport function to enqueue and kick start a non-blocking
  * collective */
-int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
-                             MPIR_Request ** request);
+int MPII_Genutil_queue_sched_enqueue(MPII_Genutil_sched_t * sched, MPIR_Comm * comm,
+                                     MPIR_Request ** request);
 
 
 /* Transport function to schedule a sink */

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -57,7 +57,7 @@ extern int MPII_Genutil_progress_hook_id;
 /* Transport function to initialize a new schedule */
 int MPII_Genutil_sched_create(MPII_Genutil_sched_t * sched);
 
-/* Transport function to schedule a isend vertex */
+/* Transport function to schedule an isend vertex */
 int MPII_Genutil_sched_isend(const void *buf,
                              int count,
                              MPI_Datatype dt,
@@ -66,7 +66,7 @@ int MPII_Genutil_sched_isend(const void *buf,
                              MPIR_Comm * comm_ptr,
                              MPII_Genutil_sched_t * sched, int n_in_vtcs, int *in_vtcs);
 
-/* Transport function to schedule a irecv vertex */
+/* Transport function to schedule an irecv vertex */
 int MPII_Genutil_sched_irecv(void *buf,
                              int count,
                              MPI_Datatype dt,
@@ -75,7 +75,7 @@ int MPII_Genutil_sched_irecv(void *buf,
                              MPIR_Comm * comm_ptr,
                              MPII_Genutil_sched_t * sched, int n_in_vtcs, int *in_vtcs);
 
-/* Transport function to schedule a imcast vertex */
+/* Transport function to schedule an imcast vertex */
 int MPII_Genutil_sched_imcast(const void *buf,
                               int count,
                               MPI_Datatype dt,

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.c
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.c
@@ -62,8 +62,8 @@ void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched)
     return MPI_SUCCESS;
 }
 
-int MPII_Stubutil_sched_start(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
-                              MPII_Coll_req_t ** request)
+int MPII_Stubutil_queue_sched_enqueue(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
+                                      MPII_Coll_req_t ** request)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.h
@@ -25,7 +25,7 @@
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
 #undef MPIR_TSP_sched_malloc
-#undef MPIR_TSP_sched_start
+#undef MPIR_TSP_queue_sched_enqueue
 #undef MPIR_TSP_sched_free
 #undef MPIR_TSP_sched_optimize
 #undef MPIR_TSP_sched_reset
@@ -46,7 +46,7 @@
 #define MPIR_TSP_sched_sink                 MPII_Stubutil_sched_sink
 #define MPIR_TSP_sched_fence                MPII_Stubutil_sched_fence
 #define MPIR_TSP_sched_malloc               MPII_Stubutil_sched_malloc
-#define MPIR_TSP_sched_start                MPII_Stubutil_sched_start
+#define MPIR_TSP_queue_sched_enqueue                MPII_Stubutil_queue_sched_enqueue
 
 int MPII_Stubutil_sched_create(MPII_Stubutil_sched_t * sched);
 int MPII_Stubutil_sched_isend(const void *buf, int count, MPI_Datatype dt, int dest, int tag,
@@ -68,7 +68,7 @@ int MPII_Stubutil_sched_selective_sink(MPII_Stubutil_sched_t * sched, int n_in_v
 int MPII_Genutil_sched_sink(MPII_Genutil_sched_t * sched);
 void MPII_Genutil_sched_fence(MPII_Genutil_sched_t * sched);
 void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched);
-int MPII_Stubutil_sched_start(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
-                              MPII_Coll_req_t ** request);
+int MPII_Stubutil_queue_sched_enqueue(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
+                                      MPII_Coll_req_t ** request);
 
 #endif /* TSP_STUBTRAN_H_INCLUDED */

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -308,7 +308,7 @@ struct gcn_state {
     uint64_t tag;
     MPIR_Comm *comm_ptr;
     MPIR_Comm *comm_ptr_inter;
-    MPIR_Sched_t s;
+    MPIR_Sched_element_t s;
     MPIR_Comm *new_comm;
     MPIR_Comm_kind_t gcn_cid_kind;
     uint32_t local_mask[MPIR_MAX_CONTEXT_MASK + 1];
@@ -679,13 +679,13 @@ static int sched_cb_gcn_bcast(MPIR_Comm * comm, int tag, void *state)
     if (st->gcn_cid_kind == MPIR_COMM_KIND__INTERCOMM) {
         if (st->comm_ptr_inter->rank == 0) {
             mpi_errno =
-                MPIR_Sched_recv(st->ctx1, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, st->comm_ptr_inter,
-                                st->s);
+                MPIR_Sched_element_recv(st->ctx1, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0,
+                                        st->comm_ptr_inter, st->s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             mpi_errno =
-                MPIR_Sched_send(st->ctx0, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, st->comm_ptr_inter,
-                                st->s);
+                MPIR_Sched_element_send(st->ctx0, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0,
+                                        st->comm_ptr_inter, st->s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(st->s);
@@ -698,10 +698,10 @@ static int sched_cb_gcn_bcast(MPIR_Comm * comm, int tag, void *state)
         MPIR_SCHED_BARRIER(st->s);
     }
 
-    mpi_errno = MPIR_Sched_cb(&sched_cb_commit_comm, st, st->s);
+    mpi_errno = MPIR_Sched_element_cb(&sched_cb_commit_comm, st, st->s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_cb(&MPIR_Sched_cb_free_buf, st, st->s);
+    mpi_errno = MPIR_Sched_element_cb(&MPIR_Sched_element_cb_free_buf, st, st->s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -797,20 +797,20 @@ static int sched_cb_gcn_allocate_cid(MPIR_Comm * comm, int tag, void *state)
                  *       are not necessarily completed in the same order as they are issued, also on the
                  *       same communicator. To avoid deadlocks, we cannot add the elements to the
                  *       list bevfore the first iallreduce is completed. The "tag" is created for the
-                 *       scheduling - by calling  MPIR_Sched_next_tag(comm_ptr, &tag) - and the same
+                 *       scheduling - by calling  MPIR_Sched_list_get_next_tag(comm_ptr, &tag) - and the same
                  *       for a idup operation on all processes. So we use it here. */
                 /* FIXME I'm not sure if there can be an overflows for this tag */
                 st->tag = (uint64_t) tag + MPIR_Process.attrs.tag_ub;
                 add_gcn_to_list(st);
             }
-            mpi_errno = MPIR_Sched_cb(&sched_cb_gcn_copy_mask, st, st->s);
+            mpi_errno = MPIR_Sched_element_cb(&sched_cb_gcn_copy_mask, st, st->s);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(st->s);
         }
     } else {
         /* Successfully allocated a context id */
-        mpi_errno = MPIR_Sched_cb(&sched_cb_gcn_bcast, st, st->s);
+        mpi_errno = MPIR_Sched_element_cb(&sched_cb_gcn_bcast, st, st->s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIR_SCHED_BARRIER(st->s);
@@ -885,7 +885,7 @@ static int sched_cb_gcn_copy_mask(MPIR_Comm * comm, int tag, void *state)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(st->s);
 
-    mpi_errno = MPIR_Sched_cb(&sched_cb_gcn_allocate_cid, st, st->s);
+    mpi_errno = MPIR_Sched_element_cb(&sched_cb_gcn_allocate_cid, st, st->s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(st->s);
@@ -898,11 +898,11 @@ static int sched_cb_gcn_copy_mask(MPIR_Comm * comm, int tag, void *state)
 /** Allocating a new context ID collectively over the given communicator in a
  * nonblocking way.
  *
- * The nonblocking mechanism is implemented by inserting MPIDU_Sched_entry to
+ * The nonblocking mechanism is implemented by inserting MPIDU_Sched_element_entry to
  * the nonblocking collective progress, which is a part of the progress engine.
- * It uses a two-level linked list 'all_schedules' to manager all nonblocking
- * collective calls: the first level is a linked list of struct MPIDU_Sched;
- * and each struct MPIDU_Sched is an array of struct MPIDU_Sched_entry. The
+ * It uses a two-level linked list 'MPIDU_all_schedules' to manager all nonblocking
+ * collective calls: the first level is a linked list of struct MPIDU_Sched_element;
+ * and each struct MPIDU_Sched_element is an array of struct MPIDU_Sched_element_entry. The
  * following four functions are used together to implement the algorithm:
  * sched_cb_gcn_copy_mask, sched_cb_gcn_allocate_cid, sched_cb_gcn_bcast and
  * sched_get_cid_nonblock.
@@ -937,7 +937,7 @@ static int sched_cb_gcn_copy_mask(MPIR_Comm * comm, int tag, void *state)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
                                   MPIR_Context_id_t * ctx0, MPIR_Context_id_t * ctx1,
-                                  MPIR_Sched_t s, MPIR_Comm_kind_t gcn_cid_kind)
+                                  MPIR_Sched_element_t s, MPIR_Comm_kind_t gcn_cid_kind)
 {
     int mpi_errno = MPI_SUCCESS;
     struct gcn_state *st = NULL;
@@ -972,7 +972,7 @@ static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
                     MPIR_CVAR_CTXID_EAGER_SIZE < MPIR_MAX_CONTEXT_MASK - 1);
         eager_nelem = MPIR_CVAR_CTXID_EAGER_SIZE;
     }
-    mpi_errno = MPIR_Sched_cb(&sched_cb_gcn_copy_mask, st, s);
+    mpi_errno = MPIR_Sched_element_cb(&sched_cb_gcn_copy_mask, st, s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
     MPIR_SCHED_BARRIER(s);
@@ -995,17 +995,17 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
 {
     int mpi_errno = MPI_SUCCESS;
     int tag;
-    MPIR_Sched_t s;
+    MPIR_Sched_element_t s;
 
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_GET_CONTEXTID_NONBLOCK);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_GET_CONTEXTID_NONBLOCK);
 
     /* now create a schedule */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -1017,7 +1017,7 @@ int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR
         MPIR_ERR_POP(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -1039,7 +1039,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
 {
     int mpi_errno = MPI_SUCCESS;
     int tag;
-    MPIR_Sched_t s;
+    MPIR_Sched_element_t s;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_GET_INTERCOMM_CONTEXTID_NONBLOCK);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_GET_INTERCOMM_CONTEXTID_NONBLOCK);
@@ -1052,10 +1052,10 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
     }
 
     /* now create a schedule */
-    mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
+    mpi_errno = MPIR_Sched_list_get_next_tag(comm_ptr, &tag);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
-    mpi_errno = MPIR_Sched_create(&s);
+    mpi_errno = MPIR_Sched_element_create(&s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -1069,7 +1069,7 @@ int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newc
         MPIR_ERR_POP(mpi_errno);
 
     /* finally, kick off the schedule and give the caller a request */
-    mpi_errno = MPIR_Sched_start(&s, comm_ptr, tag, req);
+    mpi_errno = MPIR_Sched_list_enqueue_sched(&s, comm_ptr, tag, req);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpi/rma/rmatypeutil.c
+++ b/src/mpi/rma/rmatypeutil.c
@@ -17,7 +17,7 @@
  * as MPI_Compare_and_swap or MPI_Fetch_and_op.  Does NOT return MPICH error
  * codes. */
 #undef FUNCNAME
-#define FUNCNAME MPIR_Sched_cb_free_buf
+#define FUNCNAME MPIR_Sched_element_cb_free_buf
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIR_Type_is_rma_atomic(MPI_Datatype type)

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -89,7 +89,7 @@ cvars:
     (!MPID_nem_local_lmt_pending &&             \
      !MPIDI_CH3I_shm_active_send &&             \
      !MPIDI_CH3I_Sendq_head(MPIDI_CH3I_shm_sendq) &&       \
-     !MPIDU_Sched_are_pending() &&              \
+     !MPIDU_Sched_list_has_pending_sched() &&              \
      MPIR_Coll_safe_to_block() &&  \
      !MPIDI_RMA_Win_active_list_head)
 

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -21,7 +21,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_barrier(comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_barrier(comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -41,7 +41,7 @@ static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_bcast(buffer, count, datatype, root, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -62,7 +62,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -84,7 +84,7 @@ static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatyp
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
+    mpi_errno = MPIDI_HCOLL_coll_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -21,7 +21,7 @@ static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t * errflag)
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Barrier(comm, errflag);
+    mpi_errno = MPIDI_HCOLL_barrier(comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -41,7 +41,7 @@ static inline int MPID_Bcast(void *buffer, int count, MPI_Datatype datatype, int
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -62,7 +62,7 @@ static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, int count,
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -84,7 +84,7 @@ static inline int MPID_Allgather(const void *sendbuf, int sendcount, MPI_Datatyp
     int mpi_errno = MPI_SUCCESS;
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
+    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -781,7 +781,7 @@ static inline int MPID_Iscatterv(const void *sendbuf, const int *sendcounts,
 #define FUNCNAME MPID_Ibarrier_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -796,7 +796,7 @@ static inline int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype, int root,
-                              MPIR_Comm * comm, MPIR_Sched_t s)
+                              MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -812,7 +812,7 @@ static inline int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype dataty
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iallgather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -829,7 +829,7 @@ static inline int MPID_Iallgather_sched(const void *sendbuf, int sendcount, MPI_
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const int *recvcounts, const int *displs,
-                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Sched_t s)
+                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -846,7 +846,7 @@ static inline int MPID_Iallgatherv_sched(const void *sendbuf, int sendcount, MPI
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                  MPIR_Sched_t s)
+                                  MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -862,7 +862,7 @@ static inline int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int 
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ialltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Sched_t s)
+                                 MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -881,7 +881,7 @@ static inline int MPID_Ialltoallv_sched(const void *sendbuf, const int sendcount
                                   const int sdispls[], MPI_Datatype sendtype,
                                   void *recvbuf, const int recvcounts[],
                                   const int rdispls[], MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -900,7 +900,7 @@ static inline int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcount
                                   const int sdispls[], const MPI_Datatype sendtypes[],
                                   void *recvbuf, const int recvcounts[],
                                   const int rdispls[], const MPI_Datatype recvtypes[],
-                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -917,7 +917,7 @@ static inline int MPID_Ialltoallw_sched(const void *sendbuf, const int sendcount
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                               MPIR_Sched_t s)
+                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -933,7 +933,7 @@ static inline int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int cou
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Igather_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -951,7 +951,7 @@ static inline int MPID_Igather_sched(const void *sendbuf, int sendcount, MPI_Dat
 static inline int MPID_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Sched_t s)
+                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -968,7 +968,7 @@ static inline int MPID_Igatherv_sched(const void *sendbuf, int sendcount, MPI_Da
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf, int recvcount,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -985,7 +985,7 @@ static inline int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *re
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf, const int recvcounts[],
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Sched_t s)
+                                       MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1001,7 +1001,7 @@ static inline int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                               MPI_Op op, int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1016,7 +1016,7 @@ static inline int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int cou
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                             MPI_Op op, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1032,7 +1032,7 @@ static inline int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1050,7 +1050,7 @@ static inline int MPID_Iscatter_sched(const void *sendbuf, int sendcount, MPI_Da
 static inline int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                  const int *displs, MPI_Datatype sendtype,
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                 int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                 int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1068,7 +1068,7 @@ static inline int MPID_Iscatterv_sched(const void *sendbuf, const int *sendcount
 static inline int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                            MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1087,7 +1087,7 @@ static inline int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendc
                                             MPI_Datatype sendtype, void *recvbuf,
                                             const int recvcounts[], const int displs[],
                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                            MPIR_Sched_t s)
+                                            MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1104,7 +1104,7 @@ static inline int MPID_Ineighbor_allgatherv_sched(const void *sendbuf, int sendc
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                                           void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1123,7 +1123,7 @@ static inline int MPID_Ineighbor_alltoallv_sched(const void *sendbuf, const int 
                                            const int sdispls[], MPI_Datatype sendtype,
                                            void *recvbuf, const int recvcounts[],
                                            const int rdispls[], MPI_Datatype recvtype,
-                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1142,7 +1142,7 @@ static inline int MPID_Ineighbor_alltoallw_sched(const void *sendbuf, const int 
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                            void *recvbuf, const int recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch3/include/mpid_sched.h
+++ b/src/mpid/ch3/include/mpid_sched.h
@@ -8,19 +8,19 @@
 #define MPID_SCHED_H_INCLUDED
 #include "mpidu_sched.h"
 
-#define MPIR_Sched_cb MPIDU_Sched_cb
-#define MPIR_Sched_cb2 MPIDU_Sched_cb2
-#define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
-#define MPIR_Sched_create MPIDU_Sched_create
-#define MPIR_Sched_clone MPIDU_Sched_clone
-#define MPIR_Sched_start MPIDU_Sched_start
-#define MPIR_Sched_send MPIDU_Sched_send
-#define MPIR_Sched_send_defer MPIDU_Sched_send_defer
-#define MPIR_Sched_recv MPIDU_Sched_recv
-#define MPIR_Sched_recv_status MPIDU_Sched_recv_status
-#define MPIR_Sched_ssend MPIDU_Sched_ssend
-#define MPIR_Sched_reduce MPIDU_Sched_reduce
-#define MPIR_Sched_copy MPIDU_Sched_copy
-#define MPIR_Sched_barrier MPIDU_Sched_barrier
+#define MPIR_Sched_element_cb MPIDU_Sched_element_cb
+#define MPIR_Sched_element_cb2 MPIDU_Sched_element_cb2
+#define MPIR_Sched_list_get_next_tag  MPIDU_Sched_list_get_next_tag
+#define MPIR_Sched_element_create MPIDU_Sched_element_create
+#define MPIR_Sched_element_clone MPIDU_Sched_element_clone
+#define MPIR_Sched_list_enqueue_sched MPIDU_Sched_list_enqueue_sched
+#define MPIR_Sched_element_send MPIDU_Sched_element_send
+#define MPIR_Sched_element_send_defer MPIDU_Sched_element_send_defer
+#define MPIR_Sched_element_recv MPIDU_Sched_element_recv
+#define MPIR_Sched_element_recv_status MPIDU_Sched_element_recv_status
+#define MPIR_Sched_element_ssend MPIDU_Sched_element_ssend
+#define MPIR_Sched_element_reduce MPIDU_Sched_element_reduce
+#define MPIR_Sched_element_copy MPIDU_Sched_element_copy
+#define MPIR_Sched_element_barrier MPIDU_Sched_element_barrier
 
 #endif /* MPID_SCHED_H_INCLUDED */

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -97,9 +97,9 @@ int MPIDI_CH3I_Comm_init(void)
         }
 #endif
 
-        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_comm_create, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_mpi_comm_create, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_comm_destroy, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_mpi_comm_destroy, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
 #endif

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -97,9 +97,9 @@ int MPIDI_CH3I_Comm_init(void)
         }
 #endif
 
-        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(hcoll_comm_create, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_create_hook(MPIDI_HCOLL_comm_create, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
-        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(hcoll_comm_destroy, NULL);
+        mpi_errno = MPIDI_CH3U_Comm_register_destroy_hook(MPIDI_HCOLL_comm_destroy, NULL);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }
 #endif

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -212,7 +212,7 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
         MPIDIG_enqueue_posted(rreq, &MPIDIG_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     } else {
-        MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = (uint64_t) rreq;
+        MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = rreq;
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
     }
   fn_exit:

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -17,26 +17,7 @@
 #include "ch4r_recv.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIDIG_prepare_recv_req
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDIG_prepare_recv_req(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                                          MPIR_Request * rreq)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_PREPARE_RECV_REQ);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_PREPARE_RECV_REQ);
-
-    MPIDIG_REQUEST(rreq, datatype) = datatype;
-    MPIDIG_REQUEST(rreq, buffer) = (char *) buf;
-    MPIDIG_REQUEST(rreq, count) = count;
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PREPARE_RECV_REQ);
-    return mpi_errno;
-}
-
-#undef FUNCNAME
-#define FUNCNAME MPIDIG_handle_unexpected
+#define FUNCNAME MPIDI_handle_unexpected
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDIG_handle_unexpected(void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -217,11 +198,8 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
     MPIDIG_REQUEST(rreq, tag) = tag;
     MPIDIG_REQUEST(rreq, context_id) = context_id;
     MPIDIG_REQUEST(rreq, datatype) = datatype;
-
-    mpi_errno = MPIDIG_prepare_recv_req(buf, count, datatype, rreq);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
+    MPIDIG_REQUEST(rreq, buffer) = (char *) buf;
+    MPIDIG_REQUEST(rreq, count) = count;
 
     if (!unexp_req) {
         /* MPIDI_CS_ENTER(); */

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -134,13 +134,6 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
     unexp_req = MPIDIG_dequeue_unexp(rank, tag, context_id, &MPIDIG_COMM(root_comm, unexp_list));
 
     if (unexp_req) {
-        if (*request != NULL) {
-            MPIDIG_request_copy(*request, unexp_req);
-            MPIR_Request_add_ref(*request);
-            MPIR_Object_set_ref(unexp_req, 0);
-            MPIR_Handle_obj_free(&MPIR_Request_mem, unexp_req);
-            unexp_req = *request;
-        }
         MPIR_Comm_release(root_comm);   /* -1 for removing from unexp_list */
         if (MPIDIG_REQUEST(unexp_req, req->status) & MPIDIG_REQ_BUSY) {
             MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_MATCHED;
@@ -150,7 +143,20 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
             MPIDIG_REQUEST(unexp_req, datatype) = datatype;
             MPIDIG_REQUEST(unexp_req, buffer) = (char *) buf;
             MPIDIG_REQUEST(unexp_req, count) = count;
-            *request = unexp_req;
+            if (*request == NULL) {
+                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+                 * a request. Here we simply return `unexp_req` */
+                *request = unexp_req;
+                /* Mark `match_req` as NULL so that we know nothing else to complete when
+                 * `unexp_req` finally completes. (See below) */
+                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = NULL;
+            } else {
+                /* Enqueuing path: CH4 already allocated a request.
+                 * Record the passed `*request` to `match_req` so that we can complete it
+                 * later when `unexp_req` completes.
+                 * See MPIDI_recv_target_cmpl_cb for actual completion handler. */
+                MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = *request;
+            }
 #ifdef MPIDI_CH4_DIRECT_NETMOD
             mpi_errno = MPIDI_NM_am_recv(unexp_req);
 #else
@@ -163,11 +169,24 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
                 MPIR_ERR_POP(mpi_errno);
             goto fn_exit;
         } else {
-            *request = unexp_req;
             mpi_errno =
                 MPIDIG_handle_unexpected(buf, count, datatype, root_comm, context_id, unexp_req);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
+            if (*request == NULL) {
+                /* Regular (non-enqueuing) path: MPIDIG is responsbile for allocating
+                 * a request. Here we simply return `unexp_req`, which is already completed. */
+                *request = unexp_req;
+            } else {
+                /* Enqueuing path: CH4 already allocated request as `*request`.
+                 * Since the real operations has completed in `unexp_req`, here we
+                 * simply copy the status to `*request` and complete it. */
+                (*request)->status = unexp_req->status;
+                MPIR_Request_add_ref(*request);
+                MPID_Request_complete(*request);
+                /* Need to free here because we don't return this to user */
+                MPIR_Request_free(unexp_req);
+            }
             goto fn_exit;
         }
     }

--- a/src/mpid/ch4/include/mpid_sched.h
+++ b/src/mpid/ch4/include/mpid_sched.h
@@ -12,19 +12,19 @@
 #define MPID_SCHED_H_INCLUDED
 #include "mpidu_sched.h"
 
-#define MPIR_Sched_cb MPIDU_Sched_cb
-#define MPIR_Sched_cb2 MPIDU_Sched_cb2
-#define MPIR_Sched_next_tag  MPIDU_Sched_next_tag
-#define MPIR_Sched_create MPIDU_Sched_create
-#define MPIR_Sched_clone MPIDU_Sched_clone
-#define MPIR_Sched_start MPIDU_Sched_start
-#define MPIR_Sched_send MPIDU_Sched_send
-#define MPIR_Sched_send_defer MPIDU_Sched_send_defer
-#define MPIR_Sched_recv MPIDU_Sched_recv
-#define MPIR_Sched_recv_status MPIDU_Sched_recv_status
-#define MPIR_Sched_ssend MPIDU_Sched_ssend
-#define MPIR_Sched_reduce MPIDU_Sched_reduce
-#define MPIR_Sched_copy MPIDU_Sched_copy
-#define MPIR_Sched_barrier MPIDU_Sched_barrier
+#define MPIR_Sched_element_cb MPIDU_Sched_element_cb
+#define MPIR_Sched_element_cb2 MPIDU_Sched_element_cb2
+#define MPIR_Sched_list_get_next_tag  MPIDU_Sched_list_get_next_tag
+#define MPIR_Sched_element_create MPIDU_Sched_element_create
+#define MPIR_Sched_element_clone MPIDU_Sched_element_clone
+#define MPIR_Sched_list_enqueue_sched MPIDU_Sched_list_enqueue_sched
+#define MPIR_Sched_element_send MPIDU_Sched_element_send
+#define MPIR_Sched_element_send_defer MPIDU_Sched_element_send_defer
+#define MPIR_Sched_element_recv MPIDU_Sched_element_recv
+#define MPIR_Sched_element_recv_status MPIDU_Sched_element_recv_status
+#define MPIR_Sched_element_ssend MPIDU_Sched_element_ssend
+#define MPIR_Sched_element_reduce MPIDU_Sched_element_reduce
+#define MPIR_Sched_element_copy MPIDU_Sched_element_copy
+#define MPIR_Sched_element_barrier MPIDU_Sched_element_barrier
 
 #endif /* MPID_SCHED_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -214,7 +214,14 @@ typedef struct {
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)
 #define MPIDI_REQUEST(req,field)       (((req)->dev).field)
 #define MPIDIG_REQUEST(req,field)       (((req)->dev.ch4.am).field)
+
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+/* `(r)->dev.ch4.am.req` might not be allocated right after SHM_mpi_recv when
+ * the operations are enqueued with trylock/handoff models. */
+#define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req && ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS))
+#else
 #define MPIDIG_REQUEST_IN_PROGRESS(r)   ((r)->dev.ch4.am.req->status & MPIDIG_REQ_IN_PROGRESS)
+#endif /* #ifdef MPIDI_CH4_USE_WORK_QUEUES */
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
 #define MPIDI_REQUEST_ANYSOURCE_PARTNER(req)  (((req)->dev).anysource_partner_request)

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -95,8 +95,8 @@ typedef struct MPIDIG_rreq_t {
 
     uint64_t ignore;
     uint64_t peer_req_ptr;
-    uint64_t match_req;
-    uint64_t request;
+    MPIR_Request *match_req;
+    MPIR_Request *request;
 
     struct MPIDIG_rreq_t *prev, *next;
 } MPIDIG_rreq_t;

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -378,87 +378,88 @@ typedef int (*MPIDI_NM_mpi_iscatterv_t) (const void *sendbuf, const int *sendcou
                                          const int *displs, MPI_Datatype sendtype, void *recvbuf,
                                          int recvcount, MPI_Datatype recvtype, int root,
                                          MPIR_Comm * comm_ptr, MPIR_Request ** req);
-typedef int (*MPIDI_NM_mpi_ibarrier_sched_t) (MPIR_Comm * comm, MPIR_Sched_t s);
+typedef int (*MPIDI_NM_mpi_ibarrier_sched_t) (MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ibcast_sched_t) (void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s);
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallgather_sched_t) (const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s);
+                                                MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallgatherv_sched_t) (const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s);
+                                                 MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iallreduce_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s);
+                                                MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoall_sched_t) (const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s);
+                                               MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoallv_sched_t) (const void *sendbuf, const int sendcounts[],
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s);
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ialltoallw_sched_t) (const void *sendbuf, const int sendcounts[],
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s);
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iexscan_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_igather_sched_t) (const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s);
+                                             MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_igatherv_sched_t) (const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_scatter_block_sched_t) (const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s);
+                                                           MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_scatter_sched_t) (const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s);
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ireduce_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s);
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscan_sched_t) (const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s);
+                                           MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscatter_sched_t) (const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s);
+                                              MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_iscatterv_sched_t) (const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s);
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_allgather_sched_t) (const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_allgatherv_sched_t) (const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s);
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoall_sched_t) (const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s);
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoallv_sched_t) (const void *sendbuf,
                                                          const int sendcounts[],
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_ineighbor_alltoallw_sched_t) (const void *sendbuf,
                                                          const int sendcounts[],
                                                          const MPI_Aint sdispls[],
@@ -466,7 +467,7 @@ typedef int (*MPIDI_NM_mpi_ineighbor_alltoallw_sched_t) (const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s);
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s);
 typedef int (*MPIDI_NM_mpi_type_commit_hook_t) (MPIR_Datatype * datatype_p);
 typedef int (*MPIDI_NM_mpi_type_free_hook_t) (MPIR_Datatype * datatype_p);
 typedef int (*MPIDI_NM_mpi_op_commit_hook_t) (MPIR_Op * op_p);
@@ -1208,32 +1209,37 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
                                                     MPIR_Comm * comm_ptr,
                                                     MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
                                                        MPIR_Comm * comm,
-                                                       MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                       MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
                                                            MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1241,7 +1247,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            const int sendcounts[],
                                                            const int sdispls[],
@@ -1250,60 +1257,68 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
                                                            MPIR_Comm * comm,
-                                                           MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                           MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
                                                          MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf,
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm,
-                                                                MPIR_Sched_t s)
+                                                                MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
                                                         int root, MPIR_Comm * comm,
-                                                        MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
                                                       MPIR_Comm * comm,
-                                                      MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
                                                          int root, MPIR_Comm * comm,
-                                                         MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           const int *sendcounts, const int *displs,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s) MPL_STATIC_INLINE_SUFFIX;
+                                                          MPIR_Sched_element_t s)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf,
                                                                     int sendcount,
                                                                     MPI_Datatype sendtype,
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf,
                                                                      int sendcount,
@@ -1313,7 +1328,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf,
                                                                    int sendcount,
@@ -1321,7 +1336,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm,
-                                                                   MPIR_Sched_t s)
+                                                                   MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                                     const int sendcounts[],
@@ -1332,7 +1347,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                                     const int sendcounts[],
@@ -1343,7 +1358,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype *
                                                            datatype_p) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -2170,7 +2170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2185,7 +2185,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2201,7 +2201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2220,7 +2220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2237,7 +2237,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2254,7 +2254,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2275,7 +2275,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2297,7 +2297,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            void *recvbuf, const int recvcounts[],
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2314,7 +2314,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2330,7 +2330,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, voi
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2348,7 +2349,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, in
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2367,7 +2368,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2384,7 +2385,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                MPIR_Comm * comm,
+                                                                MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2400,7 +2402,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2417,7 +2420,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2433,7 +2436,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         int root, MPIR_Comm * comm,
+                                                         MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2452,7 +2456,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2472,7 +2476,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2494,7 +2498,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2514,7 +2518,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                   MPIR_Comm * comm,
+                                                                   MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2537,7 +2542,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -2561,7 +2566,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int ret;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -1376,7 +1376,7 @@ static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcou
 #define FUNCNAME MPIDI_NM_mpi_ibarrier_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1394,7 +1394,7 @@ static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1414,7 +1414,7 @@ static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatyp
 static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1436,7 +1436,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1456,7 +1456,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1476,7 +1476,7 @@ static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvb
 static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1498,7 +1498,7 @@ static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf, const int s
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1520,7 +1520,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1540,7 +1540,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1560,7 +1560,7 @@ static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
 static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1582,7 +1582,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1603,7 +1603,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1623,7 +1623,8 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, 
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1643,7 +1644,7 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1662,7 +1663,7 @@ static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1682,7 +1683,7 @@ static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, i
 static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1703,7 +1704,7 @@ static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1724,7 +1725,7 @@ static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *s
 static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1746,7 +1747,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1768,7 +1769,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
 static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1791,7 +1792,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1817,7 +1818,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_coll.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_coll.h
@@ -901,7 +901,7 @@ static inline int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const int *sendcou
 #define FUNCNAME MPIDI_NM_mpi_ibarrier_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -919,7 +919,7 @@ static inline int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                            int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -939,7 +939,7 @@ static inline int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count, MPI_Datatyp
 static inline int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -961,7 +961,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -981,7 +981,7 @@ static inline int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf, int sendco
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1001,7 +1001,7 @@ static inline int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvb
 static inline int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                MPI_Datatype recvtype, MPIR_Comm * comm,
-                                               MPIR_Sched_t s)
+                                               MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1023,7 +1023,7 @@ static inline int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf, const int s
                                                 const int sdispls[], MPI_Datatype sendtype,
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], MPI_Datatype recvtype,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1045,7 +1045,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
                                                 const int sdispls[], const MPI_Datatype sendtypes[],
                                                 void *recvbuf, const int recvcounts[],
                                                 const int rdispls[], const MPI_Datatype recvtypes[],
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1065,7 +1065,7 @@ static inline int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf, const int s
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1085,7 +1085,7 @@ static inline int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
 static inline int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                              MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                              MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                             MPIR_Sched_t s)
+                                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1107,7 +1107,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const int *recvcounts, const int *displs,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1128,7 +1128,7 @@ static inline int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                            int recvcount, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1148,7 +1148,8 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void *sendbuf, 
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                      const int recvcounts[], MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                     MPI_Op op, MPIR_Comm * comm,
+                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1168,7 +1169,7 @@ static inline int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, int root,
-                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1187,7 +1188,7 @@ static inline int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                            MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                           MPIR_Sched_t s)
+                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1207,7 +1208,7 @@ static inline int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, i
 static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                               MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                               MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1228,7 +1229,7 @@ static inline int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount
 static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *sendcounts,
                                                const int *displs, MPI_Datatype sendtype,
                                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1249,7 +1250,7 @@ static inline int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf, const int *s
 static inline int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1271,7 +1272,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           const int recvcounts[],
                                                           const int displs[], MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1292,7 +1293,7 @@ static inline int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void *sendbuf, i
 static inline int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1315,7 +1316,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *sendbuf,
                                                          const int sdispls[], MPI_Datatype sendtype,
                                                          void *recvbuf, const int recvcounts[],
                                                          const int rdispls[], MPI_Datatype recvtype,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1340,7 +1341,7 @@ static inline int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *sendbuf,
                                                          void *recvbuf, const int recvcounts[],
                                                          const MPI_Aint rdispls[],
                                                          const MPI_Datatype recvtypes[],
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -994,7 +994,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf, const i
 #define FUNCNAME MPIDI_NM_mpi_ibarrier_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1013,7 +1013,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier_sched(MPIR_Comm * comm, MPIR_
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
                                                        MPI_Datatype datatype, int root,
-                                                       MPIR_Comm * comm, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno;
 
@@ -1033,7 +1033,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast_sched(void *buffer, int count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1056,7 +1056,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
                                                             const int *recvcounts,
                                                             const int *displs,
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1077,7 +1077,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv_sched(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, void *recvbuf,
                                                            int count, MPI_Datatype datatype,
                                                            MPI_Op op, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1097,7 +1097,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce_sched(const void *sendbuf, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall_sched(const void *sendbuf, int sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1122,7 +1122,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv_sched(const void *sendbuf,
                                                            const int recvcounts[],
                                                            const int rdispls[],
                                                            MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                           MPIR_Sched_t s)
+                                                           MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1147,7 +1147,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
                                                            void *recvbuf, const int recvcounts[],
                                                            const int rdispls[],
                                                            const MPI_Datatype recvtypes[],
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1167,7 +1167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw_sched(const void *sendbuf,
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1187,7 +1187,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan_sched(const void *sendbuf, voi
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather_sched(const void *sendbuf, int sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         int recvcount, MPI_Datatype recvtype,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1209,7 +1210,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv_sched(const void *sendbuf, in
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          const int *recvcounts, const int *displs,
                                                          MPI_Datatype recvtype, int root,
-                                                         MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1231,7 +1232,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
                                                                       void *recvbuf, int recvcount,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Sched_t s)
+                                                                      MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1252,7 +1253,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block_sched(const void
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                                 const int recvcounts[],
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                MPIR_Comm * comm,
+                                                                MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1272,7 +1274,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_sched(const void *send
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, void *recvbuf,
                                                         int count, MPI_Datatype datatype, MPI_Op op,
-                                                        int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        int root, MPIR_Comm * comm,
+                                                        MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1291,7 +1294,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_sched(const void *sendbuf, voi
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                       MPI_Datatype datatype, MPI_Op op,
-                                                      MPIR_Comm * comm, MPIR_Sched_t s)
+                                                      MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1311,7 +1314,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan_sched(const void *sendbuf, void 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter_sched(const void *sendbuf, int sendcount,
                                                          MPI_Datatype sendtype, void *recvbuf,
                                                          int recvcount, MPI_Datatype recvtype,
-                                                         int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                                         int root, MPIR_Comm * comm,
+                                                         MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1334,7 +1338,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv_sched(const void *sendbuf,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           int recvcount, MPI_Datatype recvtype,
                                                           int root, MPIR_Comm * comm,
-                                                          MPIR_Sched_t s)
+                                                          MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1358,7 +1362,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgather_sched(const void *
                                                                     void *recvbuf, int recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1384,7 +1388,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_allgatherv_sched(const void 
                                                                      const int displs[],
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm,
-                                                                     MPIR_Sched_t s)
+                                                                     MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1407,7 +1411,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoall_sched(const void *s
                                                                    MPI_Datatype sendtype,
                                                                    void *recvbuf, int recvcount,
                                                                    MPI_Datatype recvtype,
-                                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                                   MPIR_Comm * comm,
+                                                                   MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1434,7 +1439,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallv_sched(const void *
                                                                     const int rdispls[],
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1461,7 +1466,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw_sched(const void *
                                                                     const MPI_Aint rdispls[],
                                                                     const MPI_Datatype recvtypes[],
                                                                     MPIR_Comm * comm,
-                                                                    MPIR_Sched_t s)
+                                                                    MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BARRIER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_barrier(comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_barrier(comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BCAST);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_bcast(buffer, count, datatype, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -79,7 +79,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno =
+        MPIDI_HCOLL_coll_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -106,8 +107,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLGATHER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                      recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_allgather(sendbuf, sendcount, sendtype, recvbuf,
+                                           recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -248,8 +249,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int send
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALL);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_alltoall(sendbuf, sendcount, sendtype, recvbuf,
+                                          recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -278,8 +279,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALLV);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                      recvcounts, rdispls, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_coll_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                           recvcounts, rdispls, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -330,7 +331,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_REDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = MPIDI_HCOLL_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno =
+        MPIDI_HCOLL_coll_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BARRIER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Barrier(comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_barrier(comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, int count, MPI_Dat
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_BCAST);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_bcast(buffer, count, datatype, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -79,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLREDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -106,8 +106,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, int sen
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLGATHER);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_allgather(sendbuf, sendcount, sendtype, recvbuf,
+                                      recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -248,8 +248,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, int send
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALL);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                               recvcount, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_alltoall(sendbuf, sendcount, sendtype, recvbuf,
+                                     recvcount, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -278,8 +278,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf, const i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ALLTOALLV);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                recvcounts, rdispls, recvtype, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                      recvcounts, rdispls, recvtype, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif
@@ -330,7 +330,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_REDUCE);
 
 #ifdef HAVE_LIBHCOLL
-    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno = MPIDI_HCOLL_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
     if (mpi_errno == MPI_SUCCESS)
         goto fn_exit;
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.h
@@ -56,7 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 #if defined HAVE_LIBHCOLL
-    hcoll_comm_create(comm, NULL);
+    MPIDI_HCOLL_comm_create(comm, NULL);
 #endif
 
   fn_exit:
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
 
     mpi_errno = MPIDIG_destroy_comm(comm);
 #ifdef HAVE_LIBHCOLL
-    hcoll_comm_destroy(comm, NULL);
+    MPIDI_HCOLL_comm_destroy(comm, NULL);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.h
@@ -56,7 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 #if defined HAVE_LIBHCOLL
-    MPIDI_HCOLL_comm_create(comm, NULL);
+    MPIDI_HCOLL_mpi_comm_create(comm, NULL);
 #endif
 
   fn_exit:
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_free_hook(MPIR_Comm * comm)
 
     mpi_errno = MPIDIG_destroy_comm(comm);
 #ifdef HAVE_LIBHCOLL
-    MPIDI_HCOLL_comm_destroy(comm, NULL);
+    MPIDI_HCOLL_mpi_comm_destroy(comm, NULL);
 #endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMM_FREE_HOOK);

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -136,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatyp
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
 #if HAVE_LIBHCOLL
-    MPIDI_HCOLL_type_free_hook(datatype_p);
+    MPIDI_HCOLL_dtype_free_hook(datatype_p);
 #endif
 
     return 0;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datat
 
     }
 #if HAVE_LIBHCOLL
-    MPIDI_HCOLL_type_commit_hook(datatype_p);
+    MPIDI_HCOLL_dtype_commit_hook(datatype_p);
 #endif
 
     return 0;

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.h
@@ -136,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatyp
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
 #if HAVE_LIBHCOLL
-    hcoll_type_free_hook(datatype_p);
+    MPIDI_HCOLL_type_free_hook(datatype_p);
 #endif
 
     return 0;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_type_commit_hook(MPIR_Datatype * datat
 
     }
 #if HAVE_LIBHCOLL
-    hcoll_type_commit_hook(datatype_p);
+    MPIDI_HCOLL_type_commit_hook(datatype_p);
 #endif
 
     return 0;

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -1132,7 +1132,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const int *send
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t s)
+MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1146,7 +1146,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier_sched(MPIR_Comm * comm, MPIR_Sched_t 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Datatype datatype,
-                                               int root, MPIR_Comm * comm, MPIR_Sched_t s)
+                                               int root, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret;
 
@@ -1162,7 +1162,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast_sched(void *buffer, int count, MPI_Data
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgather_sched(const void *sendbuf, int sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    int recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1180,7 +1180,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sen
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const int *recvcounts, const int *displs,
                                                     MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                    MPIR_Sched_t s)
+                                                    MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1196,7 +1196,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv_sched(const void *sendbuf, int sen
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                    MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1212,7 +1212,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce_sched(const void *sendbuf, void *re
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall_sched(const void *sendbuf, int sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   int recvcount, MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1230,7 +1230,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv_sched(const void *sendbuf, const in
                                                    const int sdispls[], MPI_Datatype sendtype,
                                                    void *recvbuf, const int recvcounts[],
                                                    const int rdispls[], MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1249,7 +1249,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const in
                                                    const MPI_Datatype sendtypes[], void *recvbuf,
                                                    const int recvcounts[], const int rdispls[],
                                                    const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                                   MPIR_Sched_t s)
+                                                   MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1265,7 +1265,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw_sched(const void *sendbuf, const in
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1281,7 +1281,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan_sched(const void *sendbuf, void *recvb
 MPL_STATIC_INLINE_PREFIX int MPID_Igather_sched(const void *sendbuf, int sendcount,
                                                 MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                MPIR_Sched_t s)
+                                                MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1299,7 +1299,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendco
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  const int *recvcounts, const int *displs,
                                                  MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                 MPIR_Sched_t s)
+                                                 MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1316,7 +1316,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv_sched(const void *sendbuf, int sendco
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbuf, void *recvbuf,
                                                               int recvcount, MPI_Datatype datatype,
                                                               MPI_Op op, MPIR_Comm * comm,
-                                                              MPIR_Sched_t s)
+                                                              MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1333,7 +1333,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block_sched(const void *sendbu
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, void *recvbuf,
                                                         const int recvcounts[],
                                                         MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1348,7 +1348,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_sched(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvbuf, int count,
                                                 MPI_Datatype datatype, MPI_Op op, int root,
-                                                MPIR_Comm * comm, MPIR_Sched_t s)
+                                                MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1363,7 +1363,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_sched(const void *sendbuf, void *recvb
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf, int count,
                                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                              MPIR_Sched_t s)
+                                              MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1379,7 +1379,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan_sched(const void *sendbuf, void *recvbuf
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatter_sched(const void *sendbuf, int sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  int recvcount, MPI_Datatype recvtype, int root,
-                                                 MPIR_Comm * comm, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1397,7 +1397,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int
                                                   const int *displs, MPI_Datatype sendtype,
                                                   void *recvbuf, int recvcount,
                                                   MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                                  MPIR_Sched_t s)
+                                                  MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1414,7 +1414,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv_sched(const void *sendbuf, const int
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgather_sched(const void *sendbuf, int sendcount,
                                                             MPI_Datatype sendtype, void *recvbuf,
                                                             int recvcount, MPI_Datatype recvtype,
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+                                                            MPIR_Comm * comm,
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1433,7 +1434,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf
                                                              const int recvcounts[],
                                                              const int displs[],
                                                              MPI_Datatype recvtype,
-                                                             MPIR_Comm * comm, MPIR_Sched_t s)
+                                                             MPIR_Comm * comm,
+                                                             MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1450,7 +1452,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_allgatherv_sched(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoall_sched(const void *sendbuf, int sendcount,
                                                            MPI_Datatype sendtype, void *recvbuf,
                                                            int recvcount, MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1471,7 +1473,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallv_sched(const void *sendbuf,
                                                             const int recvcounts[],
                                                             const int rdispls[],
                                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                            MPIR_Sched_t s)
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 
@@ -1493,7 +1495,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw_sched(const void *sendbuf,
                                                             void *recvbuf, const int recvcounts[],
                                                             const MPI_Aint rdispls[],
                                                             const MPI_Datatype recvtypes[],
-                                                            MPIR_Comm * comm, MPIR_Sched_t s)
+                                                            MPIR_Comm * comm,
+                                                            MPIR_Sched_element_t s)
 {
     int ret = MPI_SUCCESS;
 

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -327,6 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_SCHED_LIST_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_TSP_QUEUE_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_CH4_Global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -326,7 +326,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
-    MPID_Thread_mutex_create(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_SCHED_LIST_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_CH4_Global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -326,6 +326,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX, &thr_err);
 
     MPID_Thread_mutex_create(&MPIDI_CH4_Global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {
@@ -570,6 +571,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_CS_finalize(void)
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
+    MPIR_Assert(thr_err == 0);
+    MPID_Thread_mutex_destroy(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_CS_FINALIZE);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -328,6 +328,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_SCHED_LIST_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_TSP_QUEUE_MUTEX, &thr_err);
+#ifdef HAVE_LIBHCOLL
+    MPID_Thread_mutex_create(&MPIDIU_THREAD_HCOLL_MUTEX, &thr_err);
+#endif
 
     MPID_Thread_mutex_create(&MPIDI_CH4_Global.vci_lock, &mpi_errno);
     if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[4];
+    MPID_Thread_mutex_t m[5];
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -326,5 +326,6 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_CH4_Global.m[2]
 /* Protects MPIDIG global structures (e.g. global unexpected message queue) */
 #define MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX  MPIDI_CH4_Global.m[3]
+#define MPIDIU_THREAD_SCHED_LIST_MUTEX  MPIDI_CH4_Global.m[4]
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[5];
+    MPID_Thread_mutex_t m[6];
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -327,5 +327,6 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 /* Protects MPIDIG global structures (e.g. global unexpected message queue) */
 #define MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX  MPIDI_CH4_Global.m[3]
 #define MPIDIU_THREAD_SCHED_LIST_MUTEX  MPIDI_CH4_Global.m[4]
+#define MPIDIU_THREAD_TSP_QUEUE_MUTEX  MPIDI_CH4_Global.m[5]
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,11 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
+#ifdef HAVE_LIBHCOLL
+    MPID_Thread_mutex_t m[7];
+#else
     MPID_Thread_mutex_t m[6];
+#endif
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -328,5 +332,7 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX  MPIDI_CH4_Global.m[3]
 #define MPIDIU_THREAD_SCHED_LIST_MUTEX  MPIDI_CH4_Global.m[4]
 #define MPIDIU_THREAD_TSP_QUEUE_MUTEX  MPIDI_CH4_Global.m[5]
-
+#ifdef HAVE_LIBHCOLL
+#define MPIDIU_THREAD_HCOLL_MUTEX  MPIDI_CH4_Global.m[6]
+#endif
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -290,7 +290,7 @@ typedef struct MPIDI_CH4_Global_t {
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
-    MPID_Thread_mutex_t m[3];
+    MPID_Thread_mutex_t m[4];
     MPIDIU_map_t *win_map;
     char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
@@ -324,5 +324,7 @@ extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
 #define MPIDIU_THREAD_PROGRESS_MUTEX  MPIDI_CH4_Global.m[0]
 #define MPIDIU_THREAD_PROGRESS_HOOK_MUTEX  MPIDI_CH4_Global.m[1]
 #define MPIDIU_THREAD_UTIL_MUTEX  MPIDI_CH4_Global.m[2]
+/* Protects MPIDIG global structures (e.g. global unexpected message queue) */
+#define MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX  MPIDI_CH4_Global.m[3]
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -120,7 +120,7 @@ static inline int MPIDIG_handle_unexp_cmpl(MPIR_Request * rreq)
 
     /* If this request was previously matched, but not handled */
     if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_MATCHED) {
-        match_req = (MPIR_Request *) MPIDIG_REQUEST(rreq, req->rreq.match_req);
+        match_req = MPIDIG_REQUEST(rreq, req->rreq.match_req);
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (unlikely(match_req && MPIDI_REQUEST_ANYSOURCE_PARTNER(match_req))) {

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -386,6 +386,19 @@ static inline int MPIDIG_recv_target_cmpl_cb(MPIR_Request * rreq)
 #endif
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+    if ((MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_LONG_RTS) &&
+        MPIDIG_REQUEST(rreq, req->rreq.match_req) != NULL) {
+        /* This block is executed only when the receive is enqueued (trylock/handoff) &&
+         * receive was matched with an unexpected long RTS message.
+         * `rreq` is the unexpected message received and `sigreq` is the message
+         * that came from CH4 (e.g. MPIDI_recv_safe) */
+        MPIR_Request *sigreq = MPIDIG_REQUEST(rreq, req->rreq.match_req);
+        sigreq->status = rreq->status;
+        MPIR_Request_add_ref(sigreq);
+        MPID_Request_complete(sigreq);
+        /* Free the unexpected request on behalf of the user */
+        MPIR_Request_free(rreq);
+    }
     MPID_Request_complete(rreq);
   fn_exit:
     MPIDIG_progress_compl_list();
@@ -643,6 +656,9 @@ static inline int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hd
         MPIDIG_REQUEST(rreq, tag) = hdr->tag;
         MPIDIG_REQUEST(rreq, context_id) = hdr->context_id;
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
+        /* Mark `match_req` as NULL so that we know nothing else to complete when
+         * `unexp_req` finally completes. (See MPIDI_recv_target_cmpl_cb) */
+        MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_REQUEST(rreq, is_local))

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -474,6 +474,7 @@ static inline int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_TARGET_MSG_CB);
     root_comm = MPIDIG_context_id_to_comm(hdr->context_id);
     if (root_comm) {
+      root_comm_retry:
         /* MPIDI_CS_ENTER(); */
 #ifdef MPIDI_CH4_DIRECT_NETMOD
         rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
@@ -528,14 +529,33 @@ static inline int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
-        /* MPIDI_CS_ENTER(); */
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
         if (root_comm) {
             MPIR_Comm_add_ref(root_comm);
             MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
         } else {
+            MPIR_Comm *root_comm_again;
+            /* This branch means that last time we checked, there was no communicator
+             * associated with the arriving message.
+             * In a multi-threaded environment, it is possible that the communicator
+             * has been created since we checked root_comm last time.
+             * If that is the case, the new message must be put into a queue in
+             * the new communicator. Otherwise that message will be lost forever.
+             * Here that strategy is to query root_comm again, and if found,
+             * simply re-execute the per-communicator enqueue logic above. */
+            root_comm_again = MPIDIG_context_id_to_comm(hdr->context_id);
+            if (unlikely(root_comm_again != NULL)) {
+                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
+                MPL_free(MPIDIG_REQUEST(rreq, buffer));
+                MPIR_Request_free(rreq);
+                MPID_Request_complete(rreq);
+                rreq = NULL;
+                root_comm = root_comm_again;
+                goto root_comm_retry;
+            }
             MPIDIG_enqueue_unexp(rreq, MPIDIG_context_id_to_uelist(hdr->context_id));
         }
-        /* MPIDI_CS_EXIT(); */
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     } else {
         /* rreq != NULL <=> root_comm != NULL */
         MPIR_Assert(root_comm);
@@ -589,6 +609,7 @@ static inline int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hd
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_SEND_LONG_REQ_TARGET_MSG_CB);
 
     root_comm = MPIDIG_context_id_to_comm(hdr->context_id);
+  root_comm_retry:
     if (root_comm) {
         /* MPIDI_CS_ENTER(); */
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -638,15 +659,34 @@ static inline int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hd
         MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
 
-        /* MPIDI_CS_ENTER(); */
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
         if (root_comm) {
             MPIR_Comm_add_ref(root_comm);
             MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
         } else {
+            MPIR_Comm *root_comm_again;
+            /* This branch means that last time we checked, there was no communicator
+             * associated with the arriving message.
+             * In a multi-threaded environment, it is possible that the communicator
+             * has been created since we checked root_comm last time.
+             * If that is the case, the new message must be put into a queue in
+             * the new communicator. Otherwise that message will be lost forever.
+             * Here that strategy is to query root_comm again, and if found,
+             * simply re-execute the per-communicator enqueue logic above. */
+            root_comm_again = MPIDIG_context_id_to_comm(hdr->context_id);
+            if (unlikely(root_comm_again != NULL)) {
+                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
+                MPL_free(MPIDIG_REQUEST(rreq, buffer));
+                MPIR_Request_free(rreq);
+                MPID_Request_complete(rreq);
+                rreq = NULL;
+                root_comm = root_comm_again;
+                goto root_comm_retry;
+            }
             MPIDIG_enqueue_unexp(rreq,
                                  MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
         }
-        /* MPIDI_CS_EXIT(); */
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     } else {
         /* Matching receive was posted, tell the netmod */
         MPIR_Comm_release(root_comm);   /* -1 for posted_list */

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -51,6 +51,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_init_comm(MPIR_Comm * comm)
 
     MPIR_Assert(subcomm_type <= 3);
     MPIR_Assert(is_localcomm <= 1);
+
+    /* There is a potential race between this code (likely called by a user/main thread)
+     * and an MPIDIG callback handler (called by a progress thread, when async progress
+     * is turned on).
+     * Thus we take a lock here to make sure the following operations are atomically done.
+     * (transferring unexpected messages from a global queue to the newly created communicator) */
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     MPIDI_CH4_Global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] = comm;
     MPIDIG_COMM(comm, posted_list) = NULL;
     MPIDIG_COMM(comm, unexp_list) = NULL;
@@ -65,6 +72,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_init_comm(MPIR_Comm * comm)
         }
         *uelist = NULL;
     }
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
 
     MPIDIG_COMM(comm, window_instance) = 0;
   fn_exit:
@@ -90,6 +98,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_destroy_comm(MPIR_Comm * comm)
 
     MPIR_Assert(subcomm_type <= 3);
     MPIR_Assert(is_localcomm <= 1);
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     MPIR_Assert(MPIDI_CH4_Global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] != NULL);
 
     if (MPIDI_CH4_Global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type]) {
@@ -101,6 +111,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_destroy_comm(MPIR_Comm * comm)
                      unexp_list) == NULL);
     }
     MPIDI_CH4_Global.comm_req_lists[comm_idx].comm[is_localcomm][subcomm_type] = NULL;
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DESTROY_COMM);

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_posted(MPIR_Request * req, MPIDIG_r
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_unexp(MPIR_Request * req, MPIDIG_rr
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
@@ -274,7 +274,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_posted(MPIR_Request * req, MPIDIG_r
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(MPIDI_CH4_Global.posted_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
@@ -288,7 +288,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_unexp(MPIR_Request * req, MPIDIG_rr
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(MPIDI_CH4_Global.unexp_list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_request_copy(MPIR_Request * dest, MPIR_Requ
 #endif
 
     MPIDIG_REQUEST(dest, req) = MPIDIG_REQUEST(src, req);;
-    MPIDIG_REQUEST(dest, req->rreq.request) = (uint64_t) dest;
+    MPIDIG_REQUEST(dest, req->rreq.request) = dest;
     MPIDIG_REQUEST(dest, datatype) = MPIDIG_REQUEST(src, datatype);
     MPIDIG_REQUEST(dest, buffer) = MPIDIG_REQUEST(src, buffer);
     MPIDIG_REQUEST(dest, count) = MPIDIG_REQUEST(src, count);

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -87,35 +87,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_request_init(MPIR_Request * req,
     return req;
 }
 
-#undef FUNCNAME
-#define FUNCNAME MPIDIG_request_copy
-#undef FCNAME
-#define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX void MPIDIG_request_copy(MPIR_Request * dest, MPIR_Request * src)
-{
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_REQUEST_COPY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_REQUEST_COPY);
-
-    MPIR_Assert(dest != NULL && src != NULL);
-    MPIDI_NM_am_request_init(dest);
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    MPIDI_SHM_am_request_init(dest);
-#endif
-
-    MPIDIG_REQUEST(dest, req) = MPIDIG_REQUEST(src, req);;
-    MPIDIG_REQUEST(dest, req->rreq.request) = dest;
-    MPIDIG_REQUEST(dest, datatype) = MPIDIG_REQUEST(src, datatype);
-    MPIDIG_REQUEST(dest, buffer) = MPIDIG_REQUEST(src, buffer);
-    MPIDIG_REQUEST(dest, count) = MPIDIG_REQUEST(src, count);
-    MPIDIG_REQUEST(dest, rank) = MPIDIG_REQUEST(src, rank);
-    MPIDIG_REQUEST(dest, tag) = MPIDIG_REQUEST(src, tag);
-    MPIDIG_REQUEST(dest, context_id) = MPIDIG_REQUEST(src, context_id);
-    MPIDIG_REQUEST(dest, req->status) = MPIDIG_REQUEST(src, req->status);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_REQUEST_COPY);
-    return;
-}
-
 /* This function should be called any time an anysource request is matched so
  * the upper layer will have a chance to arbitrate who wins the race between
  * the netmod and the shmod. This will cancel the request of the other side and

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -13,33 +13,32 @@
 #endif
 #include "hcoll_dtypes.h"
 
-extern int world_comm_destroying;
+extern int MPIDI_HCOLL_world_comm_destroying;
 
 #if defined(MPL_USE_DBG_LOGGING)
 extern MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-int hcoll_initialize(void);
+int MPIDI_HCOLL_initialize(void);
 
-int hcoll_comm_create(MPIR_Comm * comm, void *param);
-int hcoll_comm_destroy(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_comm_create(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm, void *param);
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                    void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err);
-int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype sdtype,
-                    void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rdtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
+                         MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
 
-int hcoll_do_progress(int *made_progress);
+int MPIDI_HCOLL_do_progress(int *made_progress);
 
 #endif /* HCOLL_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -13,32 +13,35 @@
 #endif
 #include "hcoll_dtypes.h"
 
-extern int MPIDI_HCOLL_world_comm_destroying;
+extern int MPIDI_HCOLL_state_world_comm_destroying;
 
 #if defined(MPL_USE_DBG_LOGGING)
 extern MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-int MPIDI_HCOLL_initialize(void);
+int MPIDI_HCOLL_state_initialize(void);
 
-int MPIDI_HCOLL_comm_create(MPIR_Comm * comm, void *param);
-int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_mpi_comm_create(MPIR_Comm * comm, void *param);
+int MPIDI_HCOLL_mpi_comm_destroy(MPIR_Comm * comm, void *param);
 
-int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                         MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
-int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
-                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf,
+                               int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf,
+                              int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * err);
+int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                               MPI_Datatype sdtype, void *rbuf, const int *rcounts,
+                               const int *rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err);
 
-int MPIDI_HCOLL_do_progress(int *made_progress);
+int MPIDI_HCOLL_state_progress(int *made_progress);
 
 #endif /* HCOLL_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -2,10 +2,10 @@
 #include "mpiimpl.h"
 #include "hcoll_dtypes.h"
 
-extern int MPIDI_HCOLL_initialized;
-extern int MPIDI_HCOLL_enable;
+extern int MPIDI_HCOLL_state_initialized;
+extern int MPIDI_HCOLL_state_enable;
 
-static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(MPI_Datatype
+static dte_data_representation_t MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(MPI_Datatype
                                                                                    datatype)
 {
     MPI_Aint size;
@@ -63,20 +63,20 @@ static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dty
     return DTE_ZERO;
 }
 
-dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_hcoll(MPI_Datatype datatype, int count,
                                                          const int mode)
 {
     dte_data_representation_t dte_data_rep = DTE_ZERO;
 
     if (HANDLE_GET_KIND((datatype)) == HANDLE_KIND_BUILTIN) {
         /* Built-in type */
-        dte_data_rep = MPIDI_HCOLL_mpi_to_dte_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_dtype_mpi_to_dte(datatype);
     }
 #if HCOLL_API >= HCOLL_VERSION(3,6)
     else if (TRY_FIND_DERIVED == mode) {
 
         /* Check for predefined derived types */
-        dte_data_rep = MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(datatype);
         if (HCOL_DTE_IS_ZERO(dte_data_rep)) {
             MPIR_Datatype *dt_ptr;
 
@@ -100,22 +100,22 @@ dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, 
 }
 
 /* This will only get called once */
-int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p)
 {
     int mpi_errno, ret;
 
-    if (0 == MPIDI_HCOLL_initialized) {
-        mpi_errno = MPIDI_HCOLL_initialize();
+    if (0 == MPIDI_HCOLL_state_initialized) {
+        mpi_errno = MPIDI_HCOLL_state_initialize();
         if (mpi_errno)
             return MPI_ERR_OTHER;
     }
 
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         return MPI_SUCCESS;
     }
 
     dtype_p->dev.hcoll_datatype =
-        MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(dtype_p->handle);
+        MPIDI_HCOLL_dtype_mpi_predefined_derived_to_hcoll(dtype_p->handle);
     if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype)) {
         return MPI_SUCCESS;
     }
@@ -133,9 +133,9 @@ int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
     return MPI_SUCCESS;
 }
 
-int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p)
 {
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         return MPI_SUCCESS;
     }
 

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -122,7 +122,9 @@ int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p)
 
     dtype_p->dev.hcoll_datatype = DTE_ZERO;
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     ret = hcoll_create_mpi_type((void *) (intptr_t) dtype_p->handle, &dtype_p->dev.hcoll_datatype);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     if (HCOLL_SUCCESS != ret) {
         return MPI_ERR_OTHER;
     }
@@ -142,7 +144,9 @@ int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p)
     if (HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype))
         MPIR_Datatype_release_if_not_builtin(dtype_p->handle);
 
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     int rc = hcoll_dt_destroy(dtype_p->dev.hcoll_datatype);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     if (HCOLL_SUCCESS != rc) {
         return MPI_ERR_OTHER;
     }

--- a/src/mpid/common/hcoll/hcoll_dtypes.c
+++ b/src/mpid/common/hcoll/hcoll_dtypes.c
@@ -2,10 +2,11 @@
 #include "mpiimpl.h"
 #include "hcoll_dtypes.h"
 
-extern int hcoll_initialized;
-extern int hcoll_enable;
+extern int MPIDI_HCOLL_initialized;
+extern int MPIDI_HCOLL_enable;
 
-static dte_data_representation_t mpi_predefined_derived_2_hcoll(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(MPI_Datatype
+                                                                                   datatype)
 {
     MPI_Aint size;
 
@@ -62,19 +63,20 @@ static dte_data_representation_t mpi_predefined_derived_2_hcoll(MPI_Datatype dat
     return DTE_ZERO;
 }
 
-dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int count, const int mode)
+dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+                                                         const int mode)
 {
     dte_data_representation_t dte_data_rep = DTE_ZERO;
 
     if (HANDLE_GET_KIND((datatype)) == HANDLE_KIND_BUILTIN) {
         /* Built-in type */
-        dte_data_rep = mpi_dtype_2_dte_dtype(datatype);
+        dte_data_rep = MPIDI_HCOLL_mpi_to_dte_dtype(datatype);
     }
 #if HCOLL_API >= HCOLL_VERSION(3,6)
     else if (TRY_FIND_DERIVED == mode) {
 
         /* Check for predefined derived types */
-        dte_data_rep = mpi_predefined_derived_2_hcoll(datatype);
+        dte_data_rep = MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(datatype);
         if (HCOL_DTE_IS_ZERO(dte_data_rep)) {
             MPIR_Datatype *dt_ptr;
 
@@ -98,21 +100,22 @@ dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int cou
 }
 
 /* This will only get called once */
-int hcoll_type_commit_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p)
 {
     int mpi_errno, ret;
 
-    if (0 == hcoll_initialized) {
-        mpi_errno = hcoll_initialize();
+    if (0 == MPIDI_HCOLL_initialized) {
+        mpi_errno = MPIDI_HCOLL_initialize();
         if (mpi_errno)
             return MPI_ERR_OTHER;
     }
 
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         return MPI_SUCCESS;
     }
 
-    dtype_p->dev.hcoll_datatype = mpi_predefined_derived_2_hcoll(dtype_p->handle);
+    dtype_p->dev.hcoll_datatype =
+        MPIDI_HCOLL_mpi_predefined_derived_to_hcoll_dtype(dtype_p->handle);
     if (!HCOL_DTE_IS_ZERO(dtype_p->dev.hcoll_datatype)) {
         return MPI_SUCCESS;
     }
@@ -130,9 +133,9 @@ int hcoll_type_commit_hook(MPIR_Datatype * dtype_p)
     return MPI_SUCCESS;
 }
 
-int hcoll_type_free_hook(MPIR_Datatype * dtype_p)
+int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p)
 {
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         return MPI_SUCCESS;
     }
 

--- a/src/mpid/common/hcoll/hcoll_dtypes.h
+++ b/src/mpid/common/hcoll/hcoll_dtypes.h
@@ -14,11 +14,12 @@ enum {
     NO_DERIVED
 };
 
-int hcoll_type_commit_hook(MPIR_Datatype * dtype_p);
-int hcoll_type_free_hook(MPIR_Datatype * dtype_p);
-dte_data_representation_t mpi_dtype_2_hcoll_dtype(MPI_Datatype datatype, int count, const int mode);
+int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p);
+int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p);
+dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+                                                         const int mode);
 
-static dte_data_representation_t mpi_dtype_2_dte_dtype(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datatype)
 {
     switch (datatype) {
         case MPI_CHAR:
@@ -54,7 +55,7 @@ static dte_data_representation_t mpi_dtype_2_dte_dtype(MPI_Datatype datatype)
     }
 }
 
-static hcoll_dte_op_t *mpi_op_2_dte_op(MPI_Op op)
+static hcoll_dte_op_t *MPIDI_HCOLL_mpi_to_dte_op(MPI_Op op)
 {
     switch (op) {
         case MPI_MAX:

--- a/src/mpid/common/hcoll/hcoll_dtypes.h
+++ b/src/mpid/common/hcoll/hcoll_dtypes.h
@@ -14,12 +14,12 @@ enum {
     NO_DERIVED
 };
 
-int MPIDI_HCOLL_type_commit_hook(MPIR_Datatype * dtype_p);
-int MPIDI_HCOLL_type_free_hook(MPIR_Datatype * dtype_p);
-dte_data_representation_t MPIDI_HCOLL_mpi_to_hcoll_dtype(MPI_Datatype datatype, int count,
+int MPIDI_HCOLL_dtype_commit_hook(MPIR_Datatype * dtype_p);
+int MPIDI_HCOLL_dtype_free_hook(MPIR_Datatype * dtype_p);
+dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_hcoll(MPI_Datatype datatype, int count,
                                                          const int mode);
 
-static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datatype)
+static dte_data_representation_t MPIDI_HCOLL_dtype_mpi_to_dte(MPI_Datatype datatype)
 {
     switch (datatype) {
         case MPI_CHAR:
@@ -55,7 +55,7 @@ static dte_data_representation_t MPIDI_HCOLL_mpi_to_dte_dtype(MPI_Datatype datat
     }
 }
 
-static hcoll_dte_op_t *MPIDI_HCOLL_mpi_to_dte_op(MPI_Op op)
+static hcoll_dte_op_t *MPIDI_HCOLL_dtype_op_mpi_to_dte(MPI_Op op)
 {
     switch (op) {
         case MPI_MAX:

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -24,43 +24,43 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-static int hcoll_comm_world_initialized = 0;
-static int hcoll_progress_hook_id = 0;
+static int MPIDI_HCOLL_comm_world_initialized = 0;
+static int MPIDI_HCOLL_progress_hook_id = 0;
 
-int hcoll_initialized = 0;
-int hcoll_enable = -1;
-int hcoll_enable_barrier = 1;
-int hcoll_enable_bcast = 1;
-int hcoll_enable_reduce = 1;
-int hcoll_enable_allgather = 1;
-int hcoll_enable_allreduce = 1;
-int hcoll_enable_alltoall = 1;
-int hcoll_enable_alltoallv = 1;
-int hcoll_enable_ibarrier = 1;
-int hcoll_enable_ibcast = 1;
-int hcoll_enable_iallgather = 1;
-int hcoll_enable_iallreduce = 1;
-int world_comm_destroying = 0;
+int MPIDI_HCOLL_initialized = 0;
+int MPIDI_HCOLL_enable = -1;
+int MPIDI_HCOLL_enable_barrier = 1;
+int MPIDI_HCOLL_enable_bcast = 1;
+int MPIDI_HCOLL_enable_reduce = 1;
+int MPIDI_HCOLL_enable_allgather = 1;
+int MPIDI_HCOLL_enable_allreduce = 1;
+int MPIDI_HCOLL_enable_alltoall = 1;
+int MPIDI_HCOLL_enable_alltoallv = 1;
+int MPIDI_HCOLL_enable_ibarrier = 1;
+int MPIDI_HCOLL_enable_ibcast = 1;
+int MPIDI_HCOLL_enable_iallgather = 1;
+int MPIDI_HCOLL_enable_iallreduce = 1;
+int MPIDI_HCOLL_world_comm_destroying = 0;
 
 #if defined(MPL_USE_DBG_LOGGING)
 MPL_dbg_class MPIR_DBG_HCOLL;
 #endif /* MPL_USE_DBG_LOGGING */
 
-void hcoll_rte_fns_setup(void);
+void MPIDI_HCOLL_rte_fns_setup(void);
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_destroy
+#define FUNCNAME MPIDI_HCOLL_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 
-int hcoll_destroy(void *param ATTRIBUTE((unused)))
+int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
 {
-    if (1 == hcoll_initialized) {
+    if (1 == MPIDI_HCOLL_initialized) {
         hcoll_finalize();
-        MPID_Progress_deactivate_hook(hcoll_progress_hook_id);
-        MPID_Progress_deregister_hook(hcoll_progress_hook_id);
+        MPID_Progress_deactivate_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_deregister_hook(MPIDI_HCOLL_progress_hook_id);
     }
-    hcoll_initialized = 0;
+    MPIDI_HCOLL_initialized = 0;
     return 0;
 }
 
@@ -68,32 +68,32 @@ int hcoll_destroy(void *param ATTRIBUTE((unused)))
     do { \
         envar = getenv("HCOLL_ENABLE_" #nameEnv); \
         if (NULL != envar) { \
-            hcoll_enable_##name = atoi(envar); \
-            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", hcoll_enable_##name); \
+            MPIDI_HCOLL_enable_##name = atoi(envar); \
+            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_enable_##name); \
         } \
     } while (0)
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_initialize
+#define FUNCNAME MPIDI_HCOLL_initialize
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_initialize(void)
+int MPIDI_HCOLL_initialize(void)
 {
     int mpi_errno;
     char *envar;
     hcoll_init_opts_t *init_opts;
     mpi_errno = MPI_SUCCESS;
 
-    hcoll_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
+    MPIDI_HCOLL_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
         !MPIR_ThreadInfo.isThreaded;
-    if (0 >= hcoll_enable) {
+    if (0 >= MPIDI_HCOLL_enable) {
         goto fn_exit;
     }
 #if defined(MPL_USE_DBG_LOGGING)
     MPIR_DBG_HCOLL = MPL_dbg_class_alloc("HCOLL", "hcoll");
 #endif /* MPL_USE_DBG_LOGGING */
 
-    hcoll_rte_fns_setup();
+    MPIDI_HCOLL_rte_fns_setup();
 
     hcoll_read_init_opts(&init_opts);
     init_opts->base_tag = MPIR_FIRST_HCOLL_TAG;
@@ -109,15 +109,16 @@ int hcoll_initialize(void)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (!hcoll_initialized) {
-        hcoll_initialized = 1;
-        mpi_errno = MPID_Progress_register_hook(hcoll_do_progress, &hcoll_progress_hook_id);
+    if (!MPIDI_HCOLL_initialized) {
+        MPIDI_HCOLL_initialized = 1;
+        mpi_errno =
+            MPID_Progress_register_hook(MPIDI_HCOLL_do_progress, &MPIDI_HCOLL_progress_hook_id);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        MPID_Progress_activate_hook(hcoll_progress_hook_id);
+        MPID_Progress_activate_hook(MPIDI_HCOLL_progress_hook_id);
     }
-    MPIR_Add_finalize(hcoll_destroy, 0, 0);
+    MPIR_Add_finalize(MPIDI_HCOLL_destroy, 0, 0);
 
     CHECK_ENABLE_ENV_VARS(BARRIER, barrier);
     CHECK_ENABLE_ENV_VARS(BCAST, bcast);
@@ -138,31 +139,31 @@ int hcoll_initialize(void)
 
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_comm_create
+#define FUNCNAME MPIDI_HCOLL_comm_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int num_ranks;
     int context_destroyed;
     mpi_errno = MPI_SUCCESS;
 
-    if (0 == hcoll_initialized) {
-        mpi_errno = hcoll_initialize();
+    if (0 == MPIDI_HCOLL_initialized) {
+        mpi_errno = MPIDI_HCOLL_initialize();
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
-    if (0 == hcoll_enable) {
+    if (0 == MPIDI_HCOLL_enable) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
 
     if (MPIR_Process.comm_world == comm_ptr) {
-        hcoll_comm_world_initialized = 1;
+        MPIDI_HCOLL_comm_world_initialized = 1;
     }
-    if (!hcoll_comm_world_initialized) {
+    if (!MPIDI_HCOLL_comm_world_initialized) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
@@ -187,20 +188,20 @@ int hcoll_comm_create(MPIR_Comm * comm_ptr, void *param)
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_comm_destroy
+#define FUNCNAME MPIDI_HCOLL_comm_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_comm_destroy(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int context_destroyed;
-    if (0 >= hcoll_enable) {
+    if (0 >= MPIDI_HCOLL_enable) {
         goto fn_exit;
     }
     mpi_errno = MPI_SUCCESS;
 
     if (comm_ptr->handle == MPI_COMM_WORLD)
-        world_comm_destroying = 1;
+        MPIDI_HCOLL_world_comm_destroying = 1;
 
     context_destroyed = 0;
     if ((NULL != comm_ptr) && (0 != comm_ptr->hcoll_priv.is_hcoll_init)) {
@@ -214,7 +215,7 @@ int hcoll_comm_destroy(MPIR_Comm * comm_ptr, void *param)
     goto fn_exit;
 }
 
-int hcoll_do_progress(int *made_progress)
+int MPIDI_HCOLL_do_progress(int *made_progress)
 {
     *made_progress = 1;
     hcoll_progress_fn();

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -24,23 +24,23 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-static int MPIDI_HCOLL_comm_world_initialized = 0;
-static int MPIDI_HCOLL_progress_hook_id = 0;
+static int MPIDI_HCOLL_state_comm_world_initialized = 0;
+static int MPIDI_HCOLL_state_progress_hook_id = 0;
 
-int MPIDI_HCOLL_initialized = 0;
-int MPIDI_HCOLL_enable = -1;
-int MPIDI_HCOLL_enable_barrier = 1;
-int MPIDI_HCOLL_enable_bcast = 1;
-int MPIDI_HCOLL_enable_reduce = 1;
-int MPIDI_HCOLL_enable_allgather = 1;
-int MPIDI_HCOLL_enable_allreduce = 1;
-int MPIDI_HCOLL_enable_alltoall = 1;
-int MPIDI_HCOLL_enable_alltoallv = 1;
-int MPIDI_HCOLL_enable_ibarrier = 1;
-int MPIDI_HCOLL_enable_ibcast = 1;
-int MPIDI_HCOLL_enable_iallgather = 1;
-int MPIDI_HCOLL_enable_iallreduce = 1;
-int MPIDI_HCOLL_world_comm_destroying = 0;
+int MPIDI_HCOLL_state_initialized = 0;
+int MPIDI_HCOLL_state_enable = -1;
+int MPIDI_HCOLL_state_enable_barrier = 1;
+int MPIDI_HCOLL_state_enable_bcast = 1;
+int MPIDI_HCOLL_state_enable_reduce = 1;
+int MPIDI_HCOLL_state_enable_allgather = 1;
+int MPIDI_HCOLL_state_enable_allreduce = 1;
+int MPIDI_HCOLL_state_enable_alltoall = 1;
+int MPIDI_HCOLL_state_enable_alltoallv = 1;
+int MPIDI_HCOLL_state_enable_ibarrier = 1;
+int MPIDI_HCOLL_state_enable_ibcast = 1;
+int MPIDI_HCOLL_state_enable_iallgather = 1;
+int MPIDI_HCOLL_state_enable_iallreduce = 1;
+int MPIDI_HCOLL_state_world_comm_destroying = 0;
 
 #if defined(MPL_USE_DBG_LOGGING)
 MPL_dbg_class MPIR_DBG_HCOLL;
@@ -49,18 +49,18 @@ MPL_dbg_class MPIR_DBG_HCOLL;
 void MPIDI_HCOLL_rte_fns_setup(void);
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_destroy
+#define FUNCNAME MPIDI_HCOLL_state_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 
-int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
+int MPIDI_HCOLL_state_destroy(void *param ATTRIBUTE((unused)))
 {
-    if (1 == MPIDI_HCOLL_initialized) {
+    if (1 == MPIDI_HCOLL_state_initialized) {
         hcoll_finalize();
-        MPID_Progress_deactivate_hook(MPIDI_HCOLL_progress_hook_id);
-        MPID_Progress_deregister_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_deactivate_hook(MPIDI_HCOLL_state_progress_hook_id);
+        MPID_Progress_deregister_hook(MPIDI_HCOLL_state_progress_hook_id);
     }
-    MPIDI_HCOLL_initialized = 0;
+    MPIDI_HCOLL_state_initialized = 0;
     return 0;
 }
 
@@ -68,25 +68,25 @@ int MPIDI_HCOLL_destroy(void *param ATTRIBUTE((unused)))
     do { \
         envar = getenv("HCOLL_ENABLE_" #nameEnv); \
         if (NULL != envar) { \
-            MPIDI_HCOLL_enable_##name = atoi(envar); \
-            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_enable_##name); \
+            MPIDI_HCOLL_state_enable_##name = atoi(envar); \
+            MPL_DBG_MSG_D(MPIR_DBG_HCOLL, VERBOSE, "HCOLL_ENABLE_" #nameEnv " = %d\n", MPIDI_HCOLL_state_enable_##name); \
         } \
     } while (0)
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_initialize
+#define FUNCNAME MPIDI_HCOLL_state_initialize
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_initialize(void)
+int MPIDI_HCOLL_state_initialize(void)
 {
     int mpi_errno;
     char *envar;
     hcoll_init_opts_t *init_opts;
     mpi_errno = MPI_SUCCESS;
 
-    MPIDI_HCOLL_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
+    MPIDI_HCOLL_state_enable = (MPIR_CVAR_ENABLE_HCOLL | MPIR_CVAR_CH3_ENABLE_HCOLL) &&
         !MPIR_ThreadInfo.isThreaded;
-    if (0 >= MPIDI_HCOLL_enable) {
+    if (0 >= MPIDI_HCOLL_state_enable) {
         goto fn_exit;
     }
 #if defined(MPL_USE_DBG_LOGGING)
@@ -109,16 +109,17 @@ int MPIDI_HCOLL_initialize(void)
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (!MPIDI_HCOLL_initialized) {
-        MPIDI_HCOLL_initialized = 1;
+    if (!MPIDI_HCOLL_state_initialized) {
+        MPIDI_HCOLL_state_initialized = 1;
         mpi_errno =
-            MPID_Progress_register_hook(MPIDI_HCOLL_do_progress, &MPIDI_HCOLL_progress_hook_id);
+            MPID_Progress_register_hook(MPIDI_HCOLL_state_progress,
+                                        &MPIDI_HCOLL_state_progress_hook_id);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        MPID_Progress_activate_hook(MPIDI_HCOLL_progress_hook_id);
+        MPID_Progress_activate_hook(MPIDI_HCOLL_state_progress_hook_id);
     }
-    MPIR_Add_finalize(MPIDI_HCOLL_destroy, 0, 0);
+    MPIR_Add_finalize(MPIDI_HCOLL_state_destroy, 0, 0);
 
     CHECK_ENABLE_ENV_VARS(BARRIER, barrier);
     CHECK_ENABLE_ENV_VARS(BCAST, bcast);
@@ -139,31 +140,31 @@ int MPIDI_HCOLL_initialize(void)
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_comm_create
+#define FUNCNAME MPIDI_HCOLL_mpi_comm_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_mpi_comm_create(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int num_ranks;
     int context_destroyed;
     mpi_errno = MPI_SUCCESS;
 
-    if (0 == MPIDI_HCOLL_initialized) {
-        mpi_errno = MPIDI_HCOLL_initialize();
+    if (0 == MPIDI_HCOLL_state_initialized) {
+        mpi_errno = MPIDI_HCOLL_state_initialize();
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
 
-    if (0 == MPIDI_HCOLL_enable) {
+    if (0 == MPIDI_HCOLL_state_enable) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
 
     if (MPIR_Process.comm_world == comm_ptr) {
-        MPIDI_HCOLL_comm_world_initialized = 1;
+        MPIDI_HCOLL_state_comm_world_initialized = 1;
     }
-    if (!MPIDI_HCOLL_comm_world_initialized) {
+    if (!MPIDI_HCOLL_state_comm_world_initialized) {
         comm_ptr->hcoll_priv.is_hcoll_init = 0;
         goto fn_exit;
     }
@@ -188,20 +189,20 @@ int MPIDI_HCOLL_comm_create(MPIR_Comm * comm_ptr, void *param)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_comm_destroy
+#define FUNCNAME MPIDI_HCOLL_mpi_comm_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
+int MPIDI_HCOLL_mpi_comm_destroy(MPIR_Comm * comm_ptr, void *param)
 {
     int mpi_errno;
     int context_destroyed;
-    if (0 >= MPIDI_HCOLL_enable) {
+    if (0 >= MPIDI_HCOLL_state_enable) {
         goto fn_exit;
     }
     mpi_errno = MPI_SUCCESS;
 
     if (comm_ptr->handle == MPI_COMM_WORLD)
-        MPIDI_HCOLL_world_comm_destroying = 1;
+        MPIDI_HCOLL_state_world_comm_destroying = 1;
 
     context_destroyed = 0;
     if ((NULL != comm_ptr) && (0 != comm_ptr->hcoll_priv.is_hcoll_init)) {
@@ -215,7 +216,7 @@ int MPIDI_HCOLL_comm_destroy(MPIR_Comm * comm_ptr, void *param)
     goto fn_exit;
 }
 
-int MPIDI_HCOLL_do_progress(int *made_progress)
+int MPIDI_HCOLL_state_progress(int *made_progress)
 {
     *made_progress = 1;
     hcoll_progress_fn();

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -52,7 +52,6 @@ void MPIDI_HCOLL_rte_fns_setup(void);
 #define FUNCNAME MPIDI_HCOLL_state_destroy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-
 int MPIDI_HCOLL_state_destroy(void *param ATTRIBUTE((unused)))
 {
     if (1 == MPIDI_HCOLL_state_initialized) {

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -20,7 +20,9 @@ int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL BARRIER.");
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     rc = hcoll_collectives.coll_barrier(comm_ptr->hcoll_priv.hcoll_context);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     return rc;
 }
 
@@ -47,8 +49,10 @@ int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int r
         MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "unsupported data layout, calling fallback bcast.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_bcast(buffer, count, dtype, root,
                                           comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -80,8 +84,10 @@ int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_D
         MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "unsupported data layout, calling fallback bcast.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_reduce((void *) sendbuf, recvbuf, count, dtype, Op, root,
                                            comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -112,8 +118,10 @@ int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MP
                     "unsupported data layout, calling fallback allreduce.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_allreduce((void *) sendbuf, recvbuf, count, Dtype, Op,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -148,8 +156,10 @@ int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_allgather((void *) sbuf, scount, stype, rbuf, rcount, rtype,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -184,8 +194,10 @@ int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_alltoall((void *) sbuf, scount, stype, rbuf, rcount, rtype,
                                              comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }
@@ -221,9 +233,11 @@ int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *
                     "unsupported data layout; calling fallback allgather.");
         rc = -1;
     } else {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
         rc = hcoll_collectives.coll_alltoallv((void *) sbuf, (int *) scounts, (int *) sdispls,
                                               stype, rbuf, (int *) rcounts, (int *) rdispls, rtype,
                                               comm_ptr->hcoll_priv.hcoll_context);
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_HCOLL_MUTEX);
     }
     return rc;
 }

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -8,10 +8,10 @@
 #include "hcoll.h"
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Barrier
+#define FUNCNAME MPIDI_HCOLL_barrier
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -25,11 +25,11 @@ int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Bcast
+#define FUNCNAME MPIDI_HCOLL_bcast
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -38,7 +38,7 @@ int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL BCAST.");
-    dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
     MPI_Comm comm = comm_ptr->handle;
     if (HCOL_DTE_IS_COMPLEX(dtype) || HCOL_DTE_IS_ZERO(dtype)) {
         /*If we are here then datatype is not simple predefined datatype */
@@ -54,11 +54,11 @@ int hcoll_Bcast(void *buffer, int count, MPI_Datatype datatype, int root,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Reduce
+#define FUNCNAME MPIDI_HCOLL_reduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op,
-                 int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -68,8 +68,8 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL REDUCE.");
-    dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = mpi_op_2_dte_op(op);
+    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -87,11 +87,11 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dat
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Allreduce
+#define FUNCNAME MPIDI_HCOLL_allreduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -102,8 +102,8 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL ALLREDUCE.");
-    Dtype = mpi_dtype_2_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = mpi_op_2_dte_op(op);
+    Dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -119,12 +119,12 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype 
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Allgather
+#define FUNCNAME MPIDI_HCOLL_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                    void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t * err)
+int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
+                          void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                          MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -135,12 +135,12 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -155,12 +155,12 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Alltoall
+#define FUNCNAME MPIDI_HCOLL_alltoall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
-                   void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t * err)
+int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
+                         void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                         MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -171,12 +171,12 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -191,12 +191,12 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME hcoll_Alltoallv
+#define FUNCNAME MPIDI_HCOLL_alltoallv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MPI_Datatype sdtype,
-                    void *rbuf, const int *rcounts, const int *rdispls, MPI_Datatype rdtype,
-                    MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
+                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -207,12 +207,12 @@ int hcoll_Alltoallv(const void *sbuf, const int *scounts, const int *sdispls, MP
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = mpi_dtype_2_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = mpi_dtype_2_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -8,10 +8,10 @@
 #include "hcoll.h"
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_barrier
+#define FUNCNAME MPIDI_HCOLL_coll_barrier
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -25,11 +25,11 @@ int MPIDI_HCOLL_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_bcast
+#define FUNCNAME MPIDI_HCOLL_coll_bcast
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
-                      MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
+                           MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -38,7 +38,7 @@ int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL BCAST.");
-    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
+    dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
     MPI_Comm comm = comm_ptr->handle;
     if (HCOL_DTE_IS_COMPLEX(dtype) || HCOL_DTE_IS_ZERO(dtype)) {
         /*If we are here then datatype is not simple predefined datatype */
@@ -54,11 +54,11 @@ int MPIDI_HCOLL_bcast(void *buffer, int count, MPI_Datatype datatype, int root,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_reduce
+#define FUNCNAME MPIDI_HCOLL_coll_reduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                       MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -68,8 +68,8 @@ int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL REDUCE.");
-    dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
+    dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_dtype_op_mpi_to_dte(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -87,11 +87,11 @@ int MPIDI_HCOLL_reduce(const void *sendbuf, void *recvbuf, int count, MPI_Dataty
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_allreduce
+#define FUNCNAME MPIDI_HCOLL_coll_allreduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
-                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                               MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -102,8 +102,8 @@ int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Dat
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOL ALLREDUCE.");
-    Dtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(datatype, count, TRY_FIND_DERIVED);
-    Op = MPIDI_HCOLL_mpi_to_dte_op(op);
+    Dtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(datatype, count, TRY_FIND_DERIVED);
+    Op = MPIDI_HCOLL_dtype_op_mpi_to_dte(op);
     if (MPI_IN_PLACE == sendbuf) {
         sendbuf = HCOLL_IN_PLACE;
     }
@@ -119,12 +119,12 @@ int MPIDI_HCOLL_allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Dat
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_allgather
+#define FUNCNAME MPIDI_HCOLL_coll_allgather
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
-                          void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                          MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
+                               void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -135,12 +135,12 @@ int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -155,12 +155,12 @@ int MPIDI_HCOLL_allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_alltoall
+#define FUNCNAME MPIDI_HCOLL_coll_alltoall
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
-                         void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                         MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
+                              void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                              MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -171,12 +171,12 @@ int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, rcount, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, rcount, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, rcount, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, rcount, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {
@@ -191,12 +191,13 @@ int MPIDI_HCOLL_alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_alltoallv
+#define FUNCNAME MPIDI_HCOLL_coll_alltoallv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
-                          MPI_Datatype sdtype, void *rbuf, const int *rcounts, const int *rdispls,
-                          MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t * err)
+int MPIDI_HCOLL_coll_alltoallv(const void *sbuf, const int *scounts, const int *sdispls,
+                               MPI_Datatype sdtype, void *rbuf, const int *rcounts,
+                               const int *rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                               MPIR_Errflag_t * err)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -207,12 +208,12 @@ int MPIDI_HCOLL_alltoallv(const void *sbuf, const int *scounts, const int *sdisp
         return rc;
 
     MPL_DBG_MSG(MPIR_DBG_HCOLL, VERBOSE, "RUNNING HCOLL ALLGATHER.");
-    rtype = MPIDI_HCOLL_mpi_to_hcoll_dtype(rdtype, 0, TRY_FIND_DERIVED);
+    rtype = MPIDI_HCOLL_dtype_mpi_to_hcoll(rdtype, 0, TRY_FIND_DERIVED);
     if (MPI_IN_PLACE == sbuf) {
         sbuf = HCOLL_IN_PLACE;
         stype = rtype;
     } else {
-        stype = MPIDI_HCOLL_mpi_to_hcoll_dtype(sdtype, 0, TRY_FIND_DERIVED);
+        stype = MPIDI_HCOLL_dtype_mpi_to_hcoll(sdtype, 0, TRY_FIND_DERIVED);
     }
     if (HCOL_DTE_IS_COMPLEX(stype) || HCOL_DTE_IS_ZERO(stype) || HCOL_DTE_IS_ZERO(rtype) ||
         HCOL_DTE_IS_COMPLEX(rtype)) {

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -49,6 +49,8 @@ static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group);
 
 static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
 
+/* The current implementation of the function relies on its callees to be thread
+ * safe. */
 #undef FUNCNAME
 #define FUNCNAME MPIDI_HCOLL_rte_progress
 #undef FCNAME

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -10,108 +10,112 @@
 #include "hcoll/api/hcoll_dte.h"
 #include "hcoll_dtypes.h"
 
-static int MPIDI_HCOLL_recv_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t, rte_grp_handle_t, uint32_t tag,
-                               rte_request_handle_t * req);
+static int MPIDI_HCOLL_rte_recv_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t, rte_grp_handle_t, uint32_t tag,
+                                   rte_request_handle_t * req);
 
-static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req);
+static int MPIDI_HCOLL_rte_send_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag,
+                                   rte_request_handle_t * req);
 
-static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed);
+static int MPIDI_HCOLL_rte_test(rte_request_handle_t * request, int *completed);
 
-static int MPIDI_HCOLL_ec_handle_compare(rte_ec_handle_t handle_1,
-                                         rte_grp_handle_t
-                                         group_handle_1,
-                                         rte_ec_handle_t handle_2, rte_grp_handle_t group_handle_2);
+static int MPIDI_HCOLL_rte_ec_handle_compare(rte_ec_handle_t handle_1,
+                                             rte_grp_handle_t
+                                             group_handle_1,
+                                             rte_ec_handle_t handle_2,
+                                             rte_grp_handle_t group_handle_2);
 
-static int MPIDI_HCOLL_get_ec_handles(int num_ec,
-                                      int *ec_indexes, rte_grp_handle_t,
-                                      rte_ec_handle_t * ec_handles);
+static int MPIDI_HCOLL_rte_get_ec_handles(int num_ec,
+                                          int *ec_indexes, rte_grp_handle_t,
+                                          rte_ec_handle_t * ec_handles);
 
-static int MPIDI_HCOLL_group_size(rte_grp_handle_t group);
-static int MPIDI_HCOLL_my_rank(rte_grp_handle_t grp_h);
-static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group);
-static rte_grp_handle_t MPIDI_HCOLL_get_world_group_handle(void);
-static uint32_t MPIDI_HCOLL_jobid(void);
+static int MPIDI_HCOLL_rte_group_size(rte_grp_handle_t group);
+static int MPIDI_HCOLL_rte_my_rank(rte_grp_handle_t grp_h);
+static int MPIDI_HCOLL_rte_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group);
+static rte_grp_handle_t MPIDI_HCOLL_rte_get_world_group_handle(void);
+static uint32_t MPIDI_HCOLL_rte_jobid(void);
 
-static void *MPIDI_HCOLL_get_coll_handle(void);
-static int MPIDI_HCOLL_coll_handle_test(void *handle);
-static void MPIDI_HCOLL_coll_handle_free(void *handle);
-static void MPIDI_HCOLL_coll_handle_complete(void *handle);
-static int MPIDI_HCOLL_group_id(rte_grp_handle_t group);
+static void *MPIDI_HCOLL_rte_get_coll_handle(void);
+static int MPIDI_HCOLL_rte_coll_handle_test(void *handle);
+static void MPIDI_HCOLL_rte_coll_handle_free(void *handle);
+static void MPIDI_HCOLL_rte_coll_handle_complete(void *handle);
+static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group);
 
-static int MPIDI_HCOLL_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
+static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec);
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_progress
+#define FUNCNAME MPIDI_HCOLL_rte_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_progress(void)
+static void MPIDI_HCOLL_rte_progress(void)
 {
     int ret;
     int made_progress;
 
-    if (0 == MPIDI_HCOLL_world_comm_destroying) {
+    if (0 == MPIDI_HCOLL_state_world_comm_destroying) {
         MPID_Progress_test();
     } else {
         /* FIXME: The hcoll library needs to be updated to return
          * error codes.  The progress function pointer right now
          * expects that the function returns void. */
-        ret = MPIDI_HCOLL_do_progress(&made_progress);
+        ret = MPIDI_HCOLL_state_progress(&made_progress);
         MPIR_Assert(ret == MPI_SUCCESS);
     }
 }
 
 #if HCOLL_API >= HCOLL_VERSION(3,6)
-static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
-                                             int *num_addresses, int *num_datatypes,
-                                             hcoll_mpi_type_combiner_t * combiner);
-static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, int max_addresses,
-                                             int max_datatypes, int *array_of_integers,
-                                             void *array_of_addresses, void *array_of_datatypes);
-static int MPIDI_HCOLL_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type);
-static int MPIDI_HCOLL_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type);
-static int MPIDI_HCOLL_get_mpi_constants(size_t * mpi_datatype_size,
-                                         int *mpi_order_c, int *mpi_order_fortran,
-                                         int *mpi_distribute_block,
-                                         int *mpi_distribute_cyclic,
-                                         int *mpi_distribute_none, int *mpi_distribute_dflt_darg);
+static int MPIDI_HCOLL_rte_get_mpi_type_envelope(void *mpi_type, int *num_integers,
+                                                 int *num_addresses, int *num_datatypes,
+                                                 hcoll_mpi_type_combiner_t * combiner);
+static int MPIDI_HCOLL_rte_get_mpi_type_contents(void *mpi_type, int max_integers,
+                                                 int max_addresses, int max_datatypes,
+                                                 int *array_of_integers, void *array_of_addresses,
+                                                 void *array_of_datatypes);
+static int MPIDI_HCOLL_rte_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type);
+static int MPIDI_HCOLL_rte_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type);
+static int MPIDI_HCOLL_rte_get_mpi_constants(size_t * mpi_datatype_size,
+                                             int *mpi_order_c, int *mpi_order_fortran,
+                                             int *mpi_distribute_block,
+                                             int *mpi_distribute_cyclic,
+                                             int *mpi_distribute_none,
+                                             int *mpi_distribute_dflt_darg);
 #endif
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_init_module_fns
+#define FUNCNAME MPIDI_HCOLL_rte_init_module_fns
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_init_module_fns(void)
+static void MPIDI_HCOLL_rte_init_module_fns(void)
 {
-    hcoll_rte_functions.send_fn = MPIDI_HCOLL_send_nb;
-    hcoll_rte_functions.recv_fn = MPIDI_HCOLL_recv_nb;
-    hcoll_rte_functions.ec_cmp_fn = MPIDI_HCOLL_ec_handle_compare;
-    hcoll_rte_functions.get_ec_handles_fn = MPIDI_HCOLL_get_ec_handles;
-    hcoll_rte_functions.rte_group_size_fn = MPIDI_HCOLL_group_size;
-    hcoll_rte_functions.test_fn = MPIDI_HCOLL_test;
-    hcoll_rte_functions.rte_my_rank_fn = MPIDI_HCOLL_my_rank;
-    hcoll_rte_functions.rte_ec_on_local_node_fn = MPIDI_HCOLL_ec_on_local_node;
-    hcoll_rte_functions.rte_world_group_fn = MPIDI_HCOLL_get_world_group_handle;
-    hcoll_rte_functions.rte_jobid_fn = MPIDI_HCOLL_jobid;
-    hcoll_rte_functions.rte_progress_fn = MPIDI_HCOLL_progress;
-    hcoll_rte_functions.rte_get_coll_handle_fn = MPIDI_HCOLL_get_coll_handle;
-    hcoll_rte_functions.rte_coll_handle_test_fn = MPIDI_HCOLL_coll_handle_test;
-    hcoll_rte_functions.rte_coll_handle_free_fn = MPIDI_HCOLL_coll_handle_free;
-    hcoll_rte_functions.rte_coll_handle_complete_fn = MPIDI_HCOLL_coll_handle_complete;
-    hcoll_rte_functions.rte_group_id_fn = MPIDI_HCOLL_group_id;
-    hcoll_rte_functions.rte_world_rank_fn = MPIDI_HCOLL_world_rank;
+    hcoll_rte_functions.send_fn = MPIDI_HCOLL_rte_send_nb;
+    hcoll_rte_functions.recv_fn = MPIDI_HCOLL_rte_recv_nb;
+    hcoll_rte_functions.ec_cmp_fn = MPIDI_HCOLL_rte_ec_handle_compare;
+    hcoll_rte_functions.get_ec_handles_fn = MPIDI_HCOLL_rte_get_ec_handles;
+    hcoll_rte_functions.rte_group_size_fn = MPIDI_HCOLL_rte_group_size;
+    hcoll_rte_functions.test_fn = MPIDI_HCOLL_rte_test;
+    hcoll_rte_functions.rte_my_rank_fn = MPIDI_HCOLL_rte_my_rank;
+    hcoll_rte_functions.rte_ec_on_local_node_fn = MPIDI_HCOLL_rte_ec_on_local_node;
+    hcoll_rte_functions.rte_world_group_fn = MPIDI_HCOLL_rte_get_world_group_handle;
+    hcoll_rte_functions.rte_jobid_fn = MPIDI_HCOLL_rte_jobid;
+    hcoll_rte_functions.rte_progress_fn = MPIDI_HCOLL_rte_progress;
+    hcoll_rte_functions.rte_get_coll_handle_fn = MPIDI_HCOLL_rte_get_coll_handle;
+    hcoll_rte_functions.rte_coll_handle_test_fn = MPIDI_HCOLL_rte_coll_handle_test;
+    hcoll_rte_functions.rte_coll_handle_free_fn = MPIDI_HCOLL_rte_coll_handle_free;
+    hcoll_rte_functions.rte_coll_handle_complete_fn = MPIDI_HCOLL_rte_coll_handle_complete;
+    hcoll_rte_functions.rte_group_id_fn = MPIDI_HCOLL_rte_group_id;
+    hcoll_rte_functions.rte_world_rank_fn = MPIDI_HCOLL_rte_world_rank;
 #if HCOLL_API >= HCOLL_VERSION(3,6)
-    hcoll_rte_functions.rte_get_mpi_type_envelope_fn = MPIDI_HCOLL_get_mpi_type_envelope;
-    hcoll_rte_functions.rte_get_mpi_type_contents_fn = MPIDI_HCOLL_get_mpi_type_contents;
-    hcoll_rte_functions.rte_get_hcoll_type_fn = MPIDI_HCOLL_get_hcoll_type;
-    hcoll_rte_functions.rte_set_hcoll_type_fn = MPIDI_HCOLL_set_hcoll_type;
-    hcoll_rte_functions.rte_get_mpi_constants_fn = MPIDI_HCOLL_get_mpi_constants;
+    hcoll_rte_functions.rte_get_mpi_type_envelope_fn = MPIDI_HCOLL_rte_get_mpi_type_envelope;
+    hcoll_rte_functions.rte_get_mpi_type_contents_fn = MPIDI_HCOLL_rte_get_mpi_type_contents;
+    hcoll_rte_functions.rte_get_hcoll_type_fn = MPIDI_HCOLL_rte_get_hcoll_type;
+    hcoll_rte_functions.rte_set_hcoll_type_fn = MPIDI_HCOLL_rte_set_hcoll_type;
+    hcoll_rte_functions.rte_get_mpi_constants_fn = MPIDI_HCOLL_rte_get_mpi_constants;
 #endif
 }
 
@@ -121,18 +125,18 @@ static void MPIDI_HCOLL_init_module_fns(void)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 void MPIDI_HCOLL_rte_fns_setup(void)
 {
-    MPIDI_HCOLL_init_module_fns();
+    MPIDI_HCOLL_rte_init_module_fns();
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_recv_nb
+#define FUNCNAME MPIDI_HCOLL_rte_recv_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_recv_nb(struct dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
+static int MPIDI_HCOLL_rte_recv_nb(struct dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
 {
     int mpi_errno;
     MPI_Datatype dtype;
@@ -164,14 +168,14 @@ static int MPIDI_HCOLL_recv_nb(struct dte_data_representation_t data,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_send_nb
+#define FUNCNAME MPIDI_HCOLL_rte_send_nb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
-                               uint32_t count,
-                               void *buffer,
-                               rte_ec_handle_t ec_h,
-                               rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
+static int MPIDI_HCOLL_rte_send_nb(dte_data_representation_t data,
+                                   uint32_t count,
+                                   void *buffer,
+                                   rte_ec_handle_t ec_h,
+                                   rte_grp_handle_t grp_h, uint32_t tag, rte_request_handle_t * req)
 {
     int mpi_errno;
     MPI_Datatype dtype;
@@ -204,10 +208,10 @@ static int MPIDI_HCOLL_send_nb(dte_data_representation_t data,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_test
+#define FUNCNAME MPIDI_HCOLL_rte_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed)
+static int MPIDI_HCOLL_rte_test(rte_request_handle_t * request, int *completed)
 {
     MPIR_Request *req;
     req = (MPIR_Request *) request->data;
@@ -226,24 +230,25 @@ static int MPIDI_HCOLL_test(rte_request_handle_t * request, int *completed)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_ec_handle_compare
+#define FUNCNAME MPIDI_HCOLL_rte_ec_handle_compare
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_ec_handle_compare(rte_ec_handle_t handle_1,
-                                         rte_grp_handle_t
-                                         group_handle_1,
-                                         rte_ec_handle_t handle_2, rte_grp_handle_t group_handle_2)
+static int MPIDI_HCOLL_rte_ec_handle_compare(rte_ec_handle_t handle_1,
+                                             rte_grp_handle_t
+                                             group_handle_1,
+                                             rte_ec_handle_t handle_2,
+                                             rte_grp_handle_t group_handle_2)
 {
     return handle_1.handle == handle_2.handle;
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_ec_handles
+#define FUNCNAME MPIDI_HCOLL_rte_get_ec_handles
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_get_ec_handles(int num_ec,
-                                      int *ec_indexes, rte_grp_handle_t grp_h,
-                                      rte_ec_handle_t * ec_handles)
+static int MPIDI_HCOLL_rte_get_ec_handles(int num_ec,
+                                          int *ec_indexes, rte_grp_handle_t grp_h,
+                                          rte_ec_handle_t * ec_handles)
 {
     int i;
     MPIR_Comm *comm;
@@ -260,28 +265,28 @@ static int MPIDI_HCOLL_get_ec_handles(int num_ec,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_group_size
+#define FUNCNAME MPIDI_HCOLL_rte_group_size
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_group_size(rte_grp_handle_t grp_h)
+static int MPIDI_HCOLL_rte_group_size(rte_grp_handle_t grp_h)
 {
     return MPIR_Comm_size((MPIR_Comm *) grp_h);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_my_rank
+#define FUNCNAME MPIDI_HCOLL_rte_my_rank
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_my_rank(rte_grp_handle_t grp_h)
+static int MPIDI_HCOLL_rte_my_rank(rte_grp_handle_t grp_h)
 {
     return MPIR_Comm_rank((MPIR_Comm *) grp_h);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_ec_on_local_node
+#define FUNCNAME MPIDI_HCOLL_rte_ec_on_local_node
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group)
+static int MPIDI_HCOLL_rte_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t group)
 {
     MPIR_Comm *comm;
     int nodeid, my_nodeid;
@@ -295,29 +300,29 @@ static int MPIDI_HCOLL_ec_on_local_node(rte_ec_handle_t ec, rte_grp_handle_t gro
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_world_group_handle
+#define FUNCNAME MPIDI_HCOLL_rte_get_world_group_handle
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static rte_grp_handle_t MPIDI_HCOLL_get_world_group_handle(void)
+static rte_grp_handle_t MPIDI_HCOLL_rte_get_world_group_handle(void)
 {
     return (rte_grp_handle_t) (MPIR_Process.comm_world);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_jobid
+#define FUNCNAME MPIDI_HCOLL_rte_jobid
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static uint32_t MPIDI_HCOLL_jobid(void)
+static uint32_t MPIDI_HCOLL_rte_jobid(void)
 {
     /* not used currently */
     return 0;
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_group_id
+#define FUNCNAME MPIDI_HCOLL_rte_group_id
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_group_id(rte_grp_handle_t group)
+static int MPIDI_HCOLL_rte_group_id(rte_grp_handle_t group)
 {
     MPIR_Comm *comm;
     comm = (MPIR_Comm *) group;
@@ -325,10 +330,10 @@ static int MPIDI_HCOLL_group_id(rte_grp_handle_t group)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_get_coll_handle
+#define FUNCNAME MPIDI_HCOLL_rte_get_coll_handle
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void *MPIDI_HCOLL_get_coll_handle(void)
+static void *MPIDI_HCOLL_rte_get_coll_handle(void)
 {
     MPIR_Request *req;
     req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
@@ -337,10 +342,10 @@ static void *MPIDI_HCOLL_get_coll_handle(void)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_test
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_coll_handle_test(void *handle)
+static int MPIDI_HCOLL_rte_coll_handle_test(void *handle)
 {
     int completed;
     MPIR_Request *req;
@@ -350,10 +355,10 @@ static int MPIDI_HCOLL_coll_handle_test(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_free
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_free
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_coll_handle_free(void *handle)
+static void MPIDI_HCOLL_rte_coll_handle_free(void *handle)
 {
     MPIR_Request *req;
     if (NULL != handle) {
@@ -363,10 +368,10 @@ static void MPIDI_HCOLL_coll_handle_free(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_coll_handle_complete
+#define FUNCNAME MPIDI_HCOLL_rte_coll_handle_complete
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static void MPIDI_HCOLL_coll_handle_complete(void *handle)
+static void MPIDI_HCOLL_rte_coll_handle_complete(void *handle)
 {
     MPIR_Request *req;
     if (NULL != handle) {
@@ -376,10 +381,10 @@ static void MPIDI_HCOLL_coll_handle_complete(void *handle)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_HCOLL_world_rank
+#define FUNCNAME MPIDI_HCOLL_rte_world_rank
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDI_HCOLL_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec)
+static int MPIDI_HCOLL_rte_world_rank(rte_grp_handle_t grp_h, rte_ec_handle_t ec)
 {
 #ifdef MPIDCH4_H_INCLUDED
     return MPIDIU_rank_to_lpid(ec.rank, (MPIR_Comm *) grp_h);
@@ -430,9 +435,9 @@ hcoll_mpi_type_combiner_t MPIDI_HCOLL_combiner_mpi_to_hcoll(int combiner)
     return HCOLL_MPI_COMBINER_LAST;
 }
 
-static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
-                                             int *num_addresses, int *num_datatypes,
-                                             hcoll_mpi_type_combiner_t * combiner)
+static int MPIDI_HCOLL_rte_get_mpi_type_envelope(void *mpi_type, int *num_integers,
+                                                 int *num_addresses, int *num_datatypes,
+                                                 hcoll_mpi_type_combiner_t * combiner)
 {
     int mpi_combiner;
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
@@ -444,9 +449,10 @@ static int MPIDI_HCOLL_get_mpi_type_envelope(void *mpi_type, int *num_integers,
     return HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, int max_addresses,
-                                             int max_datatypes, int *array_of_integers,
-                                             void *array_of_addresses, void *array_of_datatypes)
+static int MPIDI_HCOLL_rte_get_mpi_type_contents(void *mpi_type, int max_integers,
+                                                 int max_addresses, int max_datatypes,
+                                                 int *array_of_integers, void *array_of_addresses,
+                                                 void *array_of_datatypes)
 {
     int ret;
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
@@ -460,26 +466,27 @@ static int MPIDI_HCOLL_get_mpi_type_contents(void *mpi_type, int max_integers, i
     return ret == MPI_SUCCESS ? HCOLL_SUCCESS : HCOLL_ERROR;
 }
 
-static int MPIDI_HCOLL_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type)
+static int MPIDI_HCOLL_rte_get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type)
 {
     MPI_Datatype dt_handle = (MPI_Datatype) mpi_type;
     MPIR_Datatype *dt_ptr;
 
-    *hcoll_type = MPIDI_HCOLL_mpi_to_hcoll_dtype(dt_handle, -1, TRY_FIND_DERIVED);
+    *hcoll_type = MPIDI_HCOLL_dtype_mpi_to_hcoll(dt_handle, -1, TRY_FIND_DERIVED);
 
     return HCOL_DTE_IS_ZERO((*hcoll_type)) ? HCOLL_ERR_NOT_FOUND : HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type)
+static int MPIDI_HCOLL_rte_set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type)
 {
     return HCOLL_SUCCESS;
 }
 
-static int MPIDI_HCOLL_get_mpi_constants(size_t * mpi_datatype_size,
-                                         int *mpi_order_c, int *mpi_order_fortran,
-                                         int *mpi_distribute_block,
-                                         int *mpi_distribute_cyclic,
-                                         int *mpi_distribute_none, int *mpi_distribute_dflt_darg)
+static int MPIDI_HCOLL_rte_get_mpi_constants(size_t * mpi_datatype_size,
+                                             int *mpi_order_c, int *mpi_order_fortran,
+                                             int *mpi_distribute_block,
+                                             int *mpi_distribute_cyclic,
+                                             int *mpi_distribute_none,
+                                             int *mpi_distribute_dflt_darg)
 {
     *mpi_datatype_size = sizeof(MPI_Datatype);
     *mpi_order_c = MPI_ORDER_C;

--- a/src/mpid/common/hcoll/hcollpre.h
+++ b/src/mpid/common/hcoll/hcollpre.h
@@ -10,6 +10,6 @@
 typedef struct {
     int is_hcoll_init;
     void *hcoll_context;
-} hcoll_comm_priv_t;
+} MPIDI_HCOLL_comm_priv_t;
 
 #endif /* HCOLLPRE_H_INCLUDED */

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -28,7 +28,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-static const char *entry_to_str(enum MPIDU_Sched_entry_type type)
+static const char *entry_to_str(enum MPIDU_Sched_element_entry_type type)
 {
     switch (type) {
         case MPIDU_SCHED_ENTRY_SEND:
@@ -48,12 +48,12 @@ static const char *entry_to_str(enum MPIDU_Sched_entry_type type)
     }
 }
 
-static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
+static void entry_dump(FILE * fh, struct MPIDU_Sched_element_entry *e)
 {
     switch (e->type) {
         case MPIDU_SCHED_ENTRY_SEND:
             {
-                struct MPIDU_Sched_send *s = &(e->u.send);
+                struct MPIDU_Sched_element_send *s = &(e->u.send);
                 fprintf(fh, "\t\tSend: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", s->count,
                         s->datatype, s->dest);
                 fprintf(fh, "\t\t from buff: %p\n", s->buf);
@@ -61,7 +61,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             break;
         case MPIDU_SCHED_ENTRY_RECV:
             {
-                struct MPIDU_Sched_recv *r = &(e->u.recv);
+                struct MPIDU_Sched_element_recv *r = &(e->u.recv);
                 fprintf(fh, "\t\tRecv: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", r->count,
                         r->datatype, r->src);
                 fprintf(fh, "\t\t Into buff: %p\n", r->buf);
@@ -69,7 +69,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             break;
         case MPIDU_SCHED_ENTRY_REDUCE:
             {
-                struct MPIDU_Sched_reduce *rd = &(e->u.reduce);
+                struct MPIDU_Sched_element_reduce *rd = &(e->u.reduce);
                 fprintf(fh, "\t\tReduce: %p -> %p\n", rd->inbuf, rd->inoutbuf);
                 fprintf(fh, "\t\t  " MPI_AINT_FMT_DEC_SPEC " elements of type %x\n", rd->count,
                         rd->datatype);
@@ -78,7 +78,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             break;
         case MPIDU_SCHED_ENTRY_COPY:
             {
-                struct MPIDU_Sched_copy *cp = &(e->u.copy);
+                struct MPIDU_Sched_element_copy *cp = &(e->u.copy);
                 fprintf(fh, "\t\tFrom: %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->inbuf,
                         cp->incount, cp->intype);
                 fprintf(fh, "\t\tTo:   %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->outbuf,
@@ -89,7 +89,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             break;
         case MPIDU_SCHED_ENTRY_CB:
             {
-                struct MPIDU_Sched_cb *cb = &(e->u.cb);
+                struct MPIDU_Sched_element_cb *cb = &(e->u.cb);
                 fprintf(fh, "\t\tcb_type=%d\n", cb->cb_type);
                 fprintf(fh, "\t\tcb_addr: %p\n", cb->u.cb_p);
             }
@@ -100,7 +100,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
 }
 
 /* utility function for debugging, dumps the given schedule object to fh */
-static void sched_dump(struct MPIDU_Sched *s, FILE * fh)
+static void sched_dump(struct MPIDU_Sched_element *s, FILE * fh)
 {
     int i;
 
@@ -130,30 +130,30 @@ static void sched_dump(struct MPIDU_Sched *s, FILE * fh)
      */
 }
 
-struct MPIDU_Sched_state {
-    struct MPIDU_Sched *head;
+struct MPIDU_Sched_list {
+    struct MPIDU_Sched_element *head;
     /* no need for a tail with utlist */
 };
 
 /* holds on to all incomplete schedules on which progress should be made */
-struct MPIDU_Sched_state all_schedules = { NULL };
+struct MPIDU_Sched_list MPIDU_all_schedules = { NULL };
 
 /* returns TRUE if any schedules are currently pending completion by the
  * progress engine, FALSE otherwise */
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_are_pending
+#define FUNCNAME MPIDU_Sched_list_has_pending_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_are_pending(void)
+int MPIDU_Sched_list_has_pending_sched(void)
 {
-    return (all_schedules.head != NULL);
+    return (MPIDU_all_schedules.head != NULL);
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_next_tag
+#define FUNCNAME MPIDU_Sched_list_get_next_tag
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
+int MPIDU_Sched_list_get_next_tag(MPIR_Comm * comm_ptr, int *tag)
 {
     int mpi_errno = MPI_SUCCESS;
     /* TODO there should be an internal accessor/utility macro for getting the
@@ -162,7 +162,7 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
 #if defined(HAVE_ERROR_CHECKING)
     int start = MPI_UNDEFINED;
     int end = MPI_UNDEFINED;
-    struct MPIDU_Sched *elt = NULL;
+    struct MPIDU_Sched_element *elt = NULL;
 #endif
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SCHED_NEXT_TAG);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SCHED_NEXT_TAG);
@@ -182,7 +182,7 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
         end = tag_ub / 2;
     }
     if (start != MPI_UNDEFINED) {
-        DL_FOREACH(all_schedules.head, elt) {
+        DL_FOREACH(MPIDU_all_schedules.head, elt) {
             if (elt->tag >= start && elt->tag < end) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**toomanynbc");
             }
@@ -203,13 +203,14 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_start_entry
+#define FUNCNAME MPIDU_Sched_element_start_entry
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* initiates the schedule entry "e" in the NBC described by "s", where
  * "e" is at "idx" in "s".  This means posting nonblocking sends/recvs,
  * performing reductions, calling callbacks, etc. */
-static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPIDU_Sched_entry *e)
+static int MPIDU_Sched_element_start_entry(struct MPIDU_Sched_element *s, size_t idx,
+                                           struct MPIDU_Sched_element_entry *e)
 {
     int mpi_errno = MPI_SUCCESS, ret_errno = MPI_SUCCESS;
     MPIR_Request *r = s->req;
@@ -274,7 +275,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                     }
                 }
                 /* We should set the status to failed here - since the request is not freed. this
-                 * will be handled later in MPIDU_Sched_progress_state, so set to started here */
+                 * will be handled later in MPIDU_Sched_list_progress_scheds, so set to started here */
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
                 MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Sched RECV failed. Errflag: %d\n",
                               (int) r->u.nbc.errflag);
@@ -367,10 +368,10 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
  * permitted to be started.  That is, this routine will respect schedule
  * barriers appropriately. */
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_continue
+#define FUNCNAME MPIDU_Sched_element_continue
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
+static int MPIDU_Sched_element_continue(struct MPIDU_Sched_element *s)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t i;
@@ -379,10 +380,10 @@ static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SCHED_CONTINUE);
 
     for (i = s->idx; i < s->num_entries; ++i) {
-        struct MPIDU_Sched_entry *e = &s->entries[i];
+        struct MPIDU_Sched_element_entry *e = &s->entries[i];
 
         if (e->status == MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED) {
-            mpi_errno = MPIDU_Sched_start_entry(s, i, e);
+            mpi_errno = MPIDU_Sched_element_start_entry(s, i, e);
             /* Sched entries list can be reallocated inside callback */
             e = &s->entries[i];
             if (mpi_errno)
@@ -410,14 +411,14 @@ static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_create
+#define FUNCNAME MPIDU_Sched_element_create
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* creates a new opaque schedule object and returns a handle to it in (*sp) */
-int MPIDU_Sched_create(MPIR_Sched_t * sp)
+int MPIDU_Sched_element_create(MPIR_Sched_element_t * sp)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched *s;
+    struct MPIDU_Sched_element *s;
     MPIR_CHKPMEM_DECL(2);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SCHED_CREATE);
@@ -426,8 +427,8 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
     *sp = NULL;
 
     /* this mem will be freed by the progress engine when the request is completed */
-    MPIR_CHKPMEM_MALLOC(s, struct MPIDU_Sched *, sizeof(struct MPIDU_Sched), mpi_errno,
-                        "schedule object", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(s, struct MPIDU_Sched_element *, sizeof(struct MPIDU_Sched_element),
+                        mpi_errno, "schedule object", MPL_MEM_COMM);
 
     s->size = MPIDU_SCHED_INITIAL_ENTRIES;
     s->idx = 0;
@@ -439,9 +440,9 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
     s->prev = NULL;     /* only needed for sanity checks */
 
     /* this mem will be freed by the progress engine when the request is completed */
-    MPIR_CHKPMEM_MALLOC(s->entries, struct MPIDU_Sched_entry *,
-                        MPIDU_SCHED_INITIAL_ENTRIES * sizeof(struct MPIDU_Sched_entry), mpi_errno,
-                        "schedule entries vector", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(s->entries, struct MPIDU_Sched_element_entry *,
+                        MPIDU_SCHED_INITIAL_ENTRIES * sizeof(struct MPIDU_Sched_element_entry),
+                        mpi_errno, "schedule entries vector", MPL_MEM_COMM);
 
     /* TODO in a debug build, defensively mark all entries as status=INVALID */
 
@@ -456,11 +457,11 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_clone
+#define FUNCNAME MPIDU_Sched_element_clone
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* clones orig and returns a handle to the new schedule in (*cloned) */
-int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned)
+int MPIDU_Sched_element_clone(MPIR_Sched_element_t orig, MPIR_Sched_element_t * cloned)
 {
     int mpi_errno = MPI_SUCCESS;
     /* TODO implement this function for real */
@@ -470,16 +471,17 @@ int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_start
+#define FUNCNAME MPIDU_Sched_list_enqueue_sched
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* sets (*sp) to MPIR_SCHED_NULL and gives you back a request pointer in (*req).
  * The caller is giving up ownership of the opaque schedule object. */
-int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request ** req)
+int MPIDU_Sched_list_enqueue_sched(MPIR_Sched_element_t * sp, MPIR_Comm * comm, int tag,
+                                   MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *r;
-    struct MPIDU_Sched *s = *sp;
+    struct MPIDU_Sched_element *s = *sp;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SCHED_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SCHED_START);
@@ -514,16 +516,16 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
     /* Now kick off any initial operations.  Do this before we tell the progress
      * engine about this req+sched, otherwise we have more MT issues to worry
      * about.  Skipping this step will increase latency. */
-    mpi_errno = MPIDU_Sched_continue(s);
+    mpi_errno = MPIDU_Sched_element_continue(s);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
     /* finally, enqueue in the list of all pending schedules so that the
      * progress engine can make progress on it */
-    if (all_schedules.head == NULL)
+    if (MPIDU_all_schedules.head == NULL)
         MPID_Progress_activate_hook(MPIR_Nbc_progress_hook_id);
 
-    DL_APPEND(all_schedules.head, s);
+    DL_APPEND(MPIDU_all_schedules.head, s);
 
     MPL_DBG_MSG_P(MPIR_DBG_COMM, TYPICAL, "started schedule s=%p\n", s);
     if (MPIR_CVAR_COLL_SCHED_DUMP)
@@ -545,15 +547,16 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_add_entry
+#define FUNCNAME MPIDU_Sched_element_add_entry
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* idx and e are permitted to be NULL */
-static int MPIDU_Sched_add_entry(struct MPIDU_Sched *s, int *idx, struct MPIDU_Sched_entry **e)
+static int MPIDU_Sched_element_add_entry(struct MPIDU_Sched_element *s, int *idx,
+                                         struct MPIDU_Sched_element_entry **e)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    struct MPIDU_Sched_entry *ei;
+    struct MPIDU_Sched_element_entry *ei;
 
     MPIR_Assert(s->entries != NULL);
     MPIR_Assert(s->size > 0);
@@ -561,7 +564,8 @@ static int MPIDU_Sched_add_entry(struct MPIDU_Sched *s, int *idx, struct MPIDU_S
     if (s->num_entries == s->size) {
         /* need to grow the entries array */
         s->entries =
-            MPL_realloc(s->entries, 2 * s->size * sizeof(struct MPIDU_Sched_entry), MPL_MEM_COMM);
+            MPL_realloc(s->entries, 2 * s->size * sizeof(struct MPIDU_Sched_element_entry),
+                        MPL_MEM_COMM);
         if (s->entries == NULL)
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         s->size *= 2;
@@ -581,17 +585,17 @@ static int MPIDU_Sched_add_entry(struct MPIDU_Sched *s, int *idx, struct MPIDU_S
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_send
+#define FUNCNAME MPIDU_Sched_element_send
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* do these ops need an entry handle returned? */
-int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     MPIR_Comm * comm, MPIR_Sched_t s)
+int MPIDU_Sched_element_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -622,16 +626,16 @@ int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_ssend
+#define FUNCNAME MPIDU_Sched_element_ssend
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                      MPIR_Comm * comm, MPIR_Sched_t s)
+int MPIDU_Sched_element_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                              MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -662,16 +666,16 @@ int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, in
 
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_send_defer
+#define FUNCNAME MPIDU_Sched_element_send_defer
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype, int dest,
-                           MPIR_Comm * comm, MPIR_Sched_t s)
+int MPIDU_Sched_element_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype,
+                                   int dest, MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -701,16 +705,16 @@ int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_recv_status
+#define FUNCNAME MPIDU_Sched_element_recv_status
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                            MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_t s)
+int MPIDU_Sched_element_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                                    MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -736,16 +740,16 @@ int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, in
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_recv
+#define FUNCNAME MPIDU_Sched_element_recv
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, MPIR_Comm * comm,
-                     MPIR_Sched_t s)
+int MPIDU_Sched_element_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                             MPIR_Comm * comm, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -771,17 +775,17 @@ int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, 
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_reduce
+#define FUNCNAME MPIDU_Sched_element_reduce
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
-                       MPI_Op op, MPIR_Sched_t s)
+int MPIDU_Sched_element_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Op op, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
-    struct MPIDU_Sched_reduce *reduce = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
+    struct MPIDU_Sched_element_reduce *reduce = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -806,7 +810,7 @@ int MPIDU_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Da
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_copy
+#define FUNCNAME MPIDU_Sched_element_copy
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* Schedules a copy of "incount" copies of "intype" from "inbuf" to "outbuf" as
@@ -816,14 +820,15 @@ int MPIDU_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Da
  *
  * Packing/unpacking can be accomplished by passing MPI_PACKED as either intype
  * or outtype. */
-int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
-                     void *outbuf, MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_t s)
+int MPIDU_Sched_element_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
+                             void *outbuf, MPI_Aint outcount, MPI_Datatype outtype,
+                             MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
-    struct MPIDU_Sched_copy *copy = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
+    struct MPIDU_Sched_element_copy *copy = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -864,12 +869,12 @@ int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_barrier
+#define FUNCNAME MPIDU_Sched_element_barrier
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* require that all previously added ops are complete before subsequent ops
  * may begin to execute */
-int MPIDU_Sched_barrier(MPIR_Sched_t s)
+int MPIDU_Sched_element_barrier(MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -883,17 +888,17 @@ int MPIDU_Sched_barrier(MPIR_Sched_t s)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_cb
+#define FUNCNAME MPIDU_Sched_element_cb
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* buffer management, fancy reductions, etc */
-int MPIDU_Sched_cb(MPIR_Sched_cb_t * cb_p, void *cb_state, MPIR_Sched_t s)
+int MPIDU_Sched_element_cb(MPIR_Sched_element_cb_t * cb_p, void *cb_state, MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
-    struct MPIDU_Sched_cb *cb = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
+    struct MPIDU_Sched_element_cb *cb = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -914,17 +919,18 @@ int MPIDU_Sched_cb(MPIR_Sched_cb_t * cb_p, void *cb_state, MPIR_Sched_t s)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_cb2
+#define FUNCNAME MPIDU_Sched_element_cb2
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 /* buffer management, fancy reductions, etc */
-int MPIDU_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MPIR_Sched_t s)
+int MPIDU_Sched_element_cb2(MPIR_Sched_element_cb2_t * cb_p, void *cb_state, void *cb_state2,
+                            MPIR_Sched_element_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
-    struct MPIDU_Sched_cb *cb = NULL;
+    struct MPIDU_Sched_element_entry *e = NULL;
+    struct MPIDU_Sched_element_cb *cb = NULL;
 
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
+    mpi_errno = MPIDU_Sched_element_add_entry(s, NULL, &e);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -947,15 +953,15 @@ int MPIDU_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MP
 
 /* returns TRUE in (*made_progress) if any of the outstanding schedules in state completed */
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_progress_state
+#define FUNCNAME MPIDU_Sched_list_progress_scheds
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made_progress)
+static int MPIDU_Sched_list_progress_scheds(struct MPIDU_Sched_list *state, int *made_progress)
 {
     int mpi_errno = MPI_SUCCESS;
     size_t i;
-    struct MPIDU_Sched *s;
-    struct MPIDU_Sched *tmp;
+    struct MPIDU_Sched_element *s;
+    struct MPIDU_Sched_element *tmp;
     if (made_progress)
         *made_progress = FALSE;
 
@@ -964,7 +970,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
             sched_dump(s, stderr);
 
         for (i = s->idx; i < s->num_entries; ++i) {
-            struct MPIDU_Sched_entry *e = &s->entries[i];
+            struct MPIDU_Sched_element_entry *e = &s->entries[i];
 
             switch (e->type) {
                 case MPIDU_SCHED_ENTRY_SEND:
@@ -1015,7 +1021,7 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                 MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "completed OTHER entry %d\n", (int) i);
                 if (e->is_barrier) {
                     /* post/perform the next round of operations */
-                    mpi_errno = MPIDU_Sched_continue(s);
+                    mpi_errno = MPIDU_Sched_element_continue(s);
                     if (mpi_errno)
                         MPIR_ERR_POP(mpi_errno);
                 }
@@ -1067,17 +1073,17 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
 
 /* returns TRUE in (*made_progress) if any of the outstanding schedules completed */
 #undef FUNCNAME
-#define FUNCNAME MPIDU_Sched_progress
+#define FUNCNAME MPIDU_Sched_list_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDU_Sched_progress(int *made_progress)
+int MPIDU_Sched_list_progress(int *made_progress)
 {
     int mpi_errno;
 
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 
-    mpi_errno = MPIDU_Sched_progress_state(&all_schedules, made_progress);
-    if (!mpi_errno && all_schedules.head == NULL)
+    mpi_errno = MPIDU_Sched_list_progress_scheds(&MPIDU_all_schedules, made_progress);
+    if (!mpi_errno && MPIDU_all_schedules.head == NULL)
         MPID_Progress_deactivate_hook(MPIR_Nbc_progress_hook_id);
 
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -146,7 +146,15 @@ struct MPIDU_Sched_list MPIDU_all_schedules = { NULL };
 #define FCNAME MPL_QUOTE(FUNCNAME)
 int MPIDU_Sched_list_has_pending_sched(void)
 {
-    return (MPIDU_all_schedules.head != NULL);
+    int retval;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
+
+    retval = (MPIDU_all_schedules.head != NULL);
+
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
+
+    return retval;
 }
 
 #undef FUNCNAME
@@ -182,11 +190,13 @@ int MPIDU_Sched_list_get_next_tag(MPIR_Comm * comm_ptr, int *tag)
         end = tag_ub / 2;
     }
     if (start != MPI_UNDEFINED) {
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
         DL_FOREACH(MPIDU_all_schedules.head, elt) {
             if (elt->tag >= start && elt->tag < end) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**toomanynbc");
             }
         }
+        MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
     }
 #endif
 
@@ -522,10 +532,21 @@ int MPIDU_Sched_list_enqueue_sched(MPIR_Sched_element_t * sp, MPIR_Comm * comm, 
 
     /* finally, enqueue in the list of all pending schedules so that the
      * progress engine can make progress on it */
+    /* The check for head == NULL should happen inside the lock. Consider
+     * we have another thread that is executing the progress hook through the
+     * progress engine. The other thread holds the SCHED_LIST lock and if it
+     * finishes progressing all the schedules, then it would deactivate the
+     * hook before releasing the lock. If the head == NULL check occurs outside
+     * the lock, then the hook will not be rightly activated until the user
+     * issues another non-blocking collective operation, which is incorrect since
+     * the user may not issue another non-blocking collective operation.
+     */
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
     if (MPIDU_all_schedules.head == NULL)
         MPID_Progress_activate_hook(MPIR_Nbc_progress_hook_id);
 
     DL_APPEND(MPIDU_all_schedules.head, s);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
 
     MPL_DBG_MSG_P(MPIR_DBG_COMM, TYPICAL, "started schedule s=%p\n", s);
     if (MPIR_CVAR_COLL_SCHED_DUMP)
@@ -1080,13 +1101,13 @@ int MPIDU_Sched_list_progress(int *made_progress)
 {
     int mpi_errno;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
 
     mpi_errno = MPIDU_Sched_list_progress_scheds(&MPIDU_all_schedules, made_progress);
     if (!mpi_errno && MPIDU_all_schedules.head == NULL)
         MPID_Progress_deactivate_hook(MPIR_Nbc_progress_hook_id);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_SCHED_LIST_MUTEX);
 
     return mpi_errno;
 }

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -14,7 +14,7 @@
  */
 #include "mpidu_pre.h"
 
-enum MPIDU_Sched_entry_type {
+enum MPIDU_Sched_element_entry_type {
     MPIDU_SCHED_ENTRY_INVALID_LB = 0,
     MPIDU_SCHED_ENTRY_SEND,
     /* _SEND_DEFER is easily implemented via _SEND */
@@ -27,7 +27,7 @@ enum MPIDU_Sched_entry_type {
     MPIDU_SCHED_ENTRY_INVALID_UB
 };
 
-struct MPIDU_Sched_send {
+struct MPIDU_Sched_element_send {
     const void *buf;
     MPI_Aint count;
     const MPI_Aint *count_p;
@@ -38,7 +38,7 @@ struct MPIDU_Sched_send {
     int is_sync;                /* TRUE iff this send is an ssend */
 };
 
-struct MPIDU_Sched_recv {
+struct MPIDU_Sched_element_recv {
     void *buf;
     MPI_Aint count;
     MPI_Datatype datatype;
@@ -48,7 +48,7 @@ struct MPIDU_Sched_recv {
     MPI_Status *status;
 };
 
-struct MPIDU_Sched_reduce {
+struct MPIDU_Sched_element_reduce {
     const void *inbuf;
     void *inoutbuf;
     MPI_Aint count;
@@ -56,7 +56,7 @@ struct MPIDU_Sched_reduce {
     MPI_Op op;
 };
 
-struct MPIDU_Sched_copy {
+struct MPIDU_Sched_element_copy {
     const void *inbuf;
     MPI_Aint incount;
     MPI_Datatype intype;
@@ -67,22 +67,22 @@ struct MPIDU_Sched_copy {
 
 /* nop entries have no args, so no structure is needed */
 
-enum MPIDU_Sched_cb_type {
-    MPIDU_SCHED_CB_TYPE_1 = 0,  /* single state arg type --> MPIR_Sched_cb_t */
-    MPIDU_SCHED_CB_TYPE_2       /* double state arg type --> MPIR_Sched_cb2_t */
+enum MPIDU_Sched_element_cb_type {
+    MPIDU_SCHED_CB_TYPE_1 = 0,  /* single state arg type --> MPIR_Sched_element_cb_t */
+    MPIDU_SCHED_CB_TYPE_2       /* double state arg type --> MPIR_Sched_element_cb2_t */
 };
 
-struct MPIDU_Sched_cb {
-    enum MPIDU_Sched_cb_type cb_type;
+struct MPIDU_Sched_element_cb {
+    enum MPIDU_Sched_element_cb_type cb_type;
     union {
-        MPIR_Sched_cb_t *cb_p;
-        MPIR_Sched_cb2_t *cb2_p;
+        MPIR_Sched_element_cb_t *cb_p;
+        MPIR_Sched_element_cb2_t *cb2_p;
     } u;
     void *cb_state;
     void *cb_state2;            /* unused for single-param callbacks */
 };
 
-enum MPIDU_Sched_entry_status {
+enum MPIDU_Sched_element_entry_status {
     MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED = 0,
     MPIDU_SCHED_ENTRY_STATUS_STARTED,
     MPIDU_SCHED_ENTRY_STATUS_COMPLETE,
@@ -92,50 +92,50 @@ enum MPIDU_Sched_entry_status {
 
 /* Use a tagged union for schedule entries.  Not always space optimal, but saves
  * lots of error-prone pointer arithmetic and makes scanning the schedule easy. */
-struct MPIDU_Sched_entry {
-    enum MPIDU_Sched_entry_type type;
-    enum MPIDU_Sched_entry_status status;
+struct MPIDU_Sched_element_entry {
+    enum MPIDU_Sched_element_entry_type type;
+    enum MPIDU_Sched_element_entry_status status;
     int is_barrier;
     union {
-        struct MPIDU_Sched_send send;
-        struct MPIDU_Sched_recv recv;
-        struct MPIDU_Sched_reduce reduce;
-        struct MPIDU_Sched_copy copy;
+        struct MPIDU_Sched_element_send send;
+        struct MPIDU_Sched_element_recv recv;
+        struct MPIDU_Sched_element_reduce reduce;
+        struct MPIDU_Sched_element_copy copy;
         /* nop entries have no args */
-        struct MPIDU_Sched_cb cb;
+        struct MPIDU_Sched_element_cb cb;
     } u;
 };
 
-struct MPIDU_Sched {
+struct MPIDU_Sched_element {
     size_t size;                /* capacity (in entries) of the entries array */
     size_t idx;                 /* index into entries array of first yet-outstanding entry */
     int num_entries;            /* number of populated entries, num_entries <= size */
     int tag;
     struct MPIR_Request *req;   /* really needed? could cause MT problems... */
-    struct MPIDU_Sched_entry *entries;
+    struct MPIDU_Sched_element_entry *entries;
 
-    struct MPIDU_Sched *next;   /* linked-list next pointer */
-    struct MPIDU_Sched *prev;   /* linked-list next pointer */
+    struct MPIDU_Sched_element *next;   /* linked-list next pointer */
+    struct MPIDU_Sched_element *prev;   /* linked-list next pointer */
 };
 
 /* prototypes */
-int MPIDU_Sched_progress(int *made_progress);
-int MPIDU_Sched_are_pending(void);
-int MPIDU_Sched_next_tag(struct MPIR_Comm *comm_ptr, int *tag);
-int MPIDU_Sched_create(MPIR_Sched_t * sp);
-int MPIDU_Sched_clone(MPIR_Sched_t orig, MPIR_Sched_t * cloned);
-int MPIDU_Sched_start(MPIR_Sched_t * sp, struct MPIR_Comm *comm, int tag,
-                      struct MPIR_Request **req);
-int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIR_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIR_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
-                      MPI_Op op, MPIR_Sched_t s);
-int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype, void *outbuf,
-                     MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_t s);
-int MPIDU_Sched_barrier(MPIR_Sched_t s);
+int MPIDU_Sched_list_progress(int *made_progress);
+int MPIDU_Sched_list_has_pending_sched(void);
+int MPIDU_Sched_list_get_next_tag(struct MPIR_Comm *comm_ptr, int *tag);
+int MPIDU_Sched_element_create(MPIR_Sched_element_t * sp);
+int MPIDU_Sched_element_clone(MPIR_Sched_element_t orig, MPIR_Sched_element_t * cloned);
+int MPIDU_Sched_list_enqueue_sched(MPIR_Sched_element_t * sp, struct MPIR_Comm *comm, int tag,
+                                   struct MPIR_Request **req);
+int MPIDU_Sched_element_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIR_Sched_element_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
+                             struct MPIR_Comm *comm, MPIR_Sched_element_t s);
+int MPIR_Sched_element_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count,
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype, void *outbuf,
+                             MPI_Aint outcount, MPI_Datatype outtype, MPIR_Sched_element_t s);
+int MPIDU_Sched_element_barrier(MPIR_Sched_element_t s);
 
 #endif /* MPIDU_SCHED_H_INCLUDED */

--- a/src/mpid/include/mpidu_pre.h
+++ b/src/mpid/include/mpidu_pre.h
@@ -16,10 +16,11 @@ struct MPIR_Comm;
 
 /* Scheduling forward declarations */
 
-struct MPIDU_Sched;
-typedef struct MPIDU_Sched *MPIR_Sched_t;
+struct MPIDU_Sched_element;
+typedef struct MPIDU_Sched_element *MPIR_Sched_element_t;
 
-typedef int (MPIR_Sched_cb_t) (struct MPIR_Comm * comm, int tag, void *state);
-typedef int (MPIR_Sched_cb2_t) (struct MPIR_Comm * comm, int tag, void *state, void *state2);
+typedef int (MPIR_Sched_element_cb_t) (struct MPIR_Comm * comm, int tag, void *state);
+typedef int (MPIR_Sched_element_cb2_t) (struct MPIR_Comm * comm, int tag, void *state,
+                                        void *state2);
 
 #endif /* MPIDU_PRE_H_INCLUDED */


### PR DESCRIPTION
This PR is a combination of commits from PRs #3597, #3620, and #3624 rebased on top of #3590 plus a commit to remove the global lock on non-blocking collectives with the `--enable-thread-cs=per-vci` configuration.

Without the commit that removes the global lock, the correctness of the commits in each of the nbc-related PRs cannot be tested. However, the PRs cannot be tested independently (with the global lock removed) without causing some failures since Jenkins tests both Sched and TSP code at the same time requiring changes from both the PRs to be present to pass all the tests.