### PR TITLE
condfb: Use upstream AX_TLS macro

### DIFF
--- a/confdb/ax_tls.m4
+++ b/confdb/ax_tls.m4
@@ -1,21 +1,22 @@
 # ===========================================================================
-#             http://www.nongnu.org/autoconf-archive/ax_tls.html
+#          https://www.gnu.org/software/autoconf-archive/ax_tls.html
 # ===========================================================================
 #
 # SYNOPSIS
 #
-#   AX_TLS
+#   AX_TLS([action-if-found], [action-if-not-found])
 #
 # DESCRIPTION
 #
 #   Provides a test for the compiler support of thread local storage (TLS)
-#   extensions. Defines TLS if it is found. Currently only knows about GCC
-#   and MSVC. I think SunPro uses the same as GCC, and Borland apparently
-#   supports either.
+#   extensions. Defines TLS if it is found. Currently knows about C++11,
+#   GCC/ICC, and MSVC. I think SunPro uses the same as GCC, and Borland
+#   apparently supports either.
 #
 # LICENSE
 #
 #   Copyright (c) 2008 Alan Woodland <ajw05@aber.ac.uk>
+#   Copyright (c) 2010 Diego Elio Petteno` <flameeyes@gmail.com>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -28,7 +29,7 @@
 #   Public License for more details.
 #
 #   You should have received a copy of the GNU General Public License along
-#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
 #
 #   As a special exception, the respective Autoconf Macro's copyright owner
 #   gives unlimited permission to copy, distribute and modify the configure
@@ -43,49 +44,31 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
+#serial 14
+
 AC_DEFUN([AX_TLS], [
-  AC_MSG_CHECKING(for thread local storage specifier)
-  AC_CACHE_VAL(ac_cv_tls, [
-    ax_tls_keywords="_Thread_local __thread __declspec(thread) none"
-    for ax_tls_keyword in $ax_tls_keywords; do
-       case $ax_tls_keyword in
-          none) ac_cv_tls=none ; break ;;
-	  *)
-             # MPICH modification: This was an AC_TRY_COMPILE before, but
-             # Darwin with non-standard compilers will accept __thread at
-             # compile time but fail to link due to an undefined
-             # "__emutls_get_address" symbol unless -lgcc_eh is added to the
-             # link line.
-             AC_LINK_IFELSE(
-                 [AC_LANG_PROGRAM([$ax_tls_keyword int bar = 5;],[++bar;])],
-                 [ac_cv_tls=$ax_tls_keyword],
-                 [ac_cv_tls=none])
-
-	     # MPICH modification: Also test with the extern keyword.
-	     # The intel compiler on Darwin (at least as of 15.0.1)
-	     # seems to break with the above error when the extern
-	     # keyword is specified in shared library builds.
-	     PAC_PUSH_FLAG([LIBS])
-	     PAC_APPEND_FLAG([-shared],[LIBS])
-	     if test "$ac_cv_tls" != "none" ; then
-                AC_LINK_IFELSE(
-			[AC_LANG_PROGRAM(
-				[
-					extern $ax_tls_keyword int bar;
-					$ax_tls_keyword int bar = 0;
-				],[++bar;])],
-                        [ac_cv_tls=$ax_tls_keyword],
-                        [ac_cv_tls=none])
-	     fi
-	     PAC_POP_FLAG([LIBS])
-
-	     if test "$ac_cv_tls" != "none" ; then break ; fi
-          esac
+  AC_MSG_CHECKING([for thread local storage (TLS) class])
+  AC_CACHE_VAL([ac_cv_tls],
+   [for ax_tls_keyword in thread_local _Thread_local __thread '__declspec(thread)' none; do
+       AS_CASE([$ax_tls_keyword],
+          [none], [ac_cv_tls=none ; break],
+          [AC_TRY_COMPILE(
+              [#include <stdlib.h>
+               static void
+               foo(void) {
+               static ] $ax_tls_keyword [ int bar;
+               exit(1);
+               }],
+               [],
+               [ac_cv_tls=$ax_tls_keyword ; break],
+               ac_cv_tls=none
+           )])
     done
-])
+  ])
+  AC_MSG_RESULT([$ac_cv_tls])
 
-  if test "$ac_cv_tls" != "none"; then
-    AC_DEFINE_UNQUOTED([TLS_SPECIFIER], $ac_cv_tls, [If the compiler supports a TLS storage class define it to that here])
-  fi
-  AC_MSG_RESULT($ac_cv_tls)
+  AS_IF([test "$ac_cv_tls" != "none"],
+    [AC_DEFINE_UNQUOTED([TLS],[$ac_cv_tls],[If the compiler supports a TLS storage class define it to that here])
+     m4_ifnblank([$1],[$1])],
+    [m4_ifnblank([$2],[$2])])
 ])

--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -73,8 +73,8 @@ typedef struct {
 #endif
 } MPIR_Per_thread_t;
 
-#if defined(MPICH_IS_THREADED) && defined(MPL_TLS_SPECIFIER)
-extern MPL_TLS_SPECIFIER MPIR_Per_thread_t MPIR_Per_thread;
+#if defined(MPICH_IS_THREADED) && defined(MPL_TLS)
+extern MPL_TLS MPIR_Per_thread_t MPIR_Per_thread;
 #else
 extern MPIR_Per_thread_t MPIR_Per_thread;
 #endif

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -98,8 +98,8 @@ MPIR_Process_t MPIR_Process = { OPA_INT_T_INITIALIZER(MPICH_MPI_STATE__PRE_INIT)
      /* all other fields in MPIR_Process are irrelevant */
 MPIR_Thread_info_t MPIR_ThreadInfo = { 0 };
 
-#if defined(MPICH_IS_THREADED) && defined(MPL_TLS_SPECIFIER)
-MPL_TLS_SPECIFIER MPIR_Per_thread_t MPIR_Per_thread = { 0 };
+#if defined(MPICH_IS_THREADED) && defined(MPL_TLS)
+MPL_TLS MPIR_Per_thread_t MPIR_Per_thread = { 0 };
 #else
 MPIR_Per_thread_t MPIR_Per_thread = { 0 };
 #endif

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -681,9 +681,9 @@ esac
 # know what's used in MPL
 AC_DEFINE_UNQUOTED([THREAD_PACKAGE_NAME],[$THREAD_PACKAGE_NAME],[set to the name of the thread package])
 
-# check for compiler-support for thread-local storage (MPL_TLS_SPECIFIER)
+# check for compiler-support for thread-local storage (MPL_TLS)
 if test "${with_thread_package}" != "argobots" ; then
-    AX_TLS
+    AX_TLS([], AC_MSG_WARN([thread-local storage not supported by the compiler.]))
 fi
 
 #######################################################################

--- a/src/mpl/include/mpl_thread_priv.h
+++ b/src/mpl/include/mpl_thread_priv.h
@@ -7,7 +7,7 @@
 #ifndef MPL_THREAD_PRIV_H_INCLUDED
 #define MPL_THREAD_PRIV_H_INCLUDED
 
-#if MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE && !defined(MPL_TLS_SPECIFIER)
+#if MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE && !defined(MPL_TLS)
 /* We need to provide a function that will cleanup the storage attached
  * to the key.  */
 void MPLI_cleanup_tls(void *a);
@@ -80,7 +80,7 @@ void MPLI_cleanup_tls(void *a);
         MPL_thread_tls_destroy(&(key), err_ptr_);       \
     } while (0)
 
-#else /* MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE || defined(MPL_TLS_SPECIFIER) */
+#else /* MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE || defined(MPL_TLS) */
 
 /* We have proper thread-local storage (TLS) support from the compiler, which
  * should yield the best performance and simplest code, so we'll use that. */

--- a/src/mpl/src/thread/mpl_thread.c
+++ b/src/mpl/src/thread/mpl_thread.c
@@ -8,7 +8,7 @@
 
 MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
-#if (MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE) && !defined(MPL_TLS_SPECIFIER)
+#if (MPL_THREAD_PACKAGE_NAME != MPL_THREAD_PACKAGE_NONE) && !defined(MPL_TLS)
 
 /* This routine is called when a thread exits; it is passed the value
  * associated with the key.  In our case, this is simply storage


### PR DESCRIPTION
Remove MPICH modifications to AX_TLS, which we added to hack around
bad compilers years ago.