### PR TITLE
test/dtpools: add nested datatypes

### DIFF
--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -15,6 +15,7 @@
 #include "dtpools.h"
 
 #define ERR_STRING_MAX_LEN (512)
+#define DTPI_MAX_TYPE_NESTING (3)
 
 #ifdef DEBUG_DTPOOLS
 #define FPRINTF(fd,...)         \
@@ -100,6 +101,18 @@ enum {
 };
 
 /*
+ * Nested derived datatype layouts:
+ * - block length = implementation defined
+ * - stride       = implementation defined
+ * - count        = implementation defined
+ * - nesting level= implementation defined
+ */
+enum {
+    DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L = DTPI_OBJ_LAYOUT_LARGE__NUM,
+    DTPI_OBJ_LAYOUT_LARGE_NESTED__NUM
+};
+
+/*
  * Only one layouts for struct datatype.
  * TODO: extend struct with multiple
  *       additional layouts ... ?
@@ -121,6 +134,7 @@ typedef enum {
     DTPI_OBJ_TYPE__HINDEXED,
     DTPI_OBJ_TYPE__SUBARRAY_C,
     DTPI_OBJ_TYPE__SUBARRAY_F,
+    DTPI_OBJ_TYPE__NESTED_VECTOR,
     DTPI_OBJ_TYPE__STRUCT,
     DTPI_OBJ_TYPE__NUM
 } DTPI_obj_type_e;
@@ -193,6 +207,9 @@ typedef enum {
             case DTPI_OBJ_LAYOUT_LARGE_BLK_STRD__SUBARRAY_F:            \
             case DTPI_OBJ_LAYOUT_LARGE_CNT_STRD__SUBARRAY_F:            \
                 obj_type = DTPI_OBJ_TYPE__##pool_type##SUBARRAY_F;      \
+                break;                                                  \
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L:           \
+                obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_VECTOR;   \
                 break;                                                  \
             default:                                                    \
                 obj_type = DTPI_OBJ_TYPE__NONE;                         \
@@ -301,6 +318,7 @@ int DTPI_Block_indexed_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Block_hindexed_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_c_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_vector_create(struct DTPI_Par *par, DTP_t dtp);
 
 int DTPI_Struct_free(DTP_t dtp, int obj_idx);
 int DTPI_Basic_free(DTP_t dtp, int obj_idx);
@@ -325,6 +343,7 @@ int DTPI_Block_indexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Block_hindexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_c_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_check_buf(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_vector_check_buf(struct DTPI_Par *par, DTP_t dtp);
 
 void DTPI_Print_error(int errcode);
 void DTPI_Init_creators(DTPI_Creator * creators);

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -218,18 +218,26 @@ typedef struct {
         struct {
             int stride;         /* stride in basic types */
             int blklen;         /* # of blocks in stride */
+            int count;          /* count in vector */
+            int nesting;        /* levels of vector nesting */
         } vector;
         struct {
             MPI_Aint stride;
             int blklen;
+            int count;
+            int nesting;
         } hvector;
         struct {
             int stride;
             int blklen;
+            int count;
+            int nesting;
         } indexed;
         struct {
             MPI_Aint stride;
             int blklen;
+            int count;
+            int nesting;
         } hindexed;
         struct {
             int stride;
@@ -274,6 +282,7 @@ struct DTPI_Par {
         MPI_Aint type_stride;   /* # of basic types between start of each block */
         MPI_Aint type_totlen;   /* tot # of basic types in datatype */
         MPI_Aint type_displ;    /* displ of first elem in buffer in bytes */
+        MPI_Aint type_nesting;  /* level of nesting of the datatype */
     } core;
 };
 

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -109,6 +109,7 @@ enum {
  */
 enum {
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L = DTPI_OBJ_LAYOUT_LARGE__NUM,
+    DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L,
     DTPI_OBJ_LAYOUT_LARGE_NESTED__NUM
 };
 
@@ -135,6 +136,7 @@ typedef enum {
     DTPI_OBJ_TYPE__SUBARRAY_C,
     DTPI_OBJ_TYPE__SUBARRAY_F,
     DTPI_OBJ_TYPE__NESTED_VECTOR,
+    DTPI_OBJ_TYPE__NESTED_HVECTOR,
     DTPI_OBJ_TYPE__STRUCT,
     DTPI_OBJ_TYPE__NUM
 } DTPI_obj_type_e;
@@ -210,6 +212,9 @@ typedef enum {
                 break;                                                  \
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L:           \
                 obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_VECTOR;   \
+                break;                                                  \
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L:          \
+                obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_HVECTOR;  \
                 break;                                                  \
             default:                                                    \
                 obj_type = DTPI_OBJ_TYPE__NONE;                         \
@@ -319,6 +324,7 @@ int DTPI_Block_hindexed_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_c_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_create(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_hvector_create(struct DTPI_Par *par, DTP_t dtp);
 
 int DTPI_Struct_free(DTP_t dtp, int obj_idx);
 int DTPI_Basic_free(DTP_t dtp, int obj_idx);
@@ -344,6 +350,7 @@ int DTPI_Block_hindexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_c_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_check_buf(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_hvector_check_buf(struct DTPI_Par *par, DTP_t dtp);
 
 void DTPI_Print_error(int errcode);
 void DTPI_Init_creators(DTPI_Creator * creators);

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -111,6 +111,7 @@ enum {
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L = DTPI_OBJ_LAYOUT_LARGE__NUM,
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L,
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L,
+    DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HINDEXED_3L,
     DTPI_OBJ_LAYOUT_LARGE_NESTED__NUM
 };
 
@@ -139,6 +140,7 @@ typedef enum {
     DTPI_OBJ_TYPE__NESTED_VECTOR,
     DTPI_OBJ_TYPE__NESTED_HVECTOR,
     DTPI_OBJ_TYPE__NESTED_INDEXED,
+    DTPI_OBJ_TYPE__NESTED_HINDEXED,
     DTPI_OBJ_TYPE__STRUCT,
     DTPI_OBJ_TYPE__NUM
 } DTPI_obj_type_e;
@@ -220,6 +222,9 @@ typedef enum {
                 break;                                                  \
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L:          \
                 obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_INDEXED;  \
+                break;                                                  \
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HINDEXED_3L:         \
+                obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_HINDEXED; \
                 break;                                                  \
             default:                                                    \
                 obj_type = DTPI_OBJ_TYPE__NONE;                         \
@@ -331,6 +336,7 @@ int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_hvector_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_indexed_create(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_hindexed_create(struct DTPI_Par *par, DTP_t dtp);
 
 int DTPI_Struct_free(DTP_t dtp, int obj_idx);
 int DTPI_Basic_free(DTP_t dtp, int obj_idx);
@@ -358,6 +364,7 @@ int DTPI_Subarray_f_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_hvector_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_indexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_hindexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
 
 void DTPI_Print_error(int errcode);
 void DTPI_Init_creators(DTPI_Creator * creators);

--- a/test/mpi/dtpools/include/dtpools_internal.h
+++ b/test/mpi/dtpools/include/dtpools_internal.h
@@ -110,6 +110,7 @@ enum {
 enum {
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L = DTPI_OBJ_LAYOUT_LARGE__NUM,
     DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L,
+    DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L,
     DTPI_OBJ_LAYOUT_LARGE_NESTED__NUM
 };
 
@@ -137,6 +138,7 @@ typedef enum {
     DTPI_OBJ_TYPE__SUBARRAY_F,
     DTPI_OBJ_TYPE__NESTED_VECTOR,
     DTPI_OBJ_TYPE__NESTED_HVECTOR,
+    DTPI_OBJ_TYPE__NESTED_INDEXED,
     DTPI_OBJ_TYPE__STRUCT,
     DTPI_OBJ_TYPE__NUM
 } DTPI_obj_type_e;
@@ -215,6 +217,9 @@ typedef enum {
                 break;                                                  \
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L:          \
                 obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_HVECTOR;  \
+                break;                                                  \
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L:          \
+                obj_type = DTPI_OBJ_TYPE__##pool_type##NESTED_INDEXED;  \
                 break;                                                  \
             default:                                                    \
                 obj_type = DTPI_OBJ_TYPE__NONE;                         \
@@ -325,6 +330,7 @@ int DTPI_Subarray_c_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_create(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_hvector_create(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_indexed_create(struct DTPI_Par *par, DTP_t dtp);
 
 int DTPI_Struct_free(DTP_t dtp, int obj_idx);
 int DTPI_Basic_free(DTP_t dtp, int obj_idx);
@@ -351,6 +357,7 @@ int DTPI_Subarray_c_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Subarray_f_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_vector_check_buf(struct DTPI_Par *par, DTP_t dtp);
 int DTPI_Nested_hvector_check_buf(struct DTPI_Par *par, DTP_t dtp);
+int DTPI_Nested_indexed_check_buf(struct DTPI_Par *par, DTP_t dtp);
 
 void DTPI_Print_error(int errcode);
 void DTPI_Init_creators(DTPI_Creator * creators);

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -347,6 +347,7 @@ int DTP_obj_create(DTP_t dtp, int user_obj_idx, int val_start, int val_stride, M
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L:
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L:
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L:
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HINDEXED_3L:
                 /*
                  * NOTE 1: this is a three level nested vector type.
                  *         This means that, including level 0, we

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -345,6 +345,7 @@ int DTP_obj_create(DTP_t dtp, int user_obj_idx, int val_start, int val_stride, M
                 par.core.type_stride = par.core.type_blklen * 4;
                 break;
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L:
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L:
                 /*
                  * NOTE 1: this is a three level nested vector type.
                  *         This means that, including level 0, we

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -346,6 +346,7 @@ int DTP_obj_create(DTP_t dtp, int user_obj_idx, int val_start, int val_stride, M
                 break;
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_VECTOR_3L:
             case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_HVECTOR_3L:
+            case DTPI_OBJ_LAYOUT_LARGE_BLK__NESTED_INDEXED_3L:
                 /*
                  * NOTE 1: this is a three level nested vector type.
                  *         This means that, including level 0, we

--- a/test/mpi/dtpools/src/dtpools_internal.c
+++ b/test/mpi/dtpools/src/dtpools_internal.c
@@ -343,6 +343,7 @@ void DTPI_Init_creators(DTPI_Creator * creators)
     creators[DTPI_OBJ_TYPE__SUBARRAY_C] = DTPI_Subarray_c_create;
     creators[DTPI_OBJ_TYPE__SUBARRAY_F] = DTPI_Subarray_f_create;
     creators[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Nested_vector_create;
+    creators[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Nested_hvector_create;
 }
 
 void DTPI_Init_destructors(DTPI_Destructor * destructors)
@@ -359,6 +360,7 @@ void DTPI_Init_destructors(DTPI_Destructor * destructors)
     destructors[DTPI_OBJ_TYPE__SUBARRAY_C] = DTPI_Subarray_c_free;
     destructors[DTPI_OBJ_TYPE__SUBARRAY_F] = DTPI_Subarray_f_free;
     destructors[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Vector_free;
+    destructors[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Hvector_free;
 }
 
 void DTPI_Init_checkers(DTPI_Checker * checkers)
@@ -375,6 +377,7 @@ void DTPI_Init_checkers(DTPI_Checker * checkers)
     checkers[DTPI_OBJ_TYPE__SUBARRAY_C] = DTPI_Subarray_c_check_buf;
     checkers[DTPI_OBJ_TYPE__SUBARRAY_F] = DTPI_Subarray_f_check_buf;
     checkers[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Nested_vector_check_buf;
+    checkers[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Nested_hvector_check_buf;
 }
 
 static void DTPI_Basic_type_init_buf(struct DTPI_Par *par, MPI_Datatype basic_type, void *buf)
@@ -2118,6 +2121,165 @@ int DTPI_Nested_vector_create(struct DTPI_Par *par, DTP_t dtp)
     goto fn_exit;
 }
 
+int DTPI_Nested_hvector_create(struct DTPI_Par *par, DTP_t dtp)
+{
+    int err = DTP_SUCCESS;
+    int len;
+    int i, j;
+    int obj_idx;
+    int count;
+    int blklen;
+    MPI_Aint stride;
+    MPI_Aint lb, extent, basic_type_size;
+    MPI_Datatype basic_type;
+    MPI_Datatype *type_at_level = NULL;
+    MPI_Datatype tmp_type;
+    void *buf = NULL;
+    DTPI_t *dtpi = NULL;
+    char type_name[TYPE_NAME_MAXLEN] = { 0 };
+    char basic_type_name[BASIC_TYPE_NAME_MAXLEN] = { 0 };
+
+    /* get basic type for pool */
+    basic_type = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type;
+
+    /* get object index in the pool */
+    obj_idx = par->user.obj_idx;
+
+    /* allocate space for holding intermediate datatypes */
+    DTPI_OBJ_ALLOC_OR_FAIL(type_at_level, sizeof(MPI_Datatype) * (par->core.type_nesting + 1));
+
+    err = MPI_Type_get_extent(basic_type, &lb, &basic_type_size);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* create level-0 hvector datatype */
+    count = par->core.type_count;
+    blklen = par->core.type_blklen / (int) (1 << par->core.type_nesting);
+    stride = par->core.type_stride * basic_type_size;
+    err = MPI_Type_hvector(count, blklen, stride, basic_type, &type_at_level[0]);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* resize level-0 hvector to make it end after first block of blklen */
+    extent = basic_type_size * blklen;
+    err = MPI_Type_create_resized(type_at_level[0], 0, extent, &tmp_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    MPI_Type_free(&type_at_level[0]);
+    type_at_level[0] = tmp_type;
+
+    /*
+     * create level-i hvector datatype by interleaving
+     * two level-(i - 1) datatypes.
+     */
+    for (i = 1; i <= par->core.type_nesting; i++) {
+        MPI_Type_get_extent(type_at_level[i - 1], &lb, &stride);
+        err = MPI_Type_hvector(2, 1, stride, type_at_level[i - 1], &type_at_level[i]);
+        if (err) {
+            DTPI_Print_error(err);
+            goto fn_fail;
+        }
+    }
+
+    /* adjust level-(nesting) hvector datatype extent */
+    MPI_Type_get_true_extent(type_at_level[par->core.type_nesting], &lb, &extent);
+    err = MPI_Type_create_resized(type_at_level[par->core.type_nesting], lb, extent, &tmp_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    MPI_Type_free(&type_at_level[par->core.type_nesting]);
+    type_at_level[par->core.type_nesting] = tmp_type;
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_type = type_at_level[par->core.type_nesting];
+
+    err = MPI_Type_commit(&dtp->DTP_obj_array[obj_idx].DTP_obj_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_count = 1;
+
+    err = MPI_Type_get_extent(dtp->DTP_obj_array[obj_idx].DTP_obj_type, &lb, &extent);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* allocate buffer */
+    DTPI_OBJ_ALLOC_OR_FAIL(buf, lb + extent);
+
+    /* initialize totlen and displ for buf init */
+    par->core.type_displ = 0;
+
+    /* initialize buffer with requested DTPI_Par */
+    DTPI_Nested_type_init_buf(par, basic_type, buf);
+
+    /* allocate space for private datatype info */
+    DTPI_OBJ_ALLOC_OR_FAIL(dtpi, sizeof(*dtpi));
+
+    /* initialize private datatype info data */
+    dtpi->obj_type = DTPI_OBJ_TYPE__NESTED_HVECTOR;
+    dtpi->type_basic_size = basic_type_size;
+    dtpi->type_extent = extent;
+    dtpi->type_lb = lb;
+    dtpi->type_ub = lb + extent;
+    dtpi->u.hvector.stride = par->core.type_stride * basic_type_size;
+    dtpi->u.hvector.blklen = par->core.type_blklen;
+    dtpi->u.hvector.count = par->core.type_count;
+    dtpi->u.hvector.nesting = par->core.type_nesting;
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_buf = buf;
+    dtp->DTP_obj_array[obj_idx].private_info = dtpi;
+
+    /* set type name for debug information */
+    err = MPI_Type_get_name(basic_type, basic_type_name, &len);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    sprintf(type_name, "nested_hvector_%dl (%s basic_type %li count %li blocklen %li stride)",
+            (int) par->core.type_nesting, basic_type_name, par->core.type_count,
+            par->core.type_blklen, par->core.type_stride);
+    err = MPI_Type_set_name(dtp->DTP_obj_array[obj_idx].DTP_obj_type, (char *) type_name);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* free intermediate datatypes */
+    for (i = 0; i < par->core.type_nesting; i++)
+        MPI_Type_free(&type_at_level[i]);
+    free(type_at_level);
+
+  fn_exit:
+    return err;
+
+  fn_fail:
+    /* cleanup datatype */
+    if (dtp->DTP_obj_array[obj_idx].DTP_obj_type != MPI_DATATYPE_NULL) {
+        MPI_Type_free(&dtp->DTP_obj_array[obj_idx].DTP_obj_type);
+    }
+
+    /* clean up buffers */
+    free(dtpi);
+    free(buf);
+
+    /* clean up intermediate datatypes */
+    for (j = 0; j < i; j++)
+        MPI_Type_free(&type_at_level[j]);
+    free(type_at_level);
+
+    goto fn_exit;
+}
+
 /* --------------------------------------------------------- */
 /* Datatype Pool Object Free Functions                       */
 /* --------------------------------------------------------- */
@@ -2489,6 +2651,27 @@ int DTPI_Nested_vector_check_buf(struct DTPI_Par *par, DTP_t dtp)
     par->core.type_count = dtpi->u.vector.count;
     par->core.type_displ = 0;
     par->core.type_nesting = dtpi->u.vector.nesting;
+
+    return DTPI_Nested_type_check_buf(par, basic_type, buf);
+}
+
+int DTPI_Nested_hvector_check_buf(struct DTPI_Par *par, DTP_t dtp)
+{
+    int obj_idx;
+    MPI_Datatype basic_type;
+    void *buf;
+    DTPI_t *dtpi;
+
+    obj_idx = par->user.obj_idx;
+    buf = dtp->DTP_obj_array[obj_idx].DTP_obj_buf;
+    basic_type = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type;
+
+    dtpi = (DTPI_t *) dtp->DTP_obj_array[obj_idx].private_info;
+    par->core.type_stride = dtpi->u.hvector.stride / dtpi->type_basic_size;
+    par->core.type_blklen = dtpi->u.hvector.blklen;
+    par->core.type_count = dtpi->u.hvector.count;
+    par->core.type_displ = 0;
+    par->core.type_nesting = dtpi->u.hvector.nesting;
 
     return DTPI_Nested_type_check_buf(par, basic_type, buf);
 }

--- a/test/mpi/dtpools/src/dtpools_internal.c
+++ b/test/mpi/dtpools/src/dtpools_internal.c
@@ -345,6 +345,7 @@ void DTPI_Init_creators(DTPI_Creator * creators)
     creators[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Nested_vector_create;
     creators[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Nested_hvector_create;
     creators[DTPI_OBJ_TYPE__NESTED_INDEXED] = DTPI_Nested_indexed_create;
+    creators[DTPI_OBJ_TYPE__NESTED_HINDEXED] = DTPI_Nested_hindexed_create;
 }
 
 void DTPI_Init_destructors(DTPI_Destructor * destructors)
@@ -363,6 +364,7 @@ void DTPI_Init_destructors(DTPI_Destructor * destructors)
     destructors[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Vector_free;
     destructors[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Hvector_free;
     destructors[DTPI_OBJ_TYPE__NESTED_INDEXED] = DTPI_Indexed_free;
+    destructors[DTPI_OBJ_TYPE__NESTED_HINDEXED] = DTPI_Hindexed_free;
 }
 
 void DTPI_Init_checkers(DTPI_Checker * checkers)
@@ -381,6 +383,7 @@ void DTPI_Init_checkers(DTPI_Checker * checkers)
     checkers[DTPI_OBJ_TYPE__NESTED_VECTOR] = DTPI_Nested_vector_check_buf;
     checkers[DTPI_OBJ_TYPE__NESTED_HVECTOR] = DTPI_Nested_hvector_check_buf;
     checkers[DTPI_OBJ_TYPE__NESTED_INDEXED] = DTPI_Nested_indexed_check_buf;
+    checkers[DTPI_OBJ_TYPE__NESTED_HINDEXED] = DTPI_Nested_hindexed_check_buf;
 }
 
 static void DTPI_Basic_type_init_buf(struct DTPI_Par *par, MPI_Datatype basic_type, void *buf)
@@ -2451,6 +2454,176 @@ int DTPI_Nested_indexed_create(struct DTPI_Par *par, DTP_t dtp)
     goto fn_exit;
 }
 
+int DTPI_Nested_hindexed_create(struct DTPI_Par *par, DTP_t dtp)
+{
+    int err = DTP_SUCCESS;
+    int len;
+    int i, j;
+    int obj_idx;
+    int count;
+    int *type_blklens = NULL;
+    MPI_Aint *type_displs = NULL;
+    MPI_Aint lb, extent, basic_type_size;
+    MPI_Datatype basic_type;
+    MPI_Datatype *type_at_level = NULL;
+    MPI_Datatype tmp_type;
+    void *buf = NULL;
+    DTPI_t *dtpi = NULL;
+    char type_name[TYPE_NAME_MAXLEN] = { 0 };
+    char basic_type_name[BASIC_TYPE_NAME_MAXLEN] = { 0 };
+
+    /* get basic type for pool */
+    basic_type = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type;
+
+    /* get object index in the pool */
+    obj_idx = par->user.obj_idx;
+
+    /* allocate space for holding intermediate datatypes */
+    DTPI_OBJ_ALLOC_OR_FAIL(type_at_level, sizeof(MPI_Datatype) * (par->core.type_nesting + 1));
+
+    err = MPI_Type_get_extent(basic_type, &lb, &basic_type_size);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    DTPI_OBJ_ALLOC_OR_FAIL(type_displs, sizeof(*type_displs) * par->core.type_count);
+    DTPI_OBJ_ALLOC_OR_FAIL(type_blklens, sizeof(*type_blklens) * par->core.type_count);
+
+    for (i = 0; i < par->core.type_count; i++) {
+        type_blklens[i] = par->core.type_blklen / (int) (1 << par->core.type_nesting);
+        type_displs[i] = (par->core.type_stride * i) * basic_type_size;
+    }
+
+    /* create level-0 hindexed datatype */
+    count = par->core.type_count;
+    err = MPI_Type_hindexed(count, type_blklens, type_displs, basic_type, &type_at_level[0]);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* resize level-0 hindexed to make it end after first block of blklen */
+    extent = basic_type_size * (par->core.type_blklen / (int) (1 << par->core.type_nesting));
+    err = MPI_Type_create_resized(type_at_level[0], 0, extent, &tmp_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    MPI_Type_free(&type_at_level[0]);
+    type_at_level[0] = tmp_type;
+
+    /*
+     * create level-i hindexed datatype by interleaving
+     * two level-(i - 1) datatypes.
+     */
+    for (i = 1; i <= par->core.type_nesting; i++) {
+        int blklens[2] = { 1, 1 };
+        MPI_Aint displs[2] = { 0, 0 };
+        MPI_Type_get_extent(type_at_level[i - 1], &lb, &displs[1]);
+        err = MPI_Type_hindexed(2, blklens, displs, type_at_level[i - 1], &type_at_level[i]);
+        if (err) {
+            DTPI_Print_error(err);
+            goto fn_fail;
+        }
+    }
+
+    /* adjust level-(nesting) hindexed datatype extent */
+    MPI_Type_get_true_extent(type_at_level[par->core.type_nesting], &lb, &extent);
+    err = MPI_Type_create_resized(type_at_level[par->core.type_nesting], lb, extent, &tmp_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    MPI_Type_free(&type_at_level[par->core.type_nesting]);
+    type_at_level[par->core.type_nesting] = tmp_type;
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_type = type_at_level[par->core.type_nesting];
+
+    err = MPI_Type_commit(&dtp->DTP_obj_array[obj_idx].DTP_obj_type);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_count = 1;
+
+    err = MPI_Type_get_extent(dtp->DTP_obj_array[obj_idx].DTP_obj_type, &lb, &extent);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* allocate buffer */
+    DTPI_OBJ_ALLOC_OR_FAIL(buf, lb + extent);
+
+    /* initialize totlen and displ for buf init */
+    par->core.type_displ = 0;
+
+    /* initialize buffer with requested DTPI_Par */
+    DTPI_Nested_type_init_buf(par, basic_type, buf);
+
+    /* allocate space for private datatype info */
+    DTPI_OBJ_ALLOC_OR_FAIL(dtpi, sizeof(*dtpi));
+
+    /* initialize private datatype info data */
+    dtpi->obj_type = DTPI_OBJ_TYPE__NESTED_HINDEXED;
+    dtpi->type_basic_size = basic_type_size;
+    dtpi->type_extent = extent;
+    dtpi->type_lb = lb;
+    dtpi->type_ub = lb + extent;
+    dtpi->u.hindexed.stride = par->core.type_stride * basic_type_size;
+    dtpi->u.hindexed.blklen = par->core.type_blklen;
+    dtpi->u.hindexed.count = par->core.type_count;
+    dtpi->u.hindexed.nesting = par->core.type_nesting;
+
+    dtp->DTP_obj_array[obj_idx].DTP_obj_buf = buf;
+    dtp->DTP_obj_array[obj_idx].private_info = dtpi;
+
+    /* set type name for debug information */
+    err = MPI_Type_get_name(basic_type, basic_type_name, &len);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+    sprintf(type_name, "nested_hindexed_%dl (%s basic_type %li count %li blocklen %li stride)",
+            (int) par->core.type_nesting, basic_type_name, par->core.type_count,
+            par->core.type_blklen, par->core.type_stride);
+    err = MPI_Type_set_name(dtp->DTP_obj_array[obj_idx].DTP_obj_type, (char *) type_name);
+    if (err) {
+        DTPI_Print_error(err);
+        goto fn_fail;
+    }
+
+    /* free intermediate datatypes */
+    for (i = 0; i < par->core.type_nesting; i++)
+        MPI_Type_free(&type_at_level[i]);
+    free(type_at_level);
+
+  fn_exit:
+    free(type_displs);
+    free(type_blklens);
+
+    return err;
+
+  fn_fail:
+    /* cleanup datatype */
+    if (dtp->DTP_obj_array[obj_idx].DTP_obj_type != MPI_DATATYPE_NULL) {
+        MPI_Type_free(&dtp->DTP_obj_array[obj_idx].DTP_obj_type);
+    }
+
+    /* clean up buffers */
+    free(dtpi);
+    free(buf);
+
+    /* clean up intermediate datatypes */
+    for (j = 0; j < i; j++)
+        MPI_Type_free(&type_at_level[j]);
+    free(type_at_level);
+
+    goto fn_exit;
+}
+
 /* --------------------------------------------------------- */
 /* Datatype Pool Object Free Functions                       */
 /* --------------------------------------------------------- */
@@ -2864,6 +3037,27 @@ int DTPI_Nested_indexed_check_buf(struct DTPI_Par *par, DTP_t dtp)
     par->core.type_count = dtpi->u.indexed.count;
     par->core.type_displ = 0;
     par->core.type_nesting = dtpi->u.indexed.nesting;
+
+    return DTPI_Nested_type_check_buf(par, basic_type, buf);
+}
+
+int DTPI_Nested_hindexed_check_buf(struct DTPI_Par *par, DTP_t dtp)
+{
+    int obj_idx;
+    MPI_Datatype basic_type;
+    void *buf;
+    DTPI_t *dtpi;
+
+    obj_idx = par->user.obj_idx;
+    buf = dtp->DTP_obj_array[obj_idx].DTP_obj_buf;
+    basic_type = dtp->DTP_type_signature.DTP_pool_basic.DTP_basic_type;
+
+    dtpi = (DTPI_t *) dtp->DTP_obj_array[obj_idx].private_info;
+    par->core.type_stride = dtpi->u.hindexed.stride / dtpi->type_basic_size;
+    par->core.type_blklen = dtpi->u.hindexed.blklen;
+    par->core.type_count = dtpi->u.hindexed.count;
+    par->core.type_displ = 0;
+    par->core.type_nesting = dtpi->u.hindexed.nesting;
 
     return DTPI_Nested_type_check_buf(par, basic_type, buf);
 }

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -426,6 +426,9 @@ sub RunList {
         @TYPES = split ' ', $ENV{"DTP_RUNTIME_TYPES"};
     }
 
+    $ENV{"DTP_MIN_OBJ_ID"} = 40;
+    $ENV{"DTP_MAX_OBJ_ID"} = 50;
+
     print "Looking in $curdir/$listfile\n" if $debug;
     if (! -s "$listfile" && -s "$srcdir/$curdir/$listfile" ) {
 	$listfileSource = "$srcdir/$curdir/$listfile";

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -732,7 +732,7 @@ sub RunMPIProgram {
     my $extraArgs = "";
     my $runtime = 0;
 
-    &RunPreMsg( $programname, $np, $curdir );
+    &RunPreMsg( $programname, $np, $progArgs, $curdir );
 
     unlink "err";
 
@@ -1163,9 +1163,10 @@ sub TestErrFatal {
 #  RunPostMsg               - Call at end of each test
 #
 sub RunPreMsg {
-    my ($programname,$np,$workdir) = @_;
+    my ($programname,$np,$progArgs,$workdir) = @_;
     if ($xmloutput) {
 	print XMLOUT "<MPITEST>$newline<NAME>$programname</NAME>$newline";
+    print XMLOUT "<ARGS>$progArgs</ARGS>$newline";
 	print XMLOUT "<NP>$np</NP>$newline";
 	print XMLOUT "<WORKDIR>$workdir</WORKDIR>$newline";
     }


### PR DESCRIPTION
Current DTPools framework only supports basic and derived datatypes. There is a need for more comprehensive testing using nested datatypes, i.e., derived datatypes with one or more levels of nesting. This PR adds nested datatypes to DTPools.

Addresses issue: https://github.com/pmodels/mpich/issues/3688