### PR TITLE
ROMIO: check whether MPI C compiler is MPICH based

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1372,8 +1372,21 @@ if test -n "$mpi_mpich"; then
       MPIOF_H_INCLUDED=1
    fi
    if test "$FROM_MPICH" = no; then
-      AC_DEFINE(NEEDS_MPI_TEST,1,[Define if mpi_test needed])
-      AC_DEFINE(MPICH,1,[Define if using MPICH])
+      dnl Check if MPI C compiler is MPICH based, e.g. Cray MPI
+      AC_MSG_CHECKING([whether MPI C compiler is MPICH based])
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <mpi.h>
+#ifdef MPICH_NAME
+#error MPICH_NAME is not defined
+#endif
+      ]])], [is_mpich_based=yes], [is_mpich_based=no])
+      AC_MSG_RESULT([$is_mpich_based])
+
+      if test "$is_mpich_based" = no; then
+         AC_DEFINE(NEEDS_MPI_TEST,1,[Define if mpi_test needed])
+         AC_DEFINE(MPICH,1,[Define if using MPICH])
+      fi
+      unset is_mpich_based
    fi
 fi
 

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -435,11 +435,7 @@ fi
 
 AC_CHECK_TYPE(long long)
 AC_CHECK_SIZEOF(long long)
-if test -z "$MPI_IMPL" ; then
-	MPI_IMPL=mpich
-	mpi_mpich=1
-fi
-if test $MPI_IMPL = "mpich" ; then
+if test "x$MPI_IMPL" = "xmpich" ; then
 	TEST_CC=mpicc
 	TEST_F77=mpifort
 else


### PR DESCRIPTION
When ROMIO is built outside of MPICH, this PR checks whether MPI C compiler is MPICH based.
It uses MPICH_NAME, a constant defined in mpi.h, to tell. If the compiler is MPICH based,
configure skips the define of NEEDS_MPI_TEST and MPICH. FYI. Calling MPI_Testall is a lot more
expensive than MPI_Waitall on Cori, whose Cray compilers is MPICH based.

@roblatham00 , This PR does not change the default to MPI_Waitall, but should build a ROMIO
on Cori that uses MPI_Waitall instead of MPI_Testall. We can keep the checking, as it may be
useful, even after we decide to make MPI_Waitall default in the future.