### PR TITLE
ch4/fbox: Add fastbox polling cache

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
@@ -42,13 +42,35 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
 
     /* Rather than polling all of the fastboxes on every loop, do a small number and rely on calling
      * this function again if needed. */
-    for (j = 0; j < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_BATCH_SIZE; j++) {
+    for (j = 0; j < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE +
+         MPIR_CVAR_CH4_POSIX_EAGER_FBOX_BATCH_SIZE; j++) {
+
+        /* Before polling *all* of the fastboxes, poll the ones that are most likely to have messages
+         * (where receives have been preposted). */
+        if (j < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE) {
+            /* Get the next fastbox to poll. */
+            local_rank = MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[j];
+        }
+        /* If we have finished the cached fastboxes, continue polling the rest of the fastboxes
+         * where we left off last time. */
+        else {
+            int16_t last_cache =
+                MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks
+                [MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE];
+            /* Figure out the next fastbox to poll by incrementing the counter. */
+            last_cache =
+                (last_cache + 1) % (int16_t) MPIDI_POSIX_eager_fbox_control_global.num_local;
+            local_rank = last_cache;
+            MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks
+                [MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE] = last_cache;
+        }
+
+        if (local_rank == -1) {
+            continue;
+        }
 
         /* Find the correct fastbox and update the pointer for the next time around the loop. */
-        local_rank = MPIDI_POSIX_eager_fbox_control_global.next_poll_local_rank;
         fbox_in = MPIDI_POSIX_eager_fbox_control_global.mailboxes.in[local_rank];
-        MPIDI_POSIX_eager_fbox_control_global.next_poll_local_rank =
-            (local_rank + 1) % MPIDI_POSIX_eager_fbox_control_global.num_local;
 
         /* If the data ready flag is set, there is a message waiting. */
         if (fbox_in->data_ready) {
@@ -129,11 +151,25 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_posted_hook(int grank)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_POSTED_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_POSTED_HOOK);
 
-    int local_rank;
+    int local_rank, i;
 
     if (grank >= 0) {
         local_rank = MPIDI_POSIX_eager_fbox_control_global.local_ranks[grank];
-        MPIDI_POSIX_eager_fbox_control_global.next_poll_local_rank = local_rank;
+
+        /* Put the posted receive in the list of fastboxes to be polled first. If the list is full,
+         * it will get polled after the boxes in the list are polled, which will be slower, but will
+         * still match the message. */
+        for (i = 0; i < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE; i++) {
+            if (MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] == -1) {
+                MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] = local_rank;
+                break;
+            } else if (MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] ==
+                       local_rank) {
+                break;
+            } else {
+                continue;
+            }
+        }
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_POSTED_HOOK);
@@ -141,8 +177,25 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_posted_hook(int grank)
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_completed_hook(int grank)
 {
+    int i, local_rank;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_COMPLETED_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_COMPLETED_HOOK);
+
+    if (grank >= 0) {
+        local_rank = MPIDI_POSIX_eager_fbox_control_global.local_ranks[grank];
+
+        /* Remove the posted receive from the list of fastboxes to be polled first now that the
+         * request is done. */
+        for (i = 0; i < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE; i++) {
+            if (MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] == local_rank) {
+                MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] = -1;
+                break;
+            } else {
+                continue;
+            }
+        }
+    }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_FBOX_EAGER_RECV_COMPLETED_HOOK);
 }

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
@@ -53,7 +53,15 @@ typedef struct MPIDI_POSIX_eager_fbox_control {
     int *local_ranks;
     int *local_procs;
 
-    int next_poll_local_rank;
+    /* A small cache of local ranks that have posted receives that we use to poll fastboxes more
+     * efficiently. The last entry in this array is a counter to keep track of the most recently
+     * checked fastbox so we can make sure we don't starve the fastboxes where receives haven't been
+     * posted (for unexpected messages). Ideally this array should remain small. By default, it has
+     * three entries for the cache and one entry for the counter, which (at 16 bits per entry)
+     * stays under a 64 byte cache line size. 16 bits should be plenty for storing local ranks (2^16
+     * is much bigger than any currently immaginable single-node without something like wildly
+     * oversubscribed ranks as threads). */
+    int16_t *first_poll_local_ranks;
 
 } MPIDI_POSIX_eager_fbox_control_t;
 


### PR DESCRIPTION
Add a small cache to keep track of fastboxes most likely to be full
(those where receives have already been posted). When checking for
messages in fastboxes, use this cache first to find a full box and only
when this list is exhausted, move on to the remainder of the fastboxes.

Initially, the CVAR used to size the cache will be set to 3 because that
will keep the entire array in a single cache line.