### PR TITLE
maint: Allow to override build date

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -123,7 +123,7 @@ foreach my $p (@cvars) {
 print "Categories include: \n".Dumper(@categories) if $debug;
 print "Cvars include :\n".Dumper(@cvars)."\n" if $debug;
 
-my $run_timestamp = localtime();
+my $run_timestamp = gmtime($ENV{SOURCE_DATE_EPOCH} || time)." UTC";
 my $uc_ns = uc($ns);
 
 # Setup output files


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Also use UTC/gmtime to be independent of timezone.

This PR was done while working on reproducible builds for openSUSE.