### PR TITLE
ch4: Message Queue Dumping Support for CH4 active message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2740,6 +2740,13 @@ on all link lines (consider adding it to LDFLAGS)])
     ## most Unix versions, libtvmpich.dylib for Mac OSX).
     ##ENVVAR END:
 
+    # We need when building CH4. The debugger interface need to build with CH4
+    # AM message queue which is not exposed through abstract device interface.
+    # This is very hacky (unfortunately) but sufficient for now.
+    if test "$device_name" = "ch4" ; then
+        AC_DEFINE(HAVE_CH4_DEBUGGER_SUPPORT,1,[Define if debugger support is included for CH4])
+    fi
+
     if test -z "$MPICH_DEBUGLIBNAME" ; then
         DEBUGLIBNAME=libtvmpich$SHLIB_EXT
     else

--- a/src/mpi/debugger/dll_mpich.c
+++ b/src/mpi/debugger/dll_mpich.c
@@ -88,6 +88,10 @@ typedef struct communicator_t {
                                  * matchine */
     int present;
     mqs_communicator comm_info; /* Info needed at the higher level */
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+    mqs_taddr_t posted_base;    /* CH4 has the option for per-communicator queue */
+    mqs_taddr_t unexp_base;
+#endif
 } communicator_t;
 
 /* Internal functions used only by routines in this package */
@@ -287,6 +291,14 @@ int mqs_image_has_queues(mqs_image * image, const char **message)
             i_info->comm_context_id_offs = dbgr_field_offset(co_type, (char *) "context_id");
             i_info->comm_recvcontext_id_offs =
                 dbgr_field_offset(co_type, (char *) "recvcontext_id");
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            int comm_dev_offs = dbgr_field_offset(co_type, (char *) "dev");
+            mqs_type *ch4_comm_type = dbgr_find_type(image, (char *) "MPIDIG_comm_t", mqs_lang_c);
+            int ch4_comm_posted_offs = dbgr_field_offset(ch4_comm_type, (char *) "posted_head_ptr");
+            int ch4_comm_unexp_offs = dbgr_field_offset(ch4_comm_type, (char *) "unexp_head_ptr");
+            i_info->comm_posted_offs = comm_dev_offs + ch4_comm_posted_offs;
+            i_info->comm_unexp_offs = comm_dev_offs + ch4_comm_unexp_offs;
+#endif
         }
     }
 
@@ -303,9 +315,40 @@ int mqs_image_has_queues(mqs_image * image, const char **message)
             i_info->req_status_offs = dbgr_field_offset(req_type, (char *) "status");
             i_info->req_cc_offs = dbgr_field_offset(req_type, (char *) "cc");
             if (dev_offs >= 0) {
+                i_info->req_dev_offs = dev_offs;
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+                /* Only support CH4 active message */
+                /* CH4 AM receive request (rreq) definition */
+                mqs_type *am_rreq_type =
+                    dbgr_find_type(image, (char *) "MPIDIG_rreq_t", mqs_lang_c);
+                if (am_rreq_type) {
+                    i_info->am_rreq_next_offs = dbgr_field_offset(am_rreq_type, (char *) "next");
+                    /* request ptr is stored in MPIDIG_rreq_t */
+                    i_info->req_offs = dbgr_field_offset(am_rreq_type, (char *) "request");
+                    /* buffer, count, rank, tag, context_id and datatype are stored in AM request */
+                    mqs_type *dreq_type =
+                        dbgr_find_type(image, (char *) "MPIDI_Devreq_t", mqs_lang_c);
+                    i_info->req_am_offs = dev_offs + dbgr_field_offset(dreq_type, (char *) "am");
+
+                    mqs_type *am_req_type =
+                        dbgr_find_type(image, (char *) "MPIDIG_req_t", mqs_lang_c);
+                    i_info->req_user_buf_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "buffer");
+                    i_info->req_user_count_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "count");
+                    i_info->req_rank_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "rank");
+                    i_info->req_tag_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "tag");
+                    i_info->req_context_id_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "context_id");
+                    i_info->req_datatype_offs =
+                        i_info->req_am_offs + dbgr_field_offset(am_req_type, (char *) "datatype");
+                }
+#else
+                /* CH3 specific request definition */
                 mqs_type *dreq_type = dbgr_find_type(image, (char *) "MPIDI_Request",
                                                      mqs_lang_c);
-                i_info->req_dev_offs = dev_offs;
                 if (dreq_type) {
                     int loff, match_offs;
                     loff = dbgr_field_offset(dreq_type, (char *) "next");
@@ -339,6 +382,7 @@ int mqs_image_has_queues(mqs_image * image, const char **message)
                         }
                     }
                 }
+#endif
             }
         }
     }
@@ -400,7 +444,9 @@ int mqs_process_has_queues(mqs_process * proc, char **msg)
     mpich_process_info *p_info = (mpich_process_info *) dbgr_get_process_info(proc);
     mqs_image *image = dbgr_get_image(proc);
     mpich_image_info *i_info = (mpich_image_info *) dbgr_get_image_info(image);
+#ifndef HAVE_CH4_DEBUGGER_SUPPORT
     mqs_taddr_t head_ptr;
+#endif
 
     /* Don't bother with a pop up here, it's unlikely to be helpful */
     *msg = 0;
@@ -411,6 +457,7 @@ int mqs_process_has_queues(mqs_process * proc, char **msg)
         return err_all_communicators;
 
     /* Check for the receive and send queues */
+#ifndef HAVE_CH4_DEBUGGER_SUPPORT
     if (dbgr_find_symbol(image, (char *) "MPID_Recvq_posted_head_ptr", &head_ptr) != mqs_ok)
         return err_posted;
     p_info->posted_base = fetch_pointer(proc, head_ptr, p_info);
@@ -418,6 +465,7 @@ int mqs_process_has_queues(mqs_process * proc, char **msg)
     if (dbgr_find_symbol(image, (char *) "MPID_Recvq_unexpected_head_ptr", &head_ptr) != mqs_ok)
         return err_unexpected;
     p_info->unexpected_base = fetch_pointer(proc, head_ptr, p_info);
+#endif
 
     /* Send queues are optional */
     if (dbgr_find_symbol(image, (char *) "MPIR_Sendq_head", &p_info->sendq_base) == mqs_ok) {
@@ -541,11 +589,25 @@ int mqs_setup_operation_iterator(mqs_process * proc, int op)
             /* The address on the receive queues is the address of a pointer to
              * the head of the list.  */
         case mqs_pending_receives:
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            /* CH4 defines message queue head in every communicator. */
+            p_info->next_msg = p_info->current_communicator->posted_base;
+            if (fetch_pointer(proc, p_info->next_msg, p_info) == 0)
+                return mqs_end_of_list;
+#else
             p_info->next_msg = p_info->posted_base;
+#endif
             return mqs_ok;
 
         case mqs_unexpected_messages:
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            /* CH4 defines message queue head in every communicator. */
+            p_info->next_msg = p_info->current_communicator->unexp_base;
+            if (fetch_pointer(proc, p_info->next_msg, p_info) == 0)
+                return mqs_end_of_list;
+#else
             p_info->next_msg = p_info->unexpected_base;
+#endif
             return mqs_ok;
 
         default:
@@ -620,7 +682,13 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
 #endif
     while (base != 0) {
         /* Check this entry to see if the context matches */
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+        mqs_taddr_t request_base = fetch_pointer(proc, base + i_info->req_offs, p_info);
+        int16_t actual_context =
+            fetch_int16(proc, request_base + i_info->req_context_id_offs, p_info);
+#else
         int16_t actual_context = fetch_int16(proc, base + i_info->req_context_id_offs, p_info);
+#endif
 
 #ifdef DEBUG_LIST_ITER
         initLogFile();
@@ -628,11 +696,20 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
 #endif
         if (actual_context == wanted_context) {
             /* Found a request for this communicator */
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            int is_complete = fetch_int(proc, base + i_info->req_cc_offs, p_info);
+            int tag = fetch_int(proc, request_base + i_info->req_tag_offs, p_info);
+            int rank = fetch_int16(proc, request_base + i_info->req_rank_offs, p_info);
+            mqs_tword_t user_buffer =
+                fetch_pointer(proc, request_base + i_info->req_user_buf_offs, p_info);
+            int user_count = fetch_int(proc, request_base + i_info->req_user_count_offs, p_info);
+#else
             int tag = fetch_int(proc, base + i_info->req_tag_offs, p_info);
             int rank = fetch_int16(proc, base + i_info->req_rank_offs, p_info);
             int is_complete = fetch_int(proc, base + i_info->req_cc_offs, p_info);
             mqs_tword_t user_buffer = fetch_pointer(proc, base + i_info->req_user_buf_offs, p_info);
             int user_count = fetch_int(proc, base + i_info->req_user_count_offs, p_info);
+#endif
 
             /* Return -1 for ANY_TAG or ANY_SOURCE */
             res->desired_tag = (tag >= 0) ? tag : -1;
@@ -655,11 +732,19 @@ static int fetch_receive(mqs_process * proc, mpich_process_info * p_info,
             res->status = (is_complete != 0) ? mqs_st_pending : mqs_st_complete;
 
             /* Don't forget to step the queue ! */
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            p_info->next_msg = base + i_info->am_rreq_next_offs;
+#else
             p_info->next_msg = base + i_info->req_next_offs;
+#endif
             return mqs_ok;
         } else {
             /* Try the next one */
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            base = fetch_pointer(proc, base + i_info->am_rreq_next_offs, p_info);
+#else
             base = fetch_pointer(proc, base + i_info->req_next_offs, p_info);
+#endif
         }
     }
 #if 0
@@ -949,6 +1034,10 @@ static int rebuild_communicator_list(mqs_process * proc)
             nc->group = g;
             nc->context_id = send_ctx;
             nc->recvcontext_id = recv_ctx;
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+            nc->posted_base = fetch_pointer(proc, comm_base + i_info->comm_posted_offs, p_info);
+            nc->unexp_base = fetch_pointer(proc, comm_base + i_info->comm_unexp_offs, p_info);
+#endif
 
             strncpy(nc->comm_info.name, name, sizeof(nc->comm_info.name));
             nc->comm_info.unique_id = comm_base;

--- a/src/mpi/debugger/mpich_dll_defs.h
+++ b/src/mpi/debugger/mpich_dll_defs.h
@@ -30,18 +30,32 @@ typedef struct {
     int comm_recvcontext_id_offs;
     int comm_next_offs;
     int comm_name_offs;
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+    /* In CH4, message queues can be global or per-communicator. */
+    int comm_posted_offs;
+    int comm_unexp_offs;
+#endif
 
     /* Fields in MPIR_Request (including structures within the request) */
     int req_status_offs;
     int req_cc_offs;
     int req_dev_offs;
-    int req_next_offs;
     int req_tag_offs;
     int req_rank_offs;
     int req_context_id_offs;
     int req_user_buf_offs;
     int req_user_count_offs;
     int req_datatype_offs;
+#ifdef HAVE_CH4_DEBUGGER_SUPPORT
+    /* CH4 only has message queue for active messages. */
+    int am_rreq_next_offs;
+    /* offset of MPIR_Request in MPIDI_CH4U_rreq_t  */
+    int req_offs;
+    /* offset of AM in MPIR_Request */
+    int req_am_offs;
+#else
+    int req_next_offs;
+#endif
 
     /* Fields in MPIR_Sendq */
     int sendq_next_offs;
@@ -72,8 +86,10 @@ typedef struct {
     mqs_target_type_sizes sizes;        /* Process architecture information */
 
     /* Addresses in the target process */
+#ifndef HAVE_CH4_DEBUGGER_SUPPORT
     mqs_taddr_t posted_base;    /* Where to find the message queues */
     mqs_taddr_t unexpected_base;
+#endif
     mqs_taddr_t sendq_base;     /* Where to find the send queue */
     mqs_taddr_t commlist_base;  /* Where to find the list of communicators */
 

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -62,6 +62,11 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
     am_hdr.context_id = comm->context_id + context_offset;
     am_hdr.error_bits = errflag;
 
+#ifdef HAVE_DEBUGGER_SUPPORT
+    MPIDIG_REQUEST(sreq, datatype) = datatype;
+    MPIDIG_REQUEST(sreq, buffer) = (char *) buf;
+    MPIDIG_REQUEST(sreq, count) = count;
+#endif
     /* Synchronous send requires a special kind of AM header to track the return message so check
      * for that and fill in the appropriate struct if necessary. */
 #ifdef MPIDI_CH4_DIRECT_NETMOD

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -412,6 +412,10 @@ typedef struct MPIDIG_comm_t {
     MPIDIG_rreq_t *posted_list;
     MPIDIG_rreq_t *unexp_list;
     uint32_t window_instance;
+#ifdef HAVE_DEBUGGER_SUPPORT
+    MPIDIG_rreq_t **posted_head_ptr;
+    MPIDIG_rreq_t **unexp_head_ptr;
+#endif
 } MPIDIG_comm_t;
 
 #define MPIDI_CALC_STRIDE(rank, stride, blocksize, offset) \

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -195,6 +195,15 @@ int MPID_Comm_create_hook(MPIR_Comm * comm)
     }
 #endif
 
+#ifdef HAVE_DEBUGGER_SUPPORT
+#ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
+    MPIDIG_COMM(comm, posted_head_ptr) = &(MPIDI_global.posted_list);
+    MPIDIG_COMM(comm, unexp_head_ptr) = &(MPIDI_global.unexp_list);
+#else
+    MPIDIG_COMM(comm, posted_head_ptr) = &(MPIDIG_COMM(comm, posted_list));
+    MPIDIG_COMM(comm, unexp_head_ptr) = &(MPIDIG_COMM(comm, unexp_list));
+#endif
+#endif
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_COMM_CREATE_HOOK);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -107,6 +107,9 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error
                  exit_code, world_str, comm_str, error_msg, sys_str);
     MPL_error_printf("%s", error_str);
 
+#ifdef HAVE_DEBUGGER_SUPPORT
+    MPIR_Debugger_set_aborting(error_msg);
+#endif
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ABORT);
     fflush(stderr);
     fflush(stdout);


### PR DESCRIPTION
- Added CH4 active message related offset definition into `mpi/debugger`.
  - As issue #2721 mentioned, device selection info (ch3 or ch4) is not exported to `mpi/debugger` at this moment, so we have to use MACRO to hard code selection for CH4. (`USING_CH4_AM` is used here).
  - We can only support message queue for active message in CH4 for now, since netmod hardware queue is not exposed now.
- Enabled debugger support for CH4 active message.