### PR TITLE
test: fix default enable-stricttest

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -562,11 +562,15 @@ if test "$enable_strict_done" != "yes" ; then
         -Wstack-usage=262144
     "
 
+    if test -z "$1"; then
+        flags=no
+    else
+        flags="`echo $1 | sed -e 's/:/ /g' -e 's/,/ /g'`"
+    fi
     add_cflags=yes
     c_std=c99
     posix_std=2001
     enable_opt=yes
-    flags="`echo $1 | sed -e 's/:/ /g' -e 's/,/ /g'`"
     for flag in ${flags}; do
         case "$flag" in
 	     stdc89)

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -679,18 +679,8 @@ AC_C_RESTRICT
 AC_PROG_RANLIB
 AM_PROG_AR
 
-# Enable STRICT CFLAGS
-AC_ARG_ENABLE(stricttest,
-AC_HELP_STRING([--enable-stricttest], [Turn on strict GCC compilation]))
-dnl Initialize enable_strict_done so PAC_CC_STRICT won't exit right away
-dnl When it is configuring from within MPICH, because enable_strict_done=yes
-dnl is set in the environment by MPICH.
-enable_strict_done=no
-PAC_CC_STRICT($enable_stricttest)
-# -Wfloat-equal isn't meaningful in testsuite,
-# remove it if it is in strict flags.
-pac_cc_strict_flags="`echo $pac_cc_strict_flags | sed -e 's|-Wfloat-equal||g'`"
-CFLAGS="$CFLAGS $pac_cc_strict_flags"
+# Check for --enable-strict
+PAC_ARG_STRICT
 
 # General headers
 AC_HEADER_STDC


### PR DESCRIPTION
In `test/mpi/configure.ac`, `$enable_stricttest` is empty by default. This empty case skips the `switch` cases in `confdb/aclocal_cc.m4`, resulting an equivallent always-on `$enable_stricttest`.

This PR fixes it by guarding the switch cases with `if test -n ...`.