### PR TITLE
VCI pool infrastructure

### DIFF
--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -34,7 +34,7 @@ extern MPIDIG_global_t MPIDIG_global;
 
 int MPIDIG_am_reg_cb(int handler_id,
                      MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vcis);
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self);
 void MPIDIG_finalize(void);
 
 int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code);

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -35,7 +35,7 @@ int MPIDIG_am_reg_cb(int handler_id,
 #define FUNCNAME MPIDIG_init
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vcis)
+int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -262,6 +262,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_av_is_local(MPIDI_av_entry_t * av);
 #endif
 
 #include "ch4i_workq.h"
+#include "ch4_vci.h"
 
 #include "ch4_init.h"
 #include "ch4_probe.h"

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -215,6 +215,7 @@ typedef struct {
         MPIDI_workq_elemt_t command;
 #endif
     } ch4;
+    int vci;
 } MPIDI_Devreq_t;
 #define MPIDI_REQUEST_HDR_SIZE              offsetof(struct MPIR_Request, dev.ch4.netmod)
 #define MPIDI_REQUEST(req,field)       (((req)->dev).field)

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -29,6 +29,7 @@
 #include "uthash.h"
 #include "ch4_coll_params.h"
 #include "ch4i_workq_types.h"
+#include "ch4_vci_types.h"
 
 #ifdef MPIDI_CH4_USE_MT_DIRECT
 #define MPIDI_CH4_MT_MODEL MPIDI_CH4_MT_DIRECT

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -493,10 +493,13 @@ typedef struct MPIDI_Devcomm_t {
 
         MPIDI_rank_map_t map;
         MPIDI_rank_map_t local_map;
+
+        MPIDI_vci_hash_t vci_hash;
     } ch4;
 } MPIDI_Devcomm_t;
 #define MPIDIG_COMM(comm,field) ((comm)->dev.ch4.am).field
 #define MPIDI_COMM(comm,field) ((comm)->dev.ch4).field
+#define MPIDI_COMM_VCI(comm,field) ((comm)->dev.ch4).vci_hash.u.single.field
 
 typedef struct {
     union {

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -20,7 +20,7 @@ typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bit
                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
                                     int *n_vcis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_vci_get_attr_t) (int vci);
+typedef MPIDI_vci_resource_t(*MPIDI_NM_vci_get_resource_info_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
@@ -475,7 +475,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_vci_get_attr_t vci_get_attr;
+    MPIDI_NM_vci_get_resource_info_t vci_get_resource_info;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -660,7 +660,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
                                                     int spawned, int *n_vcis_provided)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -18,10 +18,10 @@
 
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
-                                    int *n_vcis_provided);
+                                    int *n_vnis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef MPIDI_vci_resource_t(*MPIDI_NM_vci_get_resource_info_t) (int vci);
-typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
+typedef MPIDI_vci_resource_t(*MPIDI_NM_vni_get_resource_info_t) (int vni);
+typedef int (*MPIDI_NM_progress_t) (int vni, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
                                             MPIR_Comm ** newcomm_ptr);
@@ -475,7 +475,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_vci_get_resource_info_t vci_get_resource_info;
+    MPIDI_NM_vni_get_resource_info_t vni_get_resource_info;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -657,12 +657,12 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int *n_vcis_provided)
+                                                    int spawned, int *n_vnis_provided)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
     MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,
                                                        MPIR_Comm * comm, MPIR_Comm **

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -20,7 +20,7 @@ typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bit
                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
                                     int *n_vcis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_get_vci_attr_t) (int vci);
+typedef int (*MPIDI_NM_vci_get_attr_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
@@ -475,7 +475,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_get_vci_attr_t get_vci_attr;
+    MPIDI_NM_vci_get_attr_t vci_get_attr;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -660,7 +660,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
                                                     int spawned, int *n_vcis_provided)
     MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vci_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -16,11 +16,16 @@
 
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
+#define MPIDI_NM_VNI_INVALID -1
+
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self, int spawned,
                                     int *n_vnis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
 typedef MPIDI_vci_resource_t(*MPIDI_NM_vni_get_resource_info_t) (int vni);
+typedef int (*MPIDI_NM_vni_alloc_t) (MPIDI_vci_resource_t resources,
+                                     MPIDI_vci_property_t properties, int *vni);
+typedef int (*MPIDI_NM_vni_free_t) (int vni);
 typedef int (*MPIDI_NM_progress_t) (int vni, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
@@ -476,6 +481,8 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
     MPIDI_NM_vni_get_resource_info_t vni_get_resource_info;
+    MPIDI_NM_vni_alloc_t vni_alloc;
+    MPIDI_NM_vni_free_t vni_free;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -662,6 +669,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
     MPL_STATIC_INLINE_SUFFIX;
+int MPIDI_NM_vni_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vni);
+int MPIDI_NM_vni_free(int vni);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                        int root, int timeout,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -18,7 +18,7 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                                     MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                                    int spawned, int *n_vcis_provided)
+                                                    int spawned, int *n_vnis_provided)
 {
     int ret;
 
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank, int size, int appn
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
     ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, comm_world, comm_self, spawned,
-                                  n_vcis_provided);
+                                  n_vnis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     return ret;
@@ -45,27 +45,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
 {
     MPIDI_vci_resource_t ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VNI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VNI);
 
-    ret = MPIDI_NM_func->vci_get_resource_info(vci);
+    ret = MPIDI_NM_func->vni_get_resource_info(vni);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VNI);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
-    ret = MPIDI_NM_func->progress(vci, blocking);
+    ret = MPIDI_NM_func->progress(vni, blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROGRESS);
     return ret;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -45,14 +45,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
 {
-    int ret;
+    MPIDI_vci_resource_t ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
 
-    ret = MPIDI_NM_func->vci_get_attr(vci);
+    ret = MPIDI_NM_func->vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -45,14 +45,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vci_attr(int vci)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
 
-    ret = MPIDI_NM_func->get_vci_attr(vci);
+    ret = MPIDI_NM_func->vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -58,6 +58,32 @@ MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int
     return ret;
 }
 
+int MPIDI_NM_vni_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vni)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_VNI_ALLOC);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_VNI_ALLOC);
+
+    ret = MPIDI_NM_func->vni_alloc(resources, properties, vni);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_VNI_ALLOC);
+    return ret;
+}
+
+int MPIDI_NM_vni_free(int vni)
+{
+    int ret;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_VNI_FREE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_VNI_FREE);
+
+    ret = MPIDI_NM_func->vni_free(vni);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_VNI_FREE);
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int ret;

--- a/src/mpid/ch4/netmod/ofi/Makefile.mk
+++ b/src/mpid/ch4/netmod/ofi/Makefile.mk
@@ -14,7 +14,8 @@ if BUILD_CH4_NETMOD_OFI
 noinst_HEADERS     +=
 mpi_core_sources   += src/mpid/ch4/netmod/ofi/func_table.c \
                       src/mpid/ch4/netmod/ofi/globals.c \
-                      src/mpid/ch4/netmod/ofi/util.c
+                      src/mpid/ch4/netmod/ofi/util.c \
+                      src/mpid/ch4/netmod/ofi/ofi_vni.c
 errnames_txt_files += src/mpid/ch4/netmod/ofi/errnames.txt
 external_subdirs   += @ofisrcdir@
 pmpi_convenience_libs += @ofilib@

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .vci_get_resource_info = MPIDI_NM_vci_get_resource_info,
+    .vni_get_resource_info = MPIDI_NM_vni_get_resource_info,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -20,6 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
+    .get_vci_attr = MPIDI_NM_get_vci_attr,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .vci_get_attr = MPIDI_NM_vci_get_attr,
+    .vci_get_resource_info = MPIDI_NM_vci_get_resource_info,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .get_vci_attr = MPIDI_NM_get_vci_attr,
+    .vci_get_attr = MPIDI_NM_vci_get_attr,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -14,7 +14,7 @@
 #include "ofi_am_impl.h"
 #include "ofi_am_events.h"
 
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx);
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 static inline void MPIDI_NM_am_request_init(MPIR_Request * req)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -174,7 +174,7 @@ static inline int MPIDI_OFI_do_rdma_read(void *dst,
             .data = 0
         };
 
-        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[0].tx,
+        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_CTX(0).tx,
                                            &msg, FI_COMPLETION), FALSE /* no lock */ , read);
 
         done += curr_len;
@@ -375,7 +375,7 @@ static inline int MPIDI_OFI_dispatch_ack(int rank, int context_id, uint64_t sreq
     msg.hdr.data_sz = 0;
     msg.hdr.am_type = am_type;
     msg.pyld.sreq_ptr = sreq_ptr;
-    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, &msg, sizeof(msg),
+    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_CTX(0).tx, &msg, sizeof(msg),
                                       MPIDI_OFI_comm_to_phys(comm, rank)),
                             FALSE /* no lock */ , inject);
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -123,7 +123,7 @@ static inline int MPIDI_OFI_repost_buffer(void *buf, MPIR_Request * req)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_REPOST_BUFFER);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_REPOST_BUFFER);
-    MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[0].rx,
+    MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_CTX(0).rx,
                                        &MPIDI_OFI_global.am_msg[am->index],
                                        FI_MULTI_RECV | FI_COMPLETION), FALSE /* lock */ , repost);
   fn_exit:
@@ -147,7 +147,7 @@ static inline int MPIDI_OFI_progress_do_queue(int vni_idx)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
 
-    ret = fi_cq_read(MPIDI_OFI_global.ctx[vni_idx].cq, &cq_entry, 1);
+    ret = fi_cq_read(MPIDI_OFI_CTX(vni_idx).cq, &cq_entry, 1);
 
     if (unlikely(ret == -FI_EAGAIN))
         goto fn_exit;
@@ -229,7 +229,7 @@ static inline int MPIDI_OFI_do_am_isend_header(int rank,
     iov[1].iov_len = am_hdr_sz;
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND;
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
-    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 2,
+    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_CTX(0).tx, iov, NULL, 2,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
                                      &MPIDI_OFI_AMREQUEST(sreq, context)), need_lock, sendv);
   fn_exit:
@@ -321,7 +321,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
     iov[2].iov_len = sizeof(*lmt_info);
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND;
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
-    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 3,
+    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_CTX(0).tx, iov, NULL, 3,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
                                      &MPIDI_OFI_AMREQUEST(sreq, context)), need_lock, sendv);
   fn_exit:
@@ -375,7 +375,7 @@ static inline int MPIDI_OFI_am_isend_short(int rank,
     MPIR_cc_incr(sreq->cc_ptr, &c);
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND;
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
-    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 3,
+    MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_CTX(0).tx, iov, NULL, 3,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
                                      &MPIDI_OFI_AMREQUEST(sreq, context)), need_lock, sendv);
   fn_exit:
@@ -502,7 +502,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
     MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
     OPA_incr_int(&MPIDI_OFI_global.am_inflight_inject_emus);
 
-    MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[0].tx, ibuf, len,
+    MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_CTX(0).tx, ibuf, len,
                                     NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),
                             need_lock, send);
   fn_exit:
@@ -554,7 +554,7 @@ static inline int MPIDI_OFI_do_inject(int rank,
     memcpy(buff, &msg_hdr, sizeof(msg_hdr));
     memcpy(buff + sizeof(msg_hdr), am_hdr, am_hdr_sz);
 
-    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, buff, buff_len, addr),
+    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_CTX(0).tx, buff, buff_len, addr),
                             need_lock, inject);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -13,7 +13,7 @@
 
 #include "ofi_impl.h"
 
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx);
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 /*
   Per-object lock for OFI
@@ -40,7 +40,7 @@ static inline int MPIDI_OFI_progress_do_queue(int vci_idx);
                                    __LINE__,                            \
                                    FCNAME,                              \
                                    fi_strerror(-_ret));                 \
-            mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vci_idx */);    \
+            mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vni_idx */);    \
             if (mpi_errno != MPI_SUCCESS)                                \
                 MPIR_ERR_POP(mpi_errno);                                \
         } while (_ret == -FI_EAGAIN);                                   \
@@ -137,7 +137,7 @@ static inline int MPIDI_OFI_repost_buffer(void *buf, MPIR_Request * req)
 #define FUNCNAME MPIDI_OFI_progress_do_queue
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx)
 {
     int mpi_errno = MPI_SUCCESS, ret;
     struct fi_cq_tagged_entry cq_entry;
@@ -147,13 +147,13 @@ static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
 
-    ret = fi_cq_read(MPIDI_OFI_global.ctx[vci_idx].cq, &cq_entry, 1);
+    ret = fi_cq_read(MPIDI_OFI_global.ctx[vni_idx].cq, &cq_entry, 1);
 
     if (unlikely(ret == -FI_EAGAIN))
         goto fn_exit;
 
     if (ret < 0) {
-        mpi_errno = MPIDI_OFI_handle_cq_error_util(vci_idx, ret);
+        mpi_errno = MPIDI_OFI_handle_cq_error_util(vni_idx, ret);
         goto fn_fail;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
                                                   MPIDI_OFI_SYNC_SEND_ACK);
         MPIR_Comm *c = MPIDI_OFI_REQUEST(rreq, util_comm);
         int r = rreq->status.MPI_SOURCE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, NULL, 0, NULL,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, NULL, 0, NULL,
                                            MPIDI_OFI_REQUEST(rreq, util_comm->rank),
                                            MPIDI_OFI_comm_to_phys(c, r),
                                            ss_bits, NULL, MPIDI_OFI_DO_INJECT,
@@ -417,7 +417,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry 
         remote_key = recv->remote_info.rma_key;
 
         MPIDI_OFI_cntr_incr();
-        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[0].tx,        /* endpoint     */
+        MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_CTX(0).tx,       /* endpoint     */
                                      (void *) ((uintptr_t) recv->wc.buf + recv->cur_offset),    /* local buffer */
                                      bytesToGet,        /* bytes        */
                                      NULL,      /* descriptor   */
@@ -853,7 +853,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
 
     switch (ret) {
         case -FI_EAVAIL:
-            fi_cq_readerr(MPIDI_OFI_global.ctx[vni_idx].cq, &e, 0);
+            fi_cq_readerr(MPIDI_OFI_CTX(vni_idx).cq, &e, 0);
 
             switch (e.err) {
                 case FI_ETRUNC:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -843,7 +843,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_ent
 #define FUNCNAME MPIDI_OFI_handle_cq_error
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vci_idx, ssize_t ret)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_err_entry e;
@@ -853,7 +853,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_error(int vci_idx, ssize_t ret)
 
     switch (ret) {
         case -FI_EAVAIL:
-            fi_cq_readerr(MPIDI_OFI_global.ctx[vci_idx].cq, &e, 0);
+            fi_cq_readerr(MPIDI_OFI_global.ctx[vni_idx].cq, &e, 0);
 
             switch (e.err) {
                 case FI_ETRUNC:

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -574,7 +574,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dynproc_send_disconnect(int conn_id)
         msg.ignore = context_id;
         msg.context = (void *) &req.context;
         msg.data = 0;
-        MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg,
+        MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_CTX(0).tx, &msg,
                                          FI_COMPLETION | FI_TRANSMIT_COMPLETE | FI_REMOTE_CQ_DATA),
                              tsendmsg, MPIDI_OFI_CALL_LOCK, FALSE);
         MPIDI_OFI_PROGRESS_WHILE(!req.done);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -114,9 +114,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
          * for recursive locking in more than one lock (currently limited
          * to one due to scalar TLS counter), this lock yielding
          * operation can be avoided since we are inside a finite loop. */\
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);         \
         mpi_errno = MPIDI_OFI_retry_progress();                      \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);        \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);        \
         if (mpi_errno != MPI_SUCCESS)                                \
             MPIR_ERR_POP(mpi_errno);                                 \
         _retry--;                                           \
@@ -139,9 +139,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
                               __LINE__,                     \
                               FCNAME,                       \
                               fi_strerror(-_ret));          \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);         \
         mpi_errno = MPIDI_OFI_retry_progress();                      \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);        \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);        \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);\
         if (mpi_errno != MPI_SUCCESS)                                \
             MPIR_ERR_POP(mpi_errno);                                 \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1042,10 +1042,10 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-static inline int MPIDI_NM_vci_get_attr(int vci)
+static inline MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 static inline void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -1042,7 +1042,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-static inline int MPIDI_NM_get_vci_attr(int vci)
+static inline int MPIDI_NM_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -221,7 +221,7 @@ cvars:
         minor version of the OFI library used with MPICH. If using this CVAR,
         it is recommended that the user also specifies a specific OFI provider.
 
-    - name        : MPIR_CVAR_CH4_OFI_MAX_VCIS
+    - name        : MPIR_CVAR_CH4_OFI_MAX_VNIS
       category    : CH4_OFI
       type        : int
       default     : 1
@@ -229,7 +229,7 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        If set to positive, this CVAR specifies the maximum number of CH4 VCIs
+        If set to positive, this CVAR specifies the maximum number of CH4 VNIs
         that OFI netmod exposes.
 
     - name        : MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX
@@ -415,7 +415,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int appnum,
                                          int *tag_bits,
                                          MPIR_Comm * comm_world,
-                                         MPIR_Comm * comm_self, int spawned, int *n_vcis_provided)
+                                         MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS, pmi_errno, i, fi_version;
     int thr_err = 0;
@@ -757,13 +757,13 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* completion queues, etc.                                                  */
     /* ------------------------------------------------------------------------ */
 
-    MPIDI_OFI_global.max_ch4_vcis = 1;
+    MPIDI_OFI_global.max_vnis = 1;
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int max_by_prov = MPL_MIN(prov_use->domain_attr->tx_ctx_cnt,
                                   prov_use->domain_attr->rx_ctx_cnt);
-        if (MPIR_CVAR_CH4_OFI_MAX_VCIS > 0)
-            MPIDI_OFI_global.max_ch4_vcis = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_VCIS, max_by_prov);
-        if (MPIDI_OFI_global.max_ch4_vcis < 1) {
+        if (MPIR_CVAR_CH4_OFI_MAX_VNIS > 0)
+            MPIDI_OFI_global.max_vnis = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_VNIS, max_by_prov);
+        if (MPIDI_OFI_global.max_vnis < 1) {
             MPIR_ERR_SETFATALANDJUMP4(mpi_errno,
                                       MPI_ERR_OTHER,
                                       "**ofid_ep",
@@ -772,11 +772,11 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                       "Not enough scalable endpoints");
         }
         /* Specify the number of TX/RX contexts we want */
-        prov_use->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_ch4_vcis;
-        prov_use->ep_attr->rx_ctx_cnt = MPIDI_OFI_global.max_ch4_vcis;
+        prov_use->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_vnis;
+        prov_use->ep_attr->rx_ctx_cnt = MPIDI_OFI_global.max_vnis;
     }
 
-    for (i = 0; i < MPIDI_OFI_global.max_ch4_vcis; i++) {
+    for (i = 0; i < MPIDI_OFI_global.max_vnis; i++) {
         MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_create_endpoint(prov_use,
                                                          MPIDI_OFI_global.domain,
                                                          MPIDI_OFI_global.p2p_cq,
@@ -785,7 +785,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                                          i));
     }
 
-    *n_vcis_provided = MPIDI_OFI_global.max_ch4_vcis;
+    *n_vnis_provided = MPIDI_OFI_global.max_vnis;
 
     if (do_av_insert) {
         /* ---------------------------------- */
@@ -855,7 +855,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
     /* ---------------------------------- */
     /* Initialize Active Message          */
     /* ---------------------------------- */
-    mpi_errno = MPIDIG_init(comm_world, comm_self, *n_vcis_provided);
+    mpi_errno = MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -980,7 +980,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     MPIR_Assert(OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        for (i = 0; i < MPIDI_OFI_global.max_ch4_vcis; i++) {
+        for (i = 0; i < MPIDI_OFI_global.max_vnis; i++) {
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].tx), epclose);
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].rx), epclose);
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].cq), cqclose);
@@ -1042,9 +1042,9 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-static inline MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+static inline MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vni && vni < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -62,7 +62,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
     msg.context = (void *) &(MPIDI_OFI_REQUEST(rreq, context));
     msg.data = 0;
 
-    MPIDI_OFI_CALL_RETURN(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg,
+    MPIDI_OFI_CALL_RETURN(fi_trecvmsg(MPIDI_OFI_CTX(0).rx, &msg,
                                       peek_flags | FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA),
                           ofi_err);
     if (ofi_err == -FI_ENOMSG) {

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -19,7 +19,7 @@
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];
@@ -30,14 +30,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
     else if (likely(1)) {
-        ret = fi_cq_read(MPIDI_OFI_global.ctx[vci].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
+        ret = fi_cq_read(MPIDI_OFI_global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
             mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret);
         else if (ret == -FI_EAGAIN)
             mpi_errno = MPI_SUCCESS;
         else
-            mpi_errno = MPIDI_OFI_handle_cq_error(vci, ret);
+            mpi_errno = MPIDI_OFI_handle_cq_error(vni, ret);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROGRESS);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
     else if (likely(1)) {
-        ret = fi_cq_read(MPIDI_OFI_global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
+        ret = fi_cq_read(MPIDI_OFI_CTX(vni).cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
             mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.data = 0;
     msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr);
 
-    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv,
+    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_CTX(0).rx, &msg, flags), trecv,
                          MPIDI_OFI_CALL_LOCK, FALSE);
 
   fn_exit:
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV;
 
     if (!flags) /* Branch should compile out */
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,
                                       recv_buf,
                                       data_sz,
                                       NULL,
@@ -284,7 +284,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.data = 0;
         msg.addr = FI_ADDR_UNSPEC;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv,
+        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_CTX(0).rx, &msg, flags), trecv,
                              MPIDI_OFI_CALL_LOCK, FALSE);
     }
 
@@ -434,7 +434,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
     }
 #endif
 
-    ret = fi_cancel((fid_t) MPIDI_OFI_global.ctx[0].rx, &(MPIDI_OFI_REQUEST(rreq, context)));
+    ret = fi_cancel((fid_t) MPIDI_OFI_CTX(0).rx, &(MPIDI_OFI_REQUEST(rreq, context)));
 
     if (ret == 0) {
         while ((!MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) && (!MPIR_cc_is_complete(&rreq->cc))) {

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
     mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, comm->rank,
+        MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, buf, data_sz, NULL, comm->rank,
                                MPIDI_OFI_av_to_phys(addr), match_bits,
                                NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
                                MPIDI_OFI_COMM(comm).eagain);
@@ -63,7 +63,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
     MPIDI_OFI_SEND_REQUEST_CREATE_LW_CONDITIONAL(*request);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
     mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, comm->rank,
+        MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, buf, data_sz, NULL, comm->rank,
                                MPIDI_OFI_av_to_phys(addr), match_bits,
                                NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
                                MPIDI_OFI_COMM(comm).eagain);
@@ -217,7 +217,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.data = comm->rank;
     msg.addr = MPIDI_OFI_av_to_phys(addr);
 
-    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg, flags), tsendv,
+    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_CTX(0).tx, &msg, flags), tsendv,
                          MPIDI_OFI_CALL_LOCK, FALSE);
 
   fn_exit:
@@ -273,7 +273,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ssend_match =
             MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, rank, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,       /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,      /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
@@ -322,19 +322,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
         mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_av_to_phys(addr),
-                                   match_bits, NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
-                                   FALSE);
+            MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, send_buf, data_sz, NULL,
+                                   comm->rank, MPIDI_OFI_av_to_phys(addr), match_bits, NULL,
+                                   MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (data_sz <= MPIDI_OFI_global.max_msg_size) {
         mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_av_to_phys(addr),
-                                   match_bits, (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
-                                   MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+            MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, send_buf, data_sz, NULL,
+                                   comm->rank, MPIDI_OFI_av_to_phys(addr), match_bits,
+                                   (void *) &(MPIDI_OFI_REQUEST(sreq, context)), MPIDI_OFI_DO_SEND,
+                                   MPIDI_OFI_CALL_LOCK, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else if (unlikely(1)) {
@@ -378,7 +377,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
          * MPIDI_OFI_global.max_msg_size */
         MPIDI_OFI_REQUEST(sreq, util_comm) = comm;
         MPIDI_OFI_REQUEST(sreq, util_id) = rank;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, send_buf,
                                            MPIDI_OFI_global.max_msg_size,
                                            NULL,
                                            comm->rank,

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.h
@@ -248,7 +248,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
         while (req.done != MPIDI_OFI_PEEK_FOUND) {
             req.done = MPIDI_OFI_PEEK_START;
             MPIDI_OFI_CALL(fi_trecvmsg
-                           (MPIDI_OFI_global.ctx[0].rx, &msg,
+                           (MPIDI_OFI_CTX(0).rx, &msg,
                             FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA), trecv);
             do {
                 mpi_errno = MPID_Progress_test();
@@ -272,7 +272,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
         req.done = 0;
         req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,
                                       &buf,
                                       sizeof(int),
                                       NULL,
@@ -308,7 +308,7 @@ static inline int MPIDI_OFI_dynproc_handshake(int root,
 
         req.done = 0;
         req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx,
                                            &buf,
                                            sizeof(int),
                                            NULL,
@@ -378,7 +378,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         while (req[0].done != MPIDI_OFI_PEEK_FOUND) {
             req[0].done = MPIDI_OFI_PEEK_START;
             MPIDI_OFI_CALL(fi_trecvmsg
-                           (MPIDI_OFI_global.ctx[0].rx, &msg,
+                           (MPIDI_OFI_CTX(0).rx, &msg,
                             FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA), trecv);
             MPIDI_OFI_PROGRESS_WHILE(req[0].done == MPIDI_OFI_PEEK_START);
         }
@@ -398,7 +398,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         req[2].done = 0;
         req[2].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,
                                       *remote_upid_size,
                                       (*remote_size) * sizeof(size_t),
                                       NULL,
@@ -413,7 +413,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         MPIR_CHKPMEM_MALLOC((*remote_upids), char *, remote_upid_recvsize,
                             mpi_errno, "remote_upids", MPL_MEM_ADDRESS);
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,
                                       *remote_upids,
                                       remote_upid_recvsize,
                                       NULL,
@@ -422,7 +422,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
                                       mask_bits, &req[1].context), trecv, MPIDI_OFI_CALL_LOCK,
                              FALSE);
 
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_CTX(0).rx,
                                       *remote_node_ids,
                                       (*remote_size) * sizeof(int),
                                       NULL,
@@ -468,7 +468,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
         req[1].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
         req[2].done = 0;
         req[2].event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx,
+        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx,
                                            local_upid_size,
                                            local_size * sizeof(size_t),
                                            NULL,
@@ -484,7 +484,7 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
             MPIR_ERR_POP(mpi_errno);
         }
 
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx,
+        MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx,
                                local_upids,
                                local_upid_sendsize,
                                NULL,
@@ -493,9 +493,10 @@ static inline int MPIDI_OFI_dynproc_exchange_map(int root,
                                match_bits,
                                (void *) &req[1].context, MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK,
                                FALSE);
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, local_node_ids, local_size * sizeof(int),
-                               NULL, comm_ptr->rank, *conn, match_bits, (void *) &req[2].context,
-                               MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+        MPIDI_OFI_send_handler(MPIDI_OFI_CTX(0).tx, local_node_ids,
+                               local_size * sizeof(int), NULL, comm_ptr->rank, *conn, match_bits,
+                               (void *) &req[2].context, MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK,
+                               FALSE);
 
         MPIDI_OFI_PROGRESS_WHILE(!req[0].done || !req[1].done || !req[2].done);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -323,7 +323,7 @@ typedef struct {
     size_t tx_iov_limit;
     size_t rx_iov_limit;
     size_t rma_iov_limit;
-    int max_ch4_vcis;
+    int max_vnis;
     int max_rma_sep_tx_cnt;     /* Max number of transmit context on one RMA scalable EP */
     size_t max_order_raw;
     size_t max_order_war;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -329,7 +329,7 @@ typedef struct {
     size_t max_order_war;
     size_t max_order_waw;
 
-    /* Mutexex and endpoints */
+    /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[4];
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS
     MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_ENDPOINTS_SCALABLE];

--- a/src/mpid/ch4/netmod/ofi/ofi_vni.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vni.c
@@ -1,0 +1,93 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+#include <mpidimpl.h>
+#include "ofi_impl.h"
+
+void MPIDI_OFI_vni_pool_init(void)
+{
+    int vni;
+
+    for (vni = 0; vni < MPIDI_OFI_VNI_POOL(max_vnis); vni++) {
+        MPIDI_OFI_VNI(vni).is_free = 1;
+    }
+
+    MPIDI_OFI_VNI_POOL(next_free_vni) = 0;
+}
+
+int MPIDI_OFI_vni_pool_get_free_vni(void)
+{
+    int i;
+
+    for (i = 0; i < MPIDI_OFI_VNI_POOL(max_vnis); i++) {
+        if (MPIDI_OFI_VNI(i).is_free) {
+            return i;
+        }
+    }
+
+    return MPIDI_NM_VNI_INVALID;
+}
+
+void MPIDI_OFI_vni_arm(MPIDI_OFI_vni_t * vni)
+{
+    vni->is_free = 0;
+}
+
+void MPIDI_OFI_vni_unarm(MPIDI_OFI_vni_t * vni)
+{
+    vni->is_free = 1;
+}
+
+int MPIDI_OFI_vni_pool_alloc_vni(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties,
+                                 int *vni)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int my_vni, new_next_free_vni;
+
+    my_vni = MPIDI_OFI_VNI_POOL(next_free_vni);
+
+    if (my_vni == MPIDI_NM_VNI_INVALID) {
+        /* Search for a free vni. It might have been freed before this alloc */
+        my_vni = MPIDI_OFI_vni_pool_get_free_vni();
+        if (my_vni != MPIDI_NM_VNI_INVALID) {
+            MPIDI_OFI_vni_arm(&MPIDI_OFI_VNI(my_vni));
+        } else {
+            new_next_free_vni = MPIDI_NM_VNI_INVALID;
+            goto fn_exit;
+        }
+    } else {
+        MPIDI_OFI_vni_arm(&MPIDI_OFI_VNI(my_vni));
+    }
+    /* Update next free VNI */
+    new_next_free_vni = MPIDI_OFI_VNI_POOL(next_free_vni)++;
+    if (new_next_free_vni >= MPIDI_OFI_VNI_POOL(max_vnis) ||
+        !MPIDI_OFI_VNI(new_next_free_vni).is_free) {
+        new_next_free_vni = MPIDI_OFI_vni_pool_get_free_vni();
+    }
+  fn_exit:
+    MPIDI_OFI_VNI_POOL(next_free_vni) = new_next_free_vni;
+    *vni = my_vni;
+    return mpi_errno;
+}
+
+int MPIDI_OFI_vni_pool_free_vni(int vni)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_OFI_vni_unarm(&MPIDI_OFI_VNI(vni));
+
+    return mpi_errno;
+}
+
+int MPIDI_NM_vni_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vni)
+{
+    return MPIDI_OFI_vni_pool_alloc_vni(resources, properties, vni);
+}
+
+int MPIDI_NM_vni_free(int vni)
+{
+    return MPIDI_OFI_vni_pool_free_vni(vni);
+}

--- a/src/mpid/ch4/netmod/ofi/ofi_vni.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_vni.h
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef OFI_VNI_H_INCLUDED
+#define OFI_VNI_H_INCLUDED
+
+#include "ofi_impl.h"
+
+void MPIDI_OFI_vni_pool_init(void);
+int MPIDI_OFI_vni_pool_get_free_vni(void);
+int MPIDI_OFI_vni_pool_alloc_vni(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties,
+                                 int *vni);
+int MPIDI_OFI_vni_pool_free_vni(int vni);
+void MPIDI_OFI_vni_arm(MPIDI_OFI_vni_t * vni);
+void MPIDI_OFI_vni_unarm(MPIDI_OFI_vni_t * vni);
+
+#endif /* OFI_VNI_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -580,9 +580,9 @@ static inline int MPIDI_OFI_win_progress_fence(MPIR_Win * win)
 
     while (tcount > donecount) {
         MPIR_Assert(donecount <= tcount);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDI_OFI_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
         itercount++;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -348,7 +348,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_init_sep(MPIR_Win * win)
     utarray_pop_back(MPIDI_OFI_global.rma_sep_idx_array);
 
     MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                     &MPIDI_OFI_global.ctx[0].cq->fid,
+                                     &MPIDI_OFI_CTX(0).cq->fid,
                                      FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
     if (ret < 0) {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -447,7 +447,7 @@ static inline int MPIDI_OFI_win_init_stx(MPIR_Win * win)
         }
 
         MPIDI_OFI_CALL_RETURN(fi_ep_bind(MPIDI_OFI_WIN(win).ep,
-                                         &MPIDI_OFI_global.ctx[0].cq->fid,
+                                         &MPIDI_OFI_CTX(0).cq->fid,
                                          FI_TRANSMIT | FI_SELECTIVE_COMPLETION), ret);
         if (ret < 0) {
             MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
@@ -502,7 +502,7 @@ static inline int MPIDI_OFI_win_init_global(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_INIT_GLOBAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_INIT_GLOBAL);
 
-    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[0].tx;
+    MPIDI_OFI_WIN(win).ep = MPIDI_OFI_CTX(0).tx;
     MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.rma_cmpl_cntr;
     MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.rma_issued_cntr;
 
@@ -1217,7 +1217,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_win_free_hook(MPIR_Win * win)
             utarray_push_back(MPIDI_OFI_global.rma_sep_idx_array, &(MPIDI_OFI_WIN(win).sep_tx_idx),
                               MPL_MEM_RMA);
         }
-        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_global.ctx[0].tx)
+        if (MPIDI_OFI_WIN(win).ep != MPIDI_OFI_CTX(0).tx)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).ep->fid), epclose);
         if (MPIDI_OFI_WIN(win).cmpl_cntr != MPIDI_OFI_global.rma_cmpl_cntr)
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_WIN(win).cmpl_cntr->fid), cntrclose);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -17,13 +17,13 @@
 #define FUNCNAME MPIDI_OFI_handle_cq_error_util
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-int MPIDI_OFI_handle_cq_error_util(int vci_idx, ssize_t ret)
+int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
 
-    mpi_errno = MPIDI_OFI_handle_cq_error(vci_idx, ret);
+    mpi_errno = MPIDI_OFI_handle_cq_error(vni_idx, ret);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -442,7 +442,7 @@ static MPI_Op mpi_ops[] = {
 #define _TBL MPIDI_OFI_global.win_op_table[i][j]
 #define CHECK_ATOMIC(fcn,field1,field2)            \
   atomic_count = 0;                                \
-  ret = fcn(MPIDI_OFI_global.ctx[0].tx,                \
+  ret = fcn(MPIDI_OFI_CTX(0).tx,                \
     fi_dt,                                 \
     fi_op,                                 \
             &atomic_count);                        \

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -34,7 +34,8 @@ int MPIDI_OFI_retry_progress()
     /* We do not call progress on hooks form netmod level
      * because it is not reentrant safe.
      */
-    return MPIDI_Progress_test(MPIDI_PROGRESS_NM | MPIDI_PROGRESS_SHM);
+    return MPIDI_Progress_test(MPIDI_PROGRESS_NM | MPIDI_PROGRESS_SHM, MPIDI_PROGRESS_TYPE__GLOBAL,
+                               0);
 }
 
 typedef struct MPIDI_OFI_mr_key_allocator_t {

--- a/src/mpid/ch4/netmod/stubnm/globals.c
+++ b/src/mpid/ch4/netmod/stubnm/globals.c
@@ -16,7 +16,7 @@
 MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     MPIDI_NM_mpi_init_hook,
     MPIDI_NM_mpi_finalize_hook,
-    MPIDI_NM_vci_get_attr,
+    MPIDI_NM_vci_get_resource_info,
     MPIDI_NM_progress,
     MPIDI_NM_mpi_comm_connect,
     MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/stubnm/globals.c
+++ b/src/mpid/ch4/netmod/stubnm/globals.c
@@ -17,6 +17,8 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     MPIDI_NM_mpi_init_hook,
     MPIDI_NM_mpi_finalize_hook,
     MPIDI_NM_vni_get_resource_info,
+    MPIDI_NM_vni_alloc,
+    MPIDI_NM_vni_free,
     MPIDI_NM_progress,
     MPIDI_NM_mpi_comm_connect,
     MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/stubnm/globals.c
+++ b/src/mpid/ch4/netmod/stubnm/globals.c
@@ -16,7 +16,7 @@
 MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     MPIDI_NM_mpi_init_hook,
     MPIDI_NM_mpi_finalize_hook,
-    MPIDI_NM_vci_get_resource_info,
+    MPIDI_NM_vni_get_resource_info,
     MPIDI_NM_progress,
     MPIDI_NM_mpi_comm_connect,
     MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/stubnm/globals.c
+++ b/src/mpid/ch4/netmod/stubnm/globals.c
@@ -16,7 +16,7 @@
 MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     MPIDI_NM_mpi_init_hook,
     MPIDI_NM_mpi_finalize_hook,
-    MPIDI_NM_get_vci_attr,
+    MPIDI_NM_vci_get_attr,
     MPIDI_NM_progress,
     MPIDI_NM_mpi_comm_connect,
     MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -18,7 +18,7 @@ static inline int MPIDI_NM_mpi_init_hook(int rank,
                                          int appnum,
                                          int *tag_bits,
                                          MPIR_Comm * comm_world,
-                                         MPIR_Comm * comm_self, int spawned, int *n_vcis_provided)
+                                         MPIR_Comm * comm_self, int spawned, int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -34,7 +34,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-static inline MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+static inline MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -34,7 +34,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_get_vci_attr(int vci)
+static inline int MPIDI_NM_vci_get_attr(int vci)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.h
@@ -34,7 +34,7 @@ static inline int MPIDI_NM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_vci_get_attr(int vci)
+static inline MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
@@ -13,7 +13,7 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_progress(int vci, int blocking)
+static inline int MPIDI_NM_progress(int vni, int blocking)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_vni.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_vni.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#include <mpidimpl.h>
+
+int MPIDI_NM_vni_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vni)
+{
+    int ret = MPI_SUCCESS;
+    MPIR_Assert(0);
+    return ret;
+}
+
+int MPIDI_NM_vni_free(int vni)
+{
+    int ret = MPI_SUCCESS;
+    MPIR_Assert(0);
+    return ret;
+}

--- a/src/mpid/ch4/netmod/ucx/Makefile.mk
+++ b/src/mpid/ch4/netmod/ucx/Makefile.mk
@@ -8,7 +8,8 @@ if BUILD_CH4_NETMOD_UCX
 
 noinst_HEADERS     +=
 mpi_core_sources   += src/mpid/ch4/netmod/ucx/func_table.c\
-                      src/mpid/ch4/netmod/ucx/globals.c
+                      src/mpid/ch4/netmod/ucx/globals.c\
+                      src/mpid/ch4/netmod/ucx/ucx_vni.c
 
 errnames_txt_files += src/mpid/ch4/netmod/ucx/errnames.txt
 

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -18,6 +18,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
+    .get_vci_attr = MPIDI_NM_get_vci_attr,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -18,7 +18,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .get_vci_attr = MPIDI_NM_get_vci_attr,
+    .vci_get_attr = MPIDI_NM_vci_get_attr,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -18,7 +18,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .vci_get_resource_info = MPIDI_NM_vci_get_resource_info,
+    .vni_get_resource_info = MPIDI_NM_vni_get_resource_info,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -18,7 +18,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .mpi_init = MPIDI_NM_mpi_init_hook,
     .mpi_finalize = MPIDI_NM_mpi_finalize_hook,
-    .vci_get_attr = MPIDI_NM_vci_get_attr,
+    .vci_get_resource_info = MPIDI_NM_vci_get_resource_info,
     .progress = MPIDI_NM_progress,
     .mpi_comm_connect = MPIDI_NM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_NM_mpi_comm_disconnect,

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
         goto fn_exit;
     }
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, 0);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     /* initialize our portion of the hdr */
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, 0);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
     use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
+    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank, 0);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
@@ -377,7 +377,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, 0);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     /* initialize our portion of the hdr */
@@ -430,7 +430,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
 
     use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
+    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank, 0);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     /* initialize our portion of the hdr */

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.h
@@ -27,6 +27,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
     mpi_errno = MPIDIG_init_comm(comm);
 
     /* if this is MPI_COMM_WORLD, finish bc exchange */
+    /* TODO: extend the following to support multiple VNIs. Currently non-functional
+     * and program will fail if run with ROOTS_ONLY. Putting in placeholder value of
+     * 0 so that build doesn't fail. */
     if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
         ucs_status_t ucx_status;
         ucp_ep_params_t ep_params;
@@ -34,8 +37,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
         size_t *bc_indices;
 
         MPIR_Assert(MPII_Comm_is_node_consecutive(comm));
-        MPIDU_bc_allgather(comm, MPIDI_global.node_map[0], MPIDI_UCX_global.if_address,
-                           (int) MPIDI_UCX_global.addrname_len, FALSE,
+        MPIDU_bc_allgather(comm, MPIDI_global.node_map[0], MPIDI_UCX_VNI(0 /*WRONG*/).if_address,
+                           (int) MPIDI_UCX_VNI(0 /*WRONG*/).addrname_len, FALSE,
                            (void **) &MPIDI_UCX_global.pmi_addr_table, &bc_indices);
 
         /* insert new addresses, skipping over node roots */
@@ -48,8 +51,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm)
             ep_params.address =
                 (ucp_address_t *) & MPIDI_UCX_global.pmi_addr_table[bc_indices[curr]];
             ucx_status =
-                ucp_ep_create(MPIDI_UCX_global.worker, &ep_params,
-                              &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest);
+                ucp_ep_create(MPIDI_UCX_VNI(0 /*WRONG*/).worker, &ep_params,
+                              &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest[0 /*WRONG*/]);
             MPIDI_UCX_CHK_STATUS(ucx_status);
             curr++;
         }

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -19,9 +19,9 @@
 #define MPIDI_UCX_COMM(comm)     ((comm)->dev.ch4.netmod.ucx)
 #define MPIDI_UCX_REQ(req)       ((req)->dev.ch4.netmod.ucx)
 #define COMM_TO_INDEX(comm,rank) MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
-#define MPIDI_UCX_COMM_TO_EP(comm,rank) \
-    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(comm, rank)).dest
-#define MPIDI_UCX_AV_TO_EP(av) MPIDI_UCX_AV((av)).dest
+#define MPIDI_UCX_COMM_TO_EP(comm,rank,vni) \
+    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(comm, rank)).dest[vni]
+#define MPIDI_UCX_AV_TO_EP(av,vni) MPIDI_UCX_AV((av)).dest[vni]
 
 #define MPIDI_UCX_WIN(win) ((win)->dev.netmod.ucx)
 #define MPIDI_UCX_WIN_INFO(win, rank) MPIDI_UCX_WIN(win).info_table[rank]

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -12,6 +12,7 @@
 #include "ucx_impl.h"
 #include "mpir_cvars.h"
 #include "ucx_types.h"
+#include "ucx_vni.h"
 #include "mpidu_bc.h"
 #include <ucp/api/ucp.h>
 #undef FUNCNAME
@@ -116,7 +117,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 
-    MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
+    /* Initialize the pool of VNIs */
+    MPIDI_UCX_vni_pool_init();
+
+    MPIDIG_init(comm_world, comm_self);
 
     *tag_bits = MPIR_TAG_BITS_DEFAULT;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
                                                     int *tag_bits,
                                                     MPIR_Comm * comm_world,
                                                     MPIR_Comm * comm_self, int spawned,
-                                                    int *n_vcis_provided)
+                                                    int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_config_t *config;
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_INIT);
 
-    *n_vcis_provided = 1;
+    *n_vnis_provided = 1;
 
     ucx_status = ucp_config_read(NULL, NULL, &config);
     MPIDI_UCX_CHK_STATUS(ucx_status);
@@ -105,7 +105,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_init_hook(int rank,
         MPIDU_bc_table_destroy(MPIDI_UCX_global.pmi_addr_table);
     }
 
-    MPIDIG_init(comm_world, comm_self, *n_vcis_provided);
+    MPIDIG_init(comm_world, comm_self, *n_vnis_provided);
 
     *tag_bits = MPIR_TAG_BITS_DEFAULT;
 
@@ -209,12 +209,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_NM_vci_get_resource_info
+#define FUNCNAME MPIDI_NM_vni_get_resource_info
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vni && vni < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -209,10 +209,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_NM_get_vci_attr
+#define FUNCNAME MPIDI_NM_vci_get_attr
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_get_vci_attr(int vci)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.h
@@ -209,13 +209,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_finalize_hook(void)
 }
 
 #undef FUNCNAME
-#define FUNCNAME MPIDI_NM_vci_get_attr
+#define FUNCNAME MPIDI_NM_vci_get_resource_info
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_vci_get_attr(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 #undef FUNCNAME

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -12,6 +12,8 @@
 #include <ucp/api/ucp.h>
 
 #define MPIDI_UCX_KVSAPPSTRLEN 4096
+/* TODO: what is the right number? */
+#define MPIDI_UCX_MAX_WORKERS 256
 
 typedef struct {
     void *req;
@@ -62,7 +64,7 @@ typedef struct {
 } MPIDI_UCX_win_t;
 
 typedef struct {
-    ucp_ep_h dest;
+    ucp_ep_h dest[MPIDI_UCX_MAX_WORKERS];
 } MPIDI_UCX_addr_t;
 
 typedef struct {

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
-    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.worker, ucp_tag, tag_mask, 1, &info);
+    message_h = ucp_tag_probe_nb(MPIDI_UCX_VNI(0).worker, ucp_tag, tag_mask, 1, &info);
 
     if (message_h) {
         *flag = 1;
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
-    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.worker, ucp_tag, tag_mask, 0, &info);
+    message_h = ucp_tag_probe_nb(MPIDI_UCX_VNI(0).worker, ucp_tag, tag_mask, 0, &info);
 
     if (message_h) {
         *flag = 1;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -102,7 +102,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_Handle_am_recv(void *request, ucs_status
 #define FUNCNAME MPIDI_NM_progress
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_tag_recv_info_t info;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -111,28 +111,29 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vni, int blocking)
     ucp_tag_message_h message_handle;
     /* check for active messages */
     message_handle =
-        ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
+        ucp_tag_probe_nb(MPIDI_UCX_VNI(vni).worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
     while (message_handle) {
         am_buf = MPL_malloc(info.length, MPL_MEM_BUFFER);
-        ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
+        ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_VNI(vni).worker,
                                                                       am_buf,
                                                                       info.length,
                                                                       ucp_dt_make_contig(1),
                                                                       message_handle,
                                                                       &MPIDI_UCX_Handle_am_recv);
         while (!ucp_request_is_completed(ucp_request)) {
-            ucp_worker_progress(MPIDI_UCX_global.worker);
+            ucp_worker_progress(MPIDI_UCX_VNI(vni).worker);
         }
 
         ucp_request_release(ucp_request);
         MPIDI_UCX_am_handler(am_buf, info.length);
         MPL_free(am_buf);
         message_handle =
-            ucp_tag_probe_nb(MPIDI_UCX_global.worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1, &info);
+            ucp_tag_probe_nb(MPIDI_UCX_VNI(vni).worker, MPIDI_UCX_AM_TAG, MPIDI_UCX_AM_TAG, 1,
+                             &info);
 
     }
 
-    ucp_worker_progress(MPIDI_UCX_global.worker);
+    ucp_worker_progress(MPIDI_UCX_VNI(vni).worker);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -133,14 +133,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
 
     if (dt_contig) {
         ucp_request =
-            (MPIDI_UCX_ucp_request_t *) ucp_tag_recv_nb(MPIDI_UCX_global.worker,
+            (MPIDI_UCX_ucp_request_t *) ucp_tag_recv_nb(MPIDI_UCX_VNI(0).worker,
                                                         (char *) buf + dt_true_lb, data_sz,
                                                         ucp_dt_make_contig(1),
                                                         ucp_tag, tag_mask, &MPIDI_UCX_recv_cmpl_cb);
     } else {
         MPIR_Datatype_ptr_add_ref(dt_ptr);
         ucp_request =
-            (MPIDI_UCX_ucp_request_t *) ucp_tag_recv_nb(MPIDI_UCX_global.worker,
+            (MPIDI_UCX_ucp_request_t *) ucp_tag_recv_nb(MPIDI_UCX_VNI(0).worker,
                                                         buf, count,
                                                         dt_ptr->dev.netmod.ucx.ucp_datatype,
                                                         ucp_tag, tag_mask, &MPIDI_UCX_recv_cmpl_cb);
@@ -196,7 +196,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     if (dt_contig) {
         ucp_request =
-            (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
+            (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_VNI(0).worker,
                                                             (char *) buf + dt_true_lb,
                                                             data_sz,
                                                             ucp_dt_make_contig(1),
@@ -206,7 +206,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     } else {
         MPIR_Datatype_ptr_add_ref(dt_ptr);
         ucp_request =
-            (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_global.worker,
+            (MPIDI_UCX_ucp_request_t *) ucp_tag_msg_recv_nb(MPIDI_UCX_VNI(0).worker,
                                                             buf, count,
                                                             dt_ptr->dev.netmod.ucx.ucp_datatype,
                                                             MPIDI_UCX_REQ(message).
@@ -296,7 +296,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv_init(void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
 {
     if (!MPIR_Request_is_complete(rreq)) {
-        ucp_request_cancel(MPIDI_UCX_global.worker, MPIDI_UCX_REQ(rreq).a.ucp_request);
+        ucp_request_cancel(MPIDI_UCX_VNI(0).worker, MPIDI_UCX_REQ(rreq).a.ucp_request);
     }
 
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
     MPIR_Comm *comm = win->comm_ptr;
-    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
+    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr, 0);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
@@ -120,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
     struct MPIR_Segment *segment_ptr;
     char *buffer = NULL;
     MPIR_Comm *comm = win->comm_ptr;
-    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
+    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr, 0);
 
     segment_ptr = MPIR_Segment_alloc(origin_addr, origin_count, origin_datatype);
     MPIR_ERR_CHKANDJUMP1(segment_ptr == NULL, mpi_errno,
@@ -167,7 +167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
     MPIR_Comm *comm = win->comm_ptr;
-    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
+    ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr, 0);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -60,7 +60,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_SEND);
 
-    ep = MPIDI_UCX_AV_TO_EP(addr);
+    ep = MPIDI_UCX_AV_TO_EP(addr, 0);
     ucx_tag = MPIDI_UCX_init_tag(comm->context_id + context_offset, comm->rank, tag);
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
@@ -253,7 +253,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
 {
     if (!MPIR_Request_is_complete(sreq)) {
-        ucp_request_cancel(MPIDI_UCX_global.worker, MPIDI_UCX_REQ(sreq).a.ucp_request);
+        ucp_request_cancel(MPIDI_UCX_VNI(0).worker, MPIDI_UCX_REQ(sreq).a.ucp_request);
     }
 
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -26,19 +26,30 @@
 #define MPIDI_UCX_AM_TAG               (1ULL << MPIR_Process.tag_bits)
 
 typedef struct {
-    int avtid;
-    ucp_context_h context;
-    ucp_worker_h worker;
-    char addrname[UCP_PEER_NAME_MAX];
-    char *pmi_addr_table;
     size_t addrname_len;
     ucp_address_t *if_address;
+    ucp_worker_h worker;
+} MPIDI_UCX_vni_t;
+
+typedef struct {
+    int total_vnis;
+    MPIDI_UCX_vni_t vni[MPIDI_UCX_MAX_WORKERS];
+} MPIDI_UCX_vni_pool_t;
+
+typedef struct {
+    int avtid;
+    ucp_context_h context;
+    char addrname[UCP_PEER_NAME_MAX];
+    char *pmi_addr_table;
     char kvsname[MPIDI_UCX_KVSAPPSTRLEN];
     char pname[MPI_MAX_PROCESSOR_NAME];
     int max_addr_len;
+    MPIDI_UCX_vni_pool_t vni_pool;
 } MPIDI_UCX_global_t;
 
 #define MPIDI_UCX_AV(av)     ((av)->netmod.ucx)
+#define MPIDI_UCX_VNI_POOL(field) MPIDI_UCX_global.vni_pool.field
+#define MPIDI_UCX_VNI(i) MPIDI_UCX_VNI_POOL(vni)[i]
 
 extern MPIDI_UCX_global_t MPIDI_UCX_global;
 extern ucp_generic_dt_ops_t MPIDI_UCX_datatype_ops;

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -26,6 +26,7 @@
 #define MPIDI_UCX_AM_TAG               (1ULL << MPIR_Process.tag_bits)
 
 typedef struct {
+    int is_free;
     size_t addrname_len;
     ucp_address_t *if_address;
     ucp_worker_h worker;
@@ -33,6 +34,7 @@ typedef struct {
 
 typedef struct {
     int total_vnis;
+    int next_free_vni;
     MPIDI_UCX_vni_t vni[MPIDI_UCX_MAX_WORKERS];
 } MPIDI_UCX_vni_pool_t;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_vni.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_vni.c
@@ -1,0 +1,96 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#include <mpidimpl.h>
+#include "ucx_impl.h"
+#include "ucx_types.h"
+
+void MPIDI_UCX_vni_pool_init(void)
+{
+    int vni;
+
+    for (vni = 0; vni < MPIDI_UCX_VNI_POOL(total_vnis); vni++) {
+        MPIDI_UCX_VNI(vni).is_free = 1;
+    }
+
+    MPIDI_UCX_VNI_POOL(next_free_vni) = 0;
+}
+
+void MPIDI_UCX_vni_arm(MPIDI_UCX_vni_t * vni)
+{
+    vni->is_free = 0;
+}
+
+void MPIDI_UCX_vni_unarm(MPIDI_UCX_vni_t * vni)
+{
+    vni->is_free = 1;
+}
+
+int MPIDI_UCX_vni_pool_get_free_vni(void)
+{
+    int i;
+
+    for (i = 0; i < MPIDI_UCX_VNI_POOL(total_vnis); i++) {
+        if (MPIDI_UCX_VNI(i).is_free) {
+            return i;
+        }
+    }
+    return MPIDI_NM_VNI_INVALID;
+}
+
+int MPIDI_UCX_vni_pool_alloc_vni(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties,
+                                 int *vni)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int my_vni, new_next_free_vni;
+
+    my_vni = MPIDI_UCX_VNI_POOL(next_free_vni);
+
+    if (my_vni == MPIDI_NM_VNI_INVALID) {
+        /* Search for a free vni. It might have been freed before this alloc */
+        my_vni = MPIDI_UCX_vni_pool_get_free_vni();
+        if (my_vni != MPIDI_NM_VNI_INVALID) {
+            MPIDI_UCX_vni_arm(&MPIDI_UCX_VNI(my_vni));
+        } else {
+            /* if no free vni, the next is still MPIDI_NM_VNI_INVALID */
+            new_next_free_vni = MPIDI_NM_VNI_INVALID;
+            goto fn_exit;
+        }
+    } else {
+        MPIDI_UCX_vni_arm(&MPIDI_UCX_VNI(my_vni));
+    }
+    /* Update next free VNI */
+    new_next_free_vni = MPIDI_UCX_VNI_POOL(next_free_vni)++;
+    if (new_next_free_vni >= MPIDI_UCX_VNI_POOL(total_vnis) ||
+        !MPIDI_UCX_VNI(new_next_free_vni).is_free) {
+        /* Search for the next free VNI */
+        new_next_free_vni = MPIDI_UCX_vni_pool_get_free_vni();
+    }
+  fn_exit:
+    MPIDI_UCX_VNI_POOL(next_free_vni) = new_next_free_vni;
+    *vni = my_vni;
+    return mpi_errno;
+}
+
+int MPIDI_UCX_vni_pool_free_vni(int vni)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_UCX_vni_unarm(&MPIDI_UCX_VNI(vni));
+
+    return mpi_errno;
+}
+
+int MPIDI_NM_vni_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vni)
+{
+    return MPIDI_UCX_vni_pool_alloc_vni(resources, properties, vni);
+}
+
+int MPIDI_NM_vni_free(int vni)
+{
+    return MPIDI_UCX_vni_pool_free_vni(vni);
+}

--- a/src/mpid/ch4/netmod/ucx/ucx_vni.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_vni.h
@@ -1,0 +1,21 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef UCX_VNI_H_INCLUDED
+#define UCX_VNI_H_INCLUDED
+
+#include "ucx_impl.h"
+
+void MPIDI_UCX_vni_pool_init(void);
+int MPIDI_UCX_vni_pool_get_free_vni(void);
+int MPIDI_UCX_vni_pool_alloc_vni(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties,
+                                 int *vni);
+int MPIDI_UCX_vni_pool_free_vni(int vni);
+void MPIDI_UCX_vni_arm(MPIDI_UCX_vni_t * vni);
+void MPIDI_UCX_vni_unarm(MPIDI_UCX_vni_t * vni);
+
+#endif /* UCX_VNI_H_INCLUDED */

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -16,11 +16,16 @@
 
 #define MPIDI_MAX_SHM_STRING_LEN 64
 
+#define MPIDI_SHM_VSI_INVALID -1
+
 /* These typedef function definitions are used when not inlining the shared memory module along
  * with the struct of function pointers below. */
 typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vsis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
 typedef MPIDI_vci_resource_t(*MPIDI_SHM_vsi_get_resource_info_t) (int vsi);
+typedef int (*MPIDI_SHM_vsi_alloc_t) (MPIDI_vci_resource_t resources,
+                                      MPIDI_vci_property_t properties, int *vsi);
+typedef int (*MPIDI_SHM_vsi_free_t) (int vsi);
 typedef int (*MPIDI_SHM_progress_t) (int vsi, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
@@ -433,6 +438,8 @@ typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
     MPIDI_SHM_vsi_get_resource_info_t vsi_get_resource_info;
+    MPIDI_SHM_vsi_alloc_t vsi_alloc;
+    MPIDI_SHM_vsi_free_t vsi_free;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -592,6 +599,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi)
     MPL_STATIC_INLINE_SUFFIX;
+int MPIDI_SHM_vsi_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vsi);
+int MPIDI_SHM_vsi_free(int vsi);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vsi, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -18,10 +18,10 @@
 
 /* These typedef function definitions are used when not inlining the shared memory module along
  * with the struct of function pointers below. */
-typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
+typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vsis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef MPIDI_vci_resource_t(*MPIDI_SHM_vci_get_resource_info_t) (int vci);
-typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
+typedef MPIDI_vci_resource_t(*MPIDI_SHM_vsi_get_resource_info_t) (int vsi);
+typedef int (*MPIDI_SHM_progress_t) (int vsi, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
                                              MPIR_Comm ** newcomm_ptr);
@@ -432,7 +432,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_vci_get_resource_info_t vci_get_resource_info;
+    MPIDI_SHM_vsi_get_resource_info_t vsi_get_resource_info;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -587,12 +587,12 @@ extern MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs;
 extern MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
-                                                     int *n_vcis_provided,
+                                                     int *n_vsis_provided,
                                                      int *tag_bits) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi)
     MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vsi, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,
                                                         MPIR_Comm **

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -20,7 +20,7 @@
  * with the struct of function pointers below. */
 typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef int (*MPIDI_SHM_get_vci_attr_t) (int vci);
+typedef int (*MPIDI_SHM_vci_get_attr_t) (int vci);
 typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
@@ -432,7 +432,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_get_vci_attr_t get_vci_attr;
+    MPIDI_SHM_vci_get_attr_t vci_get_attr;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -590,7 +590,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
                                                      int *n_vcis_provided,
                                                      int *tag_bits) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vci_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_vci_get_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -20,7 +20,7 @@
  * with the struct of function pointers below. */
 typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef int (*MPIDI_SHM_vci_get_attr_t) (int vci);
+typedef MPIDI_vci_resource_t(*MPIDI_SHM_vci_get_resource_info_t) (int vci);
 typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
@@ -432,7 +432,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_vci_get_attr_t vci_get_attr;
+    MPIDI_SHM_vci_get_resource_info_t vci_get_resource_info;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -590,7 +590,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size,
                                                      int *n_vcis_provided,
                                                      int *tag_bits) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_vci_get_attr(int vci) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info,
                                                         int root, int timeout, MPIR_Comm * comm,

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -76,7 +76,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_choose_posix_eager(void)
 #define FUNCNAME MPIDI_POSIX_mpi_init_hook
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
+static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -93,7 +93,7 @@ static inline int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_prov
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_INIT_HOOK);
 
-    *n_vcis_provided = 1;
+    *n_vsis_provided = 1;
 
     /* This is used to track messages that the eager submodule was not ready to send. */
     MPIDI_POSIX_global.postponed_queue = NULL;
@@ -149,9 +149,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_POSIX_vsi_get_resource_info(int vsi)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vsi && vsi < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -149,10 +149,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_vci_get_attr(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 MPL_STATIC_INLINE_PREFIX void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/shm/posix/posix_init.h
+++ b/src/mpid/ch4/shm/posix/posix_init.h
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_get_vci_attr(int vci)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/shm/src/Makefile.mk
+++ b/src/mpid/ch4/shm/src/Makefile.mk
@@ -19,4 +19,5 @@ noinst_HEADERS += src/mpid/ch4/shm/src/shm_impl.h  \
         src/mpid/ch4/shm/src/shm_startall.h\
         src/mpid/ch4/shm/src/shm_rma.h
 
-mpi_core_sources   += src/mpid/ch4/shm/src/func_table.c
+mpi_core_sources   += src/mpid/ch4/shm/src/func_table.c \
+                      src/mpid/ch4/shm/src/shm_vsi.c

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHM_mpi_init_hook,
     .mpi_finalize = MPIDI_SHM_mpi_finalize_hook,
-    .get_vci_attr = MPIDI_SHM_get_vci_attr,
+    .vci_get_attr = MPIDI_SHM_vci_get_attr,
     .progress = MPIDI_SHM_progress,
     .mpi_comm_connect = MPIDI_SHM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHM_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHM_mpi_init_hook,
     .mpi_finalize = MPIDI_SHM_mpi_finalize_hook,
-    .vci_get_attr = MPIDI_SHM_vci_get_attr,
+    .vci_get_resource_info = MPIDI_SHM_vci_get_resource_info,
     .progress = MPIDI_SHM_progress,
     .mpi_comm_connect = MPIDI_SHM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHM_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHM_mpi_init_hook,
     .mpi_finalize = MPIDI_SHM_mpi_finalize_hook,
-    .vci_get_resource_info = MPIDI_SHM_vci_get_resource_info,
+    .vsi_get_resource_info = MPIDI_SHM_vsi_get_resource_info,
     .progress = MPIDI_SHM_progress,
     .mpi_comm_connect = MPIDI_SHM_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHM_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -46,14 +46,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_get_vci_attr(int vci)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_SHM_src_funcs.get_vci_attr(vci);
+    ret = MPIDI_SHM_src_funcs.vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -46,14 +46,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_vci_get_attr(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
 {
-    int ret;
+    MPIDI_vci_resource_t ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_SHM_src_funcs.vci_get_attr(vci);
+    ret = MPIDI_SHM_src_funcs.vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -19,7 +19,7 @@
 #ifndef SHM_INLINE
 #ifndef SHM_DISABLE_INLINES
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vsis_provided,
                                                      int *tag_bits)
 {
     int ret;
@@ -27,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
 
-    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vcis_provided, tag_bits);
+    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vsis_provided, tag_bits);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     return ret;
@@ -46,27 +46,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
+MPL_STATIC_INLINE_PREFIX MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi)
 {
     MPIDI_vci_resource_t ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VSI);
 
-    ret = MPIDI_SHM_src_funcs.vci_get_resource_info(vci);
+    ret = MPIDI_SHM_src_funcs.vsi_get_resource_info(vsi);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VSI);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vsi, int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_PROGRESS);
 
-    ret = MPIDI_SHM_src_funcs.progress(vci, blocking);
+    ret = MPIDI_SHM_src_funcs.progress(vsi, blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_PROGRESS);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_init.h
+++ b/src/mpid/ch4/shm/src/shm_init.h
@@ -10,6 +10,7 @@
 
 #include <shm.h>
 #include "../posix/shm_inline.h"
+#include "shm_vsi.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vsis_provided,
                                                      int *tag_bits)
@@ -18,6 +19,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
+
+    MPIDI_SHM_vsi_pool_init();
 
     ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vsis_provided, tag_bits);
 

--- a/src/mpid/ch4/shm/src/shm_init.h
+++ b/src/mpid/ch4/shm/src/shm_init.h
@@ -38,14 +38,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-static inline int MPIDI_SHM_get_vci_attr(int vci)
+static inline int MPIDI_SHM_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_POSIX_get_vci_attr(vci);
+    ret = MPIDI_POSIX_vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_init.h
+++ b/src/mpid/ch4/shm/src/shm_init.h
@@ -11,7 +11,7 @@
 #include <shm.h>
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vsis_provided,
                                                      int *tag_bits)
 {
     int ret;
@@ -19,7 +19,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
 
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vcis_provided, tag_bits);
+    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vsis_provided, tag_bits);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     return ret;
@@ -38,20 +38,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-static inline MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
+static inline MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi)
 {
     MPIDI_vci_resource_t ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VSI);
 
-    ret = MPIDI_POSIX_vci_get_resource_info(vci);
+    ret = MPIDI_POSIX_vsi_get_resource_info(vsi);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_QUERY_VSI);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vsi, int blocking)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/src/shm_init.h
+++ b/src/mpid/ch4/shm/src/shm_init.h
@@ -38,14 +38,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-static inline int MPIDI_SHM_vci_get_attr(int vci)
+static inline MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
 {
-    int ret;
+    MPIDI_vci_resource_t ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_POSIX_vci_get_attr(vci);
+    ret = MPIDI_POSIX_vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_vsi.c
+++ b/src/mpid/ch4/shm/src/shm_vsi.c
@@ -1,0 +1,77 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#include <mpidimpl.h>
+#include "shm_vsi.h"
+
+MPIDI_SHM_vsi_pool_t MPIDI_SHM_vsi_pool_global;
+
+void MPIDI_SHM_vsi_pool_init(void)
+{
+    int i;
+
+    MPIDI_SHM_VSI_POOL(max_vsis) = MPIDI_SHM_MAX_VSIS;
+
+    for (i = 0; i < MPIDI_SHM_VSI_POOL(max_vsis); i++) {
+        MPIDI_SHM_VSI_POOL(vsi)[i].is_free = 1;
+    }
+
+    MPIDI_SHM_VSI_POOL(next_free_vsi) = 0;
+}
+
+void MPIDI_SHM_vsi_arm(MPIDI_SHM_vsi_t * vsi)
+{
+    vsi->is_free = 0;
+}
+
+int MPIDI_SHM_vsi_alloc(MPIDI_vci_resource_t resources, MPIDI_vci_property_t properties, int *vsi)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int i;
+    int my_vsi;
+
+    my_vsi = MPIDI_SHM_VSI_POOL(next_free_vsi);
+
+    if (my_vsi == MPIDI_SHM_VSI_INVALID) {
+        /* Check if any VSI has been freed */
+        for (i = 0; i < MPIDI_SHM_VSI_POOL(max_vsis); i++) {
+            if (MPIDI_SHM_VSI_POOL(vsi)[i].is_free) {
+                /* need to set this here to prevent this VSI
+                 * from being selected in the search for the
+                 * next free VSI */
+                my_vsi = i;
+                MPIDI_SHM_vsi_arm(&MPIDI_SHM_VSI_POOL(vsi)[my_vsi]);
+                goto found_free_vsi;
+            }
+        }
+        my_vsi = MPIDI_SHM_VSI_INVALID;
+        goto fn_exit;
+    } else {
+        MPIDI_SHM_vsi_arm(&MPIDI_SHM_VSI_POOL(vsi)[my_vsi]);
+    }
+  found_free_vsi:
+    /* Update next_free_vsi */
+    MPIDI_SHM_VSI_POOL(next_free_vsi) = MPIDI_SHM_VSI_INVALID;
+    for (i = 0; i < MPIDI_SHM_VSI_POOL(max_vsis); i++) {
+        if (MPIDI_SHM_VSI_POOL(vsi)[i].is_free) {
+            MPIDI_SHM_VSI_POOL(next_free_vsi) = i;
+            break;
+        }
+    }
+  fn_exit:
+    *vsi = my_vsi;
+    return mpi_errno;
+}
+
+int MPIDI_SHM_vsi_free(int vsi)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_SHM_VSI_POOL(vsi)[vsi].is_free = 1;
+
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/src/shm_vsi.h
+++ b/src/mpid/ch4/shm/src/shm_vsi.h
@@ -1,0 +1,32 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef SHM_VCI_H_INCLUDED
+#define SHM_VCI_H_INCLUDED
+
+#define MPIDI_SHM_MAX_VSIS 1
+
+typedef struct MPIDI_SHM_vsi {
+    int is_free;
+    /* TODO: what is a VSI */
+} MPIDI_SHM_vsi_t;
+
+typedef struct MPIDI_SHM_vsi_pool {
+    int next_free_vsi;
+    int max_vsis;
+    MPIDI_SHM_vsi_t vsi[MPIDI_SHM_MAX_VSIS];
+} MPIDI_SHM_vsi_pool_t;
+extern MPIDI_SHM_vsi_pool_t MPIDI_SHM_vsi_pool_global;
+#define MPIDI_SHM_VSI_POOL(field) MPIDI_SHM_vsi_pool_global.field
+
+/* Declare slow-path functions */
+void MPIDI_SHM_vsi_pool_init(void);
+void MPIDI_SHM_vsi_arm(MPIDI_SHM_vsi_t * vsi);
+
+/* TODO: fast-path functions */
+
+#endif /* SHM_VCI_H_INCLUDED */

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.h
@@ -24,9 +24,9 @@ static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_pr
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_STUBSHM_vci_get_attr(int vci)
+static inline MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci)
 {
-    int ret = 0;
+    MPIDI_vci_resource_t ret = 0;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.h
@@ -13,7 +13,7 @@
 
 #include "stubshm_impl.h"
 
-static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided)
+static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vsis_provided)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
@@ -24,16 +24,16 @@ static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_pr
     return MPI_SUCCESS;
 }
 
-static inline MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci)
+static inline MPIDI_vci_resource_t MPIDI_STUBSHM_vsi_get_resource_info(int vsi)
 {
     MPIDI_vci_resource_t ret = 0;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
 
     MPIR_Assert(0);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
     return ret;
 }
 

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.h
@@ -24,7 +24,7 @@ static inline int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_pr
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_STUBSHM_get_vci_attr(int vci)
+static inline int MPIDI_STUBSHM_vci_get_attr(int vci)
 {
     int ret = 0;
 

--- a/src/mpid/ch4/shm/stubshm/stubshm_progress.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_progress.h
@@ -35,7 +35,7 @@ static inline int MPIDI_STUBSHM_do_progress_send(int blocking, int *completion_c
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_STUBSHM_progress(int vci, int blocking)
+static inline int MPIDI_STUBSHM_progress(int vsi, int blocking)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_PROGRESS);

--- a/src/mpid/ch4/src/Makefile.mk
+++ b/src/mpid/ch4/src/Makefile.mk
@@ -39,7 +39,8 @@ noinst_HEADERS += src/mpid/ch4/src/ch4_comm.h     \
                   src/mpid/ch4/src/ch4r_request.h
 
 mpi_core_sources += src/mpid/ch4/src/ch4_globals.c        \
-                    src/mpid/ch4/src/mpid_ch4_net_array.c
+                    src/mpid/ch4/src/mpid_ch4_net_array.c \
+                    src/mpid/ch4/src/ch4_vci.c
 
 if BUILD_CH4_COLL_TUNING
 mpi_core_sources += src/mpid/ch4/src/ch4_coll_globals.c

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -165,6 +165,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
     int mpi_errno;
     int i, *uniq_avtids;
     int max_n_avts;
+    int vci;
+    MPIDI_vci_type_t vci_type;
+    MPIDI_vci_resource_t vci_resources;
+    MPIDI_vci_property_t vci_properties;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMM_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMM_CREATE_HOOK);
 
@@ -209,6 +214,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_create_hook(MPIR_Comm * comm)
             default:
                 MPIDIU_avt_add_ref(MPIDI_COMM(comm, local_map).avtid);
         }
+
+        /* Assign a VCI for this communicator and store the mapping.
+         * Current policy: Try allocating an exclusive VCI for this communicator.
+         * If the allocation fails, we assign the shared VCI to this communicator.
+         * In the future, we have to translate hints provided in the info object
+         * to the VCI properties and resources here.
+         * */
+        vci_type = MPIDI_VCI_TYPE__EXCLUSIVE;
+        vci_resources = MPIDI_VCI_RESOURCE__GENERIC;
+        vci_properties = MPIDI_VCI_PROPERTY__GENERIC;
+        mpi_errno = MPIDI_vci_alloc(vci_type, vci_resources, vci_properties, &vci);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+        if (vci == MPIDI_VCI_INVALID) {
+            /* Fallback to allocating a shared VCI */
+            mpi_errno =
+                MPIDI_vci_alloc(MPIDI_VCI_TYPE__SHARED, MPIDI_VCI_RESOURCE__GENERIC,
+                                MPIDI_VCI_PROPERTY__GENERIC, &vci);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+
+        MPIDI_COMM_VCI(comm, vci) = vci;
     }
 
     mpi_errno = MPIDI_NM_mpi_comm_create_hook(comm);
@@ -292,6 +322,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Comm_free_hook(MPIR_Comm * comm)
     }
     if (MPIDI_COMM(comm, local_map).mode == MPIDI_RANK_MAP_MLUT) {
         MPIDIU_release_mlut(MPIDI_COMM(comm, local_map).irreg.mlut.t);
+    }
+
+    mpi_errno = MPIDI_vci_free(MPIDI_COMM_VCI(comm, vci));
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIR_ERR_POP(mpi_errno);
     }
 
     mpi_errno = MPIDI_NM_mpi_comm_free_hook(comm);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -15,8 +15,10 @@
 #include <mpidch4.h>
 #include "mpidig.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags);
-MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci);
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(MPIDI_hook_flags_t hook_flags,
+                                                 MPIDI_progress_type_t progress_type, int vci);
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_global(MPIDI_hook_flags_t hook_flags);
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(MPIDI_hook_flags_t hook_flags, int vci);
 MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_hooks(void);
 
 /* Static inlines */

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -16,6 +16,8 @@
 #include "mpidig.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags);
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci);
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_hooks(void);
 
 /* Static inlines */
 static inline int MPIDIG_get_context_index(uint64_t context_id)

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -209,7 +209,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     int avtid;
     int n_vnis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    int n_shm_vcis_provided;
+    int n_vsis_provided;
 #endif
 #ifndef USE_PMI2_API
     int max_pmi_name_length;
@@ -429,7 +429,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     {
         int shm_tag_bits = MPIR_TAG_BITS_DEFAULT, nm_tag_bits = MPIR_TAG_BITS_DEFAULT;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vcis_provided, &shm_tag_bits);
+        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_vsis_provided, &shm_tag_bits);
 
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -327,10 +327,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_UTIL_MUTEX, &thr_err);
 
-    MPID_Thread_mutex_create(&MPIDI_global.vci_lock, &mpi_errno);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POPFATAL(mpi_errno);
-    }
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
     MPIDI_workq_init(&MPIDI_global.workqueue);
 #endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
@@ -562,8 +558,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_CS_finalize(void)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_CS_FINALIZE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_CS_FINALIZE);
 
-    MPID_Thread_mutex_destroy(&MPIDI_global.vci_lock, &thr_err);
-    MPIR_Assert(thr_err == 0);
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPIR_Assert(thr_err == 0);
     MPID_Thread_mutex_destroy(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);

--- a/src/mpid/ch4/src/ch4_init.h
+++ b/src/mpid/ch4/src/ch4_init.h
@@ -207,7 +207,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 {
     int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
     int avtid;
-    int n_nm_vcis_provided;
+    int n_vnis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int n_shm_vcis_provided;
 #endif
@@ -438,7 +438,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Init(int *argc,
 
         mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits,
                                            MPIR_Process.comm_world,
-                                           MPIR_Process.comm_self, has_parent, &n_nm_vcis_provided);
+                                           MPIR_Process.comm_self, has_parent, &n_vnis_provided);
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -124,12 +124,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_iprobe_safe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IPROBE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IPROBE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     MPIDI_workq_vci_progress_unsafe();
     mpi_errno = MPIDI_iprobe_unsafe(source, tag, comm, context_offset, av, flag, status);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -157,12 +157,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_improbe_safe(int source,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMPROBE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMPROBE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     MPIDI_workq_vci_progress_unsafe();
     mpi_errno = MPIDI_improbe_unsafe(source, tag, comm, context_offset, av, flag, message, status);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_hooks(void)
 #define FUNCNAME MPIDI_Progress_test_vci
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(MPIDI_hook_flags_t hook_flags, int vci)
 {
     int mpi_errno;
     mpi_errno = MPI_SUCCESS;
@@ -60,7 +60,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci)
         MPIR_ERR_POP(mpi_errno);
     }
 
-    if (flags & MPIDI_PROGRESS_NM) {
+    if (hook_flags & MPIDI_PROGRESS_NM) {
         /* Progress the VNI of this VCI */
         mpi_errno = MPIDI_NM_progress(MPIDI_VCI(vci).vni, 0);
         if (mpi_errno != MPI_SUCCESS) {
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci)
         }
     }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (flags & MPIDI_PROGRESS_SHM) {
+    if (hook_flags & MPIDI_PROGRESS_SHM) {
         /* Progress the VSI of this VCI */
         mpi_errno = MPIDI_SHM_progress(MPIDI_VCI(vci).vsi, 0);
         if (mpi_errno != MPI_SUCCESS) {
@@ -85,10 +85,45 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci)
 }
 
 #undef FUNCNAME
+#define FUNCNAME MPIDI_Progress_test_global
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_global(MPIDI_hook_flags_t hook_flags)
+{
+    int mpi_errno, vci;
+    mpi_errno = MPI_SUCCESS;
+
+    /* Progress the registered hooks */
+    if (hook_flags & MPIDI_PROGRESS_HOOKS) {
+        mpi_errno = MPIDI_Progress_test_hooks();
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+    }
+    /* todo: progress unexp_list */
+
+    /* Progress all the allocated VCIs */
+    for (vci = 0; vci < MPIDI_VCI_POOL(max_vcis); vci++) {
+        if (!MPIDI_VCI(vci).is_free) {
+            mpi_errno = MPIDI_Progress_test_vci(hook_flags, vci);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#undef FUNCNAME
 #define FUNCNAME MPIDI_Progress_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
-MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(MPIDI_hook_flags_t hook_flags,
+                                                 MPIDI_progress_type_t progress_type, int vci)
 {
     int mpi_errno;
     mpi_errno = MPI_SUCCESS;
@@ -105,17 +140,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     }
 #endif
 
-    if (flags & MPIDI_PROGRESS_HOOKS) {
-        mpi_errno = MPIDI_Progress_test_hooks();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
-    }
-    /* todo: progress unexp_list */
-
-    mpi_errno = MPIDI_Progress_test_vci(flags, MPIDI_VCI_ROOT);
-    if (mpi_errno != MPI_SUCCESS) {
-        MPIR_ERR_POP(mpi_errno);
+    switch (progress_type) {
+        case MPIDI_PROGRESS_TYPE__GLOBAL:
+            mpi_errno = MPIDI_Progress_test_global(hook_flags);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+            break;
+        case MPIDI_PROGRESS_TYPE__VCI:
+            /* progress the VCI */
+            if (hook_flags & MPIDI_PROGRESS_HOOKS) {
+                mpi_errno = MPIDI_Progress_test_hooks();
+                if (mpi_errno != MPI_SUCCESS) {
+                    MPIR_ERR_POP(mpi_errno);
+                }
+            }
+            mpi_errno = MPIDI_Progress_test_vci(hook_flags, vci);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+            break;
     }
 
   fn_exit:
@@ -131,7 +175,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(void)
 {
-    return MPIDI_Progress_test(MPIDI_PROGRESS_ALL);
+    return MPIDI_Progress_test(MPIDI_PROGRESS_ALL, MPIDI_PROGRESS_TYPE__GLOBAL, 0);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_poke(void)

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -14,12 +14,83 @@
 #include "ch4_impl.h"
 
 #undef FUNCNAME
+#define FUNCNAME MPIDI_Progress_test_hooks
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_hooks(void)
+{
+    int mpi_errno, made_progress, i;
+    mpi_errno = MPI_SUCCESS;
+
+    for (i = 0; i < MPIDI_global.registered_progress_hooks; i++) {
+        progress_func_ptr_t func_ptr = NULL;
+        MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
+        if (MPIDI_global.progress_hooks[i].active == TRUE) {
+            MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
+            func_ptr = MPIDI_global.progress_hooks[i].func_ptr;
+            MPIR_Assert(func_ptr != NULL);
+            mpi_errno = func_ptr(&made_progress);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        } else {
+            MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
+        }
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_Progress_test_vci
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test_vci(int flags, int vci)
+{
+    int mpi_errno;
+    mpi_errno = MPI_SUCCESS;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+
+    /* Progress the WorkQ associated with this VCI */
+    mpi_errno = MPIDI_workq_vci_progress_unsafe();
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIR_ERR_POP(mpi_errno);
+    }
+
+    if (flags & MPIDI_PROGRESS_NM) {
+        /* Progress the VNI of this VCI */
+        mpi_errno = MPIDI_NM_progress(MPIDI_VCI(vci).vni, 0);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+    }
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    if (flags & MPIDI_PROGRESS_SHM) {
+        /* Progress the VSI of this VCI */
+        mpi_errno = MPIDI_SHM_progress(MPIDI_VCI(vci).vsi, 0);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+    }
+#endif
+
+  fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#undef FUNCNAME
 #define FUNCNAME MPIDI_Progress_test
 #undef FCNAME
 #define FCNAME MPL_QUOTE(FUNCNAME)
 MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 {
-    int mpi_errno, made_progress, i;
+    int mpi_errno;
     mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PROGRESS_TEST);
@@ -35,47 +106,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
 #endif
 
     if (flags & MPIDI_PROGRESS_HOOKS) {
-        for (i = 0; i < MPIDI_global.registered_progress_hooks; i++) {
-            progress_func_ptr_t func_ptr = NULL;
-            MPID_THREAD_CS_ENTER(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
-            if (MPIDI_global.progress_hooks[i].active == TRUE) {
-                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
-                func_ptr = MPIDI_global.progress_hooks[i].func_ptr;
-                MPIR_Assert(func_ptr != NULL);
-                mpi_errno = func_ptr(&made_progress);
-                if (mpi_errno)
-                    MPIR_ERR_POP(mpi_errno);
-
-            } else {
-                MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
-            }
-
+        mpi_errno = MPIDI_Progress_test_hooks();
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
         }
     }
     /* todo: progress unexp_list */
 
-    mpi_errno = MPIDI_workq_vci_progress();
-    if (mpi_errno != MPI_SUCCESS)
+    mpi_errno = MPIDI_Progress_test_vci(flags, MPIDI_VCI_ROOT);
+    if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
-
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
-
-    if (flags & MPIDI_PROGRESS_NM) {
-        mpi_errno = MPIDI_NM_progress(0, 0);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
     }
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (flags & MPIDI_PROGRESS_SHM) {
-        mpi_errno = MPIDI_SHM_progress(0, 0);
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POP(mpi_errno);
-        }
-    }
-#endif
+
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PROGRESS_TEST);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -58,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (flags & MPIDI_PROGRESS_NM) {
         mpi_errno = MPIDI_NM_progress(0, 0);
@@ -75,7 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Progress_test(int flags)
     }
 #endif
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PROGRESS_TEST);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -244,7 +244,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RECV_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
@@ -263,7 +263,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_RECV_SAFE);
     return mpi_errno;
 
@@ -288,7 +288,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IRECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
@@ -306,7 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IRECV_SAFE);
     return mpi_errno;
 
@@ -326,7 +326,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IMRECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
@@ -343,7 +343,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_IMRECV_SAFE);
     return mpi_errno;
 
@@ -361,11 +361,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_IRECV_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     mpi_errno = MPIDI_cancel_recv_unsafe(rreq);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/src/ch4_rma.h
+++ b/src/mpid/ch4/src/ch4_rma.h
@@ -530,7 +530,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PUT_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PUT_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
@@ -547,7 +547,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_put_safe(const void *origin_addr,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_PUT_SAFE);
     return mpi_errno;
   fn_fail:
@@ -570,7 +570,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         MPIR_Datatype_add_ref_if_not_builtin(origin_datatype);
@@ -589,7 +589,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_safe(void *origin_addr,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_GET_SAFE);
     return mpi_errno;
   fn_fail:
@@ -613,19 +613,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno = MPIDI_accumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                         target_disp, target_count, target_datatype, op, win);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ACCUMULATE_SAFE);
     return mpi_errno;
   fn_fail:
@@ -647,20 +647,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_compare_and_swap_safe(const void *origin_addr
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno =
         MPIDI_compare_and_swap_unsafe(origin_addr, compare_addr, result_addr, datatype,
                                       target_rank, target_disp, win);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMPARE_AND_SWAP_SAFE);
     return mpi_errno;
   fn_fail:
@@ -686,14 +686,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_raccumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno = MPIDI_raccumulate_unsafe(origin_addr, origin_count, origin_datatype, target_rank,
                                          target_disp, target_count, target_datatype, op, win,
                                          request);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
@@ -726,7 +726,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno =
@@ -734,7 +734,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_accumulate_safe(const void *origin_addr,
                                      result_count, result_datatype, target_rank, target_disp,
                                      target_count, target_datatype, op, win, request);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -761,19 +761,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_fetch_and_op_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno = MPIDI_fetch_and_op_unsafe(origin_addr, result_addr, datatype, target_rank,
                                           target_disp, op, win);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_FETCH_AND_OP_SAFE);
     return mpi_errno;
   fn_fail:
@@ -797,14 +797,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rget_safe(void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RGET_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RGET_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno =
         MPIDI_rget_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                           target_count, target_datatype, win, request);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -833,14 +833,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rput_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_RPUT_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RPUT_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno =
         MPIDI_rput_unsafe(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                           target_count, target_datatype, win, request);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -872,14 +872,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_accumulate_safe(const void *origin_addr,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_GET_ACCUMULATE_SAFE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
     mpi_errno = MPIDI_get_accumulate_unsafe(origin_addr, origin_count, origin_datatype, result_addr,
                                             result_count, result_datatype, target_rank, target_disp,
                                             target_count, target_datatype, op, win);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
@@ -213,7 +213,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_SAFE);
     return mpi_errno;
 
@@ -237,7 +237,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
@@ -255,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_SAFE);
     return mpi_errno;
 
@@ -279,7 +279,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SSEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
@@ -297,7 +297,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_SAFE);
     return mpi_errno;
 
@@ -321,7 +321,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISSEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
 
     if (!cs_acq) {
         *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
@@ -339,7 +339,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     }
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
+    MPID_THREAD_SAFE_END(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISSEND_SAFE);
     return mpi_errno;
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -41,7 +41,7 @@ typedef struct progress_hook_slot {
  * Flags argument allows to control execution of different parts of progress function,
  * for aims of prioritization of different transports and reentrant-safety of progress call.
  *
- * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internaly,
+ * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internally,
  *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
  * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
  */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -21,12 +21,6 @@
 
 #define MAX_PROGRESS_HOOKS 4
 
-/* VCI attributes */
-enum {
-    MPIDI_VCI_TX = 0x1,         /* Can send */
-    MPIDI_VCI_RX = 0x2, /* Can receive */
-};
-
 #define MPIDIU_BUF_POOL_NUM (1024)
 #define MPIDIU_BUF_POOL_SZ (256)
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -303,6 +303,7 @@ typedef struct MPIDI_CH4_Global_t {
     OPA_int_t progress_count;
 
     MPID_Thread_mutex_t vci_lock;
+    MPIDI_vci_pool_t vci_pool;
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
     MPIDI_workq_t workqueue;
 #endif

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -30,7 +30,25 @@ typedef struct progress_hook_slot {
     int active;
 } progress_hook_slot_t;
 
-/* Flags for MPIDI_Progress_test
+/* Flags for the type of progress in MPIDI_Progress_test
+ *
+ * progress_type argument allows to control the type of progress to execute to avoid
+ * executing global progress in every execution of the progress function.
+ *
+ * MPIDI_PROGRESS_TYPE__GLOBAL - performs the global progress, that is, it progresses
+ * all the hooks, and all VCIs. Note that it will progress the progress hooks, VNIs,
+ * and VSIs only if the corresponding hook flags are set (see below).
+ *
+ * MPIDI_PROGRESS_TYPE__VCI - performs progress on only 1 VCI (specified). The VNIs
+ * and VSIs of the VCI will be progressed only if the corresponding hook flags are
+ * set.
+ */
+typedef enum {
+    MPIDI_PROGRESS_TYPE__GLOBAL = 0x1,
+    MPIDI_PROGRESS_TYPE__VCI = 0x2,
+} MPIDI_progress_type_t;
+
+/* Flags for hooks in MPIDI_Progress_test
  *
  * Flags argument allows to control execution of different parts of progress function,
  * for aims of prioritization of different transports and reentrant-safety of progress call.
@@ -39,9 +57,11 @@ typedef struct progress_hook_slot {
  *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
  * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
  */
-#define MPIDI_PROGRESS_HOOKS  (1)
-#define MPIDI_PROGRESS_NM     (1<<1)
-#define MPIDI_PROGRESS_SHM    (1<<2)
+typedef enum {
+    MPIDI_PROGRESS_HOOKS = 0x1,
+    MPIDI_PROGRESS_NM = 0x2,
+    MPIDI_PROGRESS_SHM = 0x4,
+} MPIDI_hook_flags_t;
 
 #define MPIDI_PROGRESS_ALL (MPIDI_PROGRESS_HOOKS|MPIDI_PROGRESS_NM|MPIDI_PROGRESS_SHM)
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -302,7 +302,6 @@ typedef struct MPIDI_CH4_Global_t {
 #endif
     OPA_int_t progress_count;
 
-    MPID_Thread_mutex_t vci_lock;
     MPIDI_vci_pool_t vci_pool;
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
     MPIDI_workq_t workqueue;

--- a/src/mpid/ch4/src/ch4_vci.c
+++ b/src/mpid/ch4/src/ch4_vci.c
@@ -1,0 +1,291 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpidimpl.h"
+#include "ch4_vci.h"
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_vci_pool_create_and_init
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+int MPIDI_vci_pool_create_and_init(int num_vsis, int num_vnis)
+#else
+int MPIDI_vci_pool_create_and_init(int num_vnis)
+#endif
+{
+    int mpi_errno = MPI_SUCCESS;
+    int i;
+
+    /* Statically allocate the maximum possible size of the CH4 VCI pool.
+     * The root VCI takes 1 NM and 1 SHM VCI. The rest could be VSI-only
+     * or VNI-only VCIs. It is guaranteed that we have at least 1 VNI and
+     * at least 1 VSI. */
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_VCI_POOL(max_vcis) = 1 + (num_vnis - 1) + (num_vsis - 1);
+#else
+    MPIDI_VCI_POOL(max_vcis) = num_vnis;
+#endif
+
+    MPIDI_VCI_POOL(vci) = MPL_malloc(MPIDI_VCI_POOL(max_vcis) * sizeof(MPIDI_vci_t), MPL_MEM_OTHER);
+
+    /* Initialize all VCIs in the pool */
+    for (i = 0; i < MPIDI_VCI_POOL(max_vcis); i++) {
+        MPID_Thread_mutex_create(&MPIDI_VCI(i).lock, &mpi_errno);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+
+        MPIDI_VCI(i).ref_count = 0;
+
+        MPIDI_VCI(i).vni = MPIDI_NM_VNI_INVALID;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        MPIDI_VCI(i).vsi = MPIDI_SHM_VSI_INVALID;
+#endif
+        MPIDI_VCI(i).is_free = 1;
+    }
+
+    MPID_Thread_mutex_create(&MPIDI_VCI_POOL(lock), &mpi_errno);
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIR_ERR_POP(mpi_errno);
+    }
+
+    MPIDI_VCI_POOL(next_free_vci) = MPIDI_VCI_ROOT;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* This is called only during finalize time. So, no thread
+ * safety required here. */
+#undef FUNCNAME
+#define FUNCNAME MPIDI_vci_pool_destroy
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIDI_vci_pool_destroy(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int i;
+
+    /* Free the VCIs that have not been freed yet */
+    for (i = 0; i < MPIDI_VCI_POOL(max_vcis); i++) {
+        if (!MPIDI_VCI(i).is_free) {
+            mpi_errno = MPIDI_vci_free(i);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+    }
+
+    MPID_Thread_mutex_destroy(&MPIDI_VCI_POOL(lock), &mpi_errno);
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIR_ERR_POP(mpi_errno);
+    }
+
+    MPL_free(MPIDI_VCI_POOL(vci));
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+void MPIDI_vci_arm(MPIDI_vci_t * vci, int vni, int vsi)
+#else
+void MPIDI_vci_arm(MPIDI_vci_t * vci, int vni)
+#endif
+{
+    vci->vni = vni;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    vci->vsi = vsi;
+#endif
+    vci->is_free = 0;
+}
+
+void MPIDI_vci_unarm(MPIDI_vci_t * vci)
+{
+    vci->vni = MPIDI_NM_VNI_INVALID;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    vci->vsi = MPIDI_SHM_VSI_INVALID;
+#endif
+    vci->is_free = 1;
+}
+
+void MPIDI_vci_pool_get_free_vci(int *free_vci)
+{
+    int i;
+
+    *free_vci = MPIDI_VCI_INVALID;
+
+    for (i = 0; i < MPIDI_VCI_POOL(max_vcis); i++) {
+        if (MPIDI_VCI(i).is_free) {
+            *free_vci = i;
+            return;
+        }
+    }
+}
+
+void MPIDI_vci_pool_update_next_free_vci()
+{
+    int new_next_free_vci;
+
+    new_next_free_vci = MPIDI_VCI_POOL(next_free_vci)++;
+
+    if (new_next_free_vci >= MPIDI_VCI_POOL(max_vcis) || !MPIDI_VCI(new_next_free_vci).is_free) {
+        MPIDI_vci_pool_get_free_vci(&new_next_free_vci);
+    }
+
+    MPIDI_VCI_POOL(next_free_vci) = new_next_free_vci;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_vci_alloc
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIDI_vci_alloc(MPIDI_vci_type_t type, MPIDI_vci_resource_t resources,
+                    MPIDI_vci_property_t properties, int *vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int my_vci, my_vni;
+
+    my_vci = MPIDI_VCI_INVALID;
+    my_vni = MPIDI_NM_VNI_INVALID;
+
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    int my_vsi;
+    my_vsi = MPIDI_SHM_VSI_INVALID;
+#endif
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_POOL(lock));
+
+    if (MPIDI_VCI_POOL(next_free_vci) == MPIDI_VCI_ROOT) {
+        my_vci = MPIDI_VCI_ROOT;
+        /* Allocate a VNI for the root VCI */
+        mpi_errno =
+            MPIDI_NM_vni_alloc(MPIDI_VCI_RESOURCE__GENERIC, MPIDI_VCI_PROPERTY__GENERIC, &my_vni);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+        if (my_vni == MPIDI_NM_VNI_INVALID) {
+            goto fn_exit;
+        }
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        /* Allocate a VSI for the root VCI */
+        mpi_errno =
+            MPIDI_SHM_vsi_alloc(MPIDI_VCI_RESOURCE__GENERIC, MPIDI_VCI_PROPERTY__GENERIC, &my_vsi);
+        if (mpi_errno != MPI_SUCCESS) {
+            MPIR_ERR_POP(mpi_errno);
+        }
+        if (my_vsi == MPIDI_SHM_VSI_INVALID) {
+            MPIDI_NM_vni_free(my_vni);
+            goto fn_exit;
+        }
+#endif
+    } else {
+        switch (type) {
+            case MPIDI_VCI_TYPE__EXCLUSIVE:
+                /* Obtain VNI, and/or VSI, and VCI in that order */
+                if (resources & MPIDI_VCI_RESOURCE__NM) {
+                    /* Allocate a VNI */
+                    mpi_errno = MPIDI_NM_vni_alloc(resources, properties, &my_vni);
+                    if (mpi_errno != MPI_SUCCESS) {
+                        MPIR_ERR_POP(mpi_errno);
+                    }
+                    if (my_vni == MPIDI_NM_VNI_INVALID) {
+                        goto fn_exit;
+                    }
+                }
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+                if (resources & MPIDI_VCI_RESOURCE__SHM) {
+                    /* Allocate a VSI */
+                    mpi_errno = MPIDI_SHM_vsi_alloc(resources, properties, &my_vsi);
+                    if (mpi_errno != MPI_SUCCESS) {
+                        MPIR_ERR_POP(mpi_errno);
+                    }
+                    if (my_vsi == MPIDI_SHM_VSI_INVALID) {
+                        if (resources & MPIDI_VCI_RESOURCE__NM) {
+                            MPIDI_NM_vni_free(my_vni);
+                        }
+                        goto fn_exit;
+                    }
+                }
+#endif
+                /* Get a free VCI */
+                my_vci = MPIDI_VCI_POOL(next_free_vci);
+                if (my_vci == MPIDI_VCI_INVALID) {
+                    /* Search for a free VCI. It must have been freed before this alloc.
+                     * Otherwise the VNI or VSI alloc should have failed. */
+                    MPIDI_vci_pool_get_free_vci(&my_vci);
+                }
+                break;
+            case MPIDI_VCI_TYPE__SHARED:
+                /* Return the root VCI */
+                my_vci = MPIDI_VCI_ROOT;
+                goto update_ref_count;
+        }
+    }
+    /* Arm this VCI */
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_vci_arm(&MPIDI_VCI(my_vci), my_vni, my_vsi);
+#else
+    MPIDI_vci_arm(&MPIDI_VCI(my_vci), my_vni);
+#endif
+    /* Update next free VCI */
+    MPIDI_vci_pool_update_next_free_vci();
+  update_ref_count:
+    /* Increment the reference counter for this VCI */
+    MPIDI_VCI(my_vci).ref_count++;
+  fn_exit:
+    *vci = my_vci;
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_POOL(lock));
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#undef FUNCNAME
+#define FUNCNAME MPIDI_vci_free
+#undef FCNAME
+#define FCNAME MPL_QUOTE(FUNCNAME)
+int MPIDI_vci_free(int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_vci_t *this_vci;
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_POOL(lock));
+
+    this_vci = &MPIDI_VCI(vci);
+    this_vci->ref_count--;
+
+    if (this_vci->ref_count == 0) {
+        if (this_vci->vni != MPIDI_NM_VNI_INVALID) {
+            /* Free the VNI */
+            mpi_errno = MPIDI_NM_vni_free(this_vci->vni);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        if (this_vci->vsi != MPIDI_SHM_VSI_INVALID) {
+            /* Free the VSI */
+            mpi_errno = MPIDI_SHM_vsi_free(this_vci->vsi);
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+#endif
+        /* Unarm this VCI */
+        MPIDI_vci_unarm(this_vci);
+    }
+  fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_POOL(lock));
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * (C) 2019 by Argonne National Laboratory.
+ *     See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef CH4_VCI_H_INCLUDED
+#define CH4_VCI_H_INCLUDED
+
+#include "ch4_vci_types.h"
+
+/** Slow-path function declarations **/
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+int MPIDI_vci_pool_create_and_init(int num_vsis, int num_vnis);
+#else
+int MPIDI_vci_pool_create_and_init(int num_vnis);
+#endif
+int MPIDI_vci_pool_destroy(void);
+void MPIDI_vci_pool_get_free_vci(int *free_vci);
+void MPIDI_vci_pool_update_next_free_vci();
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+void MPIDI_vci_arm(MPIDI_vci_t * vci, int vni, int vsi);
+#else
+void MPIDI_vci_arm(MPIDI_vci_t * vci, int vni);
+#endif
+void MPIDI_vci_unarm(MPIDI_vci_t * vci);
+int MPIDI_vci_alloc(MPIDI_vci_type_t type, MPIDI_vci_resource_t resources,
+                    MPIDI_vci_property_t properties, int *vci);
+int MPIDI_vci_free(int vci);
+
+/** Fast-path functions **/
+MPL_STATIC_INLINE_PREFIX int MPIDI_vci_get(MPIR_Comm * comm_ptr, int rank, int tag)
+{
+    /* only root VCI in the pool now */
+    return MPIDI_VCI_ROOT;
+}
+
+#endif /* CH4_VCI_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -32,8 +32,8 @@ int MPIDI_vci_free(int vci);
 /** Fast-path functions **/
 MPL_STATIC_INLINE_PREFIX int MPIDI_vci_get(MPIR_Comm * comm_ptr, int rank, int tag)
 {
-    /* only root VCI in the pool now */
-    return MPIDI_VCI_ROOT;
+    /* Only a single VCI per comm */
+    return MPIDI_COMM_VCI(comm_ptr, vci);
 }
 
 #endif /* CH4_VCI_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_vci_types.h
+++ b/src/mpid/ch4/src/ch4_vci_types.h
@@ -1,0 +1,20 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ * (C) 2019 by Argonne National Laboratory.
+ *     See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef CH4_VCI_TYPES_H_INCLUDED
+#define CH4_VCI_TYPES_H_INCLUDED
+
+/* VCI resources */
+typedef enum {
+    MPIDI_VCI_RESOURCE__TX = 0x1,       /* Can send */
+    MPIDI_VCI_RESOURCE__RX = 0x2,       /* Can receive */
+} MPIDI_vci_resource_t;
+
+#define MPIDI_VCI_RESOURCE__GENERIC MPIDI_VCI_RESOURCE__TX | \
+                                    MPIDI_VCI_RESOURCE__RX
+
+#endif /* CH4_VCI_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_vci_types.h
+++ b/src/mpid/ch4/src/ch4_vci_types.h
@@ -17,4 +17,21 @@ typedef enum {
 #define MPIDI_VCI_RESOURCE__GENERIC MPIDI_VCI_RESOURCE__TX | \
                                     MPIDI_VCI_RESOURCE__RX
 
+/* VCI properties */
+typedef enum {
+    MPIDI_VCI_PROPERTY__TAGGED_ORDERED = 0x1,
+    MPIDI_VCI_PROPERTY__TAGGED_UNORDERED = 0x2,
+    MPIDI_VCI_PROPERTY__RAR = 0x4,
+    MPIDI_VCI_PROPERTY__WAR = 0x8,
+    MPIDI_VCI_PROPERTY__RAW = 0x10,
+    MPIDI_VCI_PROPERTY__WAW = 0x20,
+} MPIDI_vci_property_t;
+
+#define MPIDI_VCI_PROPERTY__GENERIC MPIDI_VCI_PROPERTY__TAGGED_ORDERED | \
+                                    MPIDI_VCI_PROPERTY__TAGGED_UNORDERED | \
+                                    MPIDI_VCI_PROPERTY__RAR | \
+                                    MPIDI_VCI_PROPERTY__WAR | \
+                                    MPIDI_VCI_PROPERTY__RAW | \
+                                    MPIDI_VCI_PROPERTY__WAW
+
 #endif /* CH4_VCI_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_vci_types.h
+++ b/src/mpid/ch4/src/ch4_vci_types.h
@@ -69,4 +69,14 @@ typedef struct MPIDI_vci_pool {
     MPIDI_vci_t *vci;           /* array of VCIs */
 } MPIDI_vci_pool_t;
 
+/* VCI hash */
+typedef struct MPIDI_vci_hash {
+    union {
+        struct {
+            int vci;
+        } single;
+        /* TODO: struct multi */
+    } u;
+} MPIDI_vci_hash_t;
+
 #endif /* CH4_VCI_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_vci_types.h
+++ b/src/mpid/ch4/src/ch4_vci_types.h
@@ -8,14 +8,26 @@
 #ifndef CH4_VCI_TYPES_H_INCLUDED
 #define CH4_VCI_TYPES_H_INCLUDED
 
+#include "mpid_thread.h"
+
+#define MPIDI_VCI_ROOT 0
+#define MPIDI_VCI_INVALID -1
+
+#define MPIDI_VCI_POOL(field) MPIDI_global.vci_pool.field
+#define MPIDI_VCI(i) MPIDI_VCI_POOL(vci)[i]
+
 /* VCI resources */
 typedef enum {
     MPIDI_VCI_RESOURCE__TX = 0x1,       /* Can send */
     MPIDI_VCI_RESOURCE__RX = 0x2,       /* Can receive */
+    MPIDI_VCI_RESOURCE__NM = 0x4,       /* Can perform netmod operations */
+    MPIDI_VCI_RESOURCE__SHM = 0x8,      /* Can perform shmmod operations */
 } MPIDI_vci_resource_t;
 
 #define MPIDI_VCI_RESOURCE__GENERIC MPIDI_VCI_RESOURCE__TX | \
-                                    MPIDI_VCI_RESOURCE__RX
+                                    MPIDI_VCI_RESOURCE__RX | \
+                                    MPIDI_VCI_RESOURCE__NM | \
+                                    MPIDI_VCI_RESOURCE__SHM
 
 /* VCI properties */
 typedef enum {
@@ -33,5 +45,28 @@ typedef enum {
                                     MPIDI_VCI_PROPERTY__WAR | \
                                     MPIDI_VCI_PROPERTY__RAW | \
                                     MPIDI_VCI_PROPERTY__WAW
+
+/* VCI types */
+typedef enum {
+    MPIDI_VCI_TYPE__SHARED = 0x1,       /* VCI can be used by multiple objects */
+    MPIDI_VCI_TYPE__EXCLUSIVE = 0x2,    /* VCI will be used by only one object */
+} MPIDI_vci_type_t;
+
+/* VCI */
+typedef struct MPIDI_vci {
+    MPID_Thread_mutex_t lock;   /* lock to protect the objects in this VCI */
+    int ref_count;              /* number of objects referring to this VCI */
+    int is_free;                /* flag to check if this VCI is free or not */
+    int vni;                    /* index to the VNI in the netmod's pool */
+    int vsi;                    /* index to the VSI in the shmmod's pool */
+} MPIDI_vci_t;
+
+/* VCI pool */
+typedef struct MPIDI_vci_pool {
+    int next_free_vci;
+    int max_vcis;
+    MPID_Thread_mutex_t lock;   /* lock to protect the VCI pool */
+    MPIDI_vci_t *vci;           /* array of VCIs */
+} MPIDI_vci_pool_t;
 
 #endif /* CH4_VCI_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_win.h
+++ b/src/mpid/ch4/src/ch4_win.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_START);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_START);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_start(MPIR_Group * group, int assert, MPIR
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_START);
     return mpi_errno;
   fn_fail:
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_COMPLETE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_COMPLETE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_complete(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_COMPLETE);
     return mpi_errno;
   fn_fail:
@@ -117,7 +117,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_POST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_POST);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -132,7 +132,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_post(MPIR_Group * group, int assert, MPIR_
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_POST);
     return mpi_errno;
   fn_fail:
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_WAIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_WAIT);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -164,7 +164,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_wait(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_WAIT);
     return mpi_errno;
   fn_fail:
@@ -182,7 +182,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_TEST);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_TEST);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -197,7 +197,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_test(MPIR_Win * win, int *flag)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_TEST);
     return mpi_errno;
   fn_fail:
@@ -214,7 +214,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -229,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock(int lock_type, int rank, int assert, 
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_LOCK);
     return mpi_errno;
   fn_fail:
@@ -246,7 +246,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_UNLOCK);
     return mpi_errno;
   fn_fail:
@@ -335,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FENCE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FENCE);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -350,7 +350,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_fence(int assert, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FENCE);
     return mpi_errno;
   fn_fail:
@@ -458,7 +458,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -473,7 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_LOCAL);
     return mpi_errno;
   fn_fail:
@@ -576,7 +576,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -591,7 +591,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush(int rank, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH);
     return mpi_errno;
   fn_fail:
@@ -608,7 +608,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -623,7 +623,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_local_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_LOCAL_ALL);
     return mpi_errno;
   fn_fail:
@@ -640,7 +640,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_UNLOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_UNLOCK_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -655,7 +655,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_unlock_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_UNLOCK_ALL);
     return mpi_errno;
   fn_fail:
@@ -699,7 +699,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_SYNC);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_SYNC);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -714,7 +714,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_sync(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_SYNC);
     return mpi_errno;
   fn_fail:
@@ -731,7 +731,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_FLUSH_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -746,7 +746,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_flush_all(MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_FLUSH_ALL);
     return mpi_errno;
   fn_fail:
@@ -763,7 +763,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_WIN_LOCK_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_WIN_LOCK_ALL);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIDI_workq_vci_progress_unsafe();
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -778,7 +778,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Win_lock_all(int assert, MPIR_Win * win)
 #endif
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_WIN_LOCK_ALL);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -383,11 +383,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_workq_vci_progress(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
     mpi_errno = MPIDI_workq_vci_progress_unsafe();
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
   fn_fail:
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4r_probe.h
+++ b/src/mpid/ch4/src/ch4r_probe.h
@@ -54,9 +54,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
          * be yielded easily. Recursive locking currently only works for the global
          * lock. One way to improve this is to fix the lock yielding API to avoid this
          * constraint.*/
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     }
     /* MPIDI_CS_EXIT(); */
 
@@ -116,9 +116,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         MPIR_STATUS_SET_COUNT(*status, MPIDIG_REQUEST(unexp_req, count));
     } else {
         *flag = 0;
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     }
     /* MPIDI_CS_EXIT(); */
 

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -550,9 +550,9 @@ static inline int MPIDIG_mpi_win_complete(MPIR_Win * win)
 
     /* FIXME: now we simply set per-target counters for PSCW, can it be optimized ? */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIG_win_check_group_local_completed(win, ranks_in_win_grp, group->size,
                                                &all_local_completed);
     } while (all_local_completed != 1);
@@ -707,9 +707,9 @@ static inline int MPIDIG_mpi_win_test(MPIR_Win * win, int *flag)
         MPIR_Group_release(group);
         MPIDIG_WIN(win, sync).exposure_epoch_type = MPIDIG_EPOTYPE_NONE;
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         *flag = 0;
     }
 
@@ -822,9 +822,9 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 
     /* Ensure completion of AM operations */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     } while (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0);
 
     if (target_ptr->sync.assert_mode & MPI_MODE_NOCHECK) {
@@ -1141,9 +1141,9 @@ static inline int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 
     /* Ensure completion of AM operations */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     } while (MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) != 0);
     MPIDIG_EPOCH_FENCE_EVENT(win, massert);
 
@@ -1162,9 +1162,9 @@ static inline int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     /* MPIR_Barrier's state is protected by ALLFUNC_MUTEX.
      * In VCI granularity, individual send/recv/wait operations will take
      * the VCI lock internally. */
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     mpi_errno = MPIR_Barrier(win->comm_ptr, &errflag);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FENCE);
@@ -1652,9 +1652,9 @@ static inline int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     }
 
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     } while (target_ptr && MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0);
 
   fn_exit:
@@ -1693,9 +1693,9 @@ static inline int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
     /* FIXME: now we simply set per-target counters for lockall in case
      * user flushes per target, but this should be optimized. */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIG_win_check_all_targets_local_completed(win, &all_local_completed);
     } while (all_local_completed != 1);
 
@@ -1739,9 +1739,9 @@ static inline int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     /* FIXME: now we simply set per-target counters for lockall in case
      * user flushes per target, but this should be optimized. */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIG_win_check_all_targets_remote_completed(win, &all_remote_completed);
     } while (all_remote_completed != 1);
 
@@ -1865,9 +1865,9 @@ static inline int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win)
     }
 
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
     } while (target_ptr && MPIR_cc_get(target_ptr->local_cmpl_cnts) != 0);
 
   fn_exit:
@@ -1923,9 +1923,9 @@ static inline int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 
     /* Ensure completion of AM operations */
     do {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
         MPIDIU_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(MPIDI_VCI_ROOT).lock);
 
         /* FIXME: now we simply set per-target counters for lockall in case
          * user flushes per target, but this should be optimized. */


### PR DESCRIPTION
This PR will implement the infrastructure for allocating VCIs at CH4 layer, VNIs in the netmod, and VSIs in the shmmod.

- [ ] OFI
  - [x] Implement VNI alloc and free
  - [ ] Account for the possibility of multiple VNIs
- [ ] UCX
  - [x] Implement a VNI pool with 1 VNI
  - [x] Implement VNI alloc and free
  - [ ] Account for the possibility of multiple VNIs
- [ ] Shmmod
  - [ ] Implement a VSI pool with 1 VSI
  - [ ] Implement VSI alloc and free
- [ ] CH4
  - [x] Implement VCI alloc, free, get
  - [x] Allow for per-VCI progress