### PR TITLE
warnings: remove zero initializer for static global storage

### DIFF
--- a/src/binding/fortran/mpif_h/setbot.c.in
+++ b/src/binding/fortran/mpif_h/setbot.c.in
@@ -102,7 +102,7 @@ struct mpif_cmblk1_t_ {
 };
 typedef struct mpif_cmblk1_t_ mpif_cmblk1_t;
 /* *INDENT-OFF* */
-mpif_cmblk1_t mpifcmb1r @CMB_STATUS_ALIGNMENT@ = {{0}};
+mpif_cmblk1_t mpifcmb1r @CMB_STATUS_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk1_t _CMPIFCMB1 __attribute__ ((alias("mpifcmb1r")));
 extern mpif_cmblk1_t MPIFCMB1 __attribute__ ((alias("mpifcmb1r")));
@@ -116,7 +116,7 @@ struct mpif_cmblk2_t_ {
 };
 typedef struct mpif_cmblk2_t_ mpif_cmblk2_t;
 /* *INDENT-OFF* */
-mpif_cmblk2_t mpifcmb2r @CMB_STATUS_ALIGNMENT@ = {{{0}}};
+mpif_cmblk2_t mpifcmb2r @CMB_STATUS_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk2_t _CMPIFCMB2 __attribute__ ((alias("mpifcmb2r")));
 extern mpif_cmblk2_t MPIFCMB2 __attribute__ ((alias("mpifcmb2r")));
@@ -130,7 +130,7 @@ struct mpif_cmblk3_t_ {
 };
 typedef struct mpif_cmblk3_t_ mpif_cmblk3_t;
 /* *INDENT-OFF* */
-mpif_cmblk3_t mpifcmb3r @CMB_1INT_ALIGNMENT@ = {0};
+mpif_cmblk3_t mpifcmb3r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk3_t _CMPIFCMB3 __attribute__ ((alias("mpifcmb3r")));
 extern mpif_cmblk3_t MPIFCMB3 __attribute__ ((alias("mpifcmb3r")));
@@ -144,7 +144,7 @@ struct mpif_cmblk4_t_ {
 };
 typedef struct mpif_cmblk4_t_ mpif_cmblk4_t;
 /* *INDENT-OFF* */
-mpif_cmblk4_t mpifcmb4r @CMB_1INT_ALIGNMENT@ = {0};
+mpif_cmblk4_t mpifcmb4r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk4_t _CMPIFCMB4 __attribute__ ((alias("mpifcmb4r")));
 extern mpif_cmblk4_t MPIFCMB4 __attribute__ ((alias("mpifcmb4r")));
@@ -158,7 +158,7 @@ struct mpif_cmblk5_t_ {
 };
 typedef struct mpif_cmblk5_t_ mpif_cmblk5_t;
 /* *INDENT-OFF* */
-FORT_DLL_SPEC mpif_cmblk5_t mpifcmb5r @CMB_1INT_ALIGNMENT@ = {0};
+FORT_DLL_SPEC mpif_cmblk5_t mpifcmb5r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern FORT_DLL_SPEC mpif_cmblk5_t _CMPIFCMB5 __attribute__ ((alias("mpifcmb5r")));
 extern FORT_DLL_SPEC mpif_cmblk5_t MPIFCMB5 __attribute__ ((alias("mpifcmb5r")));
@@ -172,7 +172,7 @@ struct mpif_cmblk6_t_ {
 };
 typedef struct mpif_cmblk6_t_ mpif_cmblk6_t;
 /* *INDENT-OFF* */
-mpif_cmblk6_t mpifcmb6r @CMB_1INT_ALIGNMENT@ = {{0}};
+mpif_cmblk6_t mpifcmb6r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk6_t _CMPIFCMB6 __attribute__ ((alias("mpifcmb6r")));
 extern mpif_cmblk6_t MPIFCMB6 __attribute__ ((alias("mpifcmb6r")));
@@ -187,7 +187,7 @@ struct mpif_cmblk7_t_ {
 };
 typedef struct mpif_cmblk7_t_ mpif_cmblk7_t;
 /* *INDENT-OFF* */
-mpif_cmblk7_t mpifcmb7r @CMB_1INT_ALIGNMENT@ = {{{0}}};
+mpif_cmblk7_t mpifcmb7r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk7_t _CMPIFCMB7 __attribute__ ((alias("mpifcmb7r")));
 extern mpif_cmblk7_t MPIFCMB7 __attribute__ ((alias("mpifcmb7r")));
@@ -202,7 +202,7 @@ struct mpif_cmblk8_t_ {
 };
 typedef struct mpif_cmblk8_t_ mpif_cmblk8_t;
 /* *INDENT-OFF* */
-mpif_cmblk8_t mpifcmb8r @CMB_1INT_ALIGNMENT@ = {{0}};
+mpif_cmblk8_t mpifcmb8r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern mpif_cmblk8_t _CMPIFCMB8 __attribute__ ((alias("mpifcmb8r")));
 extern mpif_cmblk8_t MPIFCMB8 __attribute__ ((alias("mpifcmb8r")));
@@ -216,7 +216,7 @@ struct mpif_cmblk9_t_ {
 };
 typedef struct mpif_cmblk9_t_ mpif_cmblk9_t;
 /* *INDENT-OFF* */
-FORT_DLL_SPEC mpif_cmblk9_t mpifcmb9r @CMB_1INT_ALIGNMENT@ = {0};
+FORT_DLL_SPEC mpif_cmblk9_t mpifcmb9r @CMB_1INT_ALIGNMENT@ = {};
 /* *INDENT-ON* */
 extern FORT_DLL_SPEC mpif_cmblk9_t _CMPIFCMB9 __attribute__ ((alias("mpifcmb9r")));
 extern FORT_DLL_SPEC mpif_cmblk9_t MPIFCMB9 __attribute__ ((alias("mpifcmb9r")));

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -27,8 +27,7 @@
 #endif
 
 /* Preallocated keyval objects */
-MPII_Keyval MPII_Keyval_direct[MPID_KEYVAL_PREALLOC] = { {0}
-};
+MPII_Keyval MPII_Keyval_direct[MPID_KEYVAL_PREALLOC];
 
 MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, MPIR_KEYVAL,
     sizeof(MPII_Keyval),
@@ -41,8 +40,7 @@ MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, MPIR_KEYVAL,
 #endif
 
 /* Preallocated keyval objects */
-MPIR_Attribute MPID_Attr_direct[MPIR_ATTR_PREALLOC] = { {0}
-};
+MPIR_Attribute MPID_Attr_direct[MPIR_ATTR_PREALLOC];
 
 MPIR_Object_alloc_t MPID_Attr_mem = { 0, 0, 0, 0, MPIR_ATTR,
     sizeof(MPIR_Attribute),

--- a/src/mpi/coll/op/op_create.c
+++ b/src/mpi/coll/op/op_create.c
@@ -31,8 +31,8 @@ int MPI_Op_create(MPI_User_function * user_fn, int commute, MPI_Op * op)
 #endif
 
 /* Preallocated op objects */
-MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN] = { {0} };
-MPIR_Op MPIR_Op_direct[MPIR_OP_PREALLOC] = { {0} };
+MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
+MPIR_Op MPIR_Op_direct[MPIR_OP_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Op_mem = { 0, 0, 0, 0, MPIR_OP,
     sizeof(MPIR_Op),

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -19,10 +19,8 @@
 
 /* Preallocated comm objects */
 /* initialized in initthread.c */
-MPIR_Comm MPIR_Comm_builtin[MPIR_COMM_N_BUILTIN] = { {0}
-};
-MPIR_Comm MPIR_Comm_direct[MPID_COMM_PREALLOC] = { {0}
-};
+MPIR_Comm MPIR_Comm_builtin[MPIR_COMM_N_BUILTIN];
+MPIR_Comm MPIR_Comm_direct[MPID_COMM_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Comm_mem = {
     0,

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -13,10 +13,8 @@
    that is used by ROMIO to test to see if datatypes are contiguous */
 
 /* Preallocated datatype objects */
-MPIR_Datatype MPIR_Datatype_builtin[MPIR_DATATYPE_N_BUILTIN] = { {0}
-};
-MPIR_Datatype MPIR_Datatype_direct[MPIR_DATATYPE_PREALLOC] = { {0}
-};
+MPIR_Datatype MPIR_Datatype_builtin[MPIR_DATATYPE_N_BUILTIN];
+MPIR_Datatype MPIR_Datatype_direct[MPIR_DATATYPE_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, MPIR_DATATYPE,
     sizeof(MPIR_Datatype), MPIR_Datatype_direct,

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -144,8 +144,8 @@ static int checkForUserErrcode(int);
 #endif
 
 /* Preallocated errorhandler objects */
-MPIR_Errhandler MPIR_Errhandler_builtin[MPIR_ERRHANDLER_N_BUILTIN] = { {0} };
-MPIR_Errhandler MPIR_Errhandler_direct[MPIR_ERRHANDLER_PREALLOC] = { {0} };
+MPIR_Errhandler MPIR_Errhandler_builtin[MPIR_ERRHANDLER_N_BUILTIN];
+MPIR_Errhandler MPIR_Errhandler_direct[MPIR_ERRHANDLER_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, MPIR_ERRHANDLER,
     sizeof(MPIR_Errhandler),

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -12,10 +12,8 @@
 #endif
 
 /* Preallocated group objects */
-MPIR_Group MPIR_Group_builtin[MPIR_GROUP_N_BUILTIN] = { {0}
-};
-MPIR_Group MPIR_Group_direct[MPID_GROUP_PREALLOC] = { {0}
-};
+MPIR_Group MPIR_Group_builtin[MPIR_GROUP_N_BUILTIN];
+MPIR_Group MPIR_Group_direct[MPID_GROUP_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Group_mem = { 0, 0, 0, 0, MPIR_GROUP,
     sizeof(MPIR_Group), MPIR_Group_direct,

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -15,10 +15,8 @@
 #endif
 
 /* Preallocated info objects */
-MPIR_Info MPIR_Info_builtin[MPIR_INFO_N_BUILTIN] = { {0}
-};
-MPIR_Info MPIR_Info_direct[MPIR_INFO_PREALLOC] = { {0}
-};
+MPIR_Info MPIR_Info_builtin[MPIR_INFO_N_BUILTIN];
+MPIR_Info MPIR_Info_direct[MPIR_INFO_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, MPIR_INFO,
     sizeof(MPIR_Info), MPIR_Info_direct,

--- a/src/mpi/request/greq_start.c
+++ b/src/mpi/request/greq_start.c
@@ -34,7 +34,7 @@ PMPI_LOCAL int MPIR_Grequest_free_classes_on_finalize(void *extra_data);
 #define MPIR_GREQ_CLASS_PREALLOC 2
 #endif
 
-MPIR_Grequest_class MPIR_Grequest_class_direct[MPIR_GREQ_CLASS_PREALLOC] = { {0} };
+MPIR_Grequest_class MPIR_Grequest_class_direct[MPIR_GREQ_CLASS_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Grequest_class_mem = { 0, 0, 0, 0, MPIR_GREQ_CLASS,
     sizeof(MPIR_Grequest_class),

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -9,8 +9,7 @@
 
 /* style:PMPIuse:PMPI_Status_f2c:2 sig:0 */
 
-MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC] = { {0}
-};
+MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Request_mem = {
     0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct,

--- a/src/mpi/rma/winutil.c
+++ b/src/mpi/rma/winutil.c
@@ -13,8 +13,7 @@
 #endif
 
 /* Preallocated window objects */
-MPIR_Win MPIR_Win_direct[MPIR_WIN_PREALLOC] = { {0}
-};
+MPIR_Win MPIR_Win_direct[MPIR_WIN_PREALLOC];
 
 MPIR_Object_alloc_t MPIR_Win_mem = { 0, 0, 0, 0, MPIR_WIN,
     sizeof(MPIR_Win), MPIR_Win_direct,

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -298,7 +298,7 @@ typedef struct initcomp_cb
     struct initcomp_cb *next;
 } initcomp_cb_t;
 
-static struct {initcomp_cb_t *top;} initcomp_cb_stack = {0};
+static struct {initcomp_cb_t *top;} initcomp_cb_stack;
 
 #define INITCOMP_S_TOP() GENERIC_S_TOP(initcomp_cb_stack)
 #define INITCOMP_S_PUSH(ep) GENERIC_S_PUSH(&initcomp_cb_stack, ep, next)

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -58,7 +58,7 @@ cvars:
 #ifdef MEM_REGION_IN_HEAP
 MPID_nem_mem_region_t *MPID_nem_mem_region_ptr = 0;
 #else /* MEM_REGION_IN_HEAP */
-MPID_nem_mem_region_t MPID_nem_mem_region = {{0}};
+MPID_nem_mem_region_t MPID_nem_mem_region;
 #endif /* MEM_REGION_IN_HEAP */
 
 char MPID_nem_hostname[MAX_HOSTNAME_LEN] = "UNKNOWN";

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_dma.c
@@ -57,7 +57,7 @@ static struct lmt_dma_node *outstanding_head = NULL;
 
 /* MT: this stack is not thread-safe */
 static int free_idx; /* is always the index of the next free index */
-static int index_stack[KNEM_STATUS_NR] = {0};
+static int index_stack[KNEM_STATUS_NR];
 
 /* returns an index into knem_status that is available for use */
 static int alloc_status_index(void)
@@ -111,7 +111,7 @@ static int do_dma_send(MPIDI_VC_t *vc,  MPIR_Request *sreq, int send_iov_n,
     int mpi_errno = MPI_SUCCESS;
     int i, err;
 #if KNEM_ABI_VERSION < MPICH_NEW_KNEM_ABI_VERSION
-    struct knem_cmd_init_send_param sendcmd = {0};
+    struct knem_cmd_init_send_param sendcmd;
 #else
     struct knem_cmd_create_region cr;
 #endif

--- a/src/mpid/ch4/netmod/ucx/globals.c
+++ b/src/mpid/ch4/netmod/ucx/globals.c
@@ -11,5 +11,5 @@
 #include "ucx_types.h"
 
 /* *INDENT-OFF* */
-MPIDI_UCX_global_t MPIDI_UCX_global = { {0} };
+MPIDI_UCX_global_t MPIDI_UCX_global;
 /* *INDENT-ON* */

--- a/src/mpid/ch4/shm/posix/eager/fbox/globals.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/globals.c
@@ -13,7 +13,7 @@
 #include "fbox_types.h"
 
 /* *INDENT-OFF* */
-MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global = { {0} };
+MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global;
 /* *INDENT-ON* */
 
 #ifdef MPL_USE_DBG_LOGGING

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -23,8 +23,7 @@ MPIDI_NM_funcs_t *MPIDI_NM_func;
 MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
-struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC] = { {0}
-};
+struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
 
 MPIR_Object_alloc_t MPIDI_workq_elemt_mem = {
     0, 0, 0, 0, MPIR_WORKQ_ELEM, sizeof(struct MPIDI_workq_elemt), MPIDI_workq_elemt_direct,

--- a/src/pm/hydra/ui/mpich/mpiexec.c
+++ b/src/pm/hydra/ui/mpich/mpiexec.c
@@ -13,7 +13,7 @@
 #include "ui.h"
 #include "uiu.h"
 
-struct HYD_server_info_s HYD_server_info = { {0} };
+struct HYD_server_info_s HYD_server_info;
 
 struct HYD_exec *HYD_uii_mpx_exec_list = NULL;
 struct HYD_ui_info_s HYD_ui_info;

--- a/src/pm/util/simple_pmiutil2.c
+++ b/src/pm/util/simple_pmiutil2.c
@@ -41,7 +41,7 @@ struct PMIU_keyval_pairs {
     char key[MAXKEYLEN];
     char value[MAXVALLEN];
 };
-static struct PMIU_keyval_pairs PMIU_keyval_tab[64] = { {{0}, {0}} };
+static struct PMIU_keyval_pairs PMIU_keyval_tab[64];
 
 static int PMIU_keyval_tab_idx = 0;
 

--- a/src/pmi/pmi2/simple/simple_pmiutil.c
+++ b/src/pmi/pmi2/simple/simple_pmiutil.c
@@ -42,7 +42,7 @@ struct PMI2U_keyval_pairs {
     char key[MAXKEYLEN];
     char value[MAXVALLEN];
 };
-static struct PMI2U_keyval_pairs PMI2U_keyval_tab[64] = { {{0}, {0}} };
+static struct PMI2U_keyval_pairs PMI2U_keyval_tab[64];
 
 static int PMI2U_keyval_tab_idx = 0;
 

--- a/src/pmi/simple/simple_pmiutil.c
+++ b/src/pmi/simple/simple_pmiutil.c
@@ -46,7 +46,7 @@ struct PMIU_keyval_pairs {
     char key[MAXKEYLEN];
     char value[MAXVALLEN];
 };
-static struct PMIU_keyval_pairs PMIU_keyval_tab[64] = { {{0}, {0}} };
+static struct PMIU_keyval_pairs PMIU_keyval_tab[64];
 
 static int PMIU_keyval_tab_idx = 0;
 


### PR DESCRIPTION
Static global storage is automatically initialized to zero garaunteed by C standard
since C89, so let's just remove all global 0 initializer.

Previously, these initializers, `{0}`, were changed to `{{0}}` because
compilers complain when the structure contains a nested structure/union.
But these double braces are so weird and non-standard and the compilers
may still give warnings. I just encountered one in `src/mpid/ch4/netmod/ucx/globals.c`

Both of these initializers are hacks relying on the fact that
compilers set missing values to zero. `{0}` arguably has some merit of
readability only because its usage has been wide-spread, but `{{0}}` is
definitely weird and misleading.