### PR TITLE
Cleanup HAVE_HWLOC related macro definitions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1348,8 +1348,6 @@ if test "$have_hwloc" = "yes" ; then
 fi
 
 HWLOC_DO_AM_CONDITIONALS
-AM_CONDITIONAL([have_hwloc], [test "${have_hwloc}" = "yes"])
-AM_CONDITIONAL([use_embedded_hwloc], [test "${use_embedded_hwloc}" = "yes"])
 
 AM_CONDITIONAL([HAVE_HWLOC], [test x$have_hwloc = xyes])
 

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -489,8 +489,8 @@ else
 fi
 
 HWLOC_DO_AM_CONDITIONALS
-AM_CONDITIONAL([hydra_have_hwloc], [test "${have_hwloc}" = "yes"])
-AM_CONDITIONAL([hydra_use_embedded_hwloc], [test "${hydra_use_embedded_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${have_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_USE_EMBEDDED_HWLOC], [test "${hydra_use_embedded_hwloc}" = "yes"])
 
 AC_MSG_CHECKING([available processor topology libraries])
 AC_MSG_RESULT([$available_topolibs])

--- a/src/pm/hydra/tools/topo/Makefile.mk
+++ b/src/pm/hydra/tools/topo/Makefile.mk
@@ -10,6 +10,6 @@ noinst_HEADERS += tools/topo/topo.h
 
 libhydra_la_SOURCES += tools/topo/topo.c
 
-if hydra_have_hwloc
+if HYDRA_HAVE_HWLOC
 include tools/topo/hwloc/Makefile.mk
 endif

--- a/src/pm/hydra/tools/topo/hwloc/Makefile.mk
+++ b/src/pm/hydra/tools/topo/hwloc/Makefile.mk
@@ -8,7 +8,7 @@ libhydra_la_SOURCES += tools/topo/hwloc/topo_hwloc.c
 
 noinst_HEADERS += tools/topo/hwloc/topo_hwloc.h
 
-if hydra_use_embedded_hwloc
+if HYDRA_USE_EMBEDDED_HWLOC
 AM_CPPFLAGS += @HWLOC_EMBEDDED_CPPFLAGS@
 AM_CFLAGS += @HWLOC_EMBEDDED_CFLAGS@
 

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -360,8 +360,8 @@ if test "$have_hwloc" = "yes" ; then
 fi
 
 HWLOC_DO_AM_CONDITIONALS
-AM_CONDITIONAL([hydra_have_hwloc], [test "${have_hwloc}" = "yes"])
-AM_CONDITIONAL([hydra_use_embedded_hwloc], [test "${hydra_use_embedded_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_HAVE_HWLOC], [test "${have_hwloc}" = "yes"])
+AM_CONDITIONAL([HYDRA_USE_EMBEDDED_HWLOC], [test "${hydra_use_embedded_hwloc}" = "yes"])
 
 
 

--- a/src/pm/hydra2/libhydra/topo/Makefile.mk
+++ b/src/pm/hydra2/libhydra/topo/Makefile.mk
@@ -11,6 +11,6 @@ noinst_HEADERS += libhydra/topo/hydra_topo.h \
 
 libhydra_la_SOURCES += libhydra/topo/hydra_topo.c
 
-if hydra_have_hwloc
+if HYDRA_HAVE_HWLOC
 include libhydra/topo/hwloc/Makefile.mk
 endif

--- a/src/pm/hydra2/libhydra/topo/hwloc/Makefile.mk
+++ b/src/pm/hydra2/libhydra/topo/hwloc/Makefile.mk
@@ -8,7 +8,7 @@ libhydra_la_SOURCES += libhydra/topo/hwloc/hydra_topo_hwloc.c
 
 noinst_HEADERS += libhydra/topo/hwloc/hydra_topo_hwloc.h
 
-if hydra_use_embedded_hwloc
+if HYDRA_USE_EMBEDDED_HWLOC
 AM_CPPFLAGS += @HWLOC_EMBEDDED_CPPFLAGS@
 AM_CFLAGS += @HWLOC_EMBEDDED_CFLAGS@
 


### PR DESCRIPTION
There are unused macros such `have_hwloc` (a lower case dup of `HAVE_HWLOC`) and `use_embedded_hwloc` (which is never checked and hydra checks a different macro).