### PR TITLE
maint: Sort input file list

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -584,7 +584,7 @@ sub ExpandDir {
     my @subdirs = ();
     my $DIR_HANDLE;
     opendir $DIR_HANDLE, "$dir" or die "Error: open directory $dir -- $!\n";
-    while (my $filename = readdir $DIR_HANDLE) {
+    for my $filename (sort readdir $DIR_HANDLE) {
         if ($filename =~ /^\./) {
             next;
         } elsif (-d "$dir/$filename") {

--- a/maint/extractfixme.in
+++ b/maint/extractfixme.in
@@ -114,7 +114,7 @@ sub ExpandDir {
     my @otherdirs = ();
     my @files = ();
     opendir DIR, "$dir";
-    while ($filename = readdir DIR) {
+    for $filename (sort readdir DIR) {
 	if ($filename =~ /^\./ || $filename eq ".svn") {
 	    next;
 	}

--- a/maint/extractstrings.in
+++ b/maint/extractstrings.in
@@ -73,7 +73,7 @@ sub GetFileNamesInDirectory {
     my @filesFound = ();
 
     opendir DIR, $dir || die "Could not open $dir\n";
-    while (my $file = readdir DIR) {
+    for my $file (sort readdir DIR) {
 	if (! -f "$dir/$file") { next; }
 	if ($file =~ /^\.$/ || $file =~ /^\.\.$/) { next; }
 	if ($file =~ /$pattern/) {
@@ -246,7 +246,7 @@ sub processDirs {
     my @dirs = ();
     # Find the directories
     opendir DIR, "$dir" || die "Cannot open $dir\n";
-    while (my $file = readdir DIR) {
+    for my $file (sort readdir DIR) {
 	if (! -d "$dir/$file") { next; }
 	if ($file =~ /^\./) { next; }
 	if ($file =~ /^.svn/) { next; }
@@ -273,7 +273,7 @@ sub processDirsAndAction {
     my @dirs = ();
     # Find the directories
     opendir DIR, "$dir" || die "Cannot open $dir\n";
-    while (my $file = readdir DIR) {
+    for my $file (sort readdir DIR) {
 	if (! -d "$dir/$file") { next; }
 	if ($file =~ /^\./) { next; }
 	if ($file =~ /^.svn/) { next; }

--- a/maint/gen_subcfg_m4
+++ b/maint/gen_subcfg_m4
@@ -118,7 +118,7 @@ while (my $dir = pop @dirstack) {
     # the stack to continue the traversal
     opendir DH, $dir
         or die "unable to open dir='$dir', stopped";
-    my @contents = readdir DH;
+    my @contents = sort readdir DH;
     foreach my $f (@contents) {
         # avoid endless recursion
         next if $f eq "." || $f eq "..";

--- a/maint/getcoverage.in
+++ b/maint/getcoverage.in
@@ -774,7 +774,7 @@ sub ExpandDir {
     my @otherdirs = ();
     my @files = ();
     opendir DIR, "$dir";
-    while ($filename = readdir DIR) {
+    for $filename (sort readdir DIR) {
 	if ($filename =~ /^\./ || $filename eq ".svn") {
 	    next;
 	}


### PR DESCRIPTION
Sort input file list
so that mpich builds in a reproducible way
in spite of indeterministic filesystem readdir order

See https://reproducible-builds.org/ for why this is good.

Without this patch,
`README.envvar`, `/usr/lib64/mpi/gcc/mpich/bin/mpivars` and other
output files varied between builds.

This PR was done while working on reproducible builds for openSUSE.