### PR TITLE
debug: consolidate USE_MEMORY_TRACING macros

### DIFF
--- a/src/include/mpir_mem.h
+++ b/src/include/mpir_mem.h
@@ -84,31 +84,6 @@ extern "C" {
         memcpy((dst), (src), (len));            \
     } while (0)
 
-#ifdef USE_MEMORY_TRACING
-
-/* Define these as invalid C to catch their use in the code */
-#define malloc(a)         'Error use MPL_malloc' :::
-#define calloc(a,b)       'Error use MPL_calloc' :::
-#define free(a)           'Error use MPL_free'   :::
-#define realloc(a)        'Error use MPL_realloc' :::
-/* These two functions can't be guarded because we use #include <sys/mman.h>
- * throughout the code to be able to use other symbols in that header file.
- * Because we include that header directly, we bypass this guard and cause
- * compile problems.
- * #define mmap(a,b,c,d,e,f) 'Error use MPL_mmap'   :::
- * #define munmap(a,b)       'Error use MPL_munmap' :::
- */
-#if defined(strdup) || defined(__strdup)
-#undef strdup
-#endif                          /* defined(strdup) || defined(__strdup) */
-    /* The ::: should cause the compiler to choke; the string
-     * will give the explanation */
-#undef strdup                   /* in case strdup is a macro */
-#define strdup(a)         'Error use MPL_strdup' :::
-
-#endif                          /* USE_MEMORY_TRACING */
-
-
 /* Memory allocation macros. See document. */
 
 /* Standard macro for generating error codes.  We set the error to be

--- a/src/mpi/romio/adio/common/malloc.c
+++ b/src/mpi/romio/adio/common/malloc.c
@@ -20,10 +20,6 @@
 #include <stdio.h>
 #include "mpipr.h"
 
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#endif
-
 /* for the style checker */
 /* style: allow:malloc:1 sig:0 */
 /* style: allow:free:1 sig:0 */

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -73,7 +73,7 @@ AC_ARG_ENABLE(g,
 	    none|no   - No debugging
 	    log       - Enable debug event logging
 	    mem       - Enable memory tracing
-	    yes|all   - All of the above choices (except "none", obviously)
+	    most|yes|all   - All of the above choices (except "none", obviously)
 	]),,[enable_g=none])
 
 # enable-g
@@ -86,11 +86,11 @@ for option in $enable_g ; do
 	 enable_g_log=yes
 	 ;;
 
-	 mem)
+	 mem|memarena)
 	 enable_g_mem=yes
 	 ;;
 
-	 all|yes)
+	 most|yes|all)
 	 enable_g_log=yes
 	 enable_g_mem=yes
 	 ;;

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -54,8 +54,6 @@ typedef struct {
     long num_allocations;       /* The total number of alloations */
 } MPL_memory_allocation_t;
 
-#ifdef MPL_USE_MEMORY_TRACING
-
 /*M
   MPL_malloc - Allocate memory
 
@@ -86,7 +84,6 @@ typedef struct {
   Module:
   Utility
   M*/
-#define MPL_malloc(a,b)    MPL_trmalloc((a),(b),__LINE__,__FILE__)
 
 /*M
   MPL_calloc - Allocate memory that is initialized to zero.
@@ -108,7 +105,6 @@ typedef struct {
   Module:
   Utility
   M*/
-#define MPL_calloc(a,b,c)    MPL_trcalloc((a),(b),(c),__LINE__,__FILE__)
 
 /*M
   MPL_free - Free memory
@@ -137,9 +133,6 @@ typedef struct {
   Module:
   Utility
   M*/
-#define MPL_free(a)      MPL_trfree(a,__LINE__,__FILE__)
-
-#define MPL_realloc(a,b,c)    MPL_trrealloc((a),(b),(c),__LINE__,__FILE__)
 
 /*M
   MPL_mmap - Map memory
@@ -175,7 +168,6 @@ typedef struct {
   Module:
   Utility
   M*/
-#define MPL_mmap(a,b,c,d,e,f,g) MPL_trmmap((a),(b),(c),(d),(e),(f),(g),__LINE__,__FILE__)
 
 /*M
   MPL_munmap - Unmapmemory
@@ -204,9 +196,7 @@ typedef struct {
   Module:
   Utility
   M*/
-#define MPL_munmap(a,b,c) MPL_trmunmap((a),(b),(c),__LINE__,__FILE__)
 
-#ifdef MPL_DEFINE_ALIGNED_ALLOC
 /*M
   MPL_aligned_alloc - Allocate aligned memory
 
@@ -232,6 +222,34 @@ typedef struct {
   Module:
   Utility
   M*/
+
+#ifdef MPL_USE_MEMORY_TRACING
+
+/* Define these as invalid C to catch their use in the code.
+ * The ::: should cause the compiler to choke; the string will give the explanation
+ */
+#define malloc(a)         'Error use MPL_malloc' :::
+#define calloc(a,b)       'Error use MPL_calloc' :::
+#define free(a)           'Error use MPL_free'   :::
+#define realloc(a)        'Error use MPL_realloc' :::
+/* These two functions can't be guarded because we use #include <sys/mman.h>
+ * throughout the code to be able to use other symbols in that header file.
+ * Because we include that header directly, we bypass this guard and cause
+ * compile problems.
+ * #define mmap(a,b,c,d,e,f) 'Error use MPL_mmap'   :::
+ * #define munmap(a,b)       'Error use MPL_munmap' :::
+ */
+#undef strdup   /* in case strdup is a macro */
+#define strdup(a)         'Error use MPL_strdup' :::
+
+#define MPL_malloc(a,b)    MPL_trmalloc((a),(b),__LINE__,__FILE__)
+#define MPL_calloc(a,b,c)    MPL_trcalloc((a),(b),(c),__LINE__,__FILE__)
+#define MPL_free(a)      MPL_trfree(a,__LINE__,__FILE__)
+#define MPL_realloc(a,b,c)    MPL_trrealloc((a),(b),(c),__LINE__,__FILE__)
+#define MPL_mmap(a,b,c,d,e,f,g) MPL_trmmap((a),(b),(c),(d),(e),(f),(g),__LINE__,__FILE__)
+#define MPL_munmap(a,b,c) MPL_trmunmap((a),(b),(c),__LINE__,__FILE__)
+
+#ifdef MPL_DEFINE_ALIGNED_ALLOC
 #define MPL_aligned_alloc(a,b,c) MPL_traligned_alloc((a),(b),(c),__LINE__,__FILE__)
 #endif /* #ifdef MPL_DEFINE_ALIGNED_ALLOC */
 

--- a/src/mpl/src/bt/mpl_bt.c
+++ b/src/mpl/src/bt/mpl_bt.c
@@ -106,7 +106,7 @@ static inline void backtrace_libc(FILE * output)
         chars += ret;
     }
     fprintf(output, "%s", backtrace_buffer);
-    free(stack_strs);
+    MPL_free(stack_strs);
 }
 #else
 static inline void backtrace_unsupported(FILE * output)


### PR DESCRIPTION
If MPICH honors that option for memory tracing, then `mpl` has to honor it
too, or we are forcing errors for all memory calls (`malloc` et.el.)

Fixing issue #3731 