### PR TITLE
Wrapper around atomics

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -70,7 +70,8 @@ noinst_HEADERS +=                   \
     src/include/nopackage.h         \
     src/include/rlog.h              \
     src/include/rlog_macros.h       \
-    src/include/mpir_op_util.h
+    src/include/mpir_op_util.h      \
+    src/include/mpir_int.h
 
 src/include/mpir_cvars.h:
 	$(top_srcdir)/maint/extractcvars --dirs="`cat $(top_srcdir)/maint/cvardirs`"

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -163,11 +163,11 @@ typedef struct MPIR_Group MPIR_Group;
 struct MPIR_Topology;
 typedef struct MPIR_Topology MPIR_Topology;
 
-
 /*****************************************************************************/
 /******************* PART 3: DEVICE INDEPENDENT HEADERS **********************/
 /*****************************************************************************/
 
+#include "mpir_int.h"
 #include "mpir_misc.h"
 #include "mpir_dbg.h"
 #include "mpir_objects.h"

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -1070,8 +1070,8 @@ cvars:
 #ifdef HAVE_ERROR_CHECKING
 #define MPIR_ERRTEST_INITIALIZED_ORDIE()                                \
     do {                                                                \
-        if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT || \
-            OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) \
+        if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT || \
+            MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) \
             {                                                           \
                 MPIR_Err_preOrPostInit();                               \
             }                                                           \

--- a/src/include/mpir_int.h
+++ b/src/include/mpir_int.h
@@ -1,0 +1,80 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPIR_INT_H_INCLUDED
+#define MPIR_INT_H_INCLUDED
+
+#if (defined(MPICH_IS_THREADED)) && (MPICH_THREAD_GRANULARITY != MPICH_THREAD_GRANULARITY__GLOBAL)
+/* we need atomics */
+
+#define MPIR_INT_T_INITIALIZER(val) OPA_INT_T_INITIALIZER(val)
+typedef OPA_int_t MPIR_Int_t;
+
+MPL_STATIC_INLINE_PREFIX int MPIR_Int_load(MPIR_Int_t * ptr)
+{
+    return OPA_load_int(ptr);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_store(MPIR_Int_t * ptr, int val)
+{
+    OPA_store_int(ptr, val);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_incr(MPIR_Int_t * ptr)
+{
+    OPA_incr_int(ptr);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_decr(MPIR_Int_t * ptr)
+{
+    OPA_decr_int(ptr);
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_Int_fetch_and_add(MPIR_Int_t * ptr, int val)
+{
+    return OPA_fetch_and_add_int(ptr, val);
+}
+
+#else
+/* we don't need atomics */
+
+#define MPIR_INT_T_INITIALIZER(val) val
+
+typedef volatile int MPIR_Int_t;
+
+MPL_STATIC_INLINE_PREFIX int MPIR_Int_load(MPIR_Int_t * ptr)
+{
+    return *ptr;
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_store(MPIR_Int_t * ptr, int val)
+{
+    *ptr = val;
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_incr(MPIR_Int_t * ptr)
+{
+    (*ptr)++;
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_Int_decr(MPIR_Int_t * ptr)
+{
+    (*ptr)--;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIR_Int_fetch_and_add(MPIR_Int_t * ptr, int val)
+{
+    int prev_val;
+
+    prev_val = *ptr;
+    (*ptr) += val;
+
+    return prev_val;
+}
+
+#endif /* check for the need of atomics */
+
+#endif /* MPIR_INT_H_INCLUDED */

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -32,7 +32,7 @@ typedef struct PreDefined_attrs {
 } PreDefined_attrs;
 
 typedef struct MPIR_Process_t {
-    OPA_int_t mpich_state;      /* State of MPICH. Use OPA_int_t to make MPI_Initialized() etc.
+    MPIR_Int_t mpich_state;     /* State of MPICH. Use MPIR_Int_t to make MPI_Initialized() etc.
                                  * thread-safe per MPI-3.1.  See MPI-Forum ticket 357 */
     int do_error_checks;        /* runtime error check control */
     struct MPIR_Comm *comm_world;       /* Easy access to comm_world for

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -211,9 +211,9 @@ void MPII_Errhandler_set_fc(MPI_Errhandler errhand)
 /* --BEGIN ERROR HANDLING-- */
 void MPIR_Err_preOrPostInit(void)
 {
-    if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT) {
+    if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT) {
         MPL_error_printf("Attempting to use an MPI routine before initializing MPICH\n");
-    } else if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) {
+    } else if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) {
         MPL_error_printf("Attempting to use an MPI routine after finalizing MPICH\n");
     } else {
         MPL_error_printf
@@ -243,8 +243,8 @@ int MPIR_Err_return_comm(MPIR_Comm * comm_ptr, const char fcname[], int errcode)
     checkValidErrcode(error_class, fcname, &errcode);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT ||
-        OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) {
+    if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__PRE_INIT ||
+        MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_FINALIZED) {
         /* for whatever reason, we aren't initialized (perhaps error
          * during MPI_Init) */
         MPIR_Handle_fatal_error(MPIR_Process.comm_world, fcname, errcode);

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -89,8 +89,8 @@ void MPIR_Add_finalize(int (*f) (void *), void *extra_data, int priority)
          * MPIR_Process.mpich_state to decide how to signal the error */
         (void) MPL_internal_error_printf("overflow in finalize stack! "
                                          "Is MAX_FINALIZE_FUNC too small?\n");
-        if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
-            OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
+        if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
+            MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
             MPID_Abort(NULL, MPI_SUCCESS, 13, NULL);
         } else {
             exit(1);
@@ -287,7 +287,7 @@ int MPI_Finalize(void)
      * finalize callbacks */
 
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    OPA_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_FINALIZED);
+    MPIR_Int_store(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_FINALIZED);
 
 #if defined(MPICH_IS_THREADED)
     MPIR_Thread_CS_Finalize();
@@ -349,7 +349,7 @@ int MPI_Finalize(void)
     }
 #endif
     mpi_errno = MPIR_Err_return_comm(0, FCNAME, mpi_errno);
-    if (OPA_load_int(&MPIR_Process.mpich_state) < MPICH_MPI_STATE__POST_FINALIZED) {
+    if (MPIR_Int_load(&MPIR_Process.mpich_state) < MPICH_MPI_STATE__POST_FINALIZED) {
         MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     }
     goto fn_exit;

--- a/src/mpi/init/finalized.c
+++ b/src/mpi/init/finalized.c
@@ -66,7 +66,7 @@ int MPI_Finalized(int *flag)
 
     /* ... body of routine ...  */
 
-    *flag = (OPA_load_int(&MPIR_Process.mpich_state) >= MPICH_MPI_STATE__POST_FINALIZED);
+    *flag = (MPIR_Int_load(&MPIR_Process.mpich_state) >= MPICH_MPI_STATE__POST_FINALIZED);
 
     /* ... end of body of routine ... */
 
@@ -79,8 +79,8 @@ int MPI_Finalized(int *flag)
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
   fn_fail:
-    if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
-        OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
+    if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
+        MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
         {
             mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
                                              MPI_ERR_OTHER, "**mpi_finalized",

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -135,7 +135,7 @@ int MPI_Init(int *argc, char ***argv)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (OPA_load_int(&MPIR_Process.mpich_state) != MPICH_MPI_STATE__PRE_INIT) {
+            if (MPIR_Int_load(&MPIR_Process.mpich_state) != MPICH_MPI_STATE__PRE_INIT) {
                 mpi_errno =
                     MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
                                          MPI_ERR_OTHER, "**inittwice", NULL);

--- a/src/mpi/init/initialized.c
+++ b/src/mpi/init/initialized.c
@@ -66,7 +66,7 @@ int MPI_Initialized(int *flag)
 
     /* ... body of routine ...  */
 
-    *flag = (OPA_load_int(&MPIR_Process.mpich_state) >= MPICH_MPI_STATE__POST_INIT);
+    *flag = (MPIR_Int_load(&MPIR_Process.mpich_state) >= MPICH_MPI_STATE__POST_INIT);
 
     /* ... end of body of routine ... */
 
@@ -79,8 +79,8 @@ int MPI_Initialized(int *flag)
     /* --BEGIN ERROR HANDLING-- */
 #ifdef HAVE_ERROR_CHECKING
   fn_fail:
-    if (OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
-        OPA_load_int(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
+    if (MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__IN_INIT ||
+        MPIR_Int_load(&MPIR_Process.mpich_state) == MPICH_MPI_STATE__POST_INIT) {
         {
             mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, FCNAME, __LINE__,
                                              MPI_ERR_OTHER, "**mpi_initialized",

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -93,7 +93,7 @@ int MPI_Init_thread(int *argc, char ***argv, int required, int *provided)
 /* Any internal routines can go here.  Make them static if possible */
 
 /* Global variables can be initialized here */
-MPIR_Process_t MPIR_Process = { OPA_INT_T_INITIALIZER(MPICH_MPI_STATE__PRE_INIT) };
+MPIR_Process_t MPIR_Process = { MPIR_INT_T_INITIALIZER(MPICH_MPI_STATE__PRE_INIT) };
 
      /* all other fields in MPIR_Process are irrelevant */
 MPIR_Thread_info_t MPIR_ThreadInfo = { 0 };
@@ -536,7 +536,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
     /* define MPI as initialized so that we can use MPI functions within
      * MPID_Init if necessary */
-    OPA_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__IN_INIT);
+    MPIR_Int_store(&MPIR_Process.mpich_state, MPICH_MPI_STATE__IN_INIT);
 
     /* We can't acquire any critical sections until this point.  Any
      * earlier the basic data structures haven't been initialized */
@@ -663,13 +663,13 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* Make fields of MPIR_Process global visible and set mpich_state
      * atomically so that MPI_Initialized() etc. are thread safe */
     OPA_write_barrier();
-    OPA_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_INIT);
+    MPIR_Int_store(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_INIT);
     return mpi_errno;
 
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
     /* signal to error handling routines that core services are unavailable */
-    OPA_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__PRE_INIT);
+    MPIR_Int_store(&MPIR_Process.mpich_state, MPICH_MPI_STATE__PRE_INIT);
 
     if (exit_init_cs_on_failure) {
         MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
@@ -741,7 +741,7 @@ int MPI_Init_thread(int *argc, char ***argv, int required, int *provided)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (OPA_load_int(&MPIR_Process.mpich_state) != MPICH_MPI_STATE__PRE_INIT) {
+            if (MPIR_Int_load(&MPIR_Process.mpich_state) != MPICH_MPI_STATE__PRE_INIT) {
                 mpi_errno =
                     MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, "MPI_Init_thread",
                                          __LINE__, MPI_ERR_OTHER, "**inittwice", 0);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -108,7 +108,7 @@ MPID_Thread_tls_t MPIR_Per_thread_key;
 
 #ifdef MPICH_THREAD_USE_MDTA
 /* This counts how many threads allowed to stay in the progress engine. */
-OPA_int_t num_server_thread = { 0 };
+OPA_int_t num_server_thread = OPA_INT_T_INITIALIZER(0);
 
 /* Other threads will wait in a sync object, and are recorded here. */
 MPIR_Thread_sync_list_t sync_wait_list = { NULL };

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_post.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_post.h
@@ -8,7 +8,7 @@
 #define MPIDI_CH3_POST_H_INCLUDED
 
 #define MPIDI_CH3_Progress_start(progress_state_)                                                       \
-        (progress_state_)->ch.completion_count = OPA_load_int(&MPIDI_CH3I_progress_completion_count);
+        (progress_state_)->ch.completion_count = MPIR_Int_load(&MPIDI_CH3I_progress_completion_count);
 #define MPIDI_CH3_Progress_end(progress_state_)
 
 enum {

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
@@ -227,14 +227,14 @@ MPIDI_CH3I_Progress_state;
 
 #define MPIDI_CH3_PROGRESS_STATE_DECL MPIDI_CH3I_Progress_state ch;
 
-extern OPA_int_t MPIDI_CH3I_progress_completion_count;
+extern MPIR_Int_t MPIDI_CH3I_progress_completion_count;
 
 #define MPIDI_CH3I_INCR_PROGRESS_COMPLETION_COUNT do {                                  \
         OPA_write_barrier();                                                            \
-        OPA_incr_int(&MPIDI_CH3I_progress_completion_count);                            \
+        MPIR_Int_incr(&MPIDI_CH3I_progress_completion_count);                            \
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_PROGRESS,VERBOSE,                                            \
                        "just incremented MPIDI_CH3I_progress_completion_count=%d",      \
-                       OPA_load_int(&MPIDI_CH3I_progress_completion_count));            \
+                       MPIR_Int_load(&MPIDI_CH3I_progress_completion_count));            \
     } while(0)
 
 #endif /* MPIDI_CH3_PRE_H_INCLUDED */

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -45,7 +45,7 @@ extern MPIR_Request ** const MPID_Recvq_posted_tail_ptr;
 extern MPIR_Request ** const MPID_Recvq_unexpected_tail_ptr;
 #endif
 
-OPA_int_t MPIDI_CH3I_progress_completion_count = OPA_INT_T_INITIALIZER(0);
+MPIR_Int_t MPIDI_CH3I_progress_completion_count = MPIR_INT_T_INITIALIZER(0);
 
 /* NEMESIS MULTITHREADING: Extra Data Structures Added */
 #ifdef MPICH_IS_THREADED
@@ -470,14 +470,14 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
              * work is done and coming back in again if it's not done.
              * We might as well wait for the other thread to be done
              * before doing that. */
-            if (progress_state->ch.completion_count == OPA_load_int(&MPIDI_CH3I_progress_completion_count))
+            if (progress_state->ch.completion_count == MPIR_Int_load(&MPIDI_CH3I_progress_completion_count))
                 MPIDI_CH3I_Progress_delay(progress_state->ch.completion_count);
             else {
                 /* if the completion count of our progress state is
                  * different from the current completion count, some
                  * progress happened.  We reset the value for the next
                  * iteration and return from the progress engine. */
-                progress_state->ch.completion_count = OPA_load_int(&MPIDI_CH3I_progress_completion_count);
+                progress_state->ch.completion_count = MPIR_Int_load(&MPIDI_CH3I_progress_completion_count);
                 goto fn_exit;
             }
         }
@@ -610,7 +610,7 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
 
         /* in the case of progress_wait, bail out if anything completed (CC-1) */
         if (is_blocking) {
-            int completion_count = OPA_load_int(&MPIDI_CH3I_progress_completion_count);
+            int completion_count = MPIR_Int_load(&MPIDI_CH3I_progress_completion_count);
             if (progress_state->ch.completion_count != completion_count) {
                 /* Read barrier to make sure no reads get values before the
                    completion counter was incremented  */

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -52,8 +52,8 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self, int n_vcis)
 #endif
 
     MPIDI_global.cmpl_list = NULL;
-    OPA_store_int(&MPIDI_global.exp_seq_no, 0);
-    OPA_store_int(&MPIDI_global.nxt_seq_no, 0);
+    MPIR_Int_store(&MPIDI_global.exp_seq_no, 0);
+    MPIR_Int_store(&MPIDI_global.nxt_seq_no, 0);
 
     MPIDI_global.buf_pool = MPIDIU_create_buf_pool(MPIDIU_BUF_POOL_NUM, MPIDIU_BUF_POOL_SZ);
     MPIR_Assert(MPIDI_global.buf_pool);

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -32,7 +32,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_REQUEST_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_REQUEST_FREE_HOOK);
 
-    OPA_incr_int(&MPIDI_global.progress_count);
+    MPIR_Int_incr(&MPIDI_global.progress_count);
 
     if (req->kind == MPIR_REQUEST_KIND__PREQUEST_RECV &&
         NULL != MPIDI_REQUEST_ANYSOURCE_PARTNER(req))

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -338,7 +338,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
         MPIDI_OFI_mr_key_free(mr_key);
     }
     MPIDI_OFI_CALL_NOLOCK(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
-    OPA_decr_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
+    MPIR_Int_decr(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
 
     MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -302,7 +302,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
                                         lmt_info->rma_key,
                                         0ULL,
                                         &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
-    OPA_incr_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
+    MPIR_Int_incr(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
 
     if (!MPIDI_OFI_ENABLE_MR_SCALABLE) {
         /* MR_BASIC */
@@ -500,7 +500,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
 
     MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_INJECT_EMU;
     MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
-    OPA_incr_int(&MPIDI_OFI_global.am_inflight_inject_emus);
+    MPIR_Int_incr(&MPIDI_OFI_global.am_inflight_inject_emus);
 
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[0].tx, ibuf, len,
                                     NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -474,7 +474,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_inject_emu_event(struct fi_cq_tagged_entr
     if (!incomplete) {
         MPL_free(MPIDI_OFI_REQUEST(req, util.inject_buf));
         MPIR_Request_free(req);
-        OPA_decr_int(&MPIDI_OFI_global.am_inflight_inject_emus);
+        MPIR_Int_decr(&MPIDI_OFI_global.am_inflight_inject_emus);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_INJECT_EMU_EVENT);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -964,8 +964,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
             MPIDI_OFI_control_handler;
         MPIDIG_global.origin_cbs[MPIDI_OFI_INTERNAL_HANDLER_CONTROL] = NULL;
     }
-    OPA_store_int(&MPIDI_OFI_global.am_inflight_inject_emus, 0);
-    OPA_store_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 0);
+    MPIR_Int_store(&MPIDI_OFI_global.am_inflight_inject_emus, 0);
+    MPIR_Int_store(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 0);
 
     /* Initalize RMA keys allocator */
     MPIDI_OFI_mr_key_allocator_init();
@@ -1028,7 +1028,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     conn_manager_destroy();
 
     /* Progress until we drain all inflight RMA send long buffers */
-    while (OPA_load_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs) > 0)
+    while (MPIR_Int_load(&MPIDI_OFI_global.am_inflight_rma_send_mrs) > 0)
         MPIDI_OFI_PROGRESS();
 
     /* Destroy RMA key allocator */
@@ -1040,9 +1040,9 @@ int MPIDI_OFI_mpi_finalize_hook(void)
                                           MPI_SUM, MPIR_Process.comm_world, &errflag));
 
     /* Progress until we drain all inflight injection emulation requests */
-    while (OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) > 0)
+    while (MPIR_Int_load(&MPIDI_OFI_global.am_inflight_inject_emus) > 0)
         MPIDI_OFI_PROGRESS();
-    MPIR_Assert(OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
+    MPIR_Assert(MPIR_Int_load(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         for (i = 0; i < MPIDI_OFI_global.max_ch4_vcis; i++) {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -351,8 +351,8 @@ typedef struct {
     void *am_bufs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDI_OFI_am_repost_request_t am_reqs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDIU_buf_pool_t *am_buf_pool;
-    OPA_int_t am_inflight_inject_emus;
-    OPA_int_t am_inflight_rma_send_mrs;
+    MPIR_Int_t am_inflight_inject_emus;
+    MPIR_Int_t am_inflight_rma_send_mrs;
 
     /* Completion queue buffering */
     MPIDI_OFI_cq_buff_entry_t cq_buffered_static_list[MPIDI_OFI_NUM_CQ_BUFFERED];

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -137,12 +137,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Progress_wait(MPID_Progress_state * state)
         goto fn_exit;
     }
 
-    state->progress_count = OPA_load_int(&MPIDI_global.progress_count);
+    state->progress_count = MPIR_Int_load(&MPIDI_global.progress_count);
     do {
         ret = MPID_Progress_test();
         if (unlikely(ret))
             MPIR_ERR_POP(ret);
-        if (state->progress_count != OPA_load_int(&MPIDI_global.progress_count))
+        if (state->progress_count != MPIR_Int_load(&MPIDI_global.progress_count))
             break;
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     } while (1);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -298,15 +298,15 @@ typedef struct MPIDI_CH4_Global_t {
     MPIDIG_rreq_t *unexp_list;
 #endif
     MPIDIG_req_ext_t *cmpl_list;
-    OPA_int_t exp_seq_no;
-    OPA_int_t nxt_seq_no;
+    MPIR_Int_t exp_seq_no;
+    MPIR_Int_t nxt_seq_no;
     MPIDIU_buf_pool_t *buf_pool;
 #ifdef HAVE_SIGNAL
     void (*prev_sighandler) (int);
     volatile int sigusr1_count;
     int my_sigusr1_count;
 #endif
-    OPA_int_t progress_count;
+    MPIR_Int_t progress_count;
 
     MPID_Thread_mutex_t vci_lock;
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)

--- a/src/mpid/ch4/src/ch4i_workq.h
+++ b/src/mpid/ch4/src/ch4i_workq.h
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_pt2pt_enqueue(MPIDI_workq_op_t op,
                                                         MPIR_Request * request,
                                                         int *flag,
                                                         MPIR_Request ** message,
-                                                        OPA_int_t * processed)
+                                                        MPIR_Int_t * processed)
 {
     MPIDI_workq_elemt_t *pt2pt_elemt;
 
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_workq_rma_enqueue(MPIDI_workq_op_t op,
                                                       MPI_Op acc_op,
                                                       MPIR_Win * win_ptr,
                                                       MPIDI_av_entry_t * addr,
-                                                      OPA_int_t * processed)
+                                                      MPIR_Int_t * processed)
 {
     MPIDI_workq_elemt_t *rma_elemt = NULL;
     rma_elemt = MPIDI_workq_elemt_create();

--- a/src/mpid/ch4/src/ch4i_workq_types.h
+++ b/src/mpid/ch4/src/ch4i_workq_types.h
@@ -77,7 +77,7 @@ struct MPIDI_av_entry;
 typedef struct MPIDI_workq_elemt {
     MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
     MPIDI_workq_op_t op;
-    OPA_int_t *processed;       /* set to true by the progress thread when
+    MPIR_Int_t *processed;      /* set to true by the progress thread when
                                  * this work item is done */
     union {
         union {

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -31,8 +31,8 @@ int MPIDIG_check_cmpl_order(MPIR_Request * req, MPIDIG_am_target_cmpl_cb target_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CHECK_CMPL_ORDER);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_CHECK_CMPL_ORDER);
 
-    if (MPIDIG_REQUEST(req, req->seq_no) == (uint64_t) OPA_load_int(&MPIDI_global.exp_seq_no)) {
-        OPA_incr_int(&MPIDI_global.exp_seq_no);
+    if (MPIDIG_REQUEST(req, req->seq_no) == (uint64_t) MPIR_Int_load(&MPIDI_global.exp_seq_no)) {
+        MPIR_Int_incr(&MPIDI_global.exp_seq_no);
         ret = 1;
         goto fn_exit;
     }
@@ -64,7 +64,7 @@ void MPIDIG_progress_compl_list(void)
     /* MPIDI_CS_ENTER(); */
   do_check_again:
     DL_FOREACH_SAFE(MPIDI_global.cmpl_list, curr, tmp) {
-        if (curr->seq_no == (uint64_t) OPA_load_int(&MPIDI_global.exp_seq_no)) {
+        if (curr->seq_no == (uint64_t) MPIR_Int_load(&MPIDI_global.exp_seq_no)) {
             DL_DELETE(MPIDI_global.cmpl_list, curr);
             req = (MPIR_Request *) curr->request;
             target_cmpl_cb = (MPIDIG_am_target_cmpl_cb) curr->target_cmpl_cb;
@@ -279,7 +279,7 @@ static int do_send_target(void **data, size_t * p_data_sz, int *is_contig,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_DO_SEND_TARGET);
 
     *target_cmpl_cb = recv_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPIR_Int_fetch_and_add(&MPIDI_global.nxt_seq_no, 1);
 
     if (p_data_sz == NULL || 0 == MPIDIG_REQUEST(rreq, count))
         return MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -2001,7 +2001,7 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     *req = rreq;
 
     *target_cmpl_cb = cswap_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPIR_Int_fetch_and_add(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -2071,7 +2071,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     }
 
     *target_cmpl_cb = acc_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPIR_Int_fetch_and_add(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -2204,7 +2204,7 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     *data = (void *) dt_iov;
 
     *target_cmpl_cb = acc_iov_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPIR_Int_fetch_and_add(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif


### PR DESCRIPTION
Currently, atomic operations are performed even when they don't need to be. For example, when MPICH is not threaded or when the global critical section granularity is used, certain operations need not be atomic.

This PR implements a wrapper around atomic operations to use regular integer operations or atomic ones depending on requirements for thread-safety.