### PR TITLE
ch4/progress: Remove unnecessary mutual exclusion for func_ptr

### DIFF
--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -39,8 +39,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
             progress_func_ptr_t func_ptr = NULL;
             MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
             if (MPIDI_global.progress_hooks[i].active == TRUE) {
-                func_ptr = MPIDI_global.progress_hooks[i].func_ptr;
                 MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
+                func_ptr = MPIDI_global.progress_hooks[i].func_ptr;
                 MPIR_Assert(func_ptr != NULL);
                 mpi_errno = func_ptr(&made_progress);
                 if (mpi_errno)


### PR DESCRIPTION
The `func_ptr` of a progress hook is set and unset only during the hooks' registration and deregistration which occur during init and finalize time. Hence, once we have read that a hook is active, we do not need to protect the load of the `func_ptr` of the hook with the `PROGRESS_HOOK_MUTEX`.