### PR TITLE
misc: warnings fix

### DIFF
--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -1173,7 +1173,7 @@ static inline int MPIR_T_pvar_unset_first(MPIR_T_pvar_handle_t * handle)
 /* A counter that keeps track of the relative balance of calls to
  * MPI_T_init_thread and MPI_T_finalize */
 extern int MPIR_T_init_balance;
-static inline int MPIR_T_is_initialized()
+static inline int MPIR_T_is_initialized(void)
 {
     return MPIR_T_init_balance > 0;
 }

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -11,7 +11,7 @@
 #include "mpiimpl.h"
 #include "recexchalgo.h"
 
-int MPII_Recexchalgo_init()
+int MPII_Recexchalgo_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/algorithms/stubalgo/stubalgo.c
+++ b/src/mpi/coll/algorithms/stubalgo/stubalgo.c
@@ -10,7 +10,7 @@
 
 #include "mpiimpl.h"
 
-int MPII_Stubalgo_init()
+int MPII_Stubalgo_init(void)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -11,7 +11,7 @@
 #include "treealgo.h"
 #include "treeutil.h"
 
-int MPII_Treealgo_init()
+int MPII_Treealgo_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -37,6 +37,9 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, int send
         MPIR_Datatype_get_size_macro(sendtype, sendtype_sz);
         MPIR_CHKLMEM_MALLOC(tmp_buf, void *, sendcount * sendtype_sz * local_size, mpi_errno,
                             "tmp_buf", MPL_MEM_BUFFER);
+    } else {
+        /* silence -Wmaybe-uninitialized due to MPIR_{Gather,Bcast} calls by non-zero ranks */
+        sendtype_sz = 0;
     }
 
     /* Get the local intracommunicator */

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -23,8 +23,6 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcoun
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     MPI_Status status;
-    MPI_Aint sendtype_sz;
-    void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_CHKLMEM_DECL(1);
 
@@ -53,6 +51,8 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcoun
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
          * to root. */
+        MPI_Aint sendtype_sz;
+        void *tmp_buf = NULL;
 
         rank = comm_ptr->rank;
 
@@ -61,6 +61,9 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, int sendcoun
             MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
                                 sendcount * local_size * sendtype_sz, mpi_errno,
                                 "tmp_buf", MPL_MEM_BUFFER);
+        } else {
+            /* silence -Wmaybe-uninitialized due to MPIR_Gather by non-zero ranks */
+            sendtype_sz = 0;
         }
 
         /* all processes in remote group form new intracommunicator */

--- a/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_local_gather_remote_bcast.c
@@ -34,6 +34,9 @@ int MPIR_Iallgather_sched_inter_local_gather_remote_bcast(const void *sendbuf, i
         MPIR_Datatype_get_size_macro(sendtype, sendtype_sz);
         MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *, sendcount * local_size * sendtype_sz, mpi_errno,
                                   "tmp_buf", MPL_MEM_BUFFER);
+    } else {
+        /* silence -Wmaybe-uninitialized due to MPIR_{Igather,Ibcast}_sched by non-zero ranks */
+        sendtype_sz = 0;
     }
 
     /* Get the local intracommunicator */

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -35,8 +35,8 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
 
-    size_t sendtype_size, sendtype_extent, sendtype_lb;
-    size_t recvtype_size, recvtype_extent, recvtype_lb;
+    size_t sendtype_extent, sendtype_lb;
+    size_t recvtype_extent, recvtype_lb;
     size_t sendtype_true_extent, recvtype_true_extent;
 
     int delta = 1;
@@ -61,22 +61,20 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     }
 
     /* get datatype info of sendtype and recvtype */
-    MPIR_Datatype_get_size_macro(sendtype, sendtype_size);
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_lb, &sendtype_true_extent);
     sendtype_extent = MPL_MAX(sendtype_extent, sendtype_true_extent);
 
-    MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_lb, &recvtype_true_extent);
     recvtype_extent = MPL_MAX(recvtype_extent, recvtype_true_extent);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                             "send_type_size: %zu, send_type_extent: %zu, send_count: %d",
-                                             sendtype_size, sendtype_extent, sendcount));
+                                             "send_type_extent: %zu, send_count: %d",
+                                             sendtype_extent, sendcount));
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                             "recv_type_size: %zu, recv_type_extent: %zu, recv_count: %d",
-                                             recvtype_size, recvtype_extent, recvcount));
+                                             "recv_type_extent: %zu, recv_count: %d",
+                                             recvtype_extent, recvcount));
 
     while (max) {
         nphases++;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -33,7 +33,6 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
     int size;
     int rank;
     int num_children = 0;
-    int is_tree_leaf;           /* Variables to store location of this rank in the tree */
     MPII_Treealgo_tree_t my_tree;
     void **child_buffer;        /* Buffer array in which data from children is received */
     void *reduce_buffer;        /* Buffer in which allreduced data is present */
@@ -82,9 +81,6 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
         MPIR_ERR_POP(mpi_errno);
     num_children = my_tree.num_children;
 
-    /* identify my locaion in the tree */
-    is_tree_leaf = (num_children == 0) ? 1 : 0;
-
     /* Allocate buffers to receive data from children. Any memory required for execution
      * of the schedule, for example child_buffer, reduce_buffer below, is allocated using
      * MPIR_TSP_sched_malloc function. This function stores the allocated memory address
@@ -92,7 +88,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
      * programmer need not free this memory. This is unlike the MPL_malloc function that
      * will be used for any memory required to generate the schedule and then freed by
      * the programmer once that memory is no longer required */
-    if (!is_tree_leaf) {
+    if (num_children > 0) {
         child_buffer = MPIR_TSP_sched_malloc(sizeof(void *) * num_children, sched);
         child_buffer[0] = MPIR_TSP_sched_malloc(extent * count, sched);
         child_buffer[0] = (void *) ((char *) child_buffer[0] - type_lb);

--- a/src/mpi/coll/igather/igather_inter_short.c
+++ b/src/mpi/coll/igather/igather_inter_short.c
@@ -21,8 +21,6 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
     int mpi_errno = MPI_SUCCESS;
     int rank;
     MPI_Aint local_size, remote_size;
-    MPI_Aint sendtype_sz;
-    void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_SCHED_CHKPMEM_DECL(1);
 
@@ -38,6 +36,8 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
          * to root. */
+        MPI_Aint sendtype_sz;
+        void *tmp_buf = NULL;
 
         rank = comm_ptr->rank;
 
@@ -46,6 +46,9 @@ int MPIR_Igather_sched_inter_short(const void *sendbuf, int sendcount, MPI_Datat
             MPIR_SCHED_CHKPMEM_MALLOC(tmp_buf, void *,
                                       sendcount * local_size * sendtype_sz,
                                       mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        } else {
+            /* silience -Wmaybe-uninitialized due to MPIR_Igather_sched by non-zero ranks */
+            sendtype_sz = 0;
         }
 
         /* all processes in remote group form new intracommunicator */

--- a/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_remote_send_local_scatter.c
@@ -23,8 +23,6 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size;
-    MPI_Aint recvtype_sz;
-    void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_SCHED_CHKPMEM_DECL(1);
 
@@ -46,6 +44,9 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
     } else {
         /* remote group. rank 0 receives data from root. need to
          * allocate temporary buffer to store this data. */
+        MPI_Aint recvtype_sz;
+        void *tmp_buf = NULL;
+
         rank = comm_ptr->rank;
 
         if (rank == 0) {
@@ -60,6 +61,9 @@ int MPIR_Iscatter_sched_inter_remote_send_local_scatter(const void *sendbuf, int
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIR_SCHED_BARRIER(s);
+        } else {
+            /* silience -Wmaybe-uninitialized due to MPIR_Iscatter_sched by non-zero ranks */
+            recvtype_sz = 0;
         }
 
         /* Get the local intracommunicator */

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -23,8 +23,6 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendco
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     MPI_Status status;
-    MPI_Aint recvtype_sz;
-    void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_CHKLMEM_DECL(1);
 
@@ -53,6 +51,8 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendco
     } else {
         /* remote group. rank 0 receives data from root. need to
          * allocate temporary buffer to store this data. */
+        MPI_Aint recvtype_sz;
+        void *tmp_buf = NULL;
 
         rank = comm_ptr->rank;
 
@@ -72,6 +72,9 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, int sendco
                 MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
                 MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
             }
+        } else {
+            /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
+            recvtype_sz = 0;
         }
 
         /* Get the local intracommunicator */

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -122,7 +122,7 @@ int MPII_Coll_finalize(void)
 
 /* Function used by CH3 progress engine to decide whether to
  * block for a recv operation */
-int MPIR_Coll_safe_to_block()
+int MPIR_Coll_safe_to_block(void)
 {
     return MPII_Gentran_scheds_are_pending() == false;
 }

--- a/src/mpi/coll/transports/gentran/gentran_impl.c
+++ b/src/mpi/coll/transports/gentran/gentran_impl.c
@@ -36,7 +36,7 @@ MPII_Coll_queue_t coll_queue = { NULL };
 
 int MPII_Genutil_progress_hook_id = 0;
 
-int MPII_Gentran_init()
+int MPII_Gentran_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -69,7 +69,7 @@ int MPII_Gentran_comm_cleanup(MPIR_Comm * comm_ptr)
 }
 
 
-int MPII_Gentran_finalize()
+int MPII_Gentran_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -79,7 +79,7 @@ int MPII_Gentran_finalize()
 }
 
 
-int MPII_Gentran_scheds_are_pending()
+int MPII_Gentran_scheds_are_pending(void)
 {
     return coll_queue.head != NULL;
 }

--- a/src/mpi/coll/transports/stubtran/stubtran_impl.c
+++ b/src/mpi/coll/transports/stubtran/stubtran_impl.c
@@ -12,12 +12,12 @@
 #include "mpiimpl.h"
 #include "tsp_stubtran.h"
 
-int MPII_Stubtran_init()
+int MPII_Stubtran_init(void)
 {
     return MPI_SUCCESS;
 }
 
-int MPII_Stubtran_finalize()
+int MPII_Stubtran_finalize(void)
 {
     return MPI_SUCCESS;
 }

--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -22,7 +22,7 @@ kvalues="3"
 
 for algo_name in ${algo_names}; do
     for kval in ${kvalues}; do
-        if [ ${algo_name} = "tree" ]; then
+        if [ ${algo_name} = "gentran_tree" ]; then
             for tree_type in ${tree_types}; do
                 #set the environment
                 env="${testing_env} env=MPIR_CVAR_IBCAST_INTRA_ALGORITHM=${algo_name} "


### PR DESCRIPTION
This PR is a revival of #3715. I added more fixes for warnings include -- `-Werror=old-style-definition -Wstrict-prototypes -Wunused-but-set-variable`. The last one included fixes that are duplicate with @minsii PR #3725 -- we'll fix the conflicts depend on whose PR gets merged first :)

I tested on linux gcc 7.3.0, with:
`-Werror`
`-Wall -Wextra -DGCC_WALL`
`-Wstrict-prototypes -Wmissing-prototypes -Wshadow -Wmissing-declarations -Wundef -Wpointer-arith -Wbad-function-cast -Wwrite-strings -Wold-style-definition -Wnested-externs -Winvalid-pch -Wvariadic-macros -Wtype-limits -Werror-implicit-function-declaration -Wstack-usage=262144`
`-Wno-missing-field-initializers -Wno-unused-parameter -Wno-unused-label -Wno-long-long -Wno-endif-labels -Wno-sign-compare -Wno-multichar -Wno-deprecated-declarations -Wno-pointer-sign -Wno-format-zero-length`

They are the same set as our `--enable-strict`, I just regrouped them for better reading. 

After this PR, it is warnings-free on the minimum build (no fortran, cxx, romio, ch4 and pm).
