### PR TITLE
mpid/common/bc: Simplify key for PMIx bc exchange

### DIFF
--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -106,7 +106,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 {
     int rc, mpi_errno = MPI_SUCCESS;
     int start, end, i;
-    char *key = NULL, *val = NULL, *val_p;
+    char *val = NULL, *val_p;
     int out_len, val_len, rem, flag;
     pmix_value_t value, *pvalue;
     pmix_info_t *info;
@@ -141,16 +141,12 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**buscard");
     MPIR_Assert(rem >= 0);
 
-    key = MPL_malloc(KEYLEN, MPL_MEM_ADDRESS);
-    MPIR_Assert(key);
-    sprintf(key, "bc-%d", rank);
-
     if (!roots_only || rank == local_leader) {
         value.type = PMIX_STRING;
         value.data.string = val;
-        rc = PMIx_Put(PMIX_LOCAL, key, &value);
+        rc = PMIx_Put(PMIX_LOCAL, "bc", &value);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_put");
-        rc = PMIx_Put(PMIX_REMOTE, key, &value);
+        rc = PMIx_Put(PMIX_REMOTE, "bc", &value);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_put");
         rc = PMIx_Commit();
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_commit");
@@ -168,11 +164,10 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         if (local_rank == local_size - 1)
             end += size % local_size;
         for (i = start; i < end; i++) {
-            sprintf(key, "bc-%d", i);
             PMIX_PROC_CONSTRUCT(&proc);
             MPL_strncpy(proc.nspace, MPIR_Process.pmix_proc.nspace, PMIX_MAX_NSLEN);
             proc.rank = i;
-            rc = PMIx_Get(&proc, key, NULL, 0, &pvalue);
+            rc = PMIx_Get(&proc, "bc", NULL, 0, &pvalue);
             MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_get");
             rc = MPL_str_get_binary_arg(val, "mpi", &segment[i * bc_len], bc_len, &out_len);
             MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**argstr_missinghost");
@@ -187,11 +182,10 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         if (local_rank == local_size - 1)
             end += num_nodes % local_size;
         for (i = start; i < end; i++) {
-            sprintf(key, "bc-%d", i);
             PMIX_PROC_CONSTRUCT(&proc);
             MPL_strncpy(proc.nspace, MPIR_Process.pmix_proc.nspace, PMIX_MAX_NSLEN);
             proc.rank = i;
-            rc = PMIx_Get(&proc, key, NULL, 0, &pvalue);
+            rc = PMIx_Get(&proc, "bc", NULL, 0, &pvalue);
             MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_get");
             rc = MPL_str_get_binary_arg(val, "mpi", &segment[i * bc_len], bc_len, &out_len);
             MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**argstr_missinghost");
@@ -211,7 +205,6 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     }
 
   fn_exit:
-    MPL_free(key);
     MPL_free(val);
     *bc_table = segment;
 


### PR DESCRIPTION
There is no need to encode rank in the key for each process, as the
PMIx_Get interface supports retrieve values by rank. By not including
the rank, we allow the PMIx implementation to optimize KVS storage.