### PR TITLE
Ch3 intra large dtype fix

### DIFF
--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -27,7 +27,7 @@ static inline int MPID_nem_mpich_test_recv_wait (MPID_nem_cell_ptr_t *cell, int 
 static inline int MPID_nem_mpich_release_cell (MPID_nem_cell_ptr_t cell, MPIDI_VC_t *vc);
 static inline void MPID_nem_mpich_send_seg_header (MPIR_Segment *segment, intptr_t *segment_first,
                                                    intptr_t segment_size, void *header, intptr_t header_sz,
-                                                   void *ext_header, intptr_t ext_header_sz, MPIDI_VC_t *vc, int *again);
+                                                   MPIDI_VC_t *vc, int *again);
 static inline void MPID_nem_mpich_send_seg (MPIR_Segment *segment, intptr_t *segment_first, intptr_t segment_size,
                                                     MPIDI_VC_t *vc, int *again);
 
@@ -460,8 +460,7 @@ MPID_nem_mpich_sendv_header (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *aga
 */
 static inline void
 MPID_nem_mpich_send_seg_header (MPIR_Segment *segment, intptr_t *segment_first, intptr_t segment_size,
-                                void *header, intptr_t header_sz, void *ext_header, intptr_t ext_header_sz,
-                                MPIDI_VC_t *vc, int *again)
+                                void *header, intptr_t header_sz, MPIDI_VC_t *vc, int *again)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_MPICH_SEND_SEG_HEADER);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_MPICH_SEND_SEG_HEADER);
@@ -482,7 +481,7 @@ MPID_nem_mpich_send_seg_header (MPIR_Segment *segment, intptr_t *segment_first, 
     my_rank = MPID_nem_mem_region.rank;
 
 #ifdef USE_FASTBOX
-    if (ext_header_sz == 0 && sizeof(MPIDI_CH3_Pkt_t) + segment_size <= MPID_NEM_FBOX_DATALEN)
+    if (sizeof(MPIDI_CH3_Pkt_t) + segment_size <= MPID_NEM_FBOX_DATALEN)
     {
 	MPID_nem_fbox_mpich_t *pbox = vc_ch->fbox_out;
 
@@ -555,12 +554,6 @@ MPID_nem_mpich_send_seg_header (MPIR_Segment *segment, intptr_t *segment_first, 
     MPIR_Memcpy((void *)el->pkt.p.payload, header, header_sz);
     
     buf_offset += sizeof(MPIDI_CH3_Pkt_t);
-
-    if (ext_header_sz > 0) {
-        /* when extended packet header exists, copy it */
-        MPIR_Memcpy((void *)((char *)(el->pkt.p.payload) + buf_offset), ext_header, ext_header_sz);
-        buf_offset += ext_header_sz;
-    }
 
     /* copy data */
     if (segment_size - *segment_first <= MPID_NEM_MPICH_DATA_LEN - buf_offset)

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_post.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_post.h
@@ -54,8 +54,7 @@ MPID_nem_mpich_win_t;
 #if !defined (MPID_NEM_INLINE) || !MPID_NEM_INLINE
 int MPID_nem_mpich_send_header(void* buf, int size, struct MPIDI_VC *vc, int *again);
 int MPID_nem_mpich_sendv(MPL_IOV **iov, int *n_iov, struct MPIDI_VC *vc, int *again);
-int MPID_nem_mpich_sendv_header(MPL_IOV **iov, int *n_iov, void *ext_header,
-                                intptr_t ext_header_sz, struct MPIDI_VC *vc, int *again);
+int MPID_nem_mpich_sendv_header(MPL_IOV **iov, int *n_iov, struct MPIDI_VC *vc, int *again);
 int MPID_nem_mpich_test_recv(MPID_nem_cell_ptr_t *cell, int *in_fbox, int in_blocking_progress);
 int MPID_nem_mpich_test_recv_wait(MPID_nem_cell_ptr_t *cell, int *in_fbox, int timeout);
 int MPID_nem_recv_seqno_matches(MPID_nem_queue_ptr_t qhead) ;

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -56,7 +56,8 @@ int MPIDI_CH3I_Progress_deactivate_hook(int id);
 int MPIDI_CH3I_Shm_send_progress(void);
 int MPIDI_CH3I_Complete_sendq_with_error(MPIDI_VC_t * vc);
 
-int MPIDI_CH3I_SendNoncontig( MPIDI_VC_t *vc, MPIR_Request *sreq, void *header, intptr_t hdr_sz );
+int MPIDI_CH3I_SendNoncontig( MPIDI_VC_t *vc, MPIR_Request *sreq, void *header, intptr_t hdr_sz,
+                              MPL_IOV *hdr_iov, int n_hdr_iov);
 
 int MPID_nem_lmt_shm_initiate_lmt(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *rts_pkt, MPIR_Request *req);
 int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, MPL_IOV s_cookie);

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_pre.h
@@ -107,6 +107,11 @@ typedef struct MPIDI_CH3I_VC
        network module should complete the request once the message has been completely sent. */
     int (* iSendContig)(struct MPIDI_VC *vc, struct MPIR_Request *sreq, void *hdr, intptr_t hdr_sz,
                         void *data, intptr_t data_sz);
+    /* iSendIov -- sends a message consisting of multiple iovs, possibly of 0 n_iov.
+       n_iov should not exceed MPL_IOV_LIMIT - 1. network module should complete the request once the
+       message has been completely sent. */
+    int (* iSendIov)(struct MPIDI_VC *vc, struct MPIR_Request *sreq, void *hdr, intptr_t hdr_sz,
+                     MPL_IOV *iov, int n_iov);
 
 #ifdef ENABLE_CHECKPOINTING
     /* ckpt_pause_send -- netmod should stop sending on this vc and queue messages to be sent after ckpt_continue()*/

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -443,6 +443,7 @@ int MPID_nem_ofi_vc_init(MPIDI_VC_t * vc)
     vc->sendNoncontig_fn = MPID_nem_ofi_SendNoncontig;
     vc_ch->iStartContigMsg = MPID_nem_ofi_iStartContigMsg;
     vc_ch->iSendContig = MPID_nem_ofi_iSendContig;
+    vc_ch->iSendIov = MPID_nem_ofi_iSendIov;
     vc_ch->next = NULL;
     vc_ch->prev = NULL;
     vc_ofi->is_cmvc = 0;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -295,7 +295,8 @@ DECLARE_TWO_API_SETS(void, MPID_nem_ofi_anysource_posted, MPIR_Request * rreq);
 
 int MPID_nem_ofi_anysource_matched(MPIR_Request * rreq);
 int MPID_nem_ofi_send_data(cq_tagged_entry_t * wc, MPIR_Request * sreq);
-int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hdr_sz);
+int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hdr_sz,
+                               MPL_IOV * hdr_iov, int n_hdr_iov);
 int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz,
                                  void *data, intptr_t data_sz, MPIR_Request ** sreq_ptr);
 int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr,

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -300,7 +300,8 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz,
                                  void *data, intptr_t data_sz, MPIR_Request ** sreq_ptr);
 int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr,
                              intptr_t hdr_sz, void *data, intptr_t data_sz);
-
+int MPID_nem_ofi_iSendIov(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hdr_sz,
+                          MPL_IOV * iov, int n_iov);
 /* ************************************************************************** */
 /* OFI utility functions : not exposed as a netmod public API                 */
 /* ************************************************************************** */

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
@@ -104,6 +104,8 @@ int MPID_nem_tcp_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, vo
 int MPID_nem_tcp_iStartContigMsg_paused(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, void *data,
                                         intptr_t data_sz, MPIR_Request ** sreq_ptr);
 int MPID_nem_tcp_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *header, intptr_t hdr_sz);
+int MPID_nem_tcp_iSendIov(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hdr_sz,
+                          MPL_IOV * iov, int n_iov);
 int MPID_nem_tcp_get_addr_port_from_bc(const char *business_card, struct in_addr *addr,
                                        in_port_t * port);
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
@@ -103,7 +103,8 @@ int MPID_nem_tcp_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, vo
                                  intptr_t data_sz, MPIR_Request ** sreq_ptr);
 int MPID_nem_tcp_iStartContigMsg_paused(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, void *data,
                                         intptr_t data_sz, MPIR_Request ** sreq_ptr);
-int MPID_nem_tcp_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *header, intptr_t hdr_sz);
+int MPID_nem_tcp_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *header, intptr_t hdr_sz,
+                               MPL_IOV * hdr_iov, int n_hdr_iov);
 int MPID_nem_tcp_iSendIov(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hdr_sz,
                           MPL_IOV * iov, int n_iov);
 int MPID_nem_tcp_get_addr_port_from_bc(const char *business_card, struct in_addr *addr,

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
@@ -523,6 +523,7 @@ int MPID_nem_tcp_vc_init(MPIDI_VC_t * vc)
     vc->sendNoncontig_fn = MPID_nem_tcp_SendNoncontig;
     vc_ch->iStartContigMsg = MPID_nem_tcp_iStartContigMsg;
     vc_ch->iSendContig = MPID_nem_tcp_iSendContig;
+    vc_ch->iSendIov = MPID_nem_tcp_iSendIov;
 #ifdef ENABLE_CHECKPOINTING
     vc_ch->ckpt_pause_send_vc = MPID_nem_tcp_ckpt_pause_send_vc;
     vc_ch->ckpt_continue_vc = MPID_nem_tcp_ckpt_continue_vc;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_isendv.c
@@ -69,7 +69,6 @@ int MPIDI_CH3_iSendv (MPIDI_VC_t *vc, MPIR_Request *sreq, MPL_IOV *iov, int n_io
 
         MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "iSendv");
 	mpi_errno = MPID_nem_mpich_sendv_header (&remaining_iov, &remaining_n_iov,
-	                                         sreq->dev.ext_hdr_ptr, sreq->dev.ext_hdr_sz,
 	                                         vc, &again);
         if (mpi_errno) MPIR_ERR_POP (mpi_errno);
 	while (!again && remaining_n_iov > 0)

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
@@ -85,8 +85,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, MPL_IOV *iov, int n_iov, MPIR_Request 
 
                 MPL_DBG_MSG_D (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "   + len=%d ", total);
             });
-	mpi_errno = MPID_nem_mpich_sendv_header (&remaining_iov, &remaining_n_iov,
-	                                         NULL, 0, vc, &again);
+	mpi_errno = MPID_nem_mpich_sendv_header (&remaining_iov, &remaining_n_iov, vc, &again);
         if (mpi_errno) MPIR_ERR_POP (mpi_errno);
 	while (!again && (remaining_n_iov > 0))
 	{

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -220,8 +220,7 @@ int MPIDI_CH3I_Shm_send_progress(void)
         else
         {
             MPID_nem_mpich_send_seg_header(sreq->dev.segment_ptr, &sreq->dev.segment_first, sreq->dev.segment_size,
-                                           &sreq->dev.pending_pkt, sreq->ch.header_sz, sreq->dev.ext_hdr_ptr,
-                                           sreq->dev.ext_hdr_sz, sreq->ch.vc, &again);
+                                           &sreq->dev.pending_pkt, sreq->ch.header_sz, sreq->ch.vc, &again);
             if (!again)
             {
                 MPIDI_CH3I_shm_active_send = sreq;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -196,8 +196,7 @@ int MPIDI_CH3I_Shm_send_progress(void)
             iov = &sreq->dev.iov[sreq->dev.iov_offset];
             n_iov = sreq->dev.iov_count;
 
-            mpi_errno = MPID_nem_mpich_sendv_header(&iov, &n_iov, sreq->dev.ext_hdr_ptr,
-                                                    sreq->dev.ext_hdr_sz, sreq->ch.vc, &again);
+            mpi_errno = MPID_nem_mpich_sendv_header(&iov, &n_iov, sreq->ch.vc, &again);
             if (mpi_errno) MPIR_ERR_POP (mpi_errno);
             if (!again)
             {

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -490,6 +490,7 @@ MPID_nem_vc_init (MPIDI_VC_t *vc)
         /* local processes use the default method */
         vc_ch->iStartContigMsg = NULL;
         vc_ch->iSendContig     = NULL;
+        vc_ch->iSendIov     = NULL;
 
 #if MPID_NEM_LOCAL_LMT_IMPL == MPID_NEM_LOCAL_LMT_SHM_COPY
         vc_ch->lmt_initiate_lmt  = MPID_nem_lmt_shm_initiate_lmt;

--- a/src/mpid/ch3/channels/sock/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isendv.c
@@ -39,17 +39,6 @@ int MPIDI_CH3_iSendv(MPIDI_VC_t * vc, MPIR_Request * sreq, MPL_IOV * iov, int n_
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_ISENDV);
 
-    if (sreq->dev.ext_hdr_sz > 0) {
-        int i;
-        for (i = n_iov - 1; i >= 1; i--) {
-            iov[i + 1].MPL_IOV_BUF = iov[i].MPL_IOV_BUF;
-            iov[i + 1].MPL_IOV_LEN = iov[i].MPL_IOV_LEN;
-        }
-        iov[1].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) sreq->dev.ext_hdr_ptr;
-        iov[1].MPL_IOV_LEN = sreq->dev.ext_hdr_sz;
-        n_iov++;
-    }
-
     MPIR_Assert(n_iov <= MPL_IOV_LIMIT);
     MPIR_Assert(iov[0].MPL_IOV_LEN <= sizeof(MPIDI_CH3_Pkt_t));
 

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -244,6 +244,13 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     if (is_origin_contig) {
         /* origin data is contiguous */
 
+        /* translate extended header to iov */
+        if (ext_hdr_sz > 0) {
+            iov[iovcnt].MPL_IOV_BUF = (MPL_IOV_BUF_CAST) req->dev.ext_hdr_ptr;
+            iov[iovcnt].MPL_IOV_LEN = ext_hdr_sz;
+            iovcnt++;
+        }
+
         if (is_empty_origin == FALSE) {
             iov[iovcnt].MPL_IOV_BUF =
                 (MPL_IOV_BUF_CAST) ((char *) rma_op->origin_addr + dt_true_lb + stream_offset);

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -725,9 +725,13 @@ typedef struct MPIDI_VC
     /* noncontiguous send function pointer.  Called to send a
        noncontiguous message.  Caller must initialize
        sreq->dev.segment, _first and _size.  Contiguous messages are
-       called directly from CH3 and cannot be overridden. */
+       called directly from CH3 and cannot be overridden.
+       The optional hdr_iov and n_hdr_iov input parameters are used for
+       variable-length extended header, specify NULL and zero if unused.
+       n_hdr_iov should not exceed MPL_IOV_LIMIT - 2 (one for header and one
+       for packed data).*/
     int (* sendNoncontig_fn)( struct MPIDI_VC *vc, struct MPIR_Request *sreq,
-			      void *header, intptr_t hdr_sz );
+			      void *header, intptr_t hdr_sz, MPL_IOV *hdr_iov, int n_hdr_iov);
 
 #ifdef ENABLE_COMM_OVERRIDES
     MPIDI_Comm_ops_t *comm_ops;
@@ -1788,7 +1792,8 @@ int MPIDI_CH3_EagerSyncNoncontigSend( MPIR_Request **, const void *, int,
 int MPIDI_CH3_EagerSyncZero(MPIR_Request **, int, int, MPIR_Comm *, int );
 
 int MPIDI_CH3_SendNoncontig_iov( struct MPIDI_VC *vc, struct MPIR_Request *sreq,
-                                 void *header, intptr_t hdr_sz );
+                                 void *header, intptr_t hdr_sz,
+                                 MPL_IOV *hdr_iov, int n_hdr_iov);
 
 /* Routines to ack packets, called in the receive routines when a 
    message is matched */

--- a/src/mpid/ch3/src/ch3u_eagersync.c
+++ b/src/mpid/ch3/src/ch3u_eagersync.c
@@ -96,7 +96,8 @@ int MPIDI_CH3_EagerSyncNoncontigSend( MPIR_Request **sreq_p,
 	sreq->dev.segment_size = data_sz;
 	
 	MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
-        mpi_errno = vc->sendNoncontig_fn(vc, sreq, es_pkt, sizeof(MPIDI_CH3_Pkt_eager_sync_send_t));
+        mpi_errno = vc->sendNoncontig_fn(vc, sreq, es_pkt, sizeof(MPIDI_CH3_Pkt_eager_sync_send_t),
+                                         NULL, 0);
 	MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
         if (mpi_errno) MPIR_ERR_POP(mpi_errno);
     }

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -864,7 +864,8 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
 
     /* Because this is in a packet handler, it is already within a critical section */
     /* MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex); */
-    mpi_errno = vc->sendNoncontig_fn(vc, sreq, get_resp_pkt, sizeof(*get_resp_pkt));
+    mpi_errno = vc->sendNoncontig_fn(vc, sreq, get_resp_pkt, sizeof(*get_resp_pkt),
+                                     NULL, 0);
     /* MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex); */
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS) {
@@ -1150,7 +1151,8 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
         sreq->dev.segment_size = get_pkt->count * type_size;
 
         mpi_errno = target_lock_entry->vc->sendNoncontig_fn(target_lock_entry->vc, sreq,
-                                                            iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN);
+                                                            iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN,
+                                                            NULL, 0);
         MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**ch3|rmamsg");
     }
 

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -517,7 +517,8 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
             req->dev.segment_size = get_pkt->count * type_size;
 
             MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
-            mpi_errno = vc->sendNoncontig_fn(vc, req, iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN);
+            mpi_errno = vc->sendNoncontig_fn(vc, req, iov[0].MPL_IOV_BUF, iov[0].MPL_IOV_LEN,
+                                             NULL, 0);
             MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
             MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**ch3|rmamsg");
         }

--- a/src/mpid/ch3/src/ch3u_rndv.c
+++ b/src/mpid/ch3/src/ch3u_rndv.c
@@ -253,7 +253,7 @@ int MPIDI_CH3_PktHandler_RndvClrToSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
 	sreq->dev.segment_size = data_sz;
 
 	MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
-	mpi_errno = vc->sendNoncontig_fn(vc, sreq, rs_pkt, sizeof(*rs_pkt));
+	mpi_errno = vc->sendNoncontig_fn(vc, sreq, rs_pkt, sizeof(*rs_pkt), NULL, 0);
 	MPID_THREAD_CS_EXIT(POBJ, vc->pobj_mutex);
 	MPIR_ERR_CHKANDJUMP(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**ch3|senddata");
     }    


### PR DESCRIPTION
This PR refactors ch3 data transfer with extended packet header. It fixes the bug reported in issue #3749 

<h4>Why:</h4>

To support the optional variable-length extended packet header (mainly for RMA), the original code had to change `iSendV` and `iSendNoncontig` to internally insert extended header in both channel and each netmod. Moreover, handling large extended header in nemesis/shm (i.e., when size of extended header exceeds the size of single cell) can make the code even messier.

<h4>Changes include:</h4>

- reformat `ch3/tcp` send code for better code reuse
- defines new `iSendIov` nemesis send API to allow direct handling of iovs in each netmod. This eliminates unneeded copy in nemesis when passing more than 2 iovs into `iSendV`
- define the optional extended header as part of `iov` in `iSendV`. This should be cleaner than existing method
- delete support of extended header in `sendNoncontig_fn`. Instead, `extended header + noncontig data case` should use `MPIDI_CH3_SendNoncontig_iov` which internally translates segment to iovs and reuses `iSendV`.