### PR TITLE
ch4: misc fixes for removing redundant data checks

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -616,11 +616,12 @@ struct MPIDI_OFI_contig_blocks_params {
 #define FUNCNAME MPIDI_OFI_count_iov
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
-    size_t MPIDI_OFI_count_iov(int dt_count, MPI_Datatype dt_datatype, size_t max_pipe)
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_count_iov(int dt_count,       /* number of data elements in dt_datatype */
+                                                    MPI_Datatype dt_datatype, size_t total_bytes,       /* total byte size, passed in here for reusing */
+                                                    size_t max_pipe)
 {
     MPIR_Segment *dt_seg;
-    ssize_t rem_size;
+    ssize_t rem_size = total_bytes;
     size_t num_iov, total_iov = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_COUNT_IOV);
@@ -630,7 +631,6 @@ MPL_STATIC_INLINE_PREFIX
         goto fn_exit;
 
     dt_seg = MPIR_Segment_alloc(NULL, dt_count, dt_datatype);
-    MPIDI_Datatype_check_size(dt_datatype, dt_count, rem_size);
 
     do {
         size_t tmp_size = (rem_size > max_pipe) ? max_pipe : rem_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -388,10 +388,11 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
-    MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count, target_contig, target_bytes,
-                                        target_true_lb);
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig, origin_bytes,
-                                        origin_true_lb);
+    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
+                                                      origin_count, target_count,
+                                                      origin_contig, target_contig,
+                                                      origin_bytes, target_bytes,
+                                                      origin_true_lb, target_true_lb);
 
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
@@ -575,10 +576,11 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     if (unlikely(target_rank == MPI_PROC_NULL))
         goto null_op_exit;
 
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count, origin_contig,
-                                        origin_bytes, origin_true_lb);
-    MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count, target_contig,
-                                        target_bytes, target_true_lb);
+    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
+                                                      origin_count, target_count,
+                                                      origin_contig, target_contig,
+                                                      origin_bytes, target_bytes,
+                                                      origin_true_lb, target_true_lb);
 
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -71,17 +71,24 @@ static inline uint32_t MPIDI_OFI_winfo_disp_unit(MPIR_Win * win, int rank)
     return ret;
 }
 
+/* _count: count of data elements of certain datatype
+ * _datatype: the datatype
+ * _bytes: total byte size
+ * Note: _bytes is calculated based on _count & _datatype and passed in here for reusing. */
 #undef FUNCNAME
 #define FUNCNAME MPIDI_OFI_count_iovecs
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX
-    int MPIDI_OFI_count_iovecs(int origin_count,
-                               int target_count,
-                               int result_count,
-                               MPI_Datatype origin_datatype,
-                               MPI_Datatype target_datatype,
-                               MPI_Datatype result_datatype, size_t max_pipe, size_t * countp)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_count_iovecs(int origin_count,
+                                                    int target_count,
+                                                    int result_count,
+                                                    MPI_Datatype origin_datatype,
+                                                    MPI_Datatype target_datatype,
+                                                    MPI_Datatype result_datatype,
+                                                    size_t origin_bytes,
+                                                    size_t target_bytes,
+                                                    size_t result_bytes,
+                                                    size_t max_pipe, size_t * countp)
 {
     /* Count the max number of iovecs that will be generated, given the iovs    */
     /* and maximum data size.  The code adds the iovecs from all three lists    */
@@ -90,9 +97,9 @@ MPL_STATIC_INLINE_PREFIX
     /* scans two elements of the datatype to make the estimate                  */
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_COUNT_IOVECS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_COUNT_IOVECS);
-    *countp = MPIDI_OFI_count_iov(origin_count, origin_datatype, max_pipe);
-    *countp += MPIDI_OFI_count_iov(target_count, target_datatype, max_pipe);
-    *countp += MPIDI_OFI_count_iov(result_count, result_datatype, max_pipe);
+    *countp = MPIDI_OFI_count_iov(origin_count, origin_datatype, origin_bytes, max_pipe);
+    *countp += MPIDI_OFI_count_iov(target_count, target_datatype, target_bytes, max_pipe);
+    *countp += MPIDI_OFI_count_iov(result_count, result_datatype, result_bytes, max_pipe);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_COUNT_IOVECS);
     return MPI_SUCCESS;
 }
@@ -169,12 +176,18 @@ static inline void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 }
 
+/* _count: count of data elements of certain datatype
+ * _datatype: the datatype
+ * _bytes: total byte size
+ * Note: _bytes is calculated based on _count & _datatype and passed in here for reusing. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * win,
                                                                     int origin_count,
                                                                     int target_count,
                                                                     int target_rank,
                                                                     MPI_Datatype origin_datatype,
                                                                     MPI_Datatype target_datatype,
+                                                                    size_t origin_bytes,
+                                                                    size_t target_bytes,
                                                                     size_t max_pipe,
                                                                     MPIDI_OFI_win_request_t **
                                                                     winreq, uint64_t * flags,
@@ -192,7 +205,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
     t_size = sizeof(struct fi_rma_iov);
     /* An upper bound on the iov limit */
     MPIDI_OFI_count_iovecs(origin_count, target_count, 0, origin_datatype,
-                           target_datatype, MPI_DATATYPE_NULL, max_pipe, &alloc_iovs);
+                           target_datatype, MPI_DATATYPE_NULL, origin_bytes, target_bytes, 0,
+                           max_pipe, &alloc_iovs);
 
     alloc_iov_size = MPIDI_OFI_align_iov_len(alloc_iovs * o_size)
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
@@ -225,12 +239,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
     goto fn_exit;
 }
 
+/* _count: count of data elements of certain datatype
+ * _datatype: the datatype
+ * _bytes: total byte size
+ * Note: _bytes is calculated based on _count & _datatype and passed in here for reusing. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win * win,
                                                                        int origin_count,
                                                                        int target_count,
                                                                        int target_rank,
                                                                        MPI_Datatype origin_datatype,
                                                                        MPI_Datatype target_datatype,
+                                                                       size_t origin_bytes,
+                                                                       size_t target_bytes,
                                                                        size_t max_pipe,
                                                                        MPIDI_OFI_win_request_t **
                                                                        winreq, uint64_t * flags,
@@ -248,7 +268,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
     t_size = sizeof(struct fi_rma_ioc);
     /* An upper bound on the iov limit. */
     MPIDI_OFI_count_iovecs(origin_count, target_count, 0, origin_datatype,
-                           target_datatype, MPI_DATATYPE_NULL, max_pipe, &alloc_iovs);
+                           target_datatype, MPI_DATATYPE_NULL, origin_bytes, target_bytes, 0,
+                           max_pipe, &alloc_iovs);
 
     alloc_iov_size = MPIDI_OFI_align_iov_len(alloc_iovs * o_size)
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
@@ -293,6 +314,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
                                                                            target_datatype,
                                                                            MPI_Datatype
                                                                            result_datatype,
+                                                                           size_t origin_bytes,
+                                                                           size_t target_bytes,
+                                                                           size_t result_bytes,
                                                                            size_t max_pipe,
                                                                            MPIDI_OFI_win_request_t
                                                                            ** winreq,
@@ -313,7 +337,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
 
     /* An upper bound on the iov limit. */
     MPIDI_OFI_count_iovecs(origin_count, target_count, result_count, origin_datatype,
-                           target_datatype, result_datatype, max_pipe, &alloc_iovs);
+                           target_datatype, result_datatype, origin_bytes, target_bytes,
+                           result_bytes, max_pipe, &alloc_iovs);
     alloc_rma_iovs = alloc_iovs;
 
     alloc_iov_size = MPIDI_OFI_align_iov_len(alloc_iovs * o_size)
@@ -447,6 +472,8 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
                                                                   target_rank,
                                                                   origin_datatype,
                                                                   target_datatype,
+                                                                  origin_bytes,
+                                                                  target_bytes,
                                                                   MPIDI_OFI_global.max_msg_size,
                                                                   &req, &flags, &ep, sigreq));
 
@@ -464,6 +491,8 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
                              MPIDI_OFI_winfo_base(win, req->target_rank) + offset,
                              origin_count,
                              target_count,
+                             origin_bytes,
+                             target_bytes,
                              MPIDI_OFI_global.max_msg_size, origin_datatype, target_datatype);
     rc = MPIDI_OFI_SEG_EAGAIN;
 
@@ -621,6 +650,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_put_get(win, origin_count, target_count,
                                                                   target_rank,
                                                                   origin_datatype, target_datatype,
+                                                                  origin_bytes, target_bytes,
                                                                   MPIDI_OFI_global.max_msg_size,
                                                                   &req, &flags, &ep, sigreq));
 
@@ -637,6 +667,8 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
                              MPIDI_OFI_winfo_base(win, req->target_rank) + offset,
                              origin_count,
                              target_count,
+                             origin_bytes,
+                             target_bytes,
                              MPIDI_OFI_global.max_msg_size, origin_datatype, target_datatype);
     rc = MPIDI_OFI_SEG_EAGAIN;
 
@@ -880,7 +912,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     int rc, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t origin_bytes, offset, max_count, max_size, dt_size, omax, tmax, tout, oout;
+    size_t origin_bytes, target_bytes, offset, max_count, max_size, dt_size, omax, tmax, tout, oout;
     struct fid_ep *ep = NULL;
     MPI_Datatype basic_type;
     enum fi_op fi_op;
@@ -899,6 +931,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
         goto null_op_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
+    MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
     if (origin_bytes == 0)
         goto null_op_exit;
 
@@ -924,7 +957,8 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     MPIDIG_wait_am_acc(win, target_rank, (MPIDIG_ACCU_ORDER_WAW | MPIDIG_ACCU_ORDER_WAR));
     MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_accumulate
                            (win, origin_count, target_count, target_rank, origin_datatype,
-                            target_datatype, max_size, &req, &flags, &ep, sigreq));
+                            target_datatype, origin_bytes, target_bytes, max_size, &req, &flags,
+                            &ep, sigreq));
 
     req->event_id = MPIDI_OFI_EVENT_ABORT;
     req->next = MPIDI_OFI_WIN(win).syncQ;
@@ -934,7 +968,8 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
                              origin_addr,
                              MPIDI_OFI_winfo_base(win, req->target_rank) + offset,
                              origin_count,
-                             target_count, max_size, origin_datatype, target_datatype);
+                             target_count, origin_bytes, target_bytes, max_size, origin_datatype,
+                             target_datatype);
 
     msg.desc = NULL;
     msg.addr = MPIDI_OFI_av_to_phys(addr);
@@ -1021,7 +1056,8 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     int rc, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t target_bytes, offset, max_count, max_size, dt_size, omax, rmax, tmax, tout, rout, oout;
+    size_t target_bytes, origin_bytes, result_bytes, offset, max_count, max_size, dt_size, omax,
+        rmax, tmax, tout, rout, oout;
     struct fid_ep *ep = NULL;
     MPI_Datatype basic_type;
     enum fi_op fi_op;
@@ -1040,6 +1076,8 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         goto null_op_exit;
 
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
+    MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
+    MPIDI_Datatype_check_size(result_datatype, result_count, result_bytes);
     if (target_bytes == 0)
         goto null_op_exit;
 
@@ -1071,8 +1109,8 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     }
     MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_get_accumulate
                            (win, origin_count, target_count, result_count, target_rank, op,
-                            origin_datatype, target_datatype, result_datatype, max_size, &req,
-                            &flags, &ep, sigreq));
+                            origin_datatype, target_datatype, result_datatype, origin_bytes,
+                            target_bytes, result_bytes, max_size, &req, &flags, &ep, sigreq));
 
     req->event_id = MPIDI_OFI_EVENT_RMA_DONE;
     req->next = MPIDI_OFI_WIN(win).syncQ;
@@ -1084,13 +1122,15 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
                                   result_addr,
                                   MPIDI_OFI_winfo_base(win, req->target_rank) + offset,
                                   origin_count, result_count, target_count,
-                                  max_size, origin_datatype, result_datatype, target_datatype);
+                                  max_size, origin_datatype, result_datatype, target_datatype,
+                                  origin_bytes, result_bytes, target_bytes);
     else
         MPIDI_OFI_init_seg_state(&p,
                                  result_addr,
                                  MPIDI_OFI_winfo_base(win, req->target_rank) + offset,
                                  result_count,
-                                 target_count, max_size, result_datatype, target_datatype);
+                                 target_count, result_bytes, target_bytes, max_size,
+                                 result_datatype, target_datatype);
     msg.desc = NULL;
     msg.addr = MPIDI_OFI_av_to_phys(addr);
     msg.context = NULL;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -94,14 +94,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
 #define FUNCNAME MPIDI_OFI_send_iov
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,        /* data_sz is passed in here for reusing */
                                                 int rank, uint64_t match_bits, MPIR_Comm * comm,
                                                 MPIDI_av_entry_t * addr, MPIR_Request * sreq,
                                                 MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL, *originv_huge = NULL;
-    size_t countp = MPIDI_OFI_count_iov(count, MPIDI_OFI_REQUEST(sreq, datatype), INT64_MAX);
+    size_t countp =
+        MPIDI_OFI_count_iov(count, MPIDI_OFI_REQUEST(sreq, datatype), data_sz, INT64_MAX);
     size_t omax = MPIDI_OFI_global.tx_iov_limit;
     size_t o_size = sizeof(struct iovec);
     size_t cur_o = 0;
@@ -287,7 +288,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 
     if (!dt_contig) {
         if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && data_sz <= MPIDI_OFI_global.max_msg_size) {
-            mpi_errno = MPIDI_OFI_send_iov(buf, count, rank, match_bits, comm, addr, sreq, dt_ptr);
+            mpi_errno =
+                MPIDI_OFI_send_iov(buf, count, data_sz, rank, match_bits, comm, addr, sreq, dt_ptr);
             if (mpi_errno == MPI_SUCCESS)       /* Send posted using iov */
                 goto fn_exit;
             else if (mpi_errno != MPIDI_OFI_SEND_NEEDS_PACK)

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -233,10 +233,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_UCX_DO_PUT);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count,
-                                        target_contig, target_bytes, target_true_lb);
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count,
-                                        origin_contig, origin_bytes, origin_true_lb);
+    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
+                                                      origin_count, target_count,
+                                                      origin_contig, target_contig,
+                                                      origin_bytes, target_bytes,
+                                                      origin_true_lb, target_true_lb);
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
     if (unlikely(origin_bytes == 0))
@@ -294,10 +295,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_UCX_DO_GET);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    MPIDI_Datatype_check_contig_size_lb(target_datatype, target_count,
-                                        target_contig, target_bytes, target_true_lb);
-    MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count,
-                                        origin_contig, origin_bytes, origin_true_lb);
+    MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
+                                                      origin_count, target_count,
+                                                      origin_contig, target_contig,
+                                                      origin_bytes, target_bytes,
+                                                      origin_true_lb, target_true_lb);
     MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
     if (unlikely(origin_bytes == 0))

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -298,6 +298,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
                                         target_contig, target_bytes, target_true_lb);
     MPIDI_Datatype_check_contig_size_lb(origin_datatype, origin_count,
                                         origin_contig, origin_bytes, origin_true_lb);
+    MPIR_ERR_CHKANDJUMP((origin_bytes != target_bytes), mpi_errno, MPI_ERR_SIZE, "**rmasize");
 
     if (unlikely(origin_bytes == 0))
         goto fn_exit;

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -116,8 +116,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
 
-    MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_data_sz);
-    MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
+    MPIDI_Datatype_check_origin_target_size(origin_datatype, target_datatype,
+                                            origin_count, target_count,
+                                            origin_data_sz, target_data_sz);
     if (origin_data_sz == 0 || target_data_sz == 0)
         goto fn_exit;
 
@@ -165,8 +166,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
     if (target_rank == MPI_PROC_NULL)
         goto fn_exit;
 
-    MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_data_sz);
-    MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
+    MPIDI_Datatype_check_origin_target_size(origin_datatype, target_datatype,
+                                            origin_count, target_count,
+                                            origin_data_sz, target_data_sz);
     if (origin_data_sz == 0 || target_data_sz == 0)
         goto fn_exit;
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -246,193 +246,166 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_WIN_HASH_CLEAR);
 }
 
-#define MPIDI_Datatype_get_info(_count, _datatype,              \
-                                _dt_contig_out, _data_sz_out,   \
-                                _dt_ptr, _dt_true_lb)           \
+#define MPIDI_Datatype_get_info(count_, datatype_,              \
+                                dt_contig_out_, data_sz_out_,   \
+                                dt_ptr_, dt_true_lb_)           \
     do {                                                        \
-        if (IS_BUILTIN(_datatype))                              \
-        {                                                       \
-            (_dt_ptr)        = NULL;                            \
-            (_dt_contig_out) = TRUE;                            \
-            (_dt_true_lb)    = 0;                               \
-            (_data_sz_out)   = (size_t)(_count) *               \
-                MPIR_Datatype_get_basic_size(_datatype);        \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));      \
-            if (_dt_ptr)                                        \
+        if (IS_BUILTIN(datatype_)) {                            \
+            (dt_ptr_)        = NULL;                            \
+            (dt_contig_out_) = TRUE;                            \
+            (dt_true_lb_)    = 0;                               \
+            (data_sz_out_)   = (size_t)(count_) *               \
+                MPIR_Datatype_get_basic_size(datatype_);        \
+        } else {                                                \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
+            if (dt_ptr_)                                        \
             {                                                   \
-                (_dt_contig_out) = (_dt_ptr)->is_contig;        \
-                (_dt_true_lb)    = (_dt_ptr)->true_lb;          \
-                (_data_sz_out)   = (size_t)(_count) *           \
-                    (_dt_ptr)->size;                            \
+                (dt_contig_out_) = (dt_ptr_)->is_contig;        \
+                (dt_true_lb_)    = (dt_ptr_)->true_lb;          \
+                (data_sz_out_)   = (size_t)(count_) *           \
+                    (dt_ptr_)->size;                            \
             }                                                   \
             else                                                \
             {                                                   \
-                (_dt_contig_out) = 1;                           \
-                (_dt_true_lb)    = 0;                           \
-                (_data_sz_out)   = 0;                           \
+                (dt_contig_out_) = 1;                           \
+                (dt_true_lb_)    = 0;                           \
+                (data_sz_out_)   = 0;                           \
             }                                                   \
         }                                                       \
     } while (0)
 
-#define MPIDI_Datatype_get_size_dt_ptr(_count, _datatype,       \
-                                       _data_sz_out, _dt_ptr)   \
+#define MPIDI_Datatype_get_size_dt_ptr(count_, datatype_,       \
+                                       data_sz_out_, dt_ptr_)   \
     do {                                                        \
-        if (IS_BUILTIN(_datatype))                              \
-        {                                                       \
-            (_dt_ptr)        = NULL;                            \
-            (_data_sz_out)   = (size_t)(_count) *               \
-                MPIR_Datatype_get_basic_size(_datatype);        \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));      \
-            (_data_sz_out)   = (_dt_ptr) ? (size_t)(_count) *   \
-                (_dt_ptr)->size : 0;                            \
+        if (IS_BUILTIN(datatype_)) {                            \
+            (dt_ptr_)        = NULL;                            \
+            (data_sz_out_)   = (size_t)(count_) *               \
+                MPIR_Datatype_get_basic_size(datatype_);        \
+        } else {                                                \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
+            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *   \
+                (dt_ptr_)->size : 0;                            \
         }                                                       \
     } while (0)
 
-#define MPIDI_Datatype_check_contig(_datatype,_dt_contig_out)           \
+#define MPIDI_Datatype_check_contig(datatype_,dt_contig_out_)           \
     do {                                                                \
-        if (IS_BUILTIN(_datatype))                                      \
-        {                                                               \
-            (_dt_contig_out) = TRUE;                                    \
-        }                                                               \
-        else                                                            \
-        {                                                               \
-            MPIR_Datatype *_dt_ptr;                                     \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));              \
-            (_dt_contig_out) = (_dt_ptr) ? (_dt_ptr)->is_contig : 1;    \
-        }                                                               \
-    } while (0)
-
-#define MPIDI_Datatype_check_contig_size(_datatype,_count,      \
-                                         _dt_contig_out,        \
-                                         _data_sz_out)          \
-    do {                                                        \
-        if (IS_BUILTIN(_datatype))                              \
-        {                                                       \
-            (_dt_contig_out) = TRUE;                            \
-            (_data_sz_out)   = (size_t)(_count) *               \
-                MPIR_Datatype_get_basic_size(_datatype);        \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            MPIR_Datatype *_dt_ptr;                             \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));      \
-            if (_dt_ptr)                                        \
-            {                                                   \
-                (_dt_contig_out) = (_dt_ptr)->is_contig;        \
-                (_data_sz_out)   = (size_t)(_count) *           \
-                    (_dt_ptr)->size;                            \
-            }                                                   \
-            else                                                \
-            {                                                   \
-                (_dt_contig_out) = 1;                           \
-                (_data_sz_out)   = 0;                           \
-            }                                                   \
-        }                                                       \
-    } while (0)
-
-#define MPIDI_Datatype_check_size(_datatype,_count,_data_sz_out)        \
-    do {                                                                \
-        if (IS_BUILTIN(_datatype))                                      \
-        {                                                               \
-            (_data_sz_out)   = (size_t)(_count) *                       \
-                MPIR_Datatype_get_basic_size(_datatype);                \
-        }                                                               \
-        else                                                            \
-        {                                                               \
-            MPIR_Datatype *_dt_ptr;                                     \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));              \
-            (_data_sz_out)   = (_dt_ptr) ? (size_t)(_count) *           \
-                (_dt_ptr)->size : 0;                                    \
-        }                                                               \
-    } while (0)
-
-#define MPIDI_Datatype_check_size_lb(_datatype,_count,_data_sz_out,     \
-                                     _dt_true_lb)                       \
-    do {                                                                \
-        if (IS_BUILTIN(_datatype)) {                                    \
-            (_data_sz_out)   = (size_t)(_count) *                       \
-                MPIR_Datatype_get_basic_size(_datatype);                \
-            (_dt_true_lb)    = 0;                                       \
+        if (IS_BUILTIN(datatype_)) {                                    \
+            (dt_contig_out_) = TRUE;                                    \
         } else {                                                        \
-            MPIR_Datatype *_dt_ptr;                                     \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));              \
-            (_data_sz_out)   = (_dt_ptr) ? (size_t)(_count) *           \
-                (_dt_ptr)->size : 0;                                    \
-            (_dt_true_lb)    = (_dt_ptr) ? (_dt_ptr)->true_lb : 0;      \
+            MPIR_Datatype *dt_ptr_;                                     \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));              \
+            (dt_contig_out_) = (dt_ptr_) ? (dt_ptr_)->is_contig : 1;    \
         }                                                               \
     } while (0)
 
-#define MPIDI_Datatype_check_contig_size_lb(_datatype,_count,   \
-                                            _dt_contig_out,     \
-                                            _data_sz_out,       \
-                                            _dt_true_lb)        \
+#define MPIDI_Datatype_check_contig_size(datatype_,count_,      \
+                                         dt_contig_out_,        \
+                                         data_sz_out_)          \
     do {                                                        \
-        if (IS_BUILTIN(_datatype))                              \
-        {                                                       \
-            (_dt_contig_out) = TRUE;                            \
-            (_data_sz_out)   = (size_t)(_count) *               \
-                MPIR_Datatype_get_basic_size(_datatype);        \
-            (_dt_true_lb)    = 0;                               \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            MPIR_Datatype *_dt_ptr;                             \
-            MPIR_Datatype_get_ptr((_datatype), (_dt_ptr));      \
-            if (_dt_ptr)                                        \
-            {                                                   \
-                (_dt_contig_out) = (_dt_ptr)->is_contig;        \
-                (_data_sz_out)   = (size_t)(_count) *           \
-                    (_dt_ptr)->size;                            \
-                (_dt_true_lb)    = (_dt_ptr)->true_lb;          \
+        if (IS_BUILTIN(datatype_)) {                            \
+            (dt_contig_out_) = TRUE;                            \
+            (data_sz_out_)   = (size_t)(count_) *               \
+                MPIR_Datatype_get_basic_size(datatype_);        \
+        } else {                                                \
+            MPIR_Datatype *dt_ptr_;                             \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
+            if (dt_ptr_) {                                      \
+                (dt_contig_out_) = (dt_ptr_)->is_contig;        \
+                (data_sz_out_)   = (size_t)(count_) *           \
+                    (dt_ptr_)->size;                            \
+            } else {                                            \
+                (dt_contig_out_) = 1;                           \
+                (data_sz_out_)   = 0;                           \
             }                                                   \
-            else                                                \
-            {                                                   \
-                (_dt_contig_out) = 1;                           \
-                (_data_sz_out)   = 0;                           \
-                (_dt_true_lb)    = 0;                           \
+        }                                                       \
+    } while (0)
+
+#define MPIDI_Datatype_check_size(datatype_,count_,data_sz_out_)        \
+    do {                                                                \
+        if (IS_BUILTIN(datatype_)) {                                    \
+            (data_sz_out_)   = (size_t)(count_) *                       \
+                MPIR_Datatype_get_basic_size(datatype_);                \
+        } else {                                                        \
+            MPIR_Datatype *dt_ptr_;                                     \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));              \
+            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *           \
+                (dt_ptr_)->size : 0;                                    \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_Datatype_check_size_lb(datatype_,count_,data_sz_out_,     \
+                                     dt_true_lb_)                       \
+    do {                                                                \
+        if (IS_BUILTIN(datatype_)) {                                    \
+            (data_sz_out_)   = (size_t)(count_) *                       \
+                MPIR_Datatype_get_basic_size(datatype_);                \
+            (dt_true_lb_)    = 0;                                       \
+        } else {                                                        \
+            MPIR_Datatype *dt_ptr_;                                     \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));              \
+            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *           \
+                (dt_ptr_)->size : 0;                                    \
+            (dt_true_lb_)    = (dt_ptr_) ? (dt_ptr_)->true_lb : 0;      \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_Datatype_check_contig_size_lb(datatype_,count_,   \
+                                            dt_contig_out_,     \
+                                            data_sz_out_,       \
+                                            dt_true_lb_)        \
+    do {                                                        \
+        if (IS_BUILTIN(datatype_)) {                            \
+            (dt_contig_out_) = TRUE;                            \
+            (data_sz_out_)   = (size_t)(count_) *               \
+                MPIR_Datatype_get_basic_size(datatype_);        \
+            (dt_true_lb_)    = 0;                               \
+        } else {                                                \
+            MPIR_Datatype *dt_ptr_;                             \
+            MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
+            if (dt_ptr_) {                                      \
+                (dt_contig_out_) = (dt_ptr_)->is_contig;        \
+                (data_sz_out_)   = (size_t)(count_) *           \
+                    (dt_ptr_)->size;                            \
+                (dt_true_lb_)    = (dt_ptr_)->true_lb;          \
+            } else {                                            \
+                (dt_contig_out_) = 1;                           \
+                (data_sz_out_)   = 0;                           \
+                (dt_true_lb_)    = 0;                           \
             }                                                   \
         }                                                       \
     } while (0)
 
 /* Check both origin|target buffers' size. */
-#define MPIDI_Datatype_check_origin_target_size(_o_datatype, _t_datatype,         \
-                                                _o_count, _t_count,               \
-                                                _o_data_sz_out, _t_data_sz_out)   \
+#define MPIDI_Datatype_check_origin_target_size(o_datatype_, t_datatype_,         \
+                                                o_count_, t_count_,               \
+                                                o_data_sz_out_, t_data_sz_out_)   \
     do {                                                                          \
-        MPIDI_Datatype_check_size(_o_datatype, _o_count, _o_data_sz_out);         \
-        if (_t_datatype == _o_datatype && _t_count == _o_count)                   \
-        {                                                                         \
-            _t_data_sz_out = _o_data_sz_out;                                      \
-        }                                                                         \
-        else                                                                      \
-        {                                                                         \
-            MPIDI_Datatype_check_size(_t_datatype, _t_count, _t_data_sz_out);     \
+        MPIDI_Datatype_check_size(o_datatype_, o_count_, o_data_sz_out_);         \
+        if (t_datatype_ == o_datatype_ && t_count_ == o_count_) {                 \
+            t_data_sz_out_ = o_data_sz_out_;                                      \
+        } else {                                                                  \
+            MPIDI_Datatype_check_size(t_datatype_, t_count_, t_data_sz_out_);     \
         }                                                                         \
     } while (0)
 
 /* Check both origin|target buffers' size, contig and lb. */
-#define MPIDI_Datatype_check_origin_target_contig_size_lb(_o_datatype, _t_datatype,             \
-                                                          _o_count, _t_count,                   \
-                                                          _o_dt_contig_out, _t_dt_contig_out,   \
-                                                          _o_data_sz_out, _t_data_sz_out,       \
-                                                          _o_dt_true_lb, _t_dt_true_lb)         \
+#define MPIDI_Datatype_check_origin_target_contig_size_lb(o_datatype_, t_datatype_,             \
+                                                          o_count_, t_count_,                   \
+                                                          o_dt_contig_out_, t_dt_contig_out_,   \
+                                                          o_data_sz_out_, t_data_sz_out_,       \
+                                                          o_dt_true_lb_, t_dt_true_lb_)         \
     do {                                                                                        \
-        MPIDI_Datatype_check_contig_size_lb(_o_datatype, _o_count, _o_dt_contig_out,            \
-                                            _o_data_sz_out, _o_dt_true_lb);                     \
-        if (_t_datatype == _o_datatype && _t_count == _o_count) {                               \
-            _t_dt_contig_out = _o_dt_contig_out;                                                \
-            _t_data_sz_out = _o_data_sz_out;                                                    \
-            _t_dt_true_lb = _o_dt_true_lb;                                                      \
+        MPIDI_Datatype_check_contig_size_lb(o_datatype_, o_count_, o_dt_contig_out_,            \
+                                            o_data_sz_out_, o_dt_true_lb_);                     \
+        if (t_datatype_ == o_datatype_ && t_count_ == o_count_) {                               \
+            t_dt_contig_out_ = o_dt_contig_out_;                                                \
+            t_data_sz_out_ = o_data_sz_out_;                                                    \
+            t_dt_true_lb_ = o_dt_true_lb_;                                                      \
         }                                                                                       \
         else {                                                                                  \
-            MPIDI_Datatype_check_contig_size_lb(_t_datatype, _t_count, _t_dt_contig_out,        \
-                                                _t_data_sz_out, _t_dt_true_lb);                 \
+            MPIDI_Datatype_check_contig_size_lb(t_datatype_, t_count_, t_dt_contig_out_,        \
+                                                t_data_sz_out_, t_dt_true_lb_);                 \
         }                                                                                       \
     } while (0)
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -400,6 +400,42 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
         }                                                       \
     } while (0)
 
+/* Check both origin|target buffers' size. */
+#define MPIDI_Datatype_check_origin_target_size(_o_datatype, _t_datatype,         \
+                                                _o_count, _t_count,               \
+                                                _o_data_sz_out, _t_data_sz_out)   \
+    do {                                                                          \
+        MPIDI_Datatype_check_size(_o_datatype, _o_count, _o_data_sz_out);         \
+        if (_t_datatype == _o_datatype && _t_count == _o_count)                   \
+        {                                                                         \
+            _t_data_sz_out = _o_data_sz_out;                                      \
+        }                                                                         \
+        else                                                                      \
+        {                                                                         \
+            MPIDI_Datatype_check_size(_t_datatype, _t_count, _t_data_sz_out);     \
+        }                                                                         \
+    } while (0)
+
+/* Check both origin|target buffers' size, contig and lb. */
+#define MPIDI_Datatype_check_origin_target_contig_size_lb(_o_datatype, _t_datatype,             \
+                                                          _o_count, _t_count,                   \
+                                                          _o_dt_contig_out, _t_dt_contig_out,   \
+                                                          _o_data_sz_out, _t_data_sz_out,       \
+                                                          _o_dt_true_lb, _t_dt_true_lb)         \
+    do {                                                                                        \
+        MPIDI_Datatype_check_contig_size_lb(_o_datatype, _o_count, _o_dt_contig_out,            \
+                                            _o_data_sz_out, _o_dt_true_lb);                     \
+        if (_t_datatype == _o_datatype && _t_count == _o_count) {                               \
+            _t_dt_contig_out = _o_dt_contig_out;                                                \
+            _t_data_sz_out = _o_data_sz_out;                                                    \
+            _t_dt_true_lb = _o_dt_true_lb;                                                      \
+        }                                                                                       \
+        else {                                                                                  \
+            MPIDI_Datatype_check_contig_size_lb(_t_datatype, _t_count, _t_dt_contig_out,        \
+                                                _t_data_sz_out, _t_dt_true_lb);                 \
+        }                                                                                       \
+    } while (0)
+
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)        \
     do {                                                                \
         (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);         \


### PR DESCRIPTION
This PR mainly includes two fixes that try to remove the redundant data checks in ch4 RMA paths: 

(1) The `MPIDI_(OFI|UCX|POSIX)_do_(put|get)` have two checks on origin and target infos, respectively. However, in the more common case where the origin and target buffers have the same datatype and size, one of the checks can be saved (about 13 - 14 instructions). 

(2) The size of origin/target/result buffers are calculated in `MPIDI_OFI_do(put|get|...)` for initial sanity checks, but are calculated again in various occasions such as counting `iov` and initiating `seg state`. So we may reuse these data sizes. Note that besides RMA operations, MPIDI_OFI_send is also affected because it eventually uses `MPIDI_OFI_count_iovecs`.