### PR TITLE
Move the handling of MPI_PROC_NULL out from MPID for RMA

### DIFF
--- a/src/mpi/pt2pt/bsend.c
+++ b/src/mpi/pt2pt/bsend.c
@@ -147,6 +147,11 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Bsend_isend(buf, count, datatype, dest, tag, comm_ptr, BSEND, &request_ptr);

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -216,6 +216,15 @@ int MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        MPIR_Request *request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+        MPIR_ERR_CHKANDSTMT(request_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPIR_Ibsend_impl(buf, count, datatype, dest, tag, comm_ptr, request);

--- a/src/mpi/pt2pt/improbe.c
+++ b/src/mpi/pt2pt/improbe.c
@@ -91,6 +91,14 @@ int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message * mes
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (source == MPI_PROC_NULL) {
+        MPIR_Status_set_procnull(status);
+        *flag = TRUE;
+        *message = MPI_MESSAGE_NO_PROC;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     *message = MPI_MESSAGE_NULL;
@@ -99,12 +107,8 @@ int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message * mes
         MPIR_ERR_POP(mpi_errno);
 
     if (*flag) {
-        if (msgp == NULL) {
-            MPIR_Assert(source == MPI_PROC_NULL);
-            *message = MPI_MESSAGE_NO_PROC;
-        } else {
-            *message = msgp->handle;
-        }
+        MPIR_Assert(msgp != NULL);
+        *message = msgp->handle;
     }
 
     /* ... end of body of routine ... */

--- a/src/mpi/pt2pt/iprobe.c
+++ b/src/mpi/pt2pt/iprobe.c
@@ -97,6 +97,13 @@ int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status * statu
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (source == MPI_PROC_NULL) {
+        MPIR_Status_set_procnull(status);
+        *flag = TRUE;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     /* FIXME: Is this correct for intercomms? */

--- a/src/mpi/pt2pt/irecv.c
+++ b/src/mpi/pt2pt/irecv.c
@@ -119,6 +119,16 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(source == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RECV);
+        MPIR_ERR_CHKANDSTMT((request_ptr) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        MPIR_Status_set_procnull(&request_ptr->status);
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr,

--- a/src/mpi/pt2pt/irsend.c
+++ b/src/mpi/pt2pt/irsend.c
@@ -120,6 +120,15 @@ int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+        MPIR_ERR_CHKANDSTMT((request_ptr) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Irsend(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/pt2pt/isend.c
+++ b/src/mpi/pt2pt/isend.c
@@ -118,6 +118,15 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+        MPIR_ERR_CHKANDSTMT(request_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/pt2pt/issend.c
+++ b/src/mpi/pt2pt/issend.c
@@ -119,6 +119,15 @@ int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
+        MPIR_ERR_CHKANDSTMT((request_ptr) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Issend(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/pt2pt/mprobe.c
+++ b/src/mpi/pt2pt/mprobe.c
@@ -87,6 +87,13 @@ int MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message * message, MPI_St
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (source == MPI_PROC_NULL) {
+        MPIR_Status_set_procnull(status);
+        *message = MPI_MESSAGE_NO_PROC;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     *message = MPI_MESSAGE_NULL;
@@ -94,12 +101,8 @@ int MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message * message, MPI_St
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (msgp == NULL) {
-        MPIR_Assert(source == MPI_PROC_NULL);
-        *message = MPI_MESSAGE_NO_PROC;
-    } else {
-        *message = msgp->handle;
-    }
+    MPIR_Assert(msgp != NULL);
+    *message = msgp->handle;
 
     /* ... end of body of routine ... */
 

--- a/src/mpi/pt2pt/probe.c
+++ b/src/mpi/pt2pt/probe.c
@@ -93,6 +93,12 @@ int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(source == MPI_PROC_NULL)) {
+        MPIR_Status_set_procnull(status);
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Probe(source, tag, comm_ptr, MPIR_CONTEXT_INTRA_PT2PT, status);

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -127,6 +127,12 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(source == MPI_PROC_NULL)) {
+        MPIR_Status_set_procnull(status);
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     /* MT: Note that MPID_Recv may release the SINGLE_CS if it

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -114,6 +114,11 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ... */
 
     mpi_errno = MPID_Rsend(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -119,6 +119,11 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Send(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -113,6 +113,11 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(dest == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr,

--- a/src/mpi/rma/accumulate.c
+++ b/src/mpi/rma/accumulate.c
@@ -142,6 +142,11 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Accumulate(origin_addr, origin_count,

--- a/src/mpi/rma/compare_and_swap.c
+++ b/src/mpi/rma/compare_and_swap.c
@@ -128,6 +128,11 @@ int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Compare_and_swap(origin_addr,

--- a/src/mpi/rma/fetch_and_op.c
+++ b/src/mpi/rma/fetch_and_op.c
@@ -142,6 +142,11 @@ int MPI_Fetch_and_op(const void *origin_addr, void *result_addr,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Fetch_and_op(origin_addr,

--- a/src/mpi/rma/get.c
+++ b/src/mpi/rma/get.c
@@ -135,6 +135,11 @@ int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Get(origin_addr, origin_count, origin_datatype,

--- a/src/mpi/rma/get_accumulate.c
+++ b/src/mpi/rma/get_accumulate.c
@@ -194,6 +194,11 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Get_accumulate(origin_addr, origin_count,

--- a/src/mpi/rma/put.c
+++ b/src/mpi/rma/put.c
@@ -135,6 +135,11 @@ int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Put(origin_addr, origin_count, origin_datatype,

--- a/src/mpi/rma/raccumulate.c
+++ b/src/mpi/rma/raccumulate.c
@@ -156,6 +156,15 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
+        MPIR_ERR_CHKANDSTMT(request_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Raccumulate(origin_addr, origin_count,

--- a/src/mpi/rma/rget.c
+++ b/src/mpi/rma/rget.c
@@ -149,6 +149,14 @@ int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
+        MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Rget(origin_addr, origin_count, origin_datatype,

--- a/src/mpi/rma/rget_accumulate.c
+++ b/src/mpi/rma/rget_accumulate.c
@@ -183,6 +183,15 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
+        MPIR_ERR_CHKANDSTMT(request_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Rget_accumulate(origin_addr, origin_count,

--- a/src/mpi/rma/rput.c
+++ b/src/mpi/rma/rput.c
@@ -151,6 +151,15 @@ int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Create a completed request and return immediately for dummy process */
+    if (unlikely(target_rank == MPI_PROC_NULL)) {
+        request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
+        MPIR_ERR_CHKANDSTMT(request_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
+                            "**nomemreq");
+        *request = request_ptr->handle;
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Rput(origin_addr, origin_count, origin_datatype,

--- a/src/mpi/rma/win_flush.c
+++ b/src/mpi/rma/win_flush.c
@@ -98,6 +98,11 @@ int MPI_Win_flush(int rank, MPI_Win win)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (rank == MPI_PROC_NULL) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Win_flush(rank, win_ptr);

--- a/src/mpi/rma/win_flush_local.c
+++ b/src/mpi/rma/win_flush_local.c
@@ -101,6 +101,11 @@ int MPI_Win_flush_local(int rank, MPI_Win win)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (rank == MPI_PROC_NULL) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Win_flush_local(rank, win_ptr);

--- a/src/mpi/rma/win_lock.c
+++ b/src/mpi/rma/win_lock.c
@@ -132,6 +132,11 @@ int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (rank == MPI_PROC_NULL) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Win_lock(lock_type, rank, assert, win_ptr);

--- a/src/mpi/rma/win_unlock.c
+++ b/src/mpi/rma/win_unlock.c
@@ -93,6 +93,11 @@ int MPI_Win_unlock(int rank, MPI_Win win)
     }
 #endif /* HAVE_ERROR_CHECKING */
 
+    /* Return immediately for dummy process */
+    if (rank == MPI_PROC_NULL) {
+        goto fn_exit;
+    }
+
     /* ... body of routine ...  */
 
     mpi_errno = MPID_Win_unlock(rank, win_ptr);

--- a/src/mpid/ch3/src/ch3u_recvq.c
+++ b/src/mpid/ch3/src/ch3u_recvq.c
@@ -843,7 +843,7 @@ static inline int req_uses_vc(const MPIR_Request* req, const MPIDI_VC_t *vc)
 
 /* This dequeues req from the posted recv queue, set req's error code to comm_fail, and updates the req pointer.
    Note that this creates a new error code if one hasn't already been created (i.e., if *error is MPI_SUCCESS). */
-static inline void dequeue_and_set_error(MPIR_Request **req,  MPIR_Request *prev_req, MPIR_Request **head, MPIR_Request **tail, int *error, int rank)
+static inline void dequeue_and_set_error(MPIR_Request **req,  MPIR_Request *prev_req, MPIR_Request **head, MPIR_Request **tail, int *error)
 {
     MPIR_Request *next = (*req)->dev.next;
     
@@ -910,7 +910,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                         "cleaning up unexpected pt2pt pkt rank=%d tag=%d contextid=%d",
                         rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-            dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+            dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
             continue;
         }
 
@@ -922,7 +922,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                             "cleaning up unexpected collective pkt rank=%d tag=%d contextid=%d",
                             rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+                dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
                 continue;
             }
         }
@@ -938,7 +938,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up unexpected pt2pt pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
                     continue;
                 }
             }
@@ -952,7 +952,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up unexpected collective pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
                     continue;
                 }
             }
@@ -966,7 +966,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up unexpected pt2pt pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
                     continue;
                 }
             }
@@ -980,7 +980,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up unexpected collective pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_unexpected_head, &recvq_unexpected_tail, &error);
                     continue;
                 }
             }
@@ -1002,7 +1002,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
             MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                         "cleaning up posted pt2pt pkt rank=%d tag=%d contextid=%d",
                         rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-            dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+            dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
             continue;
         }
 
@@ -1014,7 +1014,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                 MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                             "cleaning up posted collective pkt rank=%d tag=%d contextid=%d",
                             rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+                dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
                 continue;
             }
         }
@@ -1030,7 +1030,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up posted pt2pt pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
                     continue;
                 }
             }
@@ -1044,7 +1044,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up posted collective pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
                     continue;
                 }
             }
@@ -1058,7 +1058,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up posted pt2pt pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
                     continue;
                 }
             }
@@ -1072,7 +1072,7 @@ int MPIDI_CH3U_Clean_recvq(MPIR_Comm *comm_ptr)
                     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                                 "cleaning up posted collective pkt rank=%d tag=%d contextid=%d",
                                 rreq->dev.match.parts.rank, rreq->dev.match.parts.tag, rreq->dev.match.parts.context_id));
-                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+                    dequeue_and_set_error(&rreq, prev_rreq, &recvq_posted_head, &recvq_posted_tail, &error);
                     continue;
                 }
             }
@@ -1106,7 +1106,7 @@ int MPIDI_CH3U_Complete_posted_with_error(MPIDI_VC_t *vc)
     prev_req = NULL;
     while (req) {
         if (req->dev.match.parts.rank != MPI_ANY_SOURCE && req_uses_vc(req, vc)) {
-            dequeue_and_set_error(&req, prev_req, &recvq_posted_head, &recvq_posted_tail, &error, MPI_PROC_NULL);
+            dequeue_and_set_error(&req, prev_req, &recvq_posted_head, &recvq_posted_tail, &error);
         } else {
             prev_req = req;
             req = req->dev.next;

--- a/src/mpid/ch3/src/ch3u_rma_ops.c
+++ b/src/mpid/ch3/src/ch3u_rma_ops.c
@@ -53,10 +53,6 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
-
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     if (data_sz == 0) {
@@ -226,10 +222,6 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
-
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, orig_data_sz, dtp,
                             dt_true_lb);
 
@@ -391,10 +383,6 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
 
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
-
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
 
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
@@ -600,10 +588,6 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
 
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
-
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
 
     MPIDI_Datatype_get_info(target_count, target_datatype, dt_contig, target_data_sz, dtp,
                             dt_true_lb);
@@ -940,10 +924,6 @@ int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
-
     rank = win_ptr->comm_ptr->rank;
 
     if (win_ptr->shm_allocated == TRUE && target_rank != rank &&
@@ -1069,10 +1049,6 @@ int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
 
     MPIR_ERR_CHKANDJUMP(win_ptr->states.access_state == MPIDI_RMA_NONE,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
-
-    if (target_rank == MPI_PROC_NULL) {
-        goto fn_exit;
-    }
 
     rank = win_ptr->comm_ptr->rank;
 

--- a/src/mpid/ch3/src/ch3u_rma_reqops.c
+++ b/src/mpid/ch3/src/ch3u_rma_reqops.c
@@ -40,7 +40,7 @@ int MPID_Rput(const void *origin_addr, int origin_count,
     MPIR_Object_set_ref(ureq, 2);
 
     /* Enqueue or perform the RMA operation */
-    if (target_rank != MPI_PROC_NULL && data_sz != 0) {
+    if (data_sz != 0) {
         mpi_errno = MPIDI_CH3I_Put(origin_addr, origin_count,
                                    origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win_ptr, ureq);
@@ -98,7 +98,7 @@ int MPID_Rget(void *origin_addr, int origin_count,
     MPIR_Object_set_ref(ureq, 2);
 
     /* Enqueue or perform the RMA operation */
-    if (target_rank != MPI_PROC_NULL && data_sz != 0) {
+    if (data_sz != 0) {
         mpi_errno = MPIDI_CH3I_Get(origin_addr, origin_count,
                                    origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win_ptr, ureq);
@@ -156,7 +156,7 @@ int MPID_Raccumulate(const void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     /* Enqueue or perform the RMA operation */
-    if (target_rank != MPI_PROC_NULL && data_sz != 0) {
+    if (data_sz != 0) {
         mpi_errno = MPIDI_CH3I_Accumulate(origin_addr, origin_count,
                                           origin_datatype, target_rank,
                                           target_disp, target_count,
@@ -217,7 +217,7 @@ int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, trg_data_sz, dtp, dt_true_lb);
 
     /* Enqueue or perform the RMA operation */
-    if (target_rank != MPI_PROC_NULL && (data_sz != 0 || trg_data_sz != 0)) {
+    if (data_sz != 0 || trg_data_sz != 0) {
         mpi_errno = MPIDI_CH3I_Get_accumulate(origin_addr, origin_count,
                                               origin_datatype, result_addr,
                                               result_count, result_datatype,

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -1111,13 +1111,11 @@ int MPID_Win_lock(int lock_type, int dest, int assert, MPIR_Win * win_ptr)
                             mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
     }
 
-    if (dest != MPI_PROC_NULL) {
-        /* check if we lock the same target window more than once. */
-        mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, dest, &target);
-        if (mpi_errno != MPI_SUCCESS)
-            MPIR_ERR_POP(mpi_errno);
-        MPIR_ERR_CHKANDJUMP(target != NULL, mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
-    }
+    /* check if we lock the same target window more than once. */
+    mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, dest, &target);
+    if (mpi_errno != MPI_SUCCESS)
+        MPIR_ERR_POP(mpi_errno);
+    MPIR_ERR_CHKANDJUMP(target != NULL, mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
     /* Error handling is finished. */
 
@@ -1126,9 +1124,6 @@ int MPID_Win_lock(int lock_type, int dest, int assert, MPIR_Win * win_ptr)
         win_ptr->states.access_state = MPIDI_RMA_PER_TARGET;
     }
     win_ptr->lock_epoch_count++;
-
-    if (dest == MPI_PROC_NULL)
-        goto finish_lock;
 
     if (win_ptr->shm_allocated == TRUE) {
         MPIDI_Comm_get_vc(win_ptr->comm_ptr, rank, &orig_vc);
@@ -1207,9 +1202,6 @@ int MPID_Win_unlock(int dest, MPIR_Win * win_ptr)
     if (win_ptr->shm_allocated) {
         OPA_read_write_barrier();
     }
-
-    if (dest == MPI_PROC_NULL)
-        goto finish_unlock;
 
     /* Find or recreate target. */
     mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, dest, &target);
@@ -1306,9 +1298,6 @@ int MPID_Win_flush(int dest, MPIR_Win * win_ptr)
         OPA_read_write_barrier();
     }
 
-    if (dest == MPI_PROC_NULL)
-        goto finish_flush;
-
     mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, dest, &target);
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -1392,9 +1381,6 @@ int MPID_Win_flush_local(int dest, MPIR_Win * win_ptr)
     if (win_ptr->shm_allocated) {
         OPA_read_write_barrier();
     }
-
-    if (dest == MPI_PROC_NULL)
-        goto fn_exit;
 
     mpi_errno = MPIDI_CH3I_Win_find_target(win_ptr, dest, &target);
     if (mpi_errno != MPI_SUCCESS)

--- a/src/mpid/ch3/src/mpid_improbe.c
+++ b/src/mpid/ch3/src/mpid_improbe.c
@@ -18,14 +18,6 @@ int MPID_Improbe(int source, int tag, MPIR_Comm *comm, int context_offset,
 
     *message = NULL;
 
-    if (source == MPI_PROC_NULL)
-    {
-        MPIR_Status_set_procnull(status);
-        *flag = TRUE;
-        *message = NULL; /* should be interpreted as MPI_MESSAGE_NO_PROC */
-        goto fn_exit;
-    }
-
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");

--- a/src/mpid/ch3/src/mpid_iprobe.c
+++ b/src/mpid/ch3/src/mpid_iprobe.c
@@ -19,15 +19,6 @@ int MPID_Iprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IPROBE);
 
-    if (source == MPI_PROC_NULL)
-    {
-	MPIR_Status_set_procnull(status);
-	/* We set the flag to true because an MPI_Recv with this rank will
-	   return immediately */
-	*flag = TRUE;
-	goto fn_exit;
-    }
-
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
             MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -21,12 +21,6 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 			"rank=%d, tag=%d, context=%d", 
 			rank, tag, comm->recvcontext_id + context_offset));
 
-    if (rank == MPI_PROC_NULL)
-    {
-        MPIDI_Request_create_null_rreq(rreq, mpi_errno, goto fn_fail);
-        goto fn_exit;
-    }
-
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
             MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -45,29 +45,19 @@ int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 	goto fn_exit;
     }
 
-    if (rank != MPI_PROC_NULL) {
-        MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
+    MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
 #ifdef ENABLE_COMM_OVERRIDES
-        /* this needs to come before the sreq is created, since the override
-         * function is responsible for creating its own request */
-        if (vc->comm_ops && vc->comm_ops->irsend)
-        {
-            mpi_errno = vc->comm_ops->irsend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
-            goto fn_exit;
-        }
-#endif
-        MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
-        MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
-        MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
-    } else {
-        /* sreq creation code is duplicated here, but it is better than add separate branch later. */
-        MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
-        MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
-        MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
-	MPIR_Object_set_ref(sreq, 1);
-        MPIR_cc_set(&sreq->cc, 0);
-	goto fn_exit;
+    /* this needs to come before the sreq is created, since the override
+     * function is responsible for creating its own request */
+    if (vc->comm_ops && vc->comm_ops->irsend)
+    {
+        mpi_errno = vc->comm_ops->irsend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
+        goto fn_exit;
     }
+#endif
+    MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
+    MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
+    MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
     
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 

--- a/src/mpid/ch3/src/mpid_isend.c
+++ b/src/mpid/ch3/src/mpid_isend.c
@@ -59,28 +59,19 @@ int MPID_Isend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 	goto fn_exit;
     }
 
-    if (rank != MPI_PROC_NULL) {
-        MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
+    MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
 #ifdef ENABLE_COMM_OVERRIDES
-        /* this needs to come before the sreq is created, since the override
-         * function is responsible for creating its own request */
-        if (vc->comm_ops && vc->comm_ops->isend)
-        {
-            mpi_errno = vc->comm_ops->isend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
-            goto fn_exit;
-        }
-#endif
+    /* this needs to come before the sreq is created, since the override
+     * function is responsible for creating its own request */
+    if (vc->comm_ops && vc->comm_ops->isend)
+    {
+        mpi_errno = vc->comm_ops->isend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
+        goto fn_exit;
     }
+#endif
 
     MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SEND);
-
-    if (rank == MPI_PROC_NULL)
-    {
-	MPIR_Object_set_ref(sreq, 1);
-        MPIR_cc_set(&sreq->cc, 0);
-	goto fn_exit;
-    }
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, 
 			    dt_true_lb);

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -44,29 +44,19 @@ int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, in
 	goto fn_exit;
     }
 
-    if (rank != MPI_PROC_NULL)
-    {
-       MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
-        /* this needs to come before the sreq is created, since the override */
-        /* function is responsible for creating its own request */       
+    MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
+     /* this needs to come before the sreq is created, since the override */
+     /* function is responsible for creating its own request */
 #ifdef ENABLE_COMM_OVERRIDES
-       if (vc->comm_ops && vc->comm_ops->issend)
-       {
-	  mpi_errno = vc->comm_ops->issend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
-	  goto fn_exit;
-       }
+    if (vc->comm_ops && vc->comm_ops->issend)
+    {
+       mpi_errno = vc->comm_ops->issend( vc, buf, count, datatype, rank, tag, comm, context_offset, &sreq);
+       goto fn_exit;
+    }
 #endif
-    }   
    
     MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SSEND);
-    
-    if (rank == MPI_PROC_NULL)
-    {
-	MPIR_Object_set_ref(sreq, 1);
-        MPIR_cc_set(&sreq->cc, 0);
-	goto fn_exit;
-    }
     
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     

--- a/src/mpid/ch3/src/mpid_mprobe.c
+++ b/src/mpid/ch3/src/mpid_mprobe.c
@@ -16,14 +16,6 @@ int MPID_Mprobe(int source, int tag, MPIR_Comm *comm, int context_offset,
 
     *message = NULL;
 
-    if (source == MPI_PROC_NULL)
-    {
-        MPIR_Status_set_procnull(status);
-        found = TRUE;
-        *message = NULL; /* should be interpreted as MPI_MESSAGE_NO_PROC */
-        goto fn_exit;
-    }
-
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked) {
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");

--- a/src/mpid/ch3/src/mpid_probe.c
+++ b/src/mpid/ch3/src/mpid_probe.c
@@ -16,12 +16,6 @@ int MPID_Probe(int source, int tag, MPIR_Comm * comm, int context_offset,
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROBE);
 
-    if (source == MPI_PROC_NULL)
-    {
-	MPIR_Status_set_procnull(status);
-	goto fn_exit;
-    }
-
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&
             MPIR_AGREE_TAG != MPIR_TAG_MASK_ERROR_BITS(tag & ~MPIR_TAG_COLL_BIT) &&

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -27,13 +27,6 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,
                       "rank=%d, tag=%d, context=%d", rank, tag,
 		      comm->recvcontext_id + context_offset));
-    
-    if (rank == MPI_PROC_NULL)
-    {
-	MPIR_Status_set_procnull(status);
-	rreq = NULL;
-	goto fn_exit;
-    }
 
     /* Check to make sure the communicator hasn't already been revoked */
     if (comm->revoked &&

--- a/src/mpid/ch3/src/mpid_rsend.c
+++ b/src/mpid/ch3/src/mpid_rsend.c
@@ -47,11 +47,6 @@ int MPID_Rsend(const void * buf, int count, MPI_Datatype datatype, int rank, int
 	goto fn_exit;
     }
 
-    if (rank == MPI_PROC_NULL)
-    {
-	goto fn_exit;
-    }
-
     MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
 
 #ifdef ENABLE_COMM_OVERRIDES

--- a/src/mpid/ch3/src/mpid_send.c
+++ b/src/mpid/ch3/src/mpid_send.c
@@ -60,11 +60,6 @@ int MPID_Send(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank,
 	goto fn_exit;
     }
 
-    if (rank == MPI_PROC_NULL)
-    {
-	goto fn_exit;
-    }
-
     MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
     MPIR_ERR_CHKANDJUMP1(vc->state == MPIDI_VC_STATE_MORIBUND, mpi_errno, MPIX_ERR_PROC_FAILED, "**comm_fail", "**comm_fail %d", rank);
 

--- a/src/mpid/ch3/src/mpid_ssend.c
+++ b/src/mpid/ch3/src/mpid_ssend.c
@@ -60,11 +60,6 @@ int MPID_Ssend(const void * buf, MPI_Aint count, MPI_Datatype datatype, int rank
 #	endif
 	goto fn_exit;
     }
-    
-    if (rank == MPI_PROC_NULL)
-    {
-	goto fn_exit;
-    }
 
     MPIDI_Comm_get_vc_set_active(comm, rank, &vc);
 

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -60,6 +60,10 @@ int MPID_Startall(int count, MPIR_Request * requests[])
     {
 	MPIR_Request * const preq = requests[i];
 
+        /* continue if the source/dest is MPI_PROC_NULL */
+        if (preq->dev.match.parts.rank == MPI_PROC_NULL)
+            continue;
+
 	/* FIXME: The odd 7th arg (match.context_id - comm->context_id) 
 	   is probably to get the context offset.  Do we really need the
 	   context offset? Is there any case where the offset isn't zero? */

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -183,14 +183,6 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
     }
 
     *request = rreq;
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        rreq->kind = MPIR_REQUEST_KIND__RECV;
-        rreq->status.MPI_ERROR = MPI_SUCCESS;
-        rreq->status.MPI_SOURCE = rank;
-        rreq->status.MPI_TAG = tag;
-        MPID_Request_complete(rreq);
-        goto fn_exit;
-    }
 
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     mpi_errno = MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -30,24 +30,6 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_AM_ISEND_IMPL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_AM_ISEND_IMPL);
 
-    /* If the message is going to MPI_PROC_NULL, we still need to create and complete the request so
-     * we have something we can pass back up the call stack to track the request status. */
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        /* for blocking calls, we directly complete the request */
-        if (!is_blocking || sreq != NULL) {
-            if (sreq == NULL) {
-                *request = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
-                MPIR_ERR_CHKANDSTMT((*request) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                                    "**nomemreq");
-            } else {
-                MPIDIG_request_init(sreq, MPIR_REQUEST_KIND__SEND);
-            }
-            MPID_Request_complete((*request));
-        }
-        goto fn_exit;
-    }
-
     if (sreq == NULL) {
         sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
         MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -399,8 +399,6 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_PUT);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto null_op_exit;
 
     MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
                                                       origin_count, target_count,
@@ -588,8 +586,6 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto null_op_exit;
 
     MPIDI_Datatype_check_origin_target_contig_size_lb(origin_datatype, target_datatype,
                                                       origin_count, target_count,
@@ -806,8 +802,6 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto fn_exit;
 
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
 
@@ -905,8 +899,6 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_ACCUMULATE);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto null_op_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
@@ -1051,8 +1043,6 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_GET_ACCUMULATE);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto null_op_exit;
 
     MPIDI_Datatype_check_size(target_datatype, target_count, target_bytes);
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_bytes);
@@ -1339,8 +1329,6 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     }
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (unlikely(target_rank == MPI_PROC_NULL))
-        goto fn_exit;
 
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -148,8 +148,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_is_reachable_win(MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_is_reachable_target(int rank, MPIR_Win * win)
 {
     /* zero win target does not have rkey. */
-    return MPIDI_UCX_is_reachable_win(win) && rank != MPI_PROC_NULL &&
-        MPIDI_UCX_WIN_INFO(win, rank).rkey != NULL;
+    return MPIDI_UCX_is_reachable_win(win) && MPIDI_UCX_WIN_INFO(win, rank).rkey != NULL;
 }
 
 #endif /* UCX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -103,8 +103,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_PUT);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_origin_target_size(origin_datatype, target_datatype,
                                             origin_count, target_count,
@@ -149,8 +147,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_GET);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_origin_target_size(origin_datatype, target_datatype,
                                             origin_count, target_count,
@@ -199,8 +195,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_GET_ACCUMULATE);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_data_sz);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -265,8 +259,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_DO_ACCUMULATE);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, origin_data_sz);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -419,8 +411,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
     }
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(datatype, 1, data_sz);
     if (data_sz == 0)
@@ -577,8 +567,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
     }
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(datatype, 1, data_sz);
     if (data_sz == 0)

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -586,11 +586,13 @@ static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group
 /* Generic routine for checking synchronization at every RMA operation.*/
 #define MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win)                                 \
     do {                                                                               \
-        MPIDIG_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);                     \
-        MPIDIG_EPOCH_OP_REFENCE(win);                                              \
-        /* Check target sync status for any target_rank except PROC_NULL. */           \
-        if (target_rank != MPI_PROC_NULL)                                              \
-            MPIDIG_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail);  \
+        /* Ignore epoch checks when target_rank is PROC_NULL. */           \
+        if (target_rank != MPI_PROC_NULL) {                                            \
+            MPIDIG_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);                     \
+            MPIDIG_EPOCH_OP_REFENCE(win);                                              \
+            /* Check target sync status for target_rank. */       \
+            MPIDIG_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail); \
+        }                                                                              \
     } while (0);
 
 /*

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -383,6 +383,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 #define IS_BUILTIN(_datatype)                           \
     (HANDLE_GET_KIND(_datatype) == HANDLE_KIND_BUILTIN)
 
+/* We assume this routine is never called with rank=MPI_PROC_NULL. */
 static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group * grp)
 {
     int lpid;
@@ -392,12 +393,6 @@ static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_VALID_GROUP_RANK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_VALID_GROUP_RANK);
-
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        /* Treat PROC_NULL as always valid */
-        ret = 1;
-        goto fn_exit;
-    }
 
     MPIDI_NM_comm_get_lpid(comm, rank, &lpid, FALSE);
 
@@ -583,16 +578,14 @@ static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group
         }                                                               \
     } while (0)
 
-/* Generic routine for checking synchronization at every RMA operation.*/
+/* Generic routine for checking synchronization at every RMA operation.
+ * Assuming no RMA operation with target_rank=PROC_NULL will call it. */
 #define MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win)                                 \
     do {                                                                               \
-        /* Ignore epoch checks when target_rank is PROC_NULL. */           \
-        if (target_rank != MPI_PROC_NULL) {                                            \
-            MPIDIG_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);                     \
-            MPIDIG_EPOCH_OP_REFENCE(win);                                              \
-            /* Check target sync status for target_rank. */       \
-            MPIDIG_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail); \
-        }                                                                              \
+        MPIDIG_EPOCH_CHECK_SYNC(win, mpi_errno, goto fn_fail);                     \
+        MPIDIG_EPOCH_OP_REFENCE(win);                                              \
+        /* Check target sync status for target_rank. */       \
+        MPIDIG_EPOCH_CHECK_TARGET_SYNC(win, target_rank, mpi_errno, goto fn_fail); \
     } while (0);
 
 /*

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -168,12 +168,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_PROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_PROBE);
 
-    if (unlikely(source == MPI_PROC_NULL)) {
-        MPIR_Status_set_procnull(status);
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, source);
     while (!flag) {
         mpi_errno = MPIDI_iprobe_safe(source, tag, comm, context_offset, av, &flag, status);
@@ -207,13 +201,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_MPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_MPROBE);
 
-    if (source == MPI_PROC_NULL) {
-        MPIR_Status_set_procnull(status);
-        *message = NULL;        /* should be interpreted as MPI_MESSAGE_NO_PROC */
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, source);
     while (!flag) {
         mpi_errno =
@@ -245,14 +232,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IMPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IMPROBE);
-
-    if (source == MPI_PROC_NULL) {
-        MPIR_Status_set_procnull(status);
-        *flag = 1;
-        *message = NULL;        /* should be interpreted as MPI_MESSAGE_NO_PROC */
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     *flag = 0;
     av = MPIDIU_comm_rank_to_av(comm, source);
@@ -286,13 +265,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iprobe(int source,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IPROBE);
-
-    if (unlikely(source == MPI_PROC_NULL)) {
-        MPIR_Status_set_procnull(status);
-        *flag = 1;
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     *flag = 0;
     av = MPIDIU_comm_rank_to_av(comm, source);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -370,19 +370,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        MPIR_Request *rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
-        MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        *request = rreq;
-        MPIR_Request_add_ref(rreq);
-        rreq->status.MPI_SOURCE = rank;
-        rreq->status.MPI_TAG = MPI_ANY_TAG;
-        MPIR_STATUS_SET_COUNT(rreq->status, 0);
-        MPIDIU_request_complete(rreq);
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =
         MPIDI_recv_safe(buf, count, datatype, rank, tag, comm, context_offset, av, status, request);
@@ -512,19 +499,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IRECV);
-
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        MPIR_Request *rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
-        MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        *request = rreq;
-        MPIR_Request_add_ref(rreq);
-        rreq->status.MPI_SOURCE = rank;
-        rreq->status.MPI_TAG = MPI_ANY_TAG;
-        MPIR_STATUS_SET_COUNT(rreq->status, 0);
-        MPIDIU_request_complete(rreq);
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -32,11 +32,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_unsafe(const void *origin_addr,
 #else
     int r;
 
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_put(origin_addr, origin_count, origin_datatype,
                                       target_rank, target_disp, target_count, target_datatype, win);
@@ -73,11 +68,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_unsafe(void *origin_addr,
                                  target_rank, target_disp, target_count, target_datatype, win, av);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_get(origin_addr, origin_count, origin_datatype,
@@ -118,11 +108,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_unsafe(const void *origin_addr,
 #else
     int r;
 
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_accumulate(origin_addr, origin_count, origin_datatype,
                                              target_rank, target_disp, target_count,
@@ -159,11 +144,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_unsafe(const void *origin_ad
                                               datatype, target_rank, target_disp, win, av);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_compare_and_swap(origin_addr, compare_addr, result_addr,
@@ -204,14 +184,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_unsafe(const void *origin_addr,
                                          target_datatype, op, win, av, request);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        /* create a completed request for user. */
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_raccumulate(origin_addr, origin_count, origin_datatype,
@@ -258,14 +230,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_unsafe(const void *origin_add
 #else
     int r;
 
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        /* create a completed request for user. */
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype,
                                                   result_addr, result_count, result_datatype,
@@ -305,11 +269,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_unsafe(const void *origin_addr,
 #else
     int r;
 
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_fetch_and_op(origin_addr, result_addr,
                                                datatype, target_rank, target_disp, op, win);
@@ -347,14 +306,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_unsafe(void *origin_addr,
                                   target_datatype, win, av, request);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        /* create a completed request for user. */
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_rget(origin_addr, origin_count, origin_datatype,
@@ -395,14 +346,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_unsafe(const void *origin_addr,
                                   target_datatype, win, av, request);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        /* create a completed request for user. */
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)))
         mpi_errno = MPIDI_SHM_mpi_rput(origin_addr, origin_count, origin_datatype,
@@ -447,11 +390,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_unsafe(const void *origin_addr
                                             op, win, av);
 #else
     int r;
-
-    if (unlikely(target_rank == MPI_PROC_NULL)) {
-        mpi_errno = MPI_SUCCESS;
-        goto fn_exit;
-    }
 
     if ((r = MPIDI_av_is_local(av)) && !MPIDIG_WIN(win, info_args).disable_shm_accumulate)
         mpi_errno = MPIDI_SHM_mpi_get_accumulate(origin_addr, origin_count, origin_datatype,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -491,13 +491,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SEND);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
@@ -523,13 +516,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_coll(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SEND_COLL);
-
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno = MPIDI_send_coll_safe(buf, count, datatype, rank, tag, comm, context_offset, av,
@@ -559,13 +545,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ISEND);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =
         MPIDI_isend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
@@ -592,13 +571,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend_coll(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ISEND_COLL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ISEND_COLL);
-
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =
@@ -635,13 +607,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RSEND);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno = MPIDI_send_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 
@@ -674,13 +639,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_IRSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_IRSEND);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =
         MPIDI_isend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
@@ -708,13 +666,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_SSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_SSEND);
 
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =
         MPIDI_ssend_safe(buf, count, datatype, rank, tag, comm, context_offset, av, request);
@@ -741,13 +692,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ISSEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_ISSEND);
-
-    if (unlikely(rank == MPI_PROC_NULL)) {
-        *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT(*request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
 
     av = MPIDIU_comm_rank_to_av(comm, rank);
     mpi_errno =

--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -22,6 +22,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Startall(int count, MPIR_Request * requests[])
 
     for (i = 0; i < count; i++) {
         MPIR_Request *const preq = requests[i];
+        /* continue if the source/dest is MPI_PROC_NULL */
+        if (MPIDIG_REQUEST(preq, rank) == MPI_PROC_NULL)
+            continue;
 
         switch (MPIDI_PREQUEST(preq, p_type)) {
 

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -22,12 +22,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IPROBE);
 
-    if (unlikely(source == MPI_PROC_NULL)) {
-        MPIR_Status_set_procnull(status);
-        *flag = true;
-        goto fn_exit;
-    }
-
     root_comm = MPIDIG_context_id_to_comm(comm->context_id);
 
     /* MPIDI_CS_ENTER(); */
@@ -64,12 +58,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_IMPROBE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_IMPROBE);
-
-    if (unlikely(source == MPI_PROC_NULL)) {
-        MPIR_Status_set_procnull(status);
-        *flag = true;
-        goto fn_exit;
-    }
 
     root_comm = MPIDIG_context_id_to_comm(comm->context_id);
 

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -41,8 +41,6 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
 #endif
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0)
@@ -200,8 +198,6 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
 #endif
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(origin_datatype, origin_count, data_sz);
     if (data_sz == 0)
@@ -338,8 +334,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 #endif
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -519,8 +513,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 #endif
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_get_size_dt_ptr(origin_count, origin_datatype, data_sz, dt_ptr);
     MPIDI_Datatype_check_size(target_datatype, target_count, target_data_sz);
@@ -923,8 +915,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
-    if (target_rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     MPIDI_Datatype_check_size(datatype, 1, data_sz);
     if (data_sz == 0)

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -325,9 +325,6 @@ static inline int MPIDIG_mpi_win_lock(int lock_type, int rank, int assert, MPIR_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_LOCK);
 
-    if (rank == MPI_PROC_NULL)
-        goto fn_exit0;
-
     MPIDIG_LOCK_EPOCH_CHECK_NONE(win, rank, mpi_errno, goto fn_fail);
 
     MPIDIG_win_target_t *target_ptr = MPIDIG_win_target_get(win, rank);
@@ -362,7 +359,6 @@ static inline int MPIDIG_mpi_win_lock(int lock_type, int rank, int assert, MPIR_
   no_check:
     target_ptr->sync.access_epoch_type = MPIDIG_EPOTYPE_LOCK;
 
-  fn_exit0:
     MPIDIG_WIN(win, sync).access_epoch_type = MPIDIG_EPOTYPE_LOCK;
     MPIDIG_WIN(win, sync).lock.count++;
 
@@ -382,11 +378,8 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_UNLOCK);
 
-    /* Check window lock epoch.
-     * PROC_NULL does not update per-target epoch. */
+    /* Check window lock epoch. */
     MPIDIG_ACCESS_EPOCH_CHECK(win, MPIDIG_EPOTYPE_LOCK, mpi_errno, return mpi_errno);
-    if (rank == MPI_PROC_NULL)
-        goto fn_exit0;
 
     MPIDIG_win_target_t *target_ptr = MPIDIG_win_target_find(win, rank);
     MPIR_Assert(target_ptr);
@@ -444,7 +437,6 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     if (MPIR_CVAR_CH4_RMA_MEM_EFFICIENT)
         MPIDIG_win_target_delete(win, target_ptr);
 
-  fn_exit0:
     MPIR_Assert(MPIDIG_WIN(win, sync).lock.count > 0);
     MPIDIG_WIN(win, sync).lock.count--;
 
@@ -567,11 +559,8 @@ static inline int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);
 
-    /* Check window lock epoch.
-     * PROC_NULL does not update per-target epoch. */
+    /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
-    if (rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
@@ -725,11 +714,8 @@ static inline int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_WIN_FLUSH_LOCAL);
 
-    /* Check window lock epoch.
-     * PROC_NULL does not update per-target epoch. */
+    /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
-    if (rank == MPI_PROC_NULL)
-        goto fn_exit;
 
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_local_cmpl_hook(rank, win);


### PR DESCRIPTION
## Pull Request Description
_Updated_:
This PR moves all the current `MPID`-involved handling of `MPI_PROC_NULL` out from `MPID` layer up to the `MPI` layer for **RMA operations** (`MPID_[send|recv|...]` are used with `MPI_PROC_NULL` for collectives). The only exception is `MPI_Win_shared_query`.
*****
_Original_:
This PR cleans up the handling logic of `MPI_PROC_NULL` in ch4. The current ch4 has `MPI_PROC_NULL` checks all over the place and it often happens multiple times in the calling stack of one MPI operation. We may move all handling logic of `MPI_PROC_NULL` in ch4 to the `MPID_*` layer and gets rid of the redundant checks otherwise.

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design