### PR TITLE
ch4: Fix PMI includes

### DIFF
--- a/src/mpid/ch4/include/mpidimpl.h
+++ b/src/mpid/ch4/include/mpidimpl.h
@@ -18,6 +18,14 @@
 #include <assert.h>
 #endif
 
+#ifdef USE_PMIX_API
+#include <pmix.h>
+#elif defined(USE_PMI2_API)
+#include <pmi2.h>
+#else
+#include <pmi.h>
+#endif
+
 #define MPICH_SKIP_MPICXX
 #include "mpiimpl.h"
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -9,7 +9,6 @@
  *  Contributor License Agreement dated February 8, 2012.
  */
 
-#include "pmi.h"
 #include "mpidimpl.h"
 #include "ofi_impl.h"
 #include "mpidu_bc.h"

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -7,7 +7,6 @@
  *  Copyright (C) Mellanox Technologies Ltd. 2016. ALL RIGHTS RESERVED
  */
 
-#include "pmi.h"
 #include "mpidimpl.h"
 #include "ucx_impl.h"
 #include "mpidu_bc.h"

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -12,7 +12,6 @@
 /* All global ADI data structures need to go in this file */
 /* reference them with externs from other files           */
 
-#include "pmi.h"
 #include <mpidimpl.h>
 #include "ch4_impl.h"
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -9,7 +9,6 @@
  *  Contributor License Agreement dated February 8, 2012.
  */
 
-#include "pmi.h"
 #include "mpidimpl.h"
 #include "mpidch4r.h"
 #include "datatype.h"

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -9,7 +9,6 @@
  *  Contributor License Agreement dated February 8, 2012.
  */
 
-#include "pmi.h"
 #include "mpidimpl.h"
 
 /*


### PR DESCRIPTION
Make sure to include the right PMI header file for the right abort
API. Fixes build issue with pmi2/simple.