### PR TITLE
configure: sanitize CFLAGS for ucx build

### DIFF
--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -70,7 +70,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
 
     if test "${ucx_embedded}" = "yes" ; then
         PAC_PUSH_FLAG(CPPFLAGS)
+        PAC_PUSH_FLAG(CFLAGS)
+        CFLAGS=
         PAC_CONFIG_SUBDIR_ARGS([src/mpid/ch4/netmod/ucx/ucx],[--disable-static --enable-embedded],[],[AC_MSG_ERROR(ucx configure failed)])
+        PAC_POP_FLAG(CFLAGS)
         PAC_POP_FLAG(CPPFLAGS)
         PAC_APPEND_FLAG([-I${master_top_builddir}/src/mpid/ch4/netmod/ucx/ucx/src], [CPPFLAGS])
         PAC_APPEND_FLAG([-I${use_top_srcdir}/src/mpid/ch4/netmod/ucx/ucx/src], [CPPFLAGS])


### PR DESCRIPTION
ucx currently does not build when configured with `--enable-strict`.
This patch resets CFLAGS when configuring ucx.

It does not silence the warnings generated from ucx header files, but it
at least will build.

We could filter CFLAGS instead of reset to only remove offending flags
(likely the -std=...).