### PR TITLE
mpi: Make sure dtp is not NULL

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -320,6 +320,7 @@ static inline void MPIR_Datatype_free(MPIR_Datatype * ptr);
     {                                                               \
         MPIR_Datatype *dtp_ = NULL;                                 \
         MPIR_Datatype_get_ptr((datatype_), dtp_);                   \
+        MPIR_Assert(dtp_ != NULL);                                  \
         MPIR_Datatype_ptr_add_ref(dtp_);                            \
     }                                                               \
     } while (0)


### PR DESCRIPTION
Some static code analyzer thinks that
MPIR_Datatype_add_ref_if_not_builtin might exhibit NULL pointer
dereference. This patch adds an assertion to make sure it is
not the case.