### PR TITLE
mpir,mpi: refactor MPIR_Find_local_and_external and reuse in ch4/posix

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -78,10 +78,10 @@ Notes:
 void MPIR_Add_finalize(int (*routine) (void *), void *extra, int priority);
 
 /* Routines for determining local and remote processes */
-int MPIR_Find_local_and_external(struct MPIR_Comm *comm, int *local_size_p, int *local_rank_p,
-                                 int **local_ranks_p, int *external_size_p, int *external_rank_p,
-                                 int **external_ranks_p, int **intranode_table,
-                                 int **internode_table_p);
+int MPIR_Find_local(struct MPIR_Comm *comm, int *local_size_p, int *local_rank_p,
+                    int **local_ranks_p, int **intranode_table);
+int MPIR_Find_external(struct MPIR_Comm *comm, int *external_size_p, int *external_rank_p,
+                       int **external_ranks_p, int **internode_table_p);
 int MPIR_Get_internode_rank(MPIR_Comm * comm_ptr, int r);
 int MPIR_Get_intranode_rank(MPIR_Comm * comm_ptr, int r);
 

--- a/src/util/procmap/local_proc.c
+++ b/src/util/procmap/local_proc.c
@@ -83,20 +83,20 @@ int MPIR_Find_local(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
         }
     }
 
-    /*
-     * printf("------------------------------------------------------------------------\n");
-     * printf("comm = %p\n", comm);
-     * printf("comm->size = %d\n", comm->remote_size);
-     * printf("comm->rank = %d\n", comm->rank);
-     * printf("local_size = %d\n", local_size);
-     * printf("local_rank = %d\n", local_rank);
-     * printf("local_ranks = %p\n", local_ranks);
-     * for (i = 0; i < local_size; ++i)
-     * printf("  local_ranks[%d] = %d\n", i, local_ranks[i]);
-     * printf("intranode_table = %p\n", intranode_table);
-     * for (i = 0; i < comm->remote_size; ++i)
-     * printf("  intranode_table[%d] = %d\n", i, intranode_table[i]);
-     */
+#ifdef ENABLE_DEBUG
+    printf("------------------------------------------------------------------------\n");
+    printf("[%d]comm = %p\n", comm->rank, comm);
+    printf("[%d]comm->size = %d\n", comm->rank, comm->remote_size);
+    printf("[%d]comm->rank = %d\n", comm->rank, comm->rank);
+    printf("[%d]local_size = %d\n", comm->rank, local_size);
+    printf("[%d]local_rank = %d\n", comm->rank, local_rank);
+    printf("[%d]local_ranks = %p\n", comm->rank, local_ranks);
+    for (i = 0; i < local_size; ++i)
+        printf("[%d]  local_ranks[%d] = %d\n", comm->rank, i, local_ranks[i]);
+    printf("[%d]intranode_table = %p\n", comm->rank, intranode_table);
+    for (i = 0; i < comm->remote_size; ++i)
+        printf("[%d]  intranode_table[%d] = %d\n", comm->rank, i, intranode_table[i]);
+#endif
 
     MPIR_CHKPMEM_COMMIT();
 
@@ -201,23 +201,23 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
         internode_table[i] = nodes[node_id];
     }
 
-    /*
-     * printf("------------------------------------------------------------------------\n");
-     * printf("comm = %p\n", comm);
-     * printf("comm->size = %d\n", comm->remote_size);
-     * printf("comm->rank = %d\n", comm->rank);
-     * printf("external_size = %d\n", external_size);
-     * printf("external_rank = %d\n", external_rank);
-     * printf("external_ranks = %p\n", external_ranks);
-     * for (i = 0; i < external_size; ++i)
-     * printf("  external_ranks[%d] = %d\n", i, external_ranks[i]);
-     * printf("internode_table = %p\n", internode_table);
-     * for (i = 0; i < comm->remote_size; ++i)
-     * printf("  internode_table[%d] = %d\n", i, internode_table[i]);
-     * printf("nodes = %p\n", nodes);
-     * for (i = 0; i < (max_node_id + 1); ++i)
-     * printf("  nodes[%d] = %d\n", i, nodes[i]);
-     */
+#ifdef ENABLE_DEBUG
+    printf("------------------------------------------------------------------------\n");
+    printf("[%d]comm = %p\n", comm->rank, comm);
+    printf("[%d]comm->size = %d\n", comm->rank, comm->remote_size);
+    printf("[%d]comm->rank = %d\n", comm->rank, comm->rank);
+    printf("[%d]external_size = %d\n", comm->rank, external_size);
+    printf("[%d]external_rank = %d\n", comm->rank, external_rank);
+    printf("[%d]external_ranks = %p\n", comm->rank, external_ranks);
+    for (i = 0; i < external_size; ++i)
+        printf("[%d]  external_ranks[%d] = %d\n", comm->rank, i, external_ranks[i]);
+    printf("[%d]internode_table = %p\n", comm->rank, internode_table);
+    for (i = 0; i < comm->remote_size; ++i)
+        printf("[%d]  internode_table[%d] = %d\n", comm->rank, i, internode_table[i]);
+    printf("[%d]nodes = %p\n", comm->rank, nodes);
+    for (i = 0; i < (max_node_id + 1); ++i)
+        printf("[%d]  nodes[%d] = %d\n", comm->rank, i, nodes[i]);
+#endif
 
     MPIR_CHKPMEM_COMMIT();
 

--- a/src/util/procmap/local_proc.c
+++ b/src/util/procmap/local_proc.c
@@ -41,12 +41,13 @@
                          of the process with external rank i.
                          This is of size (*external_size_p)
      intranode_table_p - (*internode_table_p)[i] gives the rank in
-                         *local_ranks_p of rank i in comm or -1 if not
+     (optional)          *local_ranks_p of rank i in comm or -1 if not
                          applicable.  It is of size comm->remote_size.
+                         No return if NULL is specified.
      internode_table_p - (*internode_table_p)[i] gives the rank in
-                         *external_ranks_p of the root of the node
+     (optional)          *external_ranks_p of the root of the node
                          containing rank i in comm.  It is of size
-                         comm->remote_size.
+                         comm->remote_size. No return if NULL is specified.
 */
 
 int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
@@ -176,6 +177,8 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
      * printf("  nodes[%d] = %d\n", i, nodes[i]);
      */
 
+    MPIR_CHKPMEM_COMMIT();
+
     *local_size_p = local_size;
     *local_rank_p = local_rank;
     *local_ranks_p = MPL_realloc(local_ranks, sizeof(int) * local_size, MPL_MEM_COMM);
@@ -189,10 +192,13 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
     /* no need to realloc */
     if (intranode_table_p)
         *intranode_table_p = intranode_table;
+    else
+        MPL_free(intranode_table);
+
     if (internode_table_p)
         *internode_table_p = internode_table;
-
-    MPIR_CHKPMEM_COMMIT();
+    else
+        MPL_free(internode_table);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/util/procmap/local_proc.c
+++ b/src/util/procmap/local_proc.c
@@ -16,61 +16,138 @@
 #include <errno.h>
 #endif
 
-/* MPIR_Find_local_and_external -- from the list of processes in comm,
-   builds a list of local processes, i.e., processes on this same
-   node, and a list of external processes, i.e., one process from each
-   node.
+/* MPIR_Find_local  -- from the list of processes in comm,
+ * builds a list of local processes, i.e., processes on this same node.
+ *
+ * Note that this will not work correctly for spawned or attached
+ * processes.
+ *
+ *  OUT:
+ *    local_size_p      - number of processes on this node.
+ *    local_rank_p      - rank of this processes among local processes.
+ *    local_ranks_p     - (*local_ranks_p)[i]     = the rank in comm
+ *                        of the process with local rank i.
+ *                        This is of size (*local_size_p).
+ *    intranode_table_p - (*intranode_table_p)[i] = the rank in
+ *    (optional)          *local_ranks_p of rank i in comm or -1 if not
+ *                        applicable.  It is of size comm->remote_size.
+ *                        No return if NULL is specified.
+ */
+int MPIR_Find_local(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
+                    int **local_ranks_p, int **intranode_table_p)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int i, local_size, local_rank;
+    int *local_ranks = NULL, *intranode_table = NULL;
+    int node_id = -1, my_node_id = -1;
 
-   Note that this will not work correctly for spawned or attached
-   processes.
+    MPIR_CHKPMEM_DECL(2);
 
-   external processes: For a communicator, there is one external
-                       process per node.  You can think of this as the
-                       root or master process for that node.
+    /* local_ranks will be realloc'ed later to the appropriate size (currently unknown) */
+    /* FIXME: realloc doesn't guarantee that the allocated area will be
+     * shrunk - so using realloc is not an appropriate strategy. */
+    MPIR_CHKPMEM_MALLOC(local_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno,
+                        "local_ranks", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(intranode_table, int *, sizeof(int) * comm->remote_size, mpi_errno,
+                        "intranode_table", MPL_MEM_COMM);
 
-   OUT:
-     local_size_p      - number of processes on this node
-     local_rank_p      - rank of this processes among local processes
-     local_ranks_p     - (*local_ranks_p)[i] = the rank in comm
-                         of the process with local rank i.
-                         This is of size (*local_size_p)
-     external_size_p   - number of external processes
-     external_rank_p   - rank of this process among the external
-                         processes, or -1 if this process is not external
-     external_ranks_p  - (*external_ranks_p)[i] = the rank in comm
-                         of the process with external rank i.
-                         This is of size (*external_size_p)
-     intranode_table_p - (*internode_table_p)[i] gives the rank in
-     (optional)          *local_ranks_p of rank i in comm or -1 if not
-                         applicable.  It is of size comm->remote_size.
-                         No return if NULL is specified.
-     internode_table_p - (*internode_table_p)[i] gives the rank in
-     (optional)          *external_ranks_p of the root of the node
-                         containing rank i in comm.  It is of size
-                         comm->remote_size. No return if NULL is specified.
-*/
+    for (i = 0; i < comm->remote_size; ++i)
+        intranode_table[i] = -1;
 
-int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
-                                 int **local_ranks_p, int *external_size_p, int *external_rank_p,
-                                 int **external_ranks_p, int **intranode_table_p,
-                                 int **internode_table_p)
+    mpi_errno = MPID_Get_node_id(comm, comm->rank, &my_node_id);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+    MPIR_Assert(my_node_id >= 0);
+
+    local_size = 0;
+    local_rank = -1;
+
+    /* Scan through the list of processes in comm. */
+    for (i = 0; i < comm->remote_size; ++i) {
+        mpi_errno = MPID_Get_node_id(comm, i, &node_id);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        /* The upper level can catch this non-fatal error and should be
+         * able to recover gracefully. */
+        MPIR_ERR_CHKANDJUMP(node_id < 0, mpi_errno, MPI_ERR_OTHER, "**dynamic_node_ids");
+
+        /* build list of local processes */
+        if (node_id == my_node_id) {
+            if (i == comm->rank)
+                local_rank = local_size;
+
+            intranode_table[i] = local_size;
+            local_ranks[local_size] = i;
+            ++local_size;
+        }
+    }
+
+    /*
+     * printf("------------------------------------------------------------------------\n");
+     * printf("comm = %p\n", comm);
+     * printf("comm->size = %d\n", comm->remote_size);
+     * printf("comm->rank = %d\n", comm->rank);
+     * printf("local_size = %d\n", local_size);
+     * printf("local_rank = %d\n", local_rank);
+     * printf("local_ranks = %p\n", local_ranks);
+     * for (i = 0; i < local_size; ++i)
+     * printf("  local_ranks[%d] = %d\n", i, local_ranks[i]);
+     * printf("intranode_table = %p\n", intranode_table);
+     * for (i = 0; i < comm->remote_size; ++i)
+     * printf("  intranode_table[%d] = %d\n", i, intranode_table[i]);
+     */
+
+    MPIR_CHKPMEM_COMMIT();
+
+    *local_size_p = local_size;
+    *local_rank_p = local_rank;
+
+    *local_ranks_p = MPL_realloc(local_ranks, sizeof(int) * local_size, MPL_MEM_COMM);
+    MPIR_ERR_CHKANDJUMP(*local_ranks_p == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem2");
+
+    if (intranode_table_p)
+        *intranode_table_p = intranode_table;   /* no need to realloc */
+    else
+        MPL_free(intranode_table);      /* free internally if caller passes NULL */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    MPIR_CHKPMEM_REAP();
+    goto fn_exit;
+}
+
+/* MPIR_Find_external -- from the list of processes in comm,
+ * builds a list of external processes, i.e., one process from each node.
+ * You can think of this as the root or master process for each node.
+ *
+ * Note that this will not work correctly for spawned or attached
+ * processes.
+ *
+ *  OUT:
+ *    external_size_p   - number of external processes
+ *    external_rank_p   - rank of this process among the external
+ *                        processes, or -1 if this process is not external
+ *    external_ranks_p  - (*external_ranks_p)[i]   = the rank in comm
+ *                        of the process with external rank i.
+ *                        This is of size (*external_size_p)
+ *    internode_table_p - (*internode_table_p)[i]  = the rank in
+ *    (optional)          *external_ranks_p of the root of the node
+ *                        containing rank i in comm.  It is of size
+ *                        comm->remote_size. No return if NULL is specified.
+ */
+int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_rank_p,
+                       int **external_ranks_p, int **internode_table_p)
 {
     int mpi_errno = MPI_SUCCESS;
     int *nodes;
-    int external_size;
-    int external_rank;
-    int *external_ranks;
-    int local_size;
-    int local_rank;
-    int *local_ranks;
-    int *internode_table;
-    int *intranode_table;
-    int i;
-    int max_node_id;
-    int node_id;
-    int my_node_id;
+    int i, external_size, external_rank;
+    int *external_ranks, *internode_table;
+    int max_node_id, node_id;
+
     MPIR_CHKLMEM_DECL(1);
-    MPIR_CHKPMEM_DECL(4);
+    MPIR_CHKPMEM_DECL(2);
 
     /* Scan through the list of processes in comm and add one
      * process from each node to the list of "external" processes.  We
@@ -78,18 +155,13 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
      * array where we keep track of whether we have already added that
      * node to the list. */
 
-    /* these two will be realloc'ed later to the appropriate size (currently unknown) */
+    /* external_ranks will be realloc'ed later to the appropriate size (currently unknown) */
     /* FIXME: realloc doesn't guarantee that the allocated area will be
      * shrunk - so using realloc is not an appropriate strategy. */
     MPIR_CHKPMEM_MALLOC(external_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno,
                         "external_ranks", MPL_MEM_COMM);
-    MPIR_CHKPMEM_MALLOC(local_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "local_ranks", MPL_MEM_COMM);
-
     MPIR_CHKPMEM_MALLOC(internode_table, int *, sizeof(int) * comm->remote_size, mpi_errno,
                         "internode_table", MPL_MEM_COMM);
-    MPIR_CHKPMEM_MALLOC(intranode_table, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "intranode_table", MPL_MEM_COMM);
 
     mpi_errno = MPID_Get_max_node_id(comm, &max_node_id);
     if (mpi_errno)
@@ -102,19 +174,7 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
     for (i = 0; i < (max_node_id + 1); ++i)
         nodes[i] = -1;
 
-    for (i = 0; i < comm->remote_size; ++i)
-        intranode_table[i] = -1;
-
     external_size = 0;
-
-    mpi_errno = MPID_Get_node_id(comm, comm->rank, &my_node_id);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-    MPIR_Assert(my_node_id >= 0);
-    MPIR_Assert(my_node_id <= max_node_id);
-
-    local_size = 0;
-    local_rank = -1;
     external_rank = -1;
 
     for (i = 0; i < comm->remote_size; ++i) {
@@ -139,16 +199,6 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
 
         /* build the map from rank in comm to rank in external_ranks */
         internode_table[i] = nodes[node_id];
-
-        /* build list of local processes */
-        if (node_id == my_node_id) {
-            if (i == comm->rank)
-                local_rank = local_size;
-
-            intranode_table[i] = local_size;
-            local_ranks[local_size] = i;
-            ++local_size;
-        }
     }
 
     /*
@@ -156,19 +206,11 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
      * printf("comm = %p\n", comm);
      * printf("comm->size = %d\n", comm->remote_size);
      * printf("comm->rank = %d\n", comm->rank);
-     * printf("local_size = %d\n", local_size);
-     * printf("local_rank = %d\n", local_rank);
-     * printf("local_ranks = %p\n", local_ranks);
-     * for (i = 0; i < local_size; ++i)
-     * printf("  local_ranks[%d] = %d\n", i, local_ranks[i]);
      * printf("external_size = %d\n", external_size);
      * printf("external_rank = %d\n", external_rank);
      * printf("external_ranks = %p\n", external_ranks);
      * for (i = 0; i < external_size; ++i)
      * printf("  external_ranks[%d] = %d\n", i, external_ranks[i]);
-     * printf("intranode_table = %p\n", intranode_table);
-     * for (i = 0; i < comm->remote_size; ++i)
-     * printf("  intranode_table[%d] = %d\n", i, intranode_table[i]);
      * printf("internode_table = %p\n", internode_table);
      * for (i = 0; i < comm->remote_size; ++i)
      * printf("  internode_table[%d] = %d\n", i, internode_table[i]);
@@ -179,26 +221,15 @@ int MPIR_Find_local_and_external(MPIR_Comm * comm, int *local_size_p, int *local
 
     MPIR_CHKPMEM_COMMIT();
 
-    *local_size_p = local_size;
-    *local_rank_p = local_rank;
-    *local_ranks_p = MPL_realloc(local_ranks, sizeof(int) * local_size, MPL_MEM_COMM);
-    MPIR_ERR_CHKANDJUMP(*local_ranks_p == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem2");
-
     *external_size_p = external_size;
     *external_rank_p = external_rank;
     *external_ranks_p = MPL_realloc(external_ranks, sizeof(int) * external_size, MPL_MEM_COMM);
     MPIR_ERR_CHKANDJUMP(*external_ranks_p == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem2");
 
-    /* no need to realloc */
-    if (intranode_table_p)
-        *intranode_table_p = intranode_table;
-    else
-        MPL_free(intranode_table);
-
     if (internode_table_p)
-        *internode_table_p = internode_table;
+        *internode_table_p = internode_table;   /* no need to realloc */
     else
-        MPL_free(internode_table);
+        MPL_free(internode_table);      /* free internally if caller passes NULL */
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();


### PR DESCRIPTION
This PR separates the `MPIR_Find_local_and_external ` routine to two pieces: `MPIR_Find_local` and `MPIR_Find_external`, which should be more flexible. It then replaces the manual local nodemap collection in `ch4/shm/posix/fbox_init` with the `MPIR_Find_local` routine.