### PR TITLE
test/configure: Add error checking when test_coll_algos.sh fails

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -753,7 +753,9 @@ AC_SUBST(largetest)
 
 # Extended collectives test
 if test "$enable_collalgo_tests" = "yes" ; then
+    AC_MSG_NOTICE([running $srcdir/coll/test_coll_algos.sh])
     source $srcdir/coll/test_coll_algos.sh
+    test $? != 0 &&  AC_MSG_ERROR([$srcdir/coll/test_coll_algos.sh failed.])
 else
     coll_algo_tests=""
 fi


### PR DESCRIPTION
testing failure in the test_coll_algos script, in case error occurs, they don't get silently ignored.