### PR TITLE
datatypes: correctly calculate max_contig_blocks

### DIFF
--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -88,6 +88,8 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         new_dtp->builtin_element_size = old_dtp->builtin_element_size;
         new_dtp->basic_type = old_dtp->basic_type;
 
+        new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
+
         new_dtp->dataloop = NULL;
         new_dtp->dataloop_size = old_dtp->dataloop_size;
         *newtype = new_dtp->handle;

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -252,7 +252,7 @@ int MPIR_Type_struct(int count,
 
             size += old_dtp->size * blocklength_array[i];
 
-            new_dtp->max_contig_blocks += old_dtp->max_contig_blocks;
+            new_dtp->max_contig_blocks += old_dtp->max_contig_blocks * blocklength_array[i];
         }
 
         /* element size and type */


### PR DESCRIPTION
This field was not being copied, resulting in a garbage value.