### PR TITLE
datatype: clean up argument error testing

### DIFF
--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -393,6 +393,35 @@ cvars:
         }                                                               \
     }
 
+/* MPIR_ERRTEST_DATATYPE plus test for valid ptr */
+#define MPIR_ERRTEST_DATATYPE_PTR(datatype, name_, err_) \
+    do { \
+        MPIR_ERRTEST_DATATYPE(datatype, name_, err_); \
+        if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) { \
+            MPIR_Datatype *datatype_ptr = NULL; \
+            MPIR_Datatype_get_ptr(datatype, datatype_ptr); \
+            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno); \
+            if (mpi_errno) \
+                goto fn_fail; \
+        } \
+    } while (0)
+
+/* MPIR_ERRTEST_DATATYPE plus test for valid and committed ptr */
+#define MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, name_, err_) \
+    do { \
+        MPIR_ERRTEST_DATATYPE(datatype, name_, err_); \
+        if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) { \
+            MPIR_Datatype *datatype_ptr = NULL; \
+            MPIR_Datatype_get_ptr(datatype, datatype_ptr); \
+            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno); \
+            if (mpi_errno) \
+                goto fn_fail; \
+            MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno); \
+            if (mpi_errno) \
+                goto fn_fail; \
+        } \
+    } while (0)
+
 #define MPIR_ERRTEST_TYPE_RMA_ATOMIC(datatype_, err_)                   \
     do {                                                                \
         if (!MPIR_Type_is_rma_atomic(datatype_)) {                      \

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -369,31 +369,13 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                    MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                 MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
             }
 
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -374,16 +374,7 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                    MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                 MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
 
                 /* catch common aliasing cases */
@@ -402,20 +393,11 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             else
                 comm_size = comm_ptr->remote_size;
 
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             for (i = 0; i < comm_size; i++) {
                 MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
             for (i = 0; i < comm_size; i++) {
                 if (recvcounts[i] > 0) {
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcounts[i], mpi_errno);

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -389,18 +389,8 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
                 MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, count, mpi_errno);

--- a/src/mpi/coll/alltoall/alltoall.c
+++ b/src/mpi/coll/alltoall/alltoall.c
@@ -360,17 +360,7 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                    MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
-
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                 if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM &&
                     sendbuf != MPI_IN_PLACE &&
                     sendcount == recvcount && sendtype == recvtype && sendcount != 0)
@@ -378,17 +368,7 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             }
 
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
                 MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
             }

--- a/src/mpi/coll/alltoallv/alltoallv.c
+++ b/src/mpi/coll/alltoallv/alltoallv.c
@@ -322,31 +322,15 @@ int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**sendbuf_inplace");
             }
 
+            if (check_send) {
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            }
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             for (i = 0; i < comm_size; i++) {
                 if (check_send) {
                     MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
                 }
                 MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-            }
-            if (check_send && HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
             }
 
             for (i = 0; i < comm_size && check_send; i++) {

--- a/src/mpi/coll/alltoallw/alltoallw.c
+++ b/src/mpi/coll/alltoallw/alltoallw.c
@@ -327,32 +327,13 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
                 if (check_send) {
                     MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
                     if (sendcounts[i] > 0) {
-                        MPIR_ERRTEST_DATATYPE(sendtypes[i], "sendtype[i]", mpi_errno);
-                    }
-                    if ((sendcounts[i] > 0) &&
-                        (HANDLE_GET_KIND(sendtypes[i]) != HANDLE_KIND_BUILTIN)) {
-                        MPIR_Datatype_get_ptr(sendtypes[i], sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
+                        MPIR_ERRTEST_DATATYPE_COMMITTED(sendtypes[i], "sendtype[i]", mpi_errno);
                     }
                 }
 
                 MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                 if (recvcounts[i] > 0) {
-                    MPIR_ERRTEST_DATATYPE(recvtypes[i], "recvtype[i]", mpi_errno);
-                }
-                if ((recvcounts[i] > 0) && (HANDLE_GET_KIND(recvtypes[i]) != HANDLE_KIND_BUILTIN)) {
-                    MPIR_Datatype_get_ptr(recvtypes[i], recvtype_ptr);
-                    MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtypes[i], "recvtype[i]", mpi_errno);
                 }
             }
 

--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -403,21 +403,11 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
                 MPIR_ERRTEST_INTRA_ROOT(comm_ptr, root, mpi_errno);
             } else {
                 MPIR_ERRTEST_INTER_ROOT(comm_ptr, root, mpi_errno);
-            }
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
             }
 
             MPIR_ERRTEST_BUF_INPLACE(buffer, count, mpi_errno);

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -223,18 +223,8 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
 
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             rank = comm_ptr->rank;
 

--- a/src/mpi/coll/gather/gather.c
+++ b/src/mpi/coll/gather/gather.c
@@ -307,7 +307,6 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -319,32 +318,14 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }
 
                 rank = comm_ptr->rank;
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
 
@@ -367,32 +348,14 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
 
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -285,7 +285,6 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int i, rank, comm_size;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -297,34 +296,16 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }
 
                 rank = comm_ptr->rank;
                 if (rank == root) {
                     comm_size = comm_ptr->local_size;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
 
                     for (i = 0; i < comm_size; i++) {
@@ -353,18 +334,9 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (root == MPI_ROOT) {
                     comm_size = comm_ptr->remote_size;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (recvcounts[i] > 0) {
@@ -375,16 +347,7 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     }
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -434,10 +434,10 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         MPID_BEGIN_ERROR_CHECKS;
         {
             if (sendbuf != MPI_IN_PLACE) {
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
             }
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -456,27 +456,6 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (sendbuf != MPI_IN_PLACE && HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -450,10 +450,10 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
         MPID_BEGIN_ERROR_CHECKS;
         {
             if (sendbuf != MPI_IN_PLACE) {
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
             }
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -475,16 +475,6 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                 goto fn_fail;
 
             if (sendbuf != MPI_IN_PLACE) {
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype *sendtype_ptr = NULL;
-                    MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                    MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
 
                 /* catch common aliasing cases */
                 if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM &&
@@ -499,17 +489,6 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
             MPIR_ERRTEST_ARGNULL(recvcounts, "recvcounts", mpi_errno);
             MPIR_ERRTEST_ARGNULL(displs, "displs", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
         }

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -414,7 +414,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -401,10 +401,10 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         {
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
             }
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -354,8 +354,8 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
         MPID_BEGIN_ERROR_CHECKS;
         {
             if (sendbuf != MPI_IN_PLACE)
-                MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -423,7 +423,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
@@ -444,17 +444,6 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -224,7 +224,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
@@ -245,17 +245,6 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -361,7 +361,6 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -373,32 +372,14 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }
 
                 rank = comm_ptr->rank;
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
 
@@ -421,32 +402,14 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
 
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -309,7 +309,6 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int i, rank, comm_size;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -321,34 +320,16 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
 
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }
 
                 rank = comm_ptr->rank;
                 if (rank == root) {
                     comm_size = comm_ptr->local_size;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
 
                     for (i = 0; i < comm_size; i++) {
@@ -377,18 +358,9 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
 
                 if (root == MPI_ROOT) {
                     comm_size = comm_ptr->remote_size;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (recvcounts[i] > 0) {
@@ -399,16 +371,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
                     }
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 }

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -333,8 +333,8 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -351,28 +351,6 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -340,8 +340,8 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -358,28 +358,6 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -336,8 +336,8 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -354,28 +354,6 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -350,8 +350,8 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -369,28 +369,6 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -397,7 +397,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
@@ -419,16 +419,6 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
             int rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
                 MPIR_Op *op_ptr = NULL;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -384,7 +384,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
@@ -409,17 +409,6 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
                 goto fn_fail;
 
             MPIR_ERRTEST_ARGNULL(recvcounts, "recvcounts", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -383,7 +383,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
@@ -403,17 +403,6 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -248,7 +248,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
@@ -272,17 +272,6 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
                 goto fn_fail;
 
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
             if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -387,16 +387,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (comm_ptr->rank == root) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
 
@@ -415,16 +406,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
             }
@@ -434,30 +416,12 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -301,9 +301,9 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
             if (recvbuf != MPI_IN_PLACE)
-                MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -320,7 +320,6 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int i, comm_size, rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -333,18 +332,9 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                 comm_size = comm_ptr->local_size;
 
                 if (rank == root) {
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (sendcounts[i] > 0) {
@@ -373,16 +363,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
 
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
             }
@@ -391,18 +372,9 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                 MPIR_ERRTEST_INTER_ROOT(comm_ptr, root, mpi_errno);
                 if (root == MPI_ROOT) {
                     comm_size = comm_ptr->remote_size;
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (sendcounts[i] > 0) {
@@ -413,16 +385,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                     }
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
@@ -233,8 +233,8 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -251,20 +251,6 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -236,8 +236,8 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -254,20 +254,6 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
@@ -235,8 +235,8 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -253,20 +253,6 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
@@ -246,8 +246,8 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
             MPIR_ERRTEST_COMM(comm, mpi_errno);
 
             /* TODO more checks may be appropriate */
@@ -264,20 +264,6 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *sendtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-            }
-
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *recvtype_ptr = NULL;
-                MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-            }
-
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -423,17 +423,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
                 MPIR_ERRTEST_INTRA_ROOT(comm_ptr, root, mpi_errno);
 
                 MPIR_ERRTEST_COUNT(count, mpi_errno);
-                MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                    MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
-
+                MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
                 if (sendbuf != MPI_IN_PLACE)
                     MPIR_ERRTEST_USERBUFFER(sendbuf, count, datatype, mpi_errno);
 
@@ -453,32 +443,14 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
 
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(count, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                        MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, count, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, count, datatype, mpi_errno);
                 }
 
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(count, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                        MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, count, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, count, datatype, mpi_errno);
                 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -412,7 +412,6 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
             MPIR_Op *op_ptr = NULL;
             int i, size, sum;
 
@@ -429,17 +428,7 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
                 sum += recvcounts[i];
             }
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcounts[comm_ptr->rank], mpi_errno);
             if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
                 MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sum, mpi_errno);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -376,7 +376,6 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
             MPIR_Op *op_ptr = NULL;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -385,17 +384,7 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
 
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
-
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
             if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
                 MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, recvcount, mpi_errno);

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -217,7 +217,6 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatyp
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
             MPIR_Op *op_ptr = NULL;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -226,18 +225,8 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatyp
 
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
 
             /* in_place option allowed. no error check */
             MPIR_ERRTEST_USERBUFFER(sendbuf, count, datatype, mpi_errno);

--- a/src/mpi/coll/scatter/scatter.c
+++ b/src/mpi/coll/scatter/scatter.c
@@ -312,7 +312,6 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -325,16 +324,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 rank = comm_ptr->rank;
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
 
@@ -353,16 +343,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
             }
@@ -372,30 +353,12 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     MPIR_ERRTEST_SENDBUF_INPLACE(sendbuf, sendcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(sendbuf, sendcount, sendtype, mpi_errno);
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -282,7 +282,6 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *sendtype_ptr = NULL, *recvtype_ptr = NULL;
             int i, comm_size, rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
@@ -297,16 +296,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                 if (rank == root) {
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
+                        MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (sendcounts[i] > 0) {
@@ -334,16 +324,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
 
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }
             }
@@ -354,16 +335,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                     comm_size = comm_ptr->remote_size;
                     for (i = 0; i < comm_size; i++) {
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
-                        MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
-                        MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
+                        MPIR_ERRTEST_DATATYPE_COMMITTED(sendtype, "sendtype", mpi_errno);
                     }
                     for (i = 0; i < comm_size; i++) {
                         if (sendcounts[i] > 0) {
@@ -374,16 +346,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                     }
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
-                    MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
-                        MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
-                        MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                        MPIR_Datatype_committed_ptr(recvtype_ptr, mpi_errno);
-                        if (mpi_errno != MPI_SUCCESS)
-                            goto fn_fail;
-                    }
+                    MPIR_ERRTEST_DATATYPE_COMMITTED(recvtype, "recvtype", mpi_errno);
                     MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
                     MPIR_ERRTEST_USERBUFFER(recvbuf, recvcount, recvtype, mpi_errno);
                 }

--- a/src/mpi/datatype/get_count.c
+++ b/src/mpi/datatype/get_count.c
@@ -103,20 +103,9 @@ int MPI_Get_count(const MPI_Status * status, MPI_Datatype datatype, int *count)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
             MPIR_ERRTEST_ARGNULL(count, "count", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* Validate datatype_ptr */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-                /* Q: Must the type be committed to be used with this function? */
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/get_elements.c
+++ b/src/mpi/datatype/get_elements.c
@@ -67,39 +67,14 @@ int MPI_Get_elements(const MPI_Status * status, MPI_Datatype datatype, int *coun
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_GET_ELEMENTS);
 
-    /* Validate parameters, especially handles needing to be converted */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif
-
     /* Validate parameters and objects (post conversion) */
 #ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
             MPIR_ERRTEST_ARGNULL(count, "count", mpi_errno);
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-            /* Validate datatype_ptr */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -377,33 +377,9 @@ int MPI_Get_elements_x(const MPI_Status * status, MPI_Datatype datatype, MPI_Cou
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
-
-    /* Convert MPI object handles to object pointers */
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(count, "count", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/pack.c
+++ b/src/mpi/datatype/pack.c
@@ -179,19 +179,7 @@ int MPI_Pack(const void *inbuf,
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/pack_external.c
+++ b/src/mpi/datatype/pack_external.c
@@ -88,17 +88,7 @@ int MPI_Pack_external(const char datarep[],
             }
             MPIR_ERRTEST_ARGNULL(position, "position", mpi_errno);
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/pack_external_size.c
+++ b/src/mpi/datatype/pack_external_size.c
@@ -71,31 +71,11 @@ int MPI_Pack_external_size(const char datarep[],
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_COUNT(incount, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
 #endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If datatype_ptr is not valid, it will be reset to null */
-            if (mpi_errno)
-                goto fn_fail;
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ... */
 

--- a/src/mpi/datatype/pack_size.c
+++ b/src/mpi/datatype/pack_size.c
@@ -103,8 +103,6 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
 
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(incount, mpi_errno);
             MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
 
@@ -112,15 +110,7 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
             if (mpi_errno)
                 goto fn_fail;
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/status_set_elements.c
+++ b/src/mpi/datatype/status_set_elements.c
@@ -64,18 +64,9 @@ int MPI_Status_set_elements(MPI_Status * status, MPI_Datatype datatype, int coun
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If datatype_ptr is not valid, it will be reset to null */
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/status_set_elements_x.c
+++ b/src/mpi/datatype/status_set_elements_x.c
@@ -84,31 +84,9 @@ int MPI_Status_set_elements_x(MPI_Status * status, MPI_Datatype datatype, MPI_Co
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
-
-    /* Convert MPI object handles to object pointers */
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+            MPIR_ERRTEST_COUNT(count, mpi_errno);
+            MPIR_ERRTEST_ARGNULL(status, "status", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -124,30 +124,11 @@ int MPI_Type_commit(MPI_Datatype * datatype)
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_ARGNULL(datatype, "datatype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(*datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(*datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
 #endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(*datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ... */
 

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -258,17 +258,8 @@ int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_create_darray.c
+++ b/src/mpi/datatype/type_create_darray.c
@@ -382,7 +382,7 @@ int MPI_Type_create_darray(int size,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -481,9 +481,6 @@ int MPI_Type_create_darray(int size,
                 goto fn_fail;
             }
 
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If datatype_ptr is not valid, it will be reset to null */
             /* --BEGIN ERROR HANDLING-- */
             if (mpi_errno)
                 goto fn_fail;

--- a/src/mpi/datatype/type_create_hindexed.c
+++ b/src/mpi/datatype/type_create_hindexed.c
@@ -87,14 +87,7 @@ int MPI_Type_create_hindexed(int count,
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "array_of_displacements", mpi_errno);
             }
 
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             for (j = 0; j < count; j++) {
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[j], "blocklength", mpi_errno);
             }

--- a/src/mpi/datatype/type_create_hindexed_block.c
+++ b/src/mpi/datatype/type_create_hindexed_block.c
@@ -112,22 +112,12 @@ int MPI_Type_create_hindexed_block(int count,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
             if (count > 0) {
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "indices", mpi_errno);
             }
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
-
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_create_hvector.c
+++ b/src/mpi/datatype/type_create_hvector.c
@@ -78,14 +78,7 @@ int MPI_Type_create_hvector(int count,
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_create_indexed_block.c
+++ b/src/mpi/datatype/type_create_indexed_block.c
@@ -142,22 +142,12 @@ int MPI_Type_create_indexed_block(int count,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
             if (count > 0) {
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "indices", mpi_errno);
             }
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
-
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -158,16 +158,7 @@ int MPI_Type_create_resized(MPI_Datatype oldtype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If datatype_ptr is not valid, it will be reset to null */
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_create_struct.c
+++ b/src/mpi/datatype/type_create_struct.c
@@ -123,7 +123,6 @@ int MPI_Type_create_struct(int count,
         MPID_BEGIN_ERROR_CHECKS;
         {
             int j;
-            MPIR_Datatype *datatype_ptr = NULL;
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
 
@@ -135,15 +134,7 @@ int MPI_Type_create_struct(int count,
 
             for (j = 0; j < count; j++) {
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[j], "blocklen", mpi_errno);
-                MPIR_ERRTEST_DATATYPE(array_of_types[j], "datatype[j]", mpi_errno);
-
-                if (array_of_types[j] != MPI_DATATYPE_NULL &&
-                    HANDLE_GET_KIND(array_of_types[j]) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(array_of_types[j], datatype_ptr);
-                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                    if (mpi_errno != MPI_SUCCESS)
-                        goto fn_fail;
-                }
+                MPIR_ERRTEST_DATATYPE_PTR(array_of_types[j], "datatype[j]", mpi_errno);
             }
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -150,7 +150,8 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -158,20 +159,6 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
 
     /* Convert MPI object handles to object pointers */
     MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-
-    /* Convert MPI object handles to object pointers */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If comm_ptr is not valid, it will be reset to null */
-            MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
     MPIR_Assert(datatype_ptr != NULL);
 
     /* ... body of routine ...  */

--- a/src/mpi/datatype/type_extent.c
+++ b/src/mpi/datatype/type_extent.c
@@ -66,31 +66,12 @@ int MPI_Type_extent(MPI_Datatype datatype, MPI_Aint * extent)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
-#endif /* HAVE_ERROR_CHECKING */
+#endif
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_free.c
+++ b/src/mpi/datatype/type_free.c
@@ -87,7 +87,7 @@ int MPI_Type_free(MPI_Datatype * datatype)
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_ARGNULL(datatype, "datatype", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(*datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(*datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -120,13 +120,6 @@ int MPI_Type_free(MPI_Datatype * datatype)
                                                  FCNAME, __LINE__, MPI_ERR_TYPE, "**dtypeperm", 0);
                 goto fn_fail;
             }
-            /* Validate parameters, especially handles needing to be converted */
-            MPIR_Datatype_get_ptr(*datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_contents.c
+++ b/src/mpi/datatype/type_get_contents.c
@@ -150,7 +150,7 @@ int MPI_Type_get_contents(MPI_Datatype datatype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -161,8 +161,6 @@ int MPI_Type_get_contents(MPI_Datatype datatype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             /* Check for built-in type */
             if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
@@ -185,15 +183,6 @@ int MPI_Type_get_contents(MPI_Datatype datatype,
                                                  MPI_ERR_TYPE, "**contentspredef", 0);
                 goto fn_fail;
             }
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If comm_ptr is not value, it will be reset to null */
-            if (mpi_errno)
-                goto fn_fail;
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_envelope.c
+++ b/src/mpi/datatype/type_get_envelope.c
@@ -96,31 +96,11 @@ int MPI_Type_get_envelope(MPI_Datatype datatype,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
 #endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If comm_ptr is not value, it will be reset to null */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_get_extent.c
+++ b/src/mpi/datatype/type_get_extent.c
@@ -73,31 +73,12 @@ int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint * lb, MPI_Aint * extent)
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_TYPE_GET_EXTENT);
 
-    /* Validate parameters, especially handles needing to be converted */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif
-
     /* Validate parameters and objects (post conversion) */
 #ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(lb, "lb", mpi_errno);
             MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
         }

--- a/src/mpi/datatype/type_get_extent_x.c
+++ b/src/mpi/datatype/type_get_extent_x.c
@@ -77,37 +77,14 @@ int MPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count * lb, MPI_Count * ext
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPI_TYPE_GET_EXTENT_X);
 
-    /* Validate parameters, especially handles needing to be converted */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
-
-    /* Convert MPI object handles to object pointers */
-
     /* Validate parameters and objects (post conversion) */
 #ifdef HAVE_ERROR_CHECKING
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
-            MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(lb, "lb", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(extent, "extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/type_get_name.c
+++ b/src/mpi/datatype/type_get_name.c
@@ -259,7 +259,7 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -277,11 +277,6 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
-            /* If datatype_ptr is not valid, it will be reset to null */
             MPIR_ERRTEST_ARGNULL(type_name, "type_name", mpi_errno);
             MPIR_ERRTEST_ARGNULL(resultlen, "resultlen", mpi_errno);
         }

--- a/src/mpi/datatype/type_get_true_extent.c
+++ b/src/mpi/datatype/type_get_true_extent.c
@@ -80,32 +80,13 @@ int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint * true_lb, MPI_Aint
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(true_lb, "true_lb", mpi_errno);
             MPIR_ERRTEST_ARGNULL(true_extent, "true_extent", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
-#endif /* HAVE_ERROR_CHECKING */
+#endif
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_get_true_extent_x.c
+++ b/src/mpi/datatype/type_get_true_extent_x.c
@@ -83,30 +83,7 @@ int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count * true_lb, MPI_C
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
-
-    /* Convert MPI object handles to object pointers */
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(true_lb, "true_lb", mpi_errno);
             MPIR_ERRTEST_ARGNULL(true_extent, "true_extent", mpi_errno);
         }

--- a/src/mpi/datatype/type_hindexed.c
+++ b/src/mpi/datatype/type_hindexed.c
@@ -103,21 +103,14 @@ int MPI_Type_hindexed(int count,
         MPID_BEGIN_ERROR_CHECKS;
         {
             int j;
-            MPIR_Datatype *datatype_ptr = NULL;
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             if (count > 0) {
                 MPIR_ERRTEST_ARGNULL(array_of_blocklengths, "array_of_blocklengths", mpi_errno);
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "array_of_displacements", mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno != MPI_SUCCESS)
-                    goto fn_fail;
-            }
             /* verify that all blocklengths are >= 0 */
             for (j = 0; j < count; j++) {
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[j], "blocklength", mpi_errno);

--- a/src/mpi/datatype/type_hvector.c
+++ b/src/mpi/datatype/type_hvector.c
@@ -103,19 +103,9 @@ int MPI_Type_hvector(int count,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *datatype_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklength", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-            }
-
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -349,19 +349,13 @@ int MPI_Type_indexed(int count,
         MPID_BEGIN_ERROR_CHECKS;
         {
             int j;
-            MPIR_Datatype *datatype_ptr = NULL;
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             if (count > 0) {
                 MPIR_ERRTEST_ARGNULL(array_of_blocklengths, "array_of_blocklengths", mpi_errno);
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "array_of_displacements", mpi_errno);
             }
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             /* verify that all blocklengths are >= 0 */
             for (j = 0; j < count; j++) {
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[j], "blocklength", mpi_errno);

--- a/src/mpi/datatype/type_lb.c
+++ b/src/mpi/datatype/type_lb.c
@@ -83,31 +83,12 @@ int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint * displacement)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(displacement, "displacement", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
-#endif /* HAVE_ERROR_CHECKING */
+#endif
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_set_name.c
+++ b/src/mpi/datatype/type_set_name.c
@@ -65,7 +65,7 @@ int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -81,9 +81,6 @@ int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name)
         {
             int slen;
 
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            /* If datatype_ptr is not valid, it will be reset to null */
             MPIR_ERRTEST_ARGNULL(type_name, "type_name", mpi_errno);
 
             slen = (int) strlen(type_name);

--- a/src/mpi/datatype/type_size.c
+++ b/src/mpi/datatype/type_size.c
@@ -66,7 +66,8 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -77,25 +78,6 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
         MPIR_Datatype_get_size_macro(datatype, *size);
         goto fn_exit;
     }
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            MPIR_Datatype *datatype_ptr = NULL;
-
-            /* Convert MPI object handles to object pointers */
-            MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_size_x.c
+++ b/src/mpi/datatype/type_size_x.c
@@ -75,30 +75,7 @@ int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count * size)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            /* TODO more checks may be appropriate */
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
-
-    /* Convert MPI object handles to object pointers */
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* TODO more checks may be appropriate (counts, in_place, buffer aliasing, etc) */
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(size, "size", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -525,7 +525,6 @@ int MPI_Type_struct(int count,
         MPID_BEGIN_ERROR_CHECKS;
         {
             int i;
-            MPIR_Datatype *datatype_ptr;
 
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             if (count > 0) {
@@ -536,13 +535,8 @@ int MPI_Type_struct(int count,
 
             for (i = 0; i < count; i++) {
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[i], "blocklength", mpi_errno);
-                MPIR_ERRTEST_DATATYPE(array_of_types[i], "datatype[i]", mpi_errno);
+                MPIR_ERRTEST_DATATYPE_PTR(array_of_types[i], "datatype[i]", mpi_errno);
 
-                if (array_of_types[i] != MPI_DATATYPE_NULL &&
-                    HANDLE_GET_KIND(array_of_types[i]) != HANDLE_KIND_BUILTIN) {
-                    MPIR_Datatype_get_ptr(array_of_types[i], datatype_ptr);
-                    MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                }
             }
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;

--- a/src/mpi/datatype/type_ub.c
+++ b/src/mpi/datatype/type_ub.c
@@ -70,7 +70,8 @@ int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * displacement)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_DATATYPE_PTR(datatype, "datatype", mpi_errno);
+            MPIR_ERRTEST_ARGNULL(displacement, "displacement", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }
@@ -78,21 +79,6 @@ int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * displacement)
 
     /* Convert MPI object handles to object pointers */
     MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-
-    /* Validate parameters and objects (post conversion) */
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            /* Validate datatype_ptr */
-            MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-            if (mpi_errno)
-                goto fn_fail;
-            MPIR_ERRTEST_ARGNULL(displacement, "displacement", mpi_errno);
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
 

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -245,18 +245,9 @@ int MPI_Type_vector(int count,
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            MPIR_Datatype *old_ptr = NULL;
-
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
-            MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
-
-            if (oldtype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype_get_ptr(oldtype, old_ptr);
-                MPIR_Datatype_valid_ptr(old_ptr, mpi_errno);
-                if (mpi_errno)
-                    goto fn_fail;
-            }
+            MPIR_ERRTEST_DATATYPE_PTR(oldtype, "datatype", mpi_errno);
             MPIR_ERRTEST_ARGNULL(newtype, "newtype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;

--- a/src/mpi/datatype/unpack.c
+++ b/src/mpi/datatype/unpack.c
@@ -171,17 +171,7 @@ int MPI_Unpack(const void *inbuf, int insize, int *position,
                 goto fn_fail;
             /* If comm_ptr is not valid, it will be reset to null */
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            if (datatype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-            }
-            if (mpi_errno != MPI_SUCCESS)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/datatype/unpack_external.c
+++ b/src/mpi/datatype/unpack_external.c
@@ -85,19 +85,7 @@ int MPI_Unpack_external(const char datarep[],
             MPIR_ERRTEST_COUNT(insize, mpi_errno);
             MPIR_ERRTEST_COUNT(outcount, mpi_errno);
 
-            MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-
-            if (datatype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
-                MPIR_Datatype *datatype_ptr = NULL;
-
-                MPIR_Datatype_get_ptr(datatype, datatype_ptr);
-                MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
-                MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);
-            }
-
-            /* If datatye_ptr is not valid, it will be reset to null */
-            if (mpi_errno)
-                goto fn_fail;
+            MPIR_ERRTEST_DATATYPE_COMMITTED(datatype, "datatype", mpi_errno);
         }
         MPID_END_ERROR_CHECKS;
     }


### PR DESCRIPTION
The PR is related to issue #1738, a very old issue and apparently, nobody really cared :). But as it is valid enough to have an issue for it, there is as much valid reason to take care of it -- mostly it is because it was assigned to me. As I look into it, a few gross points stick out: 

1. Why we have two `ERROR_CHECKING` blocks? 

2. Why the `_x` and none `_x` versions are different?

3. Why did we choose to manually add more datatype argument tests and duplicating everywhere rather than amending the existing macro `MPIR_ERRTEST_DATATYPE`?

So I went ahead did some cleaning (more than the original issue suggested). Let reviewers and tests to see if I had misunderstandings and broke something.

EDIT: this PR at this point serves as a demonstration of how much redundancy are in the MPI layer. Rather than merging this PR (and potentially many more to come), I am leaning toward the solution of scripting away the entire MPI layer based on man pages. 

The script will not only ensure the consistency of error checking, it will also make future changes -- updates or fixes -- easier to handle. The script can also take option to generate code with or without macros, concise or verbose versions, therefore, facilitate static analysis, debugging, or profiling.