### PR TITLE
Pre-VCI pool misc. cleanup

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -533,6 +533,15 @@ typedef struct {
 #define MPID_DEV_COMM_DECL       MPIDI_Devcomm_t dev;
 #define MPID_DEV_OP_DECL         MPIDI_Devop_t   dev;
 
+/* VCI resources */
+typedef enum {
+    MPIDI_VCI_RESOURCE__TX = 0x1,       /* Can send */
+    MPIDI_VCI_RESOURCE__RX = 0x2,       /* Can receive */
+} MPIDI_vci_resource_t;
+
+#define MPIDI_VCI_RESOURCE__GENERIC MPIDI_VCI_RESOURCE__TX | \
+                                    MPIDI_VCI_RESOURCE__RX
+
 typedef struct MPIDI_av_entry {
     union {
     MPIDI_NM_ADDR_DECL} netmod;

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -19,7 +19,7 @@
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * init_comm, int *n_vcis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_vci_get_attr_t) (int vci);
+typedef MPIDI_vci_resource_t(*MPIDI_NM_vci_get_resource_info_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
@@ -465,7 +465,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_vci_get_attr_t vci_get_attr;
+    MPIDI_NM_vci_get_resource_info_t vci_get_resource_info;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -643,7 +643,7 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                            int *n_vcis_provided);
 int MPIDI_NM_mpi_finalize_hook(void);
-int MPIDI_NM_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci);
 int MPIDI_NM_progress(int vci, int blocking);
 int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                               MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -19,7 +19,7 @@
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
                                     MPIR_Comm * init_comm, int *n_vcis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef int (*MPIDI_NM_get_vci_attr_t) (int vci);
+typedef int (*MPIDI_NM_vci_get_attr_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
@@ -465,7 +465,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_get_vci_attr_t get_vci_attr;
+    MPIDI_NM_vci_get_attr_t vci_get_attr;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -643,7 +643,7 @@ extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                            int *n_vcis_provided);
 int MPIDI_NM_mpi_finalize_hook(void);
-int MPIDI_NM_get_vci_attr(int vci);
+int MPIDI_NM_vci_get_attr(int vci);
 int MPIDI_NM_progress(int vci, int blocking);
 int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                               MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -17,10 +17,10 @@
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
-                                    MPIR_Comm * init_comm, int *n_vcis_provided);
+                                    MPIR_Comm * init_comm, int *n_vnis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
-typedef MPIDI_vci_resource_t(*MPIDI_NM_vci_get_resource_info_t) (int vci);
-typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
+typedef MPIDI_vci_resource_t(*MPIDI_NM_vni_get_resource_info_t) (int vni);
+typedef int (*MPIDI_NM_progress_t) (int vni, int blocking);
 typedef int (*MPIDI_NM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info, int root,
                                             int timeout, MPIR_Comm * comm,
                                             MPIR_Comm ** newcomm_ptr);
@@ -465,7 +465,7 @@ typedef int (*MPIDI_NM_mpi_op_free_hook_t) (MPIR_Op * op_p);
 typedef struct MPIDI_NM_funcs {
     MPIDI_NM_mpi_init_t mpi_init;
     MPIDI_NM_mpi_finalize_t mpi_finalize;
-    MPIDI_NM_vci_get_resource_info_t vci_get_resource_info;
+    MPIDI_NM_vni_get_resource_info_t vni_get_resource_info;
     MPIDI_NM_progress_t progress;
     MPIDI_NM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_NM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -641,10 +641,10 @@ extern int MPIDI_num_netmods;
 extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
 int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                           int *n_vcis_provided);
+                           int *n_vnis_provided);
 int MPIDI_NM_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci);
-int MPIDI_NM_progress(int vci, int blocking);
+MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni);
+int MPIDI_NM_progress(int vni, int blocking);
 int MPIDI_NM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                               MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 int MPIDI_NM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -29,7 +29,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_OFI_get_local_upids,
-    .get_vci_attr = MPIDI_OFI_get_vci_attr,
+    .vci_get_attr = MPIDI_OFI_vci_get_attr,
     .upids_to_lupids = MPIDI_OFI_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_OFI_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_OFI_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -29,7 +29,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_OFI_get_local_upids,
-    .vci_get_attr = MPIDI_OFI_vci_get_attr,
+    .vci_get_resource_info = MPIDI_OFI_vci_get_resource_info,
     .upids_to_lupids = MPIDI_OFI_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_OFI_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_OFI_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -29,7 +29,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_OFI_get_local_upids,
-    .vci_get_resource_info = MPIDI_OFI_vci_get_resource_info,
+    .vni_get_resource_info = MPIDI_OFI_vni_get_resource_info,
     .upids_to_lupids = MPIDI_OFI_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_OFI_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_OFI_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -14,7 +14,7 @@
 #include "ofi_am_impl.h"
 #include "ofi_am_events.h"
 
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx);
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 static inline void MPIDI_NM_am_request_init(MPIR_Request * req)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -13,7 +13,7 @@
 
 #include "ofi_impl.h"
 
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx);
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx);
 
 /* Acquire a sequence number to send, and record the next number */
 MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm * comm,
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
                                    __LINE__,                            \
                                    __func__,                              \
                                    fi_strerror(-_ret));                 \
-            mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vci_idx */);    \
+            mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vni_idx */);    \
             if (mpi_errno != MPI_SUCCESS)                                \
                 MPIR_ERR_CHECK(mpi_errno);                               \
         } while (_ret == -FI_EAGAIN);                                   \
@@ -150,7 +150,7 @@ static inline int MPIDI_OFI_repost_buffer(void *buf, MPIR_Request * req)
     goto fn_exit;
 }
 
-static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
+static inline int MPIDI_OFI_progress_do_queue(int vni_idx)
 {
     int mpi_errno = MPI_SUCCESS, ret;
     struct fi_cq_tagged_entry cq_entry;
@@ -160,13 +160,13 @@ static inline int MPIDI_OFI_progress_do_queue(int vci_idx)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS_DO_QUEUE);
 
-    ret = fi_cq_read(MPIDI_OFI_global.ctx[vci_idx].cq, &cq_entry, 1);
+    ret = fi_cq_read(MPIDI_OFI_global.ctx[vni_idx].cq, &cq_entry, 1);
 
     if (unlikely(ret == -FI_EAGAIN))
         goto fn_exit;
 
     if (ret < 0) {
-        mpi_errno = MPIDI_OFI_handle_cq_error_util(vci_idx, ret);
+        mpi_errno = MPIDI_OFI_handle_cq_error_util(vni_idx, ret);
         goto fn_fail;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -785,7 +785,7 @@ int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num)
     goto fn_exit;
 }
 
-int MPIDI_OFI_handle_cq_error(int vci_idx, ssize_t ret)
+int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_err_entry e;
@@ -795,7 +795,7 @@ int MPIDI_OFI_handle_cq_error(int vci_idx, ssize_t ret)
 
     switch (ret) {
         case -FI_EAVAIL:
-            fi_cq_readerr(MPIDI_OFI_global.ctx[vci_idx].cq, &e, 0);
+            fi_cq_readerr(MPIDI_OFI_global.ctx[vni_idx].cq, &e, 0);
 
             switch (e.err) {
                 case FI_ETRUNC:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -23,6 +23,6 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 int MPIDI_OFI_get_buffered(struct fi_cq_tagged_entry *wc, ssize_t num);
 int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num);
-int MPIDI_OFI_handle_cq_error(int vci_idx, ssize_t ret);
+int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret);
 
 #endif /* OFI_EVENTS_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -46,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
     return op_index;
 }
 
-int MPIDI_OFI_progress(int vci, int blocking);
+int MPIDI_OFI_progress(int vni, int blocking);
 /*
  * Helper routines and macros for request completion
  */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -220,7 +220,7 @@ cvars:
         minor version of the OFI library used with MPICH. If using this CVAR,
         it is recommended that the user also specifies a specific OFI provider.
 
-    - name        : MPIR_CVAR_CH4_OFI_MAX_VCIS
+    - name        : MPIR_CVAR_CH4_OFI_MAX_VNIS
       category    : CH4_OFI
       type        : int
       default     : 1
@@ -228,7 +228,7 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        If set to positive, this CVAR specifies the maximum number of CH4 VCIs
+        If set to positive, this CVAR specifies the maximum number of VNIs
         that OFI netmod exposes.
 
     - name        : MPIR_CVAR_CH4_OFI_MAX_RMA_SEP_CTX
@@ -483,7 +483,7 @@ static int dynproc_send_disconnect(int conn_id)
 }
 
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                            int *n_vcis_provided)
+                            int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS, i, ofi_version;
     int thr_err = 0;
@@ -825,13 +825,13 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     /* completion queues, etc.                                                  */
     /* ------------------------------------------------------------------------ */
 
-    MPIDI_OFI_global.max_ch4_vcis = 1;
+    MPIDI_OFI_global.max_vnis = 1;
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
         int max_by_prov = MPL_MIN(prov_use->domain_attr->tx_ctx_cnt,
                                   prov_use->domain_attr->rx_ctx_cnt);
-        if (MPIR_CVAR_CH4_OFI_MAX_VCIS > 0)
-            MPIDI_OFI_global.max_ch4_vcis = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_VCIS, max_by_prov);
-        if (MPIDI_OFI_global.max_ch4_vcis < 1) {
+        if (MPIR_CVAR_CH4_OFI_MAX_VNIS > 0)
+            MPIDI_OFI_global.max_vnis = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_VNIS, max_by_prov);
+        if (MPIDI_OFI_global.max_vnis < 1) {
             MPIR_ERR_SETFATALANDJUMP4(mpi_errno,
                                       MPI_ERR_OTHER,
                                       "**ofid_ep",
@@ -840,11 +840,11 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                                       "Not enough scalable endpoints");
         }
         /* Specify the number of TX/RX contexts we want */
-        prov_use->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_ch4_vcis;
-        prov_use->ep_attr->rx_ctx_cnt = MPIDI_OFI_global.max_ch4_vcis;
+        prov_use->ep_attr->tx_ctx_cnt = MPIDI_OFI_global.max_vnis;
+        prov_use->ep_attr->rx_ctx_cnt = MPIDI_OFI_global.max_vnis;
     }
 
-    for (i = 0; i < MPIDI_OFI_global.max_ch4_vcis; i++) {
+    for (i = 0; i < MPIDI_OFI_global.max_vnis; i++) {
         mpi_errno =
             create_endpoint(prov_use, MPIDI_OFI_global.domain, MPIDI_OFI_global.p2p_cq,
                             MPIDI_OFI_global.rma_cmpl_cntr, MPIDI_OFI_global.av,
@@ -852,7 +852,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    *n_vcis_provided = MPIDI_OFI_global.max_ch4_vcis;
+    *n_vnis_provided = MPIDI_OFI_global.max_vnis;
 
     if (do_av_insert) {
         /* ---------------------------------- */
@@ -1045,7 +1045,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIR_Assert(OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        for (i = 0; i < MPIDI_OFI_global.max_ch4_vcis; i++) {
+        for (i = 0; i < MPIDI_OFI_global.max_vnis; i++) {
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].tx), epclose);
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].rx), epclose);
             MPIDI_OFI_CALL(fi_close((fid_t) MPIDI_OFI_global.ctx[i].cq), cqclose);
@@ -1103,9 +1103,9 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-MPIDI_vci_resource_t MPIDI_OFI_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_OFI_vni_get_resource_info(int vni)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vni && vni < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1103,10 +1103,10 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-int MPIDI_OFI_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_OFI_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1103,7 +1103,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-int MPIDI_OFI_get_vci_attr(int vci)
+int MPIDI_OFI_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -87,7 +87,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                             int *n_vcis_provided);
 int MPIDI_OFI_mpi_finalize_hook(void);
-int MPIDI_OFI_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_OFI_vci_get_resource_info(int vci);
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_OFI_mpi_free_mem(void *ptr);
 int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_OFI_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_OFI_mpi_finalize_hook
-#define MPIDI_NM_vci_get_attr MPIDI_OFI_vci_get_attr
+#define MPIDI_NM_vci_get_resource_info MPIDI_OFI_vci_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_OFI_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_OFI_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_OFI_get_local_upids

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -85,9 +85,9 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win);
 
 /* ofi_init.h */
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                            int *n_vcis_provided);
+                            int *n_vnis_provided);
 int MPIDI_OFI_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_OFI_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_OFI_vni_get_resource_info(int vni);
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_OFI_mpi_free_mem(void *ptr);
 int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_OFI_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_OFI_mpi_finalize_hook
-#define MPIDI_NM_vci_get_resource_info MPIDI_OFI_vci_get_resource_info
+#define MPIDI_NM_vni_get_resource_info MPIDI_OFI_vni_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_OFI_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_OFI_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_OFI_get_local_upids
@@ -114,7 +114,7 @@ int MPIDI_OFI_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
 #define MPIDI_NM_mpi_type_commit_hook MPIDI_OFI_mpi_type_commit_hook
 #endif
 
-int MPIDI_OFI_progress(int vci, int blocking);
+int MPIDI_OFI_progress(int vni, int blocking);
 
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_progress MPIDI_OFI_progress

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -87,7 +87,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                             int *n_vcis_provided);
 int MPIDI_OFI_mpi_finalize_hook(void);
-int MPIDI_OFI_get_vci_attr(int vci);
+int MPIDI_OFI_vci_get_attr(int vci);
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_OFI_mpi_free_mem(void *ptr);
 int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_OFI_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_OFI_mpi_finalize_hook
-#define MPIDI_NM_get_vci_attr MPIDI_OFI_get_vci_attr
+#define MPIDI_NM_vci_get_attr MPIDI_OFI_vci_get_attr
 #define MPIDI_NM_mpi_alloc_mem MPIDI_OFI_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_OFI_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_OFI_get_local_upids

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -13,7 +13,7 @@
 #include "ofi_impl.h"
 #include "ofi_events.h"
 
-int MPIDI_OFI_progress(int vci, int blocking)
+int MPIDI_OFI_progress(int vni, int blocking)
 {
     int mpi_errno;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];
@@ -24,14 +24,14 @@ int MPIDI_OFI_progress(int vci, int blocking)
     if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
     else if (likely(1)) {
-        ret = fi_cq_read(MPIDI_OFI_global.ctx[vci].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
+        ret = fi_cq_read(MPIDI_OFI_global.ctx[vni].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
             mpi_errno = MPIDI_OFI_handle_cq_entries(wc, ret);
         else if (ret == -FI_EAGAIN)
             mpi_errno = MPI_SUCCESS;
         else
-            mpi_errno = MPIDI_OFI_handle_cq_error(vci, ret);
+            mpi_errno = MPIDI_OFI_handle_cq_error(vni, ret);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_PROGRESS);

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -348,7 +348,7 @@ typedef struct {
     size_t max_order_war;
     size_t max_order_waw;
 
-    /* Mutexex and endpoints */
+    /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[4];
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS
     MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_ENDPOINTS_SCALABLE];

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -342,7 +342,7 @@ typedef struct {
     size_t tx_iov_limit;
     size_t rx_iov_limit;
     size_t rma_iov_limit;
-    int max_ch4_vcis;
+    int max_vnis;
     int max_rma_sep_tx_cnt;     /* Max number of transmit context on one RMA scalable EP */
     size_t max_order_raw;
     size_t max_order_war;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -13,13 +13,13 @@
 #include "ofi_impl.h"
 #include "ofi_events.h"
 
-int MPIDI_OFI_handle_cq_error_util(int vci_idx, ssize_t ret)
+int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
 
-    mpi_errno = MPIDI_OFI_handle_cq_error(vci_idx, ret);
+    mpi_errno = MPIDI_OFI_handle_cq_error(vni_idx, ret);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_HANDLE_CQ_ERROR);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -371,14 +371,14 @@ int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-int MPIDI_NM_get_vci_attr(int vci)
+int MPIDI_NM_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
 
-    ret = MPIDI_NM_func->get_vci_attr(vci);
+    ret = MPIDI_NM_func->vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -371,14 +371,14 @@ int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-int MPIDI_NM_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
 
-    ret = MPIDI_NM_func->vci_get_attr(vci);
+    ret = MPIDI_NM_func->vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -345,14 +345,14 @@ int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win
 }
 
 int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                           int *n_vcis_provided)
+                           int *n_vnis_provided)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
-    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, init_comm, n_vcis_provided);
+    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, init_comm, n_vnis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     return ret;
@@ -371,16 +371,16 @@ int MPIDI_NM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPIDI_vci_resource_t MPIDI_NM_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_NM_vni_get_resource_info(int vni)
 {
     int ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_QUERY_VNI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_QUERY_VNI);
 
-    ret = MPIDI_NM_func->vci_get_resource_info(vci);
+    ret = MPIDI_NM_func->vni_get_resource_info(vni);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VNI);
     return ret;
 }
 
@@ -476,14 +476,14 @@ int MPIDI_NM_mpi_type_free_hook(MPIR_Datatype * datatype_p)
     return ret;
 }
 
-int MPIDI_NM_progress(int vci, int blocking)
+int MPIDI_NM_progress(int vni, int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_PROGRESS);
 
-    ret = MPIDI_NM_func->progress(vci, blocking);
+    ret = MPIDI_NM_func->progress(vni, blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_PROGRESS);
     return ret;

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_STUBNM_get_local_upids,
-    .get_vci_attr = MPIDI_STUBNM_get_vci_attr,
+    .vci_get_attr = MPIDI_STUBNM_vci_get_attr,
     .upids_to_lupids = MPIDI_STUBNM_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_STUBNM_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_STUBNM_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_STUBNM_get_local_upids,
-    .vci_get_resource_info = MPIDI_STUBNM_vci_get_resource_info,
+    .vni_get_resource_info = MPIDI_STUBNM_vni_get_resource_info,
     .upids_to_lupids = MPIDI_STUBNM_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_STUBNM_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_STUBNM_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_STUBNM_get_local_upids,
-    .vci_get_attr = MPIDI_STUBNM_vci_get_attr,
+    .vci_get_resource_info = MPIDI_STUBNM_vci_get_resource_info,
     .upids_to_lupids = MPIDI_STUBNM_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_STUBNM_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_STUBNM_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -13,7 +13,7 @@
 #include "stubnm_impl.h"
 
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
-                               MPIR_Comm * comm_world, int *n_vcis_provided)
+                               MPIR_Comm * comm_world, int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -28,7 +28,7 @@ int MPIDI_STUBNM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-MPIDI_vci_resource_t MPIDI_STUBNM_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_STUBNM_vni_get_resource_info(int vni)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -28,7 +28,7 @@ int MPIDI_STUBNM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-int MPIDI_STUBNM_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_STUBNM_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -28,7 +28,7 @@ int MPIDI_STUBNM_mpi_finalize_hook(void)
     return mpi_errno;
 }
 
-int MPIDI_STUBNM_get_vci_attr(int vci)
+int MPIDI_STUBNM_vci_get_attr(int vci)
 {
     MPIR_Assert(0);
     return 0;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
@@ -88,7 +88,7 @@ int MPIDI_STUBNM_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                MPIR_Comm * init_comm, int *n_vcis_provided);
 int MPIDI_STUBNM_mpi_finalize_hook(void);
-int MPIDI_STUBNM_get_vci_attr(int vci);
+int MPIDI_STUBNM_vci_get_attr(int vci);
 void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_STUBNM_mpi_free_mem(void *ptr);
 int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -99,7 +99,7 @@ int MPIDI_STUBNM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, 
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_STUBNM_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_STUBNM_mpi_finalize_hook
-#define MPIDI_NM_get_vci_attr MPIDI_STUBNM_get_vci_attr
+#define MPIDI_NM_vci_get_attr MPIDI_STUBNM_vci_get_attr
 #define MPIDI_NM_mpi_alloc_mem MPIDI_STUBNM_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_STUBNM_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_STUBNM_get_local_upids

--- a/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
@@ -86,9 +86,9 @@ int MPIDI_STUBNM_mpi_win_free_hook(MPIR_Win * win);
 
 /* stubnm_init.h */
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
-                               MPIR_Comm * init_comm, int *n_vcis_provided);
+                               MPIR_Comm * init_comm, int *n_vnis_provided);
 int MPIDI_STUBNM_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_STUBNM_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_STUBNM_vni_get_resource_info(int vni);
 void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_STUBNM_mpi_free_mem(void *ptr);
 int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -99,7 +99,7 @@ int MPIDI_STUBNM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, 
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_STUBNM_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_STUBNM_mpi_finalize_hook
-#define MPIDI_NM_vci_get_resource_info MPIDI_STUBNM_vci_get_resource_info
+#define MPIDI_NM_vni_get_resource_info MPIDI_STUBNM_vni_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_STUBNM_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_STUBNM_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_STUBNM_get_local_upids
@@ -115,7 +115,7 @@ int MPIDI_STUBNM_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
 #define MPIDI_NM_mpi_type_commit_hook MPIDI_STUBNM_mpi_type_commit_hook
 #endif
 
-int MPIDI_STUBNM_progress(int vci, int blocking);
+int MPIDI_STUBNM_progress(int vni, int blocking);
 int MPIDI_STUBNM_progress_test(void);
 int MPIDI_STUBNM_progress_poke(void);
 void MPIDI_STUBNM_progress_start(MPID_Progress_state * state);

--- a/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
@@ -88,7 +88,7 @@ int MPIDI_STUBNM_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                MPIR_Comm * init_comm, int *n_vcis_provided);
 int MPIDI_STUBNM_mpi_finalize_hook(void);
-int MPIDI_STUBNM_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_STUBNM_vci_get_resource_info(int vci);
 void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_STUBNM_mpi_free_mem(void *ptr);
 int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -99,7 +99,7 @@ int MPIDI_STUBNM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, 
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_STUBNM_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_STUBNM_mpi_finalize_hook
-#define MPIDI_NM_vci_get_attr MPIDI_STUBNM_vci_get_attr
+#define MPIDI_NM_vci_get_resource_info MPIDI_STUBNM_vci_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_STUBNM_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_STUBNM_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_STUBNM_get_local_upids

--- a/src/mpid/ch4/netmod/stubnm/stubnm_progress.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_progress.c
@@ -11,7 +11,7 @@
 
 #include "mpidimpl.h"
 
-int MPIDI_STUBNM_progress(int vci, int blocking)
+int MPIDI_STUBNM_progress(int vni, int blocking)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_UCX_get_local_upids,
-    .get_vci_attr = MPIDI_UCX_get_vci_attr,
+    .vci_get_attr = MPIDI_UCX_vci_get_attr,
     .upids_to_lupids = MPIDI_UCX_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_UCX_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_UCX_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_UCX_get_local_upids,
-    .vci_get_resource_info = MPIDI_UCX_vci_get_resource_info,
+    .vni_get_resource_info = MPIDI_UCX_vni_get_resource_info,
     .upids_to_lupids = MPIDI_UCX_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_UCX_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_UCX_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -27,7 +27,7 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     /* Routines that handle addressing */
     .comm_get_lpid = MPIDI_NM_comm_get_lpid,
     .get_local_upids = MPIDI_UCX_get_local_upids,
-    .vci_get_attr = MPIDI_UCX_vci_get_attr,
+    .vci_get_resource_info = MPIDI_UCX_vci_get_resource_info,
     .upids_to_lupids = MPIDI_UCX_upids_to_lupids,
     .create_intercomm_from_lpids = MPIDI_UCX_create_intercomm_from_lpids,
     .mpi_comm_create_hook = MPIDI_UCX_mpi_comm_create_hook,

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -23,7 +23,7 @@ static void request_init_callback(void *request)
 }
 
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                            int *n_vcis_provided)
+                            int *n_vnis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_config_t *config;
@@ -37,7 +37,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_INIT_HOOK);
 
-    *n_vcis_provided = 1;
+    *n_vnis_provided = 1;
 
     ucx_status = ucp_config_read(NULL, NULL, &config);
     MPIDI_UCX_CHK_STATUS(ucx_status);
@@ -188,9 +188,9 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
 }
 
-MPIDI_vci_resource_t MPIDI_UCX_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_UCX_vni_get_resource_info(int vni)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vni && vni < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -188,7 +188,7 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
 }
 
-int MPIDI_UCX_get_vci_attr(int vci)
+int MPIDI_UCX_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -188,10 +188,10 @@ int MPIDI_UCX_mpi_finalize_hook(void)
 
 }
 
-int MPIDI_UCX_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_UCX_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -85,9 +85,9 @@ int MPIDI_UCX_mpi_win_free_hook(MPIR_Win * win);
 
 /* ucx_init.h */
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
-                            int *n_vcis_provided);
+                            int *n_vnis_provided);
 int MPIDI_UCX_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_UCX_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_UCX_vni_get_resource_info(int vni);
 void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_UCX_mpi_free_mem(void *ptr);
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_UCX_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_UCX_mpi_finalize_hook
-#define MPIDI_NM_vci_get_resource_info MPIDI_UCX_vci_get_resource_info
+#define MPIDI_NM_vni_get_resource_info MPIDI_UCX_vni_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_UCX_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_UCX_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_UCX_get_local_upids
@@ -114,7 +114,7 @@ int MPIDI_UCX_mpi_type_commit_hook(MPIR_Datatype * datatype_p);
 #define MPIDI_NM_mpi_type_commit_hook MPIDI_UCX_mpi_type_commit_hook
 #endif
 
-int MPIDI_UCX_progress(int vci, int blocking);
+int MPIDI_UCX_progress(int vni, int blocking);
 
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_progress MPIDI_UCX_progress

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -87,7 +87,7 @@ int MPIDI_UCX_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                             int *n_vcis_provided);
 int MPIDI_UCX_mpi_finalize_hook(void);
-int MPIDI_UCX_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_UCX_vci_get_resource_info(int vci);
 void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_UCX_mpi_free_mem(void *ptr);
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_UCX_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_UCX_mpi_finalize_hook
-#define MPIDI_NM_vci_get_attr MPIDI_UCX_vci_get_attr
+#define MPIDI_NM_vci_get_resource_info MPIDI_UCX_vci_get_resource_info
 #define MPIDI_NM_mpi_alloc_mem MPIDI_UCX_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_UCX_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_UCX_get_local_upids

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -87,7 +87,7 @@ int MPIDI_UCX_mpi_win_free_hook(MPIR_Win * win);
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
                             int *n_vcis_provided);
 int MPIDI_UCX_mpi_finalize_hook(void);
-int MPIDI_UCX_get_vci_attr(int vci);
+int MPIDI_UCX_vci_get_attr(int vci);
 void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_UCX_mpi_free_mem(void *ptr);
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
@@ -98,7 +98,7 @@ int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
 #ifdef NETMOD_INLINE
 #define MPIDI_NM_mpi_init_hook MPIDI_UCX_mpi_init_hook
 #define MPIDI_NM_mpi_finalize_hook MPIDI_UCX_mpi_finalize_hook
-#define MPIDI_NM_get_vci_attr MPIDI_UCX_get_vci_attr
+#define MPIDI_NM_vci_get_attr MPIDI_UCX_vci_get_attr
 #define MPIDI_NM_mpi_alloc_mem MPIDI_UCX_mpi_alloc_mem
 #define MPIDI_NM_mpi_free_mem MPIDI_UCX_mpi_free_mem
 #define MPIDI_NM_get_local_upids MPIDI_UCX_get_local_upids

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -88,7 +88,7 @@ static void handle_am_recv(void *request, ucs_status_t status, ucp_tag_recv_info
     return;
 }
 
-int MPIDI_UCX_progress(int vci, int blocking)
+int MPIDI_UCX_progress(int vni, int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_tag_recv_info_t info;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -20,7 +20,7 @@
  * with the struct of function pointers below. */
 typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef int (*MPIDI_SHM_get_vci_attr_t) (int vci);
+typedef int (*MPIDI_SHM_vci_get_attr_t) (int vci);
 typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
@@ -421,7 +421,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_get_vci_attr_t get_vci_attr;
+    MPIDI_SHM_vci_get_attr_t vci_get_attr;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -572,7 +572,7 @@ extern MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs;
 
 int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_SHM_mpi_finalize_hook(void);
-int MPIDI_SHM_get_vci_attr(int vci);
+int MPIDI_SHM_vci_get_attr(int vci);
 int MPIDI_SHM_progress(int vci, int blocking);
 int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                                MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -20,7 +20,7 @@
  * with the struct of function pointers below. */
 typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef int (*MPIDI_SHM_vci_get_attr_t) (int vci);
+typedef MPIDI_vci_resource_t(*MPIDI_SHM_vci_get_resource_info_t) (int vci);
 typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
@@ -421,7 +421,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_vci_get_attr_t vci_get_attr;
+    MPIDI_SHM_vci_get_resource_info_t vci_get_resource_info;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -572,7 +572,7 @@ extern MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs;
 
 int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_SHM_mpi_finalize_hook(void);
-int MPIDI_SHM_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci);
 int MPIDI_SHM_progress(int vci, int blocking);
 int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                                MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -18,10 +18,10 @@
 
 /* These typedef function definitions are used when not inlining the shared memory module along
  * with the struct of function pointers below. */
-typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vcis_provided, int *tag_bits);
+typedef int (*MPIDI_SHM_mpi_init_hook_t) (int rank, int size, int *n_vsis_provided, int *tag_bits);
 typedef int (*MPIDI_SHM_mpi_finalize_hook_t) (void);
-typedef MPIDI_vci_resource_t(*MPIDI_SHM_vci_get_resource_info_t) (int vci);
-typedef int (*MPIDI_SHM_progress_t) (int vci, int blocking);
+typedef MPIDI_vci_resource_t(*MPIDI_SHM_vsi_get_resource_info_t) (int vsi);
+typedef int (*MPIDI_SHM_progress_t) (int vsi, int blocking);
 typedef int (*MPIDI_SHM_mpi_comm_connect_t) (const char *port_name, MPIR_Info * info,
                                              int root, int timeout, MPIR_Comm * comm,
                                              MPIR_Comm ** newcomm_ptr);
@@ -421,7 +421,7 @@ typedef int (*MPIDI_SHM_mpi_iscatterv_t) (const void *sendbuf, const int *sendco
 typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_mpi_init_hook_t mpi_init;
     MPIDI_SHM_mpi_finalize_hook_t mpi_finalize;
-    MPIDI_SHM_vci_get_resource_info_t vci_get_resource_info;
+    MPIDI_SHM_vsi_get_resource_info_t vsi_get_resource_info;
     MPIDI_SHM_progress_t progress;
     MPIDI_SHM_mpi_comm_connect_t mpi_comm_connect;
     MPIDI_SHM_mpi_comm_disconnect_t mpi_comm_disconnect;
@@ -570,10 +570,10 @@ typedef struct MPIDI_SHM_native_funcs {
 extern MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs;
 extern MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs;
 
-int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
+int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits);
 int MPIDI_SHM_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci);
-int MPIDI_SHM_progress(int vci, int blocking);
+MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi);
+int MPIDI_SHM_progress(int vsi, int blocking);
 int MPIDI_SHM_mpi_comm_connect(const char *port_name, MPIR_Info * info, int root, int timeout,
                                MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 int MPIDI_SHM_mpi_comm_disconnect(MPIR_Comm * comm_ptr);

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -71,7 +71,7 @@ static int choose_posix_eager(void)
     goto fn_exit;
 }
 
-int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
+int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, local_rank_0 = -1;
@@ -105,7 +105,7 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     MPIDI_POSIX_global.my_local_rank = MPIR_Process.local_rank;
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
-    *n_vcis_provided = 1;
+    *n_vsis_provided = 1;
 
     /* This is used to track messages that the eager submodule was not ready to send. */
     MPIDI_POSIX_global.postponed_queue = NULL;
@@ -210,9 +210,9 @@ int MPIDI_POSIX_coll_finalize(void)
     goto fn_exit;
 }
 
-MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_POSIX_vsi_get_resource_info(int vsi)
 {
-    MPIR_Assert(0 <= vci && vci < 1);
+    MPIR_Assert(0 <= vsi && vsi < 1);
     return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -210,10 +210,10 @@ int MPIDI_POSIX_coll_finalize(void)
     goto fn_exit;
 }
 
-int MPIDI_POSIX_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
-    return MPIDI_VCI_TX | MPIDI_VCI_RX;
+    return MPIDI_VCI_RESOURCE__TX | MPIDI_VCI_RESOURCE__RX;
 }
 
 void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -210,7 +210,7 @@ int MPIDI_POSIX_coll_finalize(void)
     goto fn_exit;
 }
 
-int MPIDI_POSIX_get_vci_attr(int vci)
+int MPIDI_POSIX_vci_get_attr(int vci)
 {
     MPIR_Assert(0 <= vci && vci < 1);
     return MPIDI_VCI_TX | MPIDI_VCI_RX;

--- a/src/mpid/ch4/shm/posix/posix_noinline.h
+++ b/src/mpid/ch4/shm/posix/posix_noinline.h
@@ -9,9 +9,9 @@
 
 #include "posix_impl.h"
 
-int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
+int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits);
 int MPIDI_POSIX_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_POSIX_vsi_get_resource_info(int vsi);
 
 int MPIDI_POSIX_coll_init(int rank, int size);
 int MPIDI_POSIX_coll_finalize(void);

--- a/src/mpid/ch4/shm/posix/posix_noinline.h
+++ b/src/mpid/ch4/shm/posix/posix_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_POSIX_mpi_finalize_hook(void);
-int MPIDI_POSIX_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_POSIX_vci_get_resource_info(int vci);
 
 int MPIDI_POSIX_coll_init(int rank, int size);
 int MPIDI_POSIX_coll_finalize(void);

--- a/src/mpid/ch4/shm/posix/posix_noinline.h
+++ b/src/mpid/ch4/shm/posix/posix_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_POSIX_mpi_finalize_hook(void);
-int MPIDI_POSIX_get_vci_attr(int vci);
+int MPIDI_POSIX_vci_get_attr(int vci);
 
 int MPIDI_POSIX_coll_init(int rank, int size);
 int MPIDI_POSIX_coll_finalize(void);

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHMI_mpi_init_hook,
     .mpi_finalize = MPIDI_SHMI_mpi_finalize_hook,
-    .vci_get_attr = MPIDI_SHMI_vci_get_attr,
+    .vci_get_resource_info = MPIDI_SHMI_vci_get_resource_info,
     .progress = MPIDI_SHMI_progress,
     .mpi_comm_connect = MPIDI_SHMI_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHMI_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHMI_mpi_init_hook,
     .mpi_finalize = MPIDI_SHMI_mpi_finalize_hook,
-    .get_vci_attr = MPIDI_SHMI_get_vci_attr,
+    .vci_get_attr = MPIDI_SHMI_vci_get_attr,
     .progress = MPIDI_SHMI_progress,
     .mpi_comm_connect = MPIDI_SHMI_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHMI_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -20,7 +20,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .mpi_init = MPIDI_SHMI_mpi_init_hook,
     .mpi_finalize = MPIDI_SHMI_mpi_finalize_hook,
-    .vci_get_resource_info = MPIDI_SHMI_vci_get_resource_info,
+    .vsi_get_resource_info = MPIDI_SHMI_vsi_get_resource_info,
     .progress = MPIDI_SHMI_progress,
     .mpi_comm_connect = MPIDI_SHMI_mpi_comm_connect,
     .mpi_comm_disconnect = MPIDI_SHMI_mpi_comm_disconnect,

--- a/src/mpid/ch4/shm/src/shm_impl.c
+++ b/src/mpid/ch4/shm/src/shm_impl.c
@@ -36,14 +36,14 @@ int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-int MPIDI_SHM_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_SHM_src_funcs.vci_get_attr(vci);
+    ret = MPIDI_SHM_src_funcs.vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_impl.c
+++ b/src/mpid/ch4/shm/src/shm_impl.c
@@ -36,14 +36,14 @@ int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-int MPIDI_SHM_get_vci_attr(int vci)
+int MPIDI_SHM_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
 
-    ret = MPIDI_SHM_src_funcs.get_vci_attr(vci);
+    ret = MPIDI_SHM_src_funcs.vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_impl.c
+++ b/src/mpid/ch4/shm/src/shm_impl.c
@@ -10,14 +10,14 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 #ifndef SHM_INLINE
 #ifndef SHM_DISABLE_INLINES
 
-int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
+int MPIDI_SHM_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
 
-    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vcis_provided, tag_bits);
+    ret = MPIDI_SHM_src_funcs.mpi_init(rank, size, n_vsis_provided, tag_bits);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_MPI_INIT_HOOK);
     return ret;
@@ -36,16 +36,16 @@ int MPIDI_SHM_mpi_finalize_hook(void)
     return ret;
 }
 
-MPIDI_vci_resource_t MPIDI_SHM_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_SHM_vsi_get_resource_info(int vsi)
 {
     int ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_QUERY_VSI);
 
-    ret = MPIDI_SHM_src_funcs.vci_get_resource_info(vci);
+    ret = MPIDI_SHM_src_funcs.vsi_get_resource_info(vsi);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_QUERY_VSI);
     return ret;
 }
 
@@ -473,14 +473,14 @@ int MPIDI_SHM_mpi_op_free_hook(MPIR_Op * op_p)
     return ret;
 }
 
-int MPIDI_SHM_progress(int vci, int blocking)
+int MPIDI_SHM_progress(int vsi, int blocking)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_PROGRESS);
 
-    ret = MPIDI_SHM_src_funcs.progress(vci, blocking);
+    ret = MPIDI_SHM_src_funcs.progress(vsi, blocking);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_PROGRESS);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -12,19 +12,19 @@
 #include "../xpmem/xpmem_noinline.h"
 #endif
 
-int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
+int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHMI_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHMI_MPI_INIT_HOOK);
 
-    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vcis_provided, tag_bits);
+    ret = MPIDI_POSIX_mpi_init_hook(rank, size, n_vsis_provided, tag_bits);
     MPIR_ERR_CHECK(ret);
 
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     if (MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE != -1) {
-        ret = MPIDI_XPMEM_mpi_init_hook(rank, size, n_vcis_provided, tag_bits);
+        ret = MPIDI_XPMEM_mpi_init_hook(rank, size, n_vsis_provided, tag_bits);
         MPIR_ERR_CHECK(ret);
     }
 #endif
@@ -60,20 +60,20 @@ int MPIDI_SHMI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-MPIDI_vci_resource_t MPIDI_SHMI_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_SHMI_vsi_get_resource_info(int vsi)
 {
     int ret;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHMI_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHMI_QUERY_VSI);
 
-    ret = MPIDI_POSIX_vci_get_resource_info(vci);
+    ret = MPIDI_POSIX_vsi_get_resource_info(vsi);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHMI_QUERY_VSI);
     return ret;
 }
 
-int MPIDI_SHMI_progress(int vci, int blocking)
+int MPIDI_SHMI_progress(int vsi, int blocking)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -60,14 +60,14 @@ int MPIDI_SHMI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-int MPIDI_SHMI_get_vci_attr(int vci)
+int MPIDI_SHMI_vci_get_attr(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
 
-    ret = MPIDI_POSIX_get_vci_attr(vci);
+    ret = MPIDI_POSIX_vci_get_attr(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -60,14 +60,14 @@ int MPIDI_SHMI_mpi_finalize_hook(void)
     goto fn_exit;
 }
 
-int MPIDI_SHMI_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_SHMI_vci_get_resource_info(int vci)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
 
-    ret = MPIDI_POSIX_vci_get_attr(vci);
+    ret = MPIDI_POSIX_vci_get_resource_info(vci);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHMI_QUERY_VCI);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_noinline.h
+++ b/src/mpid/ch4/shm/src/shm_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_SHMI_mpi_finalize_hook(void);
-int MPIDI_SHMI_get_vci_attr(int vci);
+int MPIDI_SHMI_vci_get_attr(int vci);
 
 int MPIDI_SHMI_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_SHMI_mpi_comm_free_hook(MPIR_Comm * comm);
@@ -60,7 +60,7 @@ int MPIDI_SHMI_progress(int vci, int blocking);
 #ifdef SHM_INLINE
 #define MPIDI_SHM_mpi_init_hook MPIDI_SHMI_mpi_init_hook
 #define MPIDI_SHM_mpi_finalize_hook MPIDI_SHMI_mpi_finalize_hook
-#define MPIDI_SHM_get_vci_attr MPIDI_SHMI_get_vci_attr
+#define MPIDI_SHM_vci_get_attr MPIDI_SHMI_vci_get_attr
 #define MPIDI_SHM_mpi_comm_create_hook MPIDI_SHMI_mpi_comm_create_hook
 #define MPIDI_SHM_mpi_comm_free_hook MPIDI_SHMI_mpi_comm_free_hook
 #define MPIDI_SHM_mpi_type_commit_hook MPIDI_SHMI_mpi_type_commit_hook

--- a/src/mpid/ch4/shm/src/shm_noinline.h
+++ b/src/mpid/ch4/shm/src/shm_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_SHMI_mpi_finalize_hook(void);
-int MPIDI_SHMI_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_SHMI_vci_get_resource_info(int vci);
 
 int MPIDI_SHMI_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_SHMI_mpi_comm_free_hook(MPIR_Comm * comm);
@@ -60,7 +60,7 @@ int MPIDI_SHMI_progress(int vci, int blocking);
 #ifdef SHM_INLINE
 #define MPIDI_SHM_mpi_init_hook MPIDI_SHMI_mpi_init_hook
 #define MPIDI_SHM_mpi_finalize_hook MPIDI_SHMI_mpi_finalize_hook
-#define MPIDI_SHM_vci_get_attr MPIDI_SHMI_vci_get_attr
+#define MPIDI_SHM_vci_get_resource_info MPIDI_SHMI_vci_get_resource_info
 #define MPIDI_SHM_mpi_comm_create_hook MPIDI_SHMI_mpi_comm_create_hook
 #define MPIDI_SHM_mpi_comm_free_hook MPIDI_SHMI_mpi_comm_free_hook
 #define MPIDI_SHM_mpi_type_commit_hook MPIDI_SHMI_mpi_type_commit_hook

--- a/src/mpid/ch4/shm/src/shm_noinline.h
+++ b/src/mpid/ch4/shm/src/shm_noinline.h
@@ -9,9 +9,9 @@
 
 #include "shm_impl.h"
 
-int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
+int MPIDI_SHMI_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits);
 int MPIDI_SHMI_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_SHMI_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_SHMI_vsi_get_resource_info(int vsi);
 
 int MPIDI_SHMI_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_SHMI_mpi_comm_free_hook(MPIR_Comm * comm);
@@ -55,12 +55,12 @@ int MPIDI_SHMI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, co
 
 void *MPIDI_SHMI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_SHMI_mpi_free_mem(void *ptr);
-int MPIDI_SHMI_progress(int vci, int blocking);
+int MPIDI_SHMI_progress(int vsi, int blocking);
 
 #ifdef SHM_INLINE
 #define MPIDI_SHM_mpi_init_hook MPIDI_SHMI_mpi_init_hook
 #define MPIDI_SHM_mpi_finalize_hook MPIDI_SHMI_mpi_finalize_hook
-#define MPIDI_SHM_vci_get_resource_info MPIDI_SHMI_vci_get_resource_info
+#define MPIDI_SHM_vsi_get_resource_info MPIDI_SHMI_vsi_get_resource_info
 #define MPIDI_SHM_mpi_comm_create_hook MPIDI_SHMI_mpi_comm_create_hook
 #define MPIDI_SHM_mpi_comm_free_hook MPIDI_SHMI_mpi_comm_free_hook
 #define MPIDI_SHM_mpi_type_commit_hook MPIDI_SHMI_mpi_type_commit_hook

--- a/src/mpid/ch4/shm/stubshm/shm_noinline.h
+++ b/src/mpid/ch4/shm/stubshm/shm_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_STUBSHM_mpi_finalize_hook(void);
-int MPIDI_STUBSHM_get_vci_attr(int vci);
+int MPIDI_STUBSHM_vci_get_attr(int vci);
 
 int MPIDI_STUBSHM_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_STUBSHM_mpi_comm_free_hook(MPIR_Comm * comm);

--- a/src/mpid/ch4/shm/stubshm/shm_noinline.h
+++ b/src/mpid/ch4/shm/stubshm/shm_noinline.h
@@ -11,7 +11,7 @@
 
 int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
 int MPIDI_STUBSHM_mpi_finalize_hook(void);
-int MPIDI_STUBSHM_vci_get_attr(int vci);
+MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci);
 
 int MPIDI_STUBSHM_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_STUBSHM_mpi_comm_free_hook(MPIR_Comm * comm);

--- a/src/mpid/ch4/shm/stubshm/shm_noinline.h
+++ b/src/mpid/ch4/shm/stubshm/shm_noinline.h
@@ -9,9 +9,9 @@
 
 #include "shm_impl.h"
 
-int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
+int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits);
 int MPIDI_STUBSHM_mpi_finalize_hook(void);
-MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci);
+MPIDI_vci_resource_t MPIDI_STUBSHM_vsi_get_resource_info(int vsi);
 
 int MPIDI_STUBSHM_mpi_comm_create_hook(MPIR_Comm * comm);
 int MPIDI_STUBSHM_mpi_comm_free_hook(MPIR_Comm * comm);
@@ -59,7 +59,7 @@ int MPIDI_STUBSHM_mpi_free_mem(void *ptr);
 
 int MPIDI_STUBSHM_do_progress_recv(int blocking, int *completion_count);
 int MPIDI_STUBSHM_do_progress_send(int blocking, int *completion_count);
-int MPIDI_STUBSHM_progress(int vci, int blocking);
+int MPIDI_STUBSHM_progress(int vsi, int blocking);
 int MPIDI_STUBSHM_progress_test(void);
 int MPIDI_STUBSHM_progress_poke(void);
 void MPIDI_STUBSHM_progress_start(MPID_Progress_state * state);

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.c
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.c
@@ -22,7 +22,7 @@ int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided)
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBSHM_get_vci_attr(int vci)
+int MPIDI_STUBSHM_vci_get_attr(int vci)
 {
     int ret = 0;
 

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.c
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.c
@@ -22,7 +22,7 @@ int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided)
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBSHM_vci_get_attr(int vci)
+MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci)
 {
     int ret = 0;
 

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.c
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.c
@@ -11,7 +11,7 @@
 
 #include "stubshm_impl.h"
 
-int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided)
+int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vsis_provided)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_INIT_HOOK);
@@ -22,16 +22,16 @@ int MPIDI_STUBSHM_mpi_init_hook(int rank, int size, int *n_vcis_provided)
     return MPI_SUCCESS;
 }
 
-MPIDI_vci_resource_t MPIDI_STUBSHM_vci_get_resource_info(int vci)
+MPIDI_vci_resource_t MPIDI_STUBSHM_vsi_get_resource_info(int vsi)
 {
     int ret = 0;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
 
     MPIR_Assert(0);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_QUERY_VCI);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_STUBSHM_QUERY_VSI);
     return ret;
 }
 

--- a/src/mpid/ch4/shm/stubshm/stubshm_progress.c
+++ b/src/mpid/ch4/shm/stubshm/stubshm_progress.c
@@ -34,7 +34,7 @@ int MPIDI_STUBSHM_do_progress_send(int blocking, int *completion_count)
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBSHM_progress(int vci, int blocking)
+int MPIDI_STUBSHM_progress(int vsi, int blocking)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_PROGRESS);

--- a/src/mpid/ch4/shm/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_init.c
@@ -10,7 +10,7 @@
 #include "mpidu_init_shm.h"
 #include "xpmem_seg.h"
 
-int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
+int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;

--- a/src/mpid/ch4/shm/xpmem/xpmem_noinline.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_noinline.h
@@ -9,7 +9,7 @@
 
 #include "xpmem_impl.h"
 
-int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits);
+int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vsis_provided, int *tag_bits);
 int MPIDI_XPMEM_mpi_finalize_hook(void);
 
 int MPIDI_XPMEM_mpi_win_create_hook(MPIR_Win * win);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -356,7 +356,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_Comm *init_comm = NULL;
     int n_vnis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    int n_shm_vcis_provided;
+    int n_vsis_provided;
 #endif
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
@@ -427,7 +427,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     {
         int shm_tag_bits = MPIR_TAG_BITS_DEFAULT, nm_tag_bits = MPIR_TAG_BITS_DEFAULT;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_shm_vcis_provided, &shm_tag_bits);
+        mpi_errno = MPIDI_SHM_mpi_init_hook(rank, size, &n_vsis_provided, &shm_tag_bits);
 
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -354,7 +354,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum, thr_err;
     MPIR_Comm *init_comm = NULL;
-    int n_nm_vcis_provided;
+    int n_vnis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int n_shm_vcis_provided;
 #endif
@@ -435,7 +435,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 #endif
 
         mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits, init_comm,
-                                           &n_nm_vcis_provided);
+                                           &n_vnis_provided);
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -41,7 +41,7 @@ typedef struct progress_hook_slot {
  * Flags argument allows to control execution of different parts of progress function,
  * for aims of prioritization of different transports and reentrant-safety of progress call.
  *
- * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internaly,
+ * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internally,
  *      that's why MPIDI_Progress_test call with MPIDI_PROGRESS_HOOKS set isn't reentrant safe, and shouldn't be called from netmod's fallback logic.
  * MPIDI_PROGRESS_NM and MPIDI_PROGRESS_SHM enables progress on transports only, and guarantee reentrant-safety.
  */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -21,12 +21,6 @@
 
 #define MAX_PROGRESS_HOOKS 4
 
-/* VCI attributes */
-enum {
-    MPIDI_VCI_TX = 0x1,         /* Can send */
-    MPIDI_VCI_RX = 0x2, /* Can receive */
-};
-
 #define MPIDIU_BUF_POOL_NUM (1024)
 #define MPIDIU_BUF_POOL_SZ (256)
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -32,7 +32,7 @@ typedef struct progress_hook_slot {
 
 /* Flags for MPIDI_Progress_test
  *
- * Flags argument allows to control execution of different parts of progress function,
+ * hook_flags argument allows to control execution of different parts of progress function,
  * for aims of prioritization of different transports and reentrant-safety of progress call.
  *
  * MPIDI_PROGRESS_HOOKS - enables progress on progress hooks. Hooks may invoke upper-level logic internally,


### PR DESCRIPTION
Summary:
- Spelling fixes in comments.
- Renaming `get_vci_attr` function to use class-style function naming: `vci_get_attr`.
- Renaming VCI attributes to VCI resources to be consistent with the design proposed in #3356.
- Removing irrelevant VCI argument in `MPIDIG_init`.
- Renaming NM VCIs to VNIs.
- Renaming SHM VCIs to VSIs.