### PR TITLE
mpl: closer timer epoch to retain nanosecond resolution

### DIFF
--- a/src/mpl/src/timer/mpl_timer_clock_gettime.c
+++ b/src/mpl/src/timer/mpl_timer_clock_gettime.c
@@ -10,6 +10,8 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #if MPL_TIMER_KIND == MPL_TIMER_KIND__CLOCK_GETTIME
 
+static time_t time_epoch;
+
 int MPL_wtime(MPL_time_t * timeval)
 {
     /* POSIX timer (14.2.1, page 311) */
@@ -34,7 +36,7 @@ int MPL_wtime_touint(MPL_time_t * t, unsigned int *val)
 
 int MPL_wtime_todouble(MPL_time_t * t, double *val)
 {
-    *val = ((double) t->tv_sec + 1.0e-9 * (double) t->tv_nsec);
+    *val = ((double) (t->tv_sec - time_epoch) + 1.0e-9 * (double) (t->tv_nsec));
 
     return MPL_TIMER_SUCCESS;
 }
@@ -75,6 +77,12 @@ int MPL_wtick(double *wtick)
 
 int MPL_wtime_init(void)
 {
+    /* set a closer time_epoch so MPL_wtime_todouble retain ns resolution */
+    /* time across process are still relavant within 1 hour */
+    MPL_time_t t;
+    MPL_wtime(&t);
+    time_epoch = t.tv_sec - t.tv_sec % (3600);
+
     init_wtick();
 
     return MPL_TIMER_SUCCESS;


### PR DESCRIPTION
A double precision number has approximately 15 decimal digits of significands. The default Unix epoch is at 1970/01/01 and current timestamp at this writing is `1553348522 `, already 10 digits. Thus, `MPI_Wtime` only have 5-6 decimal digits below a second, essentially only have microsecond-resolution. 

This patch initializes a closer epoch -- within 1 hour of process start -- so the double precision time still retains the theoretical nanosecond-resolution.

Experimental: only done for `MPL_TIMER_KIND__CLOCK_GETTIME`.