### PR TITLE
ROMIO: check MPI_VERSION for whether to use C modifier const for MPI-IO subroutines 

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1534,7 +1534,8 @@ elif test $FROM_MPICH = yes ; then
    DEFINE_HAVE_MPI_GREQUEST="#define HAVE_MPI_GREQUEST 1"
    DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS="#define HAVE_MPI_GREQUEST_EXTENSIONS 1"
    AC_DEFINE(HAVE_MPIX_H, 1, [])
-   AC_DEFINE(HAVE_MPIIO_CONST, const, Set if MPI-IO prototypes use const qualifier)
+   # HAVE_MPIIO_CONST is now determined by whether MPI_VERSION >= 3
+   # AC_DEFINE(HAVE_MPIIO_CONST, const, Set if MPI-IO prototypes use const qualifier)
    AC_DEFINE(HAVE_MPI_TYPE_SIZE_X, 1, [Define if MPI library provides MPI_TYPE_SIZE_X])
    AC_DEFINE(HAVE_MPI_STATUS_SET_ELEMENTS_X, 1, [Define if MPI library provides MPI_STATUS_SET_ELEMENTS_X])
    AC_DEFINE(HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK, 1, [Define if MPI library provides HINDEXED_BLOCK datatype])
@@ -1549,7 +1550,8 @@ if test $WITHIN_KNOWN_MPI_IMPL = no ; then
    PAC_TEST_MPI_GREQUEST
    AC_DEFINE(PRINT_ERR_MSG,1,[Define for printing error messages])
    AC_CHECK_TYPE([MPI_Count],[],[AC_DEFINE_UNQUOTED([MPI_Count],[MPI_Aint],[Define to "MPI_Aint" if MPI does not provide MPI_Count]) ], [[#include <mpi.h>]])
-   PAC_TEST_NEEDS_CONST
+   # HAVE_MPIIO_CONST is now determined by whether MPI_VERSION >= 3
+   # PAC_TEST_NEEDS_CONST
    AC_CHECK_DECLS([MPI_COMBINER_HINDEXED_BLOCK], [], [], [[#include <mpi.h>]])
    AC_CHECK_FUNCS(MPI_Type_size_x MPI_Status_set_elements_x)
 fi

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -53,7 +53,7 @@ MPI_Delete_function ADIOI_End_call;
 /* common initialization routine */
 void MPIR_MPIOInit(int *error_code);
 
-#ifdef HAVE_MPIIO_CONST
+#if MPI_VERSION >= 3
 #define ROMIO_CONST const
 #else
 #define ROMIO_CONST

--- a/src/mpi/romio/mpi-io/mpiu_external32.c
+++ b/src/mpi/romio/mpi-io/mpiu_external32.c
@@ -27,7 +27,7 @@ int MPIU_write_external32_conversion_fn(const void *userbuf, MPI_Datatype dataty
         goto fn_exit;
 
     if (is_contig) {
-#ifdef HAVE_MPIIO_CONST
+#if MPI_VERSION >= 3
         mpi_errno = MPI_Pack_external("external32", userbuf, count,
                                       datatype, filebuf, bytes, &position);
 #else
@@ -43,7 +43,7 @@ int MPIU_write_external32_conversion_fn(const void *userbuf, MPI_Datatype dataty
             mpi_errno = MPI_ERR_NO_MEM;
             goto fn_exit;
         }
-#ifdef HAVE_MPIIO_CONST
+#if MPI_VERSION >= 3
         mpi_errno = MPI_Pack_external("external32", userbuf, count,
                                       datatype, tmp_buf, bytes, &position);
 #else


### PR DESCRIPTION
Because the use of C modifier const for MPI-IO starts in MPI standard 3.0,
this patch replaces the call to PAC_TEST_NEEDS_CONST with the
check of constant MPI_VERSION defined in mpi.h against 3.
See github issue #3748 for more discussion.