### PR TITLE
whitespace: increase the line-length limit

### DIFF
--- a/maint/code-cleanup.sh
+++ b/maint/code-cleanup.sh
@@ -53,7 +53,7 @@ indent_code()
         --leave-optional-blank-lines \
         --dont-space-special-semicolon \
         `# End of K&R expansion` \
-        --line-length100 \
+        `# --line-length100` \
         --else-endif-column1 \
         --start-left-side-of-comments \
         --break-after-boolean-operator \

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -217,9 +217,14 @@ int MPIR_Allgather_impl(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
         switch (MPIR_CVAR_ALLGATHER_INTER_ALGORITHM) {
             case MPIR_CVAR_ALLGATHER_INTER_ALGORITHM_local_gather_remote_bcast:
                 mpi_errno =
-                    MPIR_Allgather_inter_local_gather_remote_bcast(sendbuf, sendcount, sendtype,
-                                                                   recvbuf, recvcount, recvtype,
-                                                                   comm_ptr, errflag);
+                    MPIR_Allgather_inter_local_gather_remote_bcast(sendbuf,
+                                                                   sendcount,
+                                                                   sendtype,
+                                                                   recvbuf,
+                                                                   recvcount,
+                                                                   recvtype,
+                                                                   comm_ptr,
+                                                                   errflag);
                 break;
             case MPIR_CVAR_ALLGATHER_INTER_ALGORITHM_nb:
                 mpi_errno =


### PR DESCRIPTION
I believe we are losing more productivity on this one rule than its
benefit if any.

1. the 100 char limit is arbitrary.
2. the automatic reformat by gnu indent does not group parameters by
semantics, often does not enhance readability. I do not object spliting
long lines, but it should always be a manual process. Automatic line
wrapping is an editor feature that all editors already have.
3. We have quite a few long function names -- forcing single or few
parameters/arguments on each new line -- definitely makes the code
grosser IMO.
4. It creates a lot of noise in the PR review.

This PR essentially eliminated the fixed long line limit -- actually, to
500, but that is essentially infinite :)

Removing the hard limit does not imply we encourage long code lines (on
the contrary).

Long lines should first be refactored semantically. For those
un-splittable statements -- function declarations and calls with long
names and many parameters -- it is left for coders and reviewers to make the heuristic judgment. 

However, some place it may be better to use long lines --
e.g. `src/include/mpir_coll.h`. Having a single statement per line can
facilitate script analyses -- e.g. most of the errcode handling
functions if all in one line can greatly simplify the extraction script.
Then, of course, some place it may be better to split long lines -- e.g.
where we want to read certain arguments more easily.