### PR TITLE
ch4: Multi-leaders based composition (inter node + intra node) for MPI_Alltoall

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -329,6 +329,7 @@ extern struct MPIR_Commops *MPIR_Comm_fns;      /* Communicator creation functio
 int MPII_Comm_init(MPIR_Comm *);
 
 int MPII_Comm_is_node_consecutive(MPIR_Comm *);
+int MPII_Comm_is_node_balanced(MPIR_Comm *, int *, bool *);
 
 /* applies the specified info chain to the specified communicator */
 int MPII_Comm_apply_hints(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr);

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -27,6 +27,7 @@ typedef enum MPIR_Comm_hierarchy_kind_t {
     MPIR_COMM_HIERARCHY_KIND__PARENT = 1,       /* has subcommunicators */
     MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS = 2,   /* is the subcomm for node roots */
     MPIR_COMM_HIERARCHY_KIND__NODE = 3, /* is the subcomm for a node */
+    MPIR_COMM_HIERARCHY_KIND__MULTI_LEADS = 4,  /* is the multi_leaders_comm for a node */
     MPIR_COMM_HIERARCHY_KIND__SIZE      /* cardinality of this enum */
 } MPIR_Comm_hierarchy_kind_t;
 

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -54,6 +54,7 @@ typedef uint16_t MPIR_Context_id_t;
 #define MPIR_CONTEXT_PARENT_OFFSET    (0 << MPIR_CONTEXT_SUBCOMM_SHIFT)
 #define MPIR_CONTEXT_INTRANODE_OFFSET (1 << MPIR_CONTEXT_SUBCOMM_SHIFT)
 #define MPIR_CONTEXT_INTERNODE_OFFSET (2 << MPIR_CONTEXT_SUBCOMM_SHIFT)
+#define MPIR_CONTEXT_MULTILEADS_OFFSET (3 << MPIR_CONTEXT_SUBCOMM_SHIFT)
 
 /* this field (IS_LOCALCOM) is used to derive a context ID for local
  * communicators of intercommunicators without communication */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -513,6 +513,53 @@ int MPII_Comm_is_node_consecutive(MPIR_Comm * comm)
     return 1;
 }
 
+/* Returns true if the communicator is node-aware and the number of processes in all the nodes are
+ * same */
+int MPII_Comm_is_node_balanced(MPIR_Comm * comm, int *num_nodes, bool * node_balanced)
+{
+    int i = 0;
+    int mpi_errno = MPI_SUCCESS;
+    int *ranks_per_node;
+    *num_nodes = 0;
+
+    MPIR_CHKPMEM_DECL(1);
+
+    if (!MPIR_Comm_is_node_aware(comm)) {
+        *node_balanced = false;
+        goto fn_exit;
+    }
+
+    /* Find maximum value in the internode_table */
+    for (i = 0; i < comm->local_size; i++) {
+        if (comm->internode_table[i] > *num_nodes) {
+            *num_nodes = comm->internode_table[i];
+        }
+    }
+    /* number of nodes is max_node_id + 1 */
+    (*num_nodes)++;
+
+    MPIR_CHKPMEM_CALLOC(ranks_per_node, int *,
+                        *num_nodes * sizeof(int), mpi_errno, "ranks per node", MPL_MEM_OTHER);
+
+    for (i = 0; i < comm->local_size; i++) {
+        ranks_per_node[comm->internode_table[i]]++;
+    }
+
+    for (i = 1; i < *num_nodes; i++) {
+        if (ranks_per_node[i - 1] != ranks_per_node[i]) {
+            *node_balanced = false;
+            goto fn_exit;
+        }
+    }
+
+    *node_balanced = true;
+  fn_exit:
+    MPIR_CHKPMEM_REAP();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 /*
  * Copy a communicator, including creating a new context and copying the
  * virtual connection tables and clearing the various fields.

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -493,10 +493,22 @@ typedef struct MPIDI_Devcomm_t {
 
         MPIDI_rank_map_t map;
         MPIDI_rank_map_t local_map;
+        struct MPIR_Comm *multi_leads_comm;
+        int spanned_num_nodes;  /* comm spans over these number of nodes */
+        struct MPIDI_Multileads_comp_info_t *alltoall_comp_info;
     } ch4;
 } MPIDI_Devcomm_t;
+
+typedef struct MPIDI_Multileads_comp_info_t {
+    int use_multi_leads;        /* if multi-leaders based composition can be used for comm */
+    MPL_shm_hnd_t shm_handle;
+    int shm_size;
+    void *shm_addr;
+} MPIDI_Multileads_comp_info_t;
+
 #define MPIDIG_COMM(comm,field) ((comm)->dev.ch4.am).field
 #define MPIDI_COMM(comm,field) ((comm)->dev.ch4).field
+#define MPIDI_COMM_ALLTOALL(comm,field) ((comm)->dev.ch4.alltoall_comp_info)->field
 
 typedef struct {
     union {

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -396,6 +396,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, int sendcount,
                                                        comm, errflag,
                                                        ch4_algo_parameters_container);
             break;
+        case MPIDI_Alltoall_intra_composition_beta_id:
+            mpi_errno =
+                MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype,
+                                                      recvbuf, recvcount, recvtype,
+                                                      comm, errflag, ch4_algo_parameters_container);
+            break;
         case MPIDI_Alltoall_inter_composition_alpha_id:
             mpi_errno =
                 MPIDI_Alltoall_inter_composition_alpha(sendbuf, sendcount, sendtype,

--- a/src/mpid/ch4/src/ch4_coll_containers.h
+++ b/src/mpid/ch4/src/ch4_coll_containers.h
@@ -26,6 +26,7 @@ extern const MPIDI_coll_algo_container_t MPIDI_Allreduce_inter_composition_alpha
 
 /* Alltoall  CH4 level containers declaration */
 extern const MPIDI_coll_algo_container_t MPIDI_Alltoall_intra_composition_alpha_cnt;
+extern const MPIDI_coll_algo_container_t MPIDI_Alltoall_intra_composition_beta_cnt;
 extern const MPIDI_coll_algo_container_t MPIDI_Alltoall_inter_composition_alpha_cnt;
 
 /* Alltoallv  CH4 level containers declaration */

--- a/src/mpid/ch4/src/ch4_coll_globals_default.c.in
+++ b/src/mpid/ch4/src/ch4_coll_globals_default.c.in
@@ -156,6 +156,12 @@ const MPIDI_coll_algo_container_t MPIDI_Alltoall_intra_composition_alpha_cnt = {
                                                       .alltoall = MPIDI_COLL_AUTO_SELECT}
 };
 
+const MPIDI_coll_algo_container_t MPIDI_Alltoall_intra_composition_beta_cnt = {
+    .id = MPIDI_Alltoall_intra_composition_beta_id,
+    .params.ch4_alltoall_params.ch4_alltoall_beta = {
+                                                     .alltoall = MPIDI_COLL_AUTO_SELECT}
+};
+
 const MPIDI_coll_algo_container_t MPIDI_Alltoall_inter_composition_alpha_cnt = {
     .id = MPIDI_Alltoall_inter_composition_alpha_id
 };

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -8,11 +8,30 @@
  *  to Argonne National Laboratory subject to Software Grant and Corporate
  *  Contributor License Agreement dated February 8, 2012.
  */
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_ALLTOALL_SHM_PER_RANK
+      category    : COLLECTIVE
+      type        : int
+      default     : 4096
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Shared memory region per rank for multi-leaders based composition for MPI_Alltoall (in bytes)
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 #ifndef CH4_COLL_IMPL_H_INCLUDED
 #define CH4_COLL_IMPL_H_INCLUDED
 
 #include "ch4_coll_params.h"
 #include "coll_algo_params.h"
+#include "ch4_comm.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * comm,
                                                                    MPIR_Errflag_t * errflag,
@@ -720,6 +739,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_inter_composition_alpha(const void *se
     goto fn_exit;
 }
 
+/* Node-aware multi-leaders based inter-node and intra-node composition. Each rank on a node places
+ * the data for ranks sitting on other nodes into a shared memory buffer. Next each rank participates
+ * as a leader in inter-node Alltoall */
 MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *sendbuf,
                                                                     int sendcount,
                                                                     MPI_Datatype sendtype,
@@ -731,6 +753,164 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_alpha(const void *
                                                                     const
                                                                     MPIDI_coll_algo_container_t
                                                                     * ch4_algo_parameters_container)
+{
+    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    const void *barrier_node_container =
+        MPIDI_coll_get_next_container(ch4_algo_parameters_container);
+    const void *alltoall_container = MPIDI_coll_get_next_container(barrier_node_container);
+    int num_nodes;
+    int num_ranks = MPIR_Comm_size(comm_ptr);
+    int node_comm_size = MPIR_Comm_size(comm_ptr->node_comm);
+    int my_node_comm_rank = MPIR_Comm_rank(comm_ptr->node_comm);
+    int i, j, p = 0;
+    MPI_Aint type_size;
+    bool mapfail_flag = false;
+
+    if (sendcount == 0)
+        goto fn_exit;
+
+    if (sendbuf != MPI_IN_PLACE) {
+        MPIR_Datatype_get_size_macro(sendtype, type_size);
+    } else {
+        MPIR_Datatype_get_size_macro(recvtype, type_size);
+    }
+
+    num_nodes = MPIDI_COMM(comm_ptr, spanned_num_nodes);
+    if (sendbuf == MPI_IN_PLACE) {
+        sendbuf = recvbuf;
+        sendcount = recvcount;
+        sendtype = recvtype;
+    }
+
+    if (MPIDI_COMM(comm_ptr, multi_leads_comm) == NULL) {
+        /* Create multi-leaders comm in a lazy manner */
+        mpi_errno = MPIDI_Comm_create_multi_leaders(comm_ptr);
+        if (mpi_errno) {
+            /* for communication errors, just record the error but continue */
+            *errflag =
+                MPIX_ERR_PROC_FAILED ==
+                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+        }
+    }
+
+    /* Allocate the shared memory buffer per node, if it is not already done */
+    if (MPIDI_COMM(comm_ptr, alltoall_comp_info->shm_addr) == NULL) {
+        MPIDI_COMM(comm_ptr, alltoall_comp_info->shm_size) =
+            node_comm_size * num_ranks * MPIR_CVAR_ALLTOALL_SHM_PER_RANK;
+        mpi_errno =
+            MPIDIU_allocate_shm_segment(comm_ptr->node_comm,
+                                        MPIDI_COMM_ALLTOALL(comm_ptr, shm_size),
+                                        &MPIDI_COMM_ALLTOALL(comm_ptr, shm_handle), (void **)
+                                        &MPIDI_COMM_ALLTOALL(comm_ptr, shm_addr), &mapfail_flag);
+        if (mpi_errno || mapfail_flag) {
+            /* for communication errors, just record the error but continue */
+            *errflag =
+                MPIX_ERR_PROC_FAILED ==
+                MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+            MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+            MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+        }
+    }
+
+    /* Barrier to make sure that the shm buffer can be reused after the previous call to Alltoall */
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag, barrier_node_container);
+#else
+    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag, barrier_node_container);
+#endif
+    if (mpi_errno) {
+        /* for communication errors, just record the error but continue */
+        *errflag =
+            MPIX_ERR_PROC_FAILED ==
+            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+    }
+
+    /* Each rank on a node copy its data into shm buffer */
+    /* Example - 2 ranks per node on 2 nodes. R0 and R1 on node 0, R2 and R3 on node 1.
+     * R0 buf is (0, 4, 8, 12). R1 buf is (1, 5, 9, 13). R2 buf is (2, 6, 10, 14) and R3 buf is
+     * (3, 7, 11, 15). In shm_buf of node 0, place data from (R0, R1) for R0, R2, R1, and R3. In
+     * shm_buf of node 1, place data from (R2, R3) for R0, R2, R1, R3. The node 0 shm_buf becomes
+     * (0, 1, 8, 9, 4, 5, 12, 13). The node 1 shm_buf becomes (2, 3, 10, 11, 6, 7, 14, 15). */
+    for (i = 0; i < node_comm_size; i++) {
+        for (j = 0; j < num_nodes; j++) {
+            mpi_errno = MPIR_Localcopy((void *) ((char *) sendbuf +
+                                                 (i + j * node_comm_size) * type_size * sendcount),
+                                       sendcount, sendtype, (void *) ((char *)
+                                                                      MPIDI_COMM_ALLTOALL(comm_ptr,
+                                                                                          shm_addr)
+                                                                      + (p * node_comm_size +
+                                                                         my_node_comm_rank) *
+                                                                      type_size * sendcount),
+                                       sendcount, sendtype);
+            if (mpi_errno) {
+                /* for communication errors, just record the error but continue */
+                *errflag =
+                    MPIX_ERR_PROC_FAILED ==
+                    MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+                MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+                MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+            }
+            p++;
+        }
+    }
+
+    /* Barrier to make sure each rank has copied the data to the shm buf */
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_mpi_barrier(comm_ptr->node_comm, errflag, barrier_node_container);
+#else
+    mpi_errno = MPIDI_NM_mpi_barrier(comm_ptr->node_comm, errflag, barrier_node_container);
+#endif
+    if (mpi_errno) {
+        /* for communication errors, just record the error but continue */
+        *errflag =
+            MPIX_ERR_PROC_FAILED ==
+            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+    }
+
+    /* Call internode alltoall on the shm_bufs and multi-leaders communicator */
+    /* In the above example, first half on shm_bufs are used by the first multi-leader comm of R0
+     * and R2 for Alltoall. Second half is used by R1 and R3, which is in the second multi-leader
+     * comm. That is, for the alltoall, R1's buf is (4, 5, 12, 13) and R3's buf is (6, 7, 14, 15).
+     * After Alltoall R1's buf is (4, 5, 6, 7) and R3's buf is (12, 13, 14, 15), which is the
+     * expected result */
+    mpi_errno = MPIDI_NM_mpi_alltoall((void *) ((char *)
+                                                MPIDI_COMM_ALLTOALL(comm_ptr,
+                                                                    shm_addr) +
+                                                my_node_comm_rank * num_nodes * node_comm_size *
+                                                type_size * sendcount), node_comm_size * sendcount,
+                                      sendtype, recvbuf, sendcount * node_comm_size, sendtype,
+                                      MPIDI_COMM(comm_ptr, multi_leads_comm), errflag,
+                                      alltoall_container);
+    if (mpi_errno) {
+        /* for communication errors, just record the error but continue */
+        *errflag =
+            MPIX_ERR_PROC_FAILED ==
+            MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
+        MPIR_ERR_SET(mpi_errno, *errflag, "**fail");
+        MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
+    }
+
+  fn_exit:
+    return mpi_errno;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_intra_composition_beta(const void *sendbuf,
+                                                                   int sendcount,
+                                                                   MPI_Datatype sendtype,
+                                                                   void *recvbuf,
+                                                                   int recvcount,
+                                                                   MPI_Datatype recvtype,
+                                                                   MPIR_Comm * comm_ptr,
+                                                                   MPIR_Errflag_t * errflag,
+                                                                   const
+                                                                   MPIDI_coll_algo_container_t
+                                                                   * ch4_algo_parameters_container)
 {
     int mpi_errno = MPI_SUCCESS;
     const void *alltoall_container = MPIDI_coll_get_next_container(ch4_algo_parameters_container);

--- a/src/mpid/ch4/src/ch4_coll_params.h
+++ b/src/mpid/ch4/src/ch4_coll_params.h
@@ -84,6 +84,7 @@ typedef union {
 
 typedef enum {
     MPIDI_Alltoall_intra_composition_alpha_id,
+    MPIDI_Alltoall_intra_composition_beta_id,
     MPIDI_Alltoall_inter_composition_alpha_id
 } MPIDI_Alltoall_id_t;
 
@@ -91,6 +92,9 @@ typedef union {
     struct MPIDI_Alltoall_alpha {
         int alltoall;
     } ch4_alltoall_alpha;
+    struct MPIDI_Alltoall_beta {
+        int alltoall;
+    } ch4_alltoall_beta;
 } MPIDI_Alltoall_params_t;
 
 typedef enum {

--- a/src/mpid/ch4/src/ch4_coll_select.h
+++ b/src/mpid/ch4/src/ch4_coll_select.h
@@ -16,7 +16,7 @@ cvars:
     - name        : MPIR_CVAR_ENABLE_MULTI_LEADS_ALLTOALL
       category    : COLLECTIVE
       type        : int
-      default     : 0
+      default     : 1
       class       : device
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -184,6 +184,10 @@ int MPID_Comm_create_hook(MPIR_Comm * comm)
         }
     }
 
+    MPIDI_COMM(comm, multi_leads_comm) = NULL;
+    MPIDI_COMM(comm, spanned_num_nodes) = -1;
+    MPIDI_COMM(comm, alltoall_comp_info) = NULL;
+
     mpi_errno = MPIDI_NM_mpi_comm_create_hook(comm);
     if (mpi_errno != MPI_SUCCESS) {
         MPIR_ERR_POP(mpi_errno);
@@ -209,6 +213,29 @@ int MPID_Comm_free_hook(MPIR_Comm * comm)
     int max_n_avts;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_COMM_FREE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_COMM_FREE_HOOK);
+
+    if (MPIDI_COMM(comm, multi_leads_comm) != NULL) {
+        MPIR_Comm_release(MPIDI_COMM(comm, multi_leads_comm));
+    }
+
+    if (MPIDI_COMM(comm, alltoall_comp_info) != NULL) {
+        if (MPIDI_COMM_ALLTOALL(comm, shm_addr) != NULL) {
+            mpi_errno = MPL_shm_seg_detach(MPIDI_COMM_ALLTOALL(comm, shm_handle),
+                                           (void **) &MPIDI_COMM_ALLTOALL(comm,
+                                                                          shm_addr),
+                                           MPIDI_COMM_ALLTOALL(comm, shm_size));
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+
+            mpi_errno = MPL_shm_hnd_finalize(&MPIDI_COMM_ALLTOALL(comm, shm_handle));
+            if (mpi_errno != MPI_SUCCESS) {
+                MPIR_ERR_POP(mpi_errno);
+            }
+        }
+        MPL_free(MPIDI_COMM(comm, alltoall_comp_info));
+    }
+
     /* release ref to avts */
     switch (MPIDI_COMM(comm, map).mode) {
         case MPIDI_RANK_MAP_NONE:
@@ -276,6 +303,118 @@ int MPID_Comm_free_hook(MPIR_Comm * comm)
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_COMM_FREE_HOOK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Create multi-leaders communicator */
+/* Create a comm with rank 0 of each node. A comm with rank 1 of each node and so on. Since these
+ * new comms do no overlap, it uses the same context id */
+int MPIDI_Comm_create_multi_leaders(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int num_local = -1, num_external = -1;
+    int local_rank = -1, external_rank = -1, rank;
+    int i = 0;
+    int *local_procs = NULL, *external_procs = NULL;
+    int *intranode_table = NULL, *internode_table = NULL;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIDI_COMM_CREATE_MULTI_LEADERS);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIDI_COMM_CREATE_MULTI_LEADERS);
+
+    mpi_errno = MPIR_Find_local(comm, &num_local, &local_rank, &local_procs, &intranode_table);
+    if (mpi_errno) {
+        if (MPIR_Err_is_fatal(mpi_errno))
+            MPIR_ERR_POP(mpi_errno);
+
+        MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE,
+                      "MPIR_Find_local_and_external failed for comm_ptr=%p", comm);
+        if (intranode_table)
+            MPL_free(intranode_table);
+
+        mpi_errno = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    mpi_errno = MPIR_Find_external(comm, &num_external, &external_rank, &external_procs,
+                                   &internode_table);
+    if (mpi_errno) {
+        if (MPIR_Err_is_fatal(mpi_errno))
+            MPIR_ERR_POP(mpi_errno);
+
+        MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE,
+                      "MPIR_Find_local_and_external failed for comm_ptr=%p", comm);
+        if (internode_table)
+            MPL_free(internode_table);
+
+        mpi_errno = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    MPIR_Assert(num_local > 0);
+    MPIR_Assert(num_local > 1 || external_rank >= 0);
+    MPIR_Assert(external_rank < 0 || external_procs != NULL);
+    rank = MPIR_Comm_rank(comm);
+
+    external_rank = comm->internode_table[rank];
+    for (i = 0; i < num_external; ++i) {
+        external_procs[i] = i * num_local + local_rank;
+    }
+
+    for (i = 0; i < num_local; i++) {
+        if (local_rank == i) {
+            mpi_errno = MPIR_Comm_create(&MPIDI_COMM(comm, multi_leads_comm));
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+
+            MPIDI_COMM(comm, multi_leads_comm)->context_id =
+                comm->context_id + MPIR_CONTEXT_MULTILEADS_OFFSET;
+            MPIDI_COMM(comm, multi_leads_comm)->recvcontext_id =
+                MPIDI_COMM(comm, multi_leads_comm)->context_id;
+            MPIDI_COMM(comm, multi_leads_comm)->rank = internode_table[rank];
+            MPIDI_COMM(comm, multi_leads_comm)->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+            MPIDI_COMM(comm, multi_leads_comm)->hierarchy_kind =
+                MPIR_COMM_HIERARCHY_KIND__MULTI_LEADS;
+            MPIDI_COMM(comm, multi_leads_comm)->local_comm = NULL;
+            MPIDI_COMM(comm, multi_leads_comm)->node_comm = NULL;
+            MPIDI_COMM(comm, multi_leads_comm)->node_roots_comm = NULL;
+            MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create multi-leaders_comm=%p\n",
+                          MPIDI_COMM(comm, multi_leads_comm));
+
+            MPIDI_COMM(comm, multi_leads_comm)->local_size = num_external;
+            MPIDI_COMM(comm, multi_leads_comm)->pof2 =
+                MPL_pof2(MPIDI_COMM(comm, multi_leads_comm)->local_size);
+            MPIDI_COMM(comm, multi_leads_comm)->remote_size = num_external;
+
+            MPIR_Comm_map_irregular(MPIDI_COMM(comm, multi_leads_comm), comm,
+                                    external_procs, num_external, MPIR_COMM_MAP_DIR__L2L, NULL);
+
+            /* Notify device of communicator creation */
+            mpi_errno = MPID_Comm_create_hook(MPIDI_COMM(comm, multi_leads_comm));
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+            /* don't call MPIR_Comm_commit here */
+
+            /* Create collectives-specific infrastructure */
+            mpi_errno = MPIR_Coll_comm_init(MPIDI_COMM(comm, multi_leads_comm));
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+
+            MPIR_Comm_map_free(MPIDI_COMM(comm, multi_leads_comm));
+        }
+    }
+
+  fn_exit:
+    if (external_procs != NULL)
+        MPL_free(external_procs);
+    if (local_procs != NULL)
+        MPL_free(local_procs);
+    if (intranode_table != NULL)
+        MPL_free(intranode_table);
+    if (internode_table != NULL)
+        MPL_free(internode_table);
+
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIDI_COMM_CREATE_MULTI_LEADERS);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/src/ch4_comm.h
+++ b/src/mpid/ch4/src/ch4_comm.h
@@ -13,6 +13,7 @@
 
 #include "ch4_impl.h"
 
+int MPIDI_Comm_create_multi_leaders(MPIR_Comm * comm);
 int MPIDI_Comm_split_type(MPIR_Comm * user_comm_ptr, int split_type, int key, MPIR_Info * info_ptr,
                           MPIR_Comm ** newcomm_ptr);
 

--- a/test/mpi/coll/test_coll_algos.sh
+++ b/test/mpi/coll/test_coll_algos.sh
@@ -521,4 +521,10 @@ for buf_size in ${buffer_sizes}; do
     done
 done
 
+############## Add tests for multi-leaders based composition for Alltoall ###############
+
+testing_env="MPIR_CVAR_ENABLE_MULTI_LEADS_ALLTOALL=1"
+
+coll_algo_tests+="alltoall1 8 ${env}${nl}"
+
 export coll_algo_tests


### PR DESCRIPTION
The two key ideas of this work -
1. Leverage shared memory buffer per node
2. Make each rank on the node as the leader, instead of only one leader rank per node.

Multi-node Alltoall is implemented in two steps -

1. Each rank copies the data to be sent to other ranks in a shared buffer
2. Use the shared buffer as the input buffer for inter-node Alltoall on the "multi-leaders" communicator

Performance benefits are higher with larger number of nodes and larger ppn. On a 32 node Intel Skylake cluster with 40 ranks per node, maximum speedup over MPICH is 3.84x.