### PR TITLE
dataloop: fix bug in MPIR_Type_get_elements

### DIFF
--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -198,6 +198,7 @@ PMPI_LOCAL MPI_Count MPIR_Type_get_elements(MPI_Count * bytes_p,
             case MPI_COMBINER_VECTOR:
             case MPI_COMBINER_HVECTOR_INTEGER:
             case MPI_COMBINER_HVECTOR:
+            case MPI_COMBINER_SUBARRAY:
                 /* count is first in ints array */
                 return MPIR_Type_get_elements(bytes_p, count * (*ints), *types);
                 break;
@@ -246,7 +247,6 @@ PMPI_LOCAL MPI_Count MPIR_Type_get_elements(MPI_Count * bytes_p,
                 }
                 return nr_elements;
                 break;
-            case MPI_COMBINER_SUBARRAY:
             case MPI_COMBINER_DARRAY:
             case MPI_COMBINER_F90_REAL:
             case MPI_COMBINER_F90_COMPLEX:


### PR DESCRIPTION
Subarrays are built recursively using `MPI_Type_vector` thus the number of
elements in a subarray should be computed by recursively counting the
number of elements in each nested vector type