### PR TITLE
warnings: implement warnings test and fix warnings

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -558,8 +558,14 @@ if test "$enable_strict_done" != "yes" ; then
     c_std=c99
     posix_std=2001
     enable_opt=yes
+    pac_cc_strict_werror=no
     for flag in ${flags}; do
         case "$flag" in
+             error)
+                # note: we can't enable -Werror early as it will break many config tests
+                #       Need apply to CFLAGS at the end of configure.
+                pac_cc_strict_werror=yes
+                ;;
 	     stdc89)
 	        c_std=c89
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -5660,6 +5660,11 @@ if test "X$f08_works" = "Xyes"; then
 fi
 
 ########################################################################
+# Some of the settings need to be applied at the end
+if test x"$pac_cc_strict_werror" = xyes ; then
+    PAC_APPEND_FLAG([-Werror],[CFLAGS])
+fi
+########################################################################
 
 if test -z "$pkgconfigdir" ; then
   # The default pkgconfig dir is under the lib dir

--- a/src/include/mpir_win.h
+++ b/src/include/mpir_win.h
@@ -73,10 +73,10 @@ struct MPIR_Win {
 
     char name[MPI_MAX_OBJECT_NAME];
 
-    MPIR_Win_flavor_t create_flavor;
-    MPIR_Win_model_t model;
-    MPIR_Win_flavor_t copyCreateFlavor;
-    MPIR_Win_model_t copyModel;
+    int create_flavor;
+    int model;
+    int copyCreateFlavor;
+    int copyModel;
 
     /* Other, device-specific information */
 #ifdef MPID_DEV_WIN_DECL

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -138,18 +138,20 @@ int MPII_Recexchalgo_get_neighbors(int rank, int nranks, int *k_,
     if (*step1_sendto == -1) {  /* calulate step2_nbrs only for participating ranks */
         int *digit = (int *) MPL_malloc(sizeof(int) * log_p_of_k, MPL_MEM_COLL);
         MPIR_Assert(digit != NULL);
-        int temprank = newrank, index = 0, remainder;
+        int temprank = newrank;
         int mask = 0x1;
         int phase = 0, cbit, cnt, nbr, power;
 
         /* calculate the digits in base k representation of newrank */
         for (i = 0; i < log_p_of_k; i++)
             digit[i] = 0;
+
+        int remainder, i_digit = 0;
         while (temprank != 0) {
             remainder = temprank % k;
             temprank = temprank / k;
-            digit[index] = remainder;
-            index++;
+            digit[i_digit] = remainder;
+            i_digit++;
         }
 
         while (mask < p_of_k) {
@@ -279,7 +281,6 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
     int i, T, rem, power, step2rank, step2_reverse_rank = 0;
     int pofk = 1, log_pofk = 0;
     int *digit, *digit_reverse;
-    int remainder, index = 0;
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL(2);
 
@@ -306,11 +307,13 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
                         mpi_errno, "digit_reverse buffer", MPL_MEM_COLL);
     for (i = 0; i < log_pofk; i++)
         digit[i] = 0;
+
+    int remainder, i_digit = 0;
     while (step2rank != 0) {
         remainder = step2rank % k;
         step2rank = step2rank / k;
-        digit[index] = remainder;
-        index++;
+        digit[i_digit] = remainder;
+        i_digit++;
     }
 
     /* reverse the number in base k representation to get the step2_reverse_rank

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -78,7 +78,7 @@ int MPII_Treeutil_tree_kary_init(int rank, int nranks, int k, int root, MPIR_Tre
 int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
                                       MPIR_Treealgo_tree_t * ct)
 {
-    int lrank, i, j, maxtime, tmp, time, parent, current_rank, running_rank, crank;
+    int lrank, i, j, maxstep, tmp, step, parent, current_rank, running_rank, crank;
     int mpi_errno = MPI_SUCCESS;
 
     ct->rank = rank;
@@ -94,20 +94,20 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
     MPIR_Assert(k >= 2);
 
     /* maximum number of steps while generating the knomial tree */
-    maxtime = 0;
+    maxstep = 0;
     for (tmp = nranks - 1; tmp; tmp /= k)
-        maxtime++;
+        maxstep++;
 
     utarray_new(ct->children, &ut_int_icd, MPL_MEM_COLL);
     ct->num_children = 0;
-    time = 0;
+    step = 0;
     parent = -1;        /* root has no parent */
     current_rank = 0;   /* start at root of the tree */
     running_rank = current_rank + 1;    /* used for calculation below
                                          * start with first child of the current_rank */
 
-    for (time = 0;; time++) {
-        MPIR_Assert(time <= nranks);    /* actually, should not need more steps than log_k(nranks) */
+    for (step = 0;; step++) {
+        MPIR_Assert(step <= nranks);    /* actually, should not need more steps than log_k(nranks) */
 
         /* desired rank found */
         if (lrank == current_rank)
@@ -115,7 +115,7 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
 
         /* check if rank lies in this range */
         for (j = 1; j < k; j++) {
-            if (lrank >= running_rank && lrank < running_rank + MPL_ipow(k, maxtime - time - 1)) {
+            if (lrank >= running_rank && lrank < running_rank + MPL_ipow(k, maxstep - step - 1)) {
                 /* move to the corresponding subtree */
                 parent = current_rank;
                 current_rank = running_rank;
@@ -123,7 +123,7 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
                 break;
             }
 
-            running_rank += MPL_ipow(k, maxtime - time - 1);
+            running_rank += MPL_ipow(k, maxstep - step - 1);
         }
     }
 
@@ -138,7 +138,7 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST, "parent of rank %d is %d, total ranks = %d (root=%d)", rank,
                      ct->parent, nranks, root));
-    for (i = time; i < maxtime; i++) {
+    for (i = step; i < maxstep; i++) {
         for (j = 1; j < k; j++) {
             if (crank < nranks) {
                 MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
@@ -148,7 +148,7 @@ int MPII_Treeutil_tree_knomial_1_init(int rank, int nranks, int k, int root,
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
             }
-            crank += MPL_ipow(k, maxtime - i - 1);
+            crank += MPL_ipow(k, maxstep - i - 1);
         }
     }
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -40,7 +40,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     size_t sendtype_true_extent, recvtype_true_extent;
 
     int delta = 1;
-    int index = 0;
+    int i_recv = 0;
     int *recv_id = NULL;
     void *tmp_recvbuf = NULL;
 
@@ -131,7 +131,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
             }
 
             /* Receive at the exact location. */
-            recv_id[index++] =
+            recv_id[i_recv++] =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                      count, recvtype, src, tag, comm, sched, 0, NULL);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -25,8 +25,6 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     int i, src, dst, copy_dst;
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *rbuf, *sbuf;
-    int vtcs[3], send_id[3], recv_id[3], dtcopy_id[3];
-    int nvtcs;
 
     int size = MPIR_Comm_size(comm);
     int rank = MPIR_Comm_rank(comm);
@@ -61,6 +59,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     buf1 = MPIR_TSP_sched_malloc(recvcount * recvtype_extent, sched);
     buf2 = MPIR_TSP_sched_malloc(recvcount * recvtype_extent, sched);
 
+    int dtcopy_id[3];
     if (is_inplace) {
         /* Copy data to buf1 from sendbuf or recvbuf(in case of inplace) */
         dtcopy_id[0] =
@@ -90,38 +89,43 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     rbuf = buf2;
 
     /* Ranks pass around the data (size - 1) times */
+    int send_id[3];
+    int recv_id[3] = { };       /* warning fix: icc: maybe used before set */
     for (i = 0; i < size - 1; i++) {
         /* Get new tag for each cycle so that the send-recv pairs are matched correctly */
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
+        int vtcs[3], nvtcs;
         if (i == 0) {
             nvtcs = 1;
             vtcs[0] = dtcopy_id[0];
+            send_id[0] = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
+                                              dst, tag, comm, sched, nvtcs, vtcs);
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                            (MPL_DBG_FDEST, "posting recv at address=%p, count=%d", rbuf,
+                             size * recvcount));
+            nvtcs = 0;
         } else {
             nvtcs = 2;
             vtcs[0] = recv_id[(i - 1) % 3];
             vtcs[1] = send_id[(i - 1) % 3];
-        }
-
-        send_id[i % 3] = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
-                                              dst, tag, comm, sched, nvtcs, vtcs);
-        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "posting recv at address=%p, count=%d", rbuf,
-                         size * recvcount));
-
-        if (i == 0)
-            nvtcs = 0;
-        else if (i == 1) {
-            nvtcs = 2;
-            vtcs[0] = send_id[(i - 1) % 3];
-            vtcs[1] = recv_id[(i - 1) % 3];
-        } else {
-            nvtcs = 3;
-            vtcs[0] = send_id[(i - 1) % 3];
-            vtcs[1] = dtcopy_id[(i - 2) % 3];
-            vtcs[2] = recv_id[(i - 1) % 3];
+            send_id[i % 3] = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
+                                                  dst, tag, comm, sched, nvtcs, vtcs);
+            MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
+                            (MPL_DBG_FDEST, "posting recv at address=%p, count=%d", rbuf,
+                             size * recvcount));
+            if (i == 1) {
+                nvtcs = 2;
+                vtcs[0] = send_id[0];
+                vtcs[1] = recv_id[0];
+            } else {
+                nvtcs = 3;
+                vtcs[0] = send_id[(i - 1) % 3];
+                vtcs[1] = dtcopy_id[(i - 2) % 3];
+                vtcs[2] = recv_id[(i - 1) % 3];
+            }
         }
 
         recv_id[i % 3] = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -28,7 +28,6 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int i, src, dst;
     int nranks, is_inplace, rank;
-    int nvtcs, vtcs[3], send_id[3], recv_id[3], dtcopy_id[3];
     int send_rank, recv_rank;
     void *data_buf, *buf1, *buf2, *sbuf, *rbuf;
     int max_count;
@@ -64,6 +63,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
     buf2 = MPIR_TSP_sched_malloc(max_count * extent, sched);
 
     /* Phase 1: copy data to buf1 from sendbuf or recvbuf(in case of inplace) */
+    int dtcopy_id[3];
     if (is_inplace) {
         dtcopy_id[0] =
             MPIR_TSP_sched_localcopy((char *) data_buf + displs[rank] * extent, sendcount, sendtype,
@@ -85,6 +85,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
     sbuf = buf1;
     rbuf = buf2;
 
+    int send_id[3];
+    int recv_id[3] = { };       /* warning fix: icc: maybe used before set */
     for (i = 0; i < nranks - 1; i++) {
         recv_rank = (rank - i - 1 + nranks) % nranks;   /* Rank whose data you're receiving */
         send_rank = (rank - i + nranks) % nranks;       /* Rank whose data you're sending */
@@ -94,31 +96,35 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
+        int nvtcs, vtcs[3];
         if (i == 0) {
             nvtcs = 1;
             vtcs[0] = dtcopy_id[0];
+
+            send_id[i % 3] =
+                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
+                                     nvtcs, vtcs);
+
+            nvtcs = 0;
         } else {
             nvtcs = 2;
             vtcs[0] = recv_id[(i - 1) % 3];
             vtcs[1] = send_id[(i - 1) % 3];
-        }
 
-        send_id[i % 3] =
-            MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
-                                 nvtcs, vtcs);
+            send_id[i % 3] =
+                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
+                                     nvtcs, vtcs);
 
-
-        if (i == 0) {
-            nvtcs = 0;
-        } else if (i == 1) {
-            nvtcs = 2;
-            vtcs[0] = send_id[(i - 1) % 3];
-            vtcs[1] = recv_id[(i - 1) % 3];
-        } else {
-            nvtcs = 3;
-            vtcs[0] = send_id[(i - 1) % 3];
-            vtcs[1] = dtcopy_id[(i - 2) % 3];
-            vtcs[2] = recv_id[(i - 1) % 3];
+            if (i == 1) {
+                nvtcs = 2;
+                vtcs[0] = send_id[0];
+                vtcs[1] = recv_id[0];
+            } else {
+                nvtcs = 3;
+                vtcs[0] = send_id[(i - 1) % 3];
+                vtcs[1] = dtcopy_id[(i - 2) % 3];
+                vtcs[2] = recv_id[(i - 1) % 3];
+            }
         }
 
         recv_id[i % 3] =

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -37,7 +37,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
     void **child_buffer;        /* Buffer array in which data from children is received */
     void *reduce_buffer;        /* Buffer in which allreduced data is present */
     int *vtcs = NULL, *recv_id = NULL, *reduce_id = NULL;       /* Arrays to store graph vertex ids */
-    int sink_id, bcast_recv_id;
+    int sink_id;
     int nvtcs;
     int buffer_per_child = MPIR_CVAR_IALLREDUCE_TREE_BUFFER_PER_CHILD;
     int tag;
@@ -100,6 +100,9 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
                 child_buffer[i] = child_buffer[0];
             }
         }
+    } else {
+        /* silence warnings */
+        child_buffer = NULL;
     }
 
     /* Set reduce_buffer based on location in the tree */
@@ -195,6 +198,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
         sink_id = MPIR_TSP_sched_sink(sched);
 
         /* Receive message from parent */
+        int bcast_recv_id = sink_id;
         if (my_tree.parent != -1) {
             bcast_recv_id =
                 MPIR_TSP_sched_irecv(reduce_address, msgsize, datatype,
@@ -204,11 +208,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
         if (num_children) {
             /* Multicast data to the children */
             nvtcs = 1;
-            if (my_tree.parent != -1) {
-                vtcs[0] = bcast_recv_id;
-            } else {
-                vtcs[0] = sink_id;
-            }
+            vtcs[0] = bcast_recv_id;
             MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
                                   my_tree.children, num_children, tag, comm, sched, nvtcs, vtcs);
         }

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -25,7 +25,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
 {
     int mpi_errno = MPI_SUCCESS;
     int src, dst;
-    int i, j, ww, index = 0;
+    int i, j, ww;
     int invtcs;
     int tag;
     int *vtcs, *recv_id, *send_id;
@@ -84,14 +84,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
 
     /* Post more send/recv pairs as the previous ones finish */
     for (i = bblock; i < size; i += batch_size) {
+        int i_vtcs = 0;
         ww = MPL_MIN(size - i, batch_size);
-        index = 0;
         /* Add dependency to ensure not to run until previous block the batch portion
          * is finished -- effectively limiting the on-going tasks to bblock
          */
         for (j = 0; j < ww; j++) {
-            vtcs[index++] = recv_id[(i + j) % bblock];
-            vtcs[index++] = send_id[(i + j) % bblock];
+            vtcs[i_vtcs++] = recv_id[(i + j) % bblock];
+            vtcs[i_vtcs++] = send_id[(i + j) % bblock];
         }
         invtcs = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs);
         for (j = 0; j < ww; j++) {

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -26,9 +26,8 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     MPI_Aint lb;
     int nranks, rank;
     int is_commutative;
-    int mask, dtcopy_id, send_id, recv_id, reduce_id, recv_reduce = -1;
+    int mask, recv_reduce = -1;
     int dst, loop_count;
-    int nvtcs, vtcs[2];
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
     int tag = 0;
@@ -56,6 +55,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
 
     partial_scan = MPIR_TSP_sched_malloc(count * extent, sched);
 
+    int dtcopy_id;
     if (sendbuf != MPI_IN_PLACE) {
         /* Since this is an inclusive scan, copy local contribution into
          * recvbuf. */
@@ -73,9 +73,13 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     mask = 0x1;
     loop_count = 0;
 
+    int send_id, recv_id;
+    int reduce_id = 0;          /* warning fix: icc: maybe used before set */
     while (mask < nranks) {
         dst = rank ^ mask;
         if (dst < nranks) {
+            int nvtcs, vtcs[2];
+
             /* Send partial_scan to dst. Recv into tmp_buf */
             nvtcs = 1;
             vtcs[0] = (loop_count == 0) ? dtcopy_id : reduce_id;

--- a/src/mpi/init/abort.c
+++ b/src/mpi/init/abort.c
@@ -71,8 +71,6 @@ int MPI_Abort(MPI_Comm comm, int errorcode)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *comm_ptr = NULL;
-    /* FIXME: 100 is arbitrary and may not be long enough */
-    char abort_str[100] = "", comm_name[MPI_MAX_OBJECT_NAME];
     int len = MPI_MAX_OBJECT_NAME;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_ABORT);
 
@@ -121,15 +119,17 @@ int MPI_Abort(MPI_Comm comm, int errorcode)
         comm_ptr = MPIR_Process.comm_self;
     }
 
-
+    char abort_str[MPI_MAX_OBJECT_NAME + 100] = "";
+    char comm_name[MPI_MAX_OBJECT_NAME];
     MPIR_Comm_get_name_impl(comm_ptr, comm_name, &len);
     if (len == 0) {
         MPL_snprintf(comm_name, MPI_MAX_OBJECT_NAME, "comm=0x%X", comm);
     }
     if (!MPIR_CVAR_SUPPRESS_ABORT_MESSAGE)
         /* FIXME: This is not internationalized */
-        MPL_snprintf(abort_str, 100, "application called MPI_Abort(%s, %d) - process %d", comm_name,
-                     errorcode, comm_ptr->rank);
+        MPL_snprintf(abort_str, sizeof(abort_str),
+                     "application called MPI_Abort(%s, %d) - process %d", comm_name, errorcode,
+                     comm_ptr->rank);
     mpi_errno = MPID_Abort(comm_ptr, mpi_errno, errorcode, abort_str);
     /* --BEGIN ERROR HANDLING-- */
     if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi_t/enum_get_item.c
+++ b/src/mpi_t/enum_get_item.c
@@ -36,7 +36,7 @@ Input Parameters:
 . enumtype - enumeration to be queried (handle)
 
 Output Parameters:
-+ index - number of the value to be queried in this enumeration (integer)
++ indx - number of the value to be queried in this enumeration (integer)
 . value - variable value (integer)
 - name - buffer to return the string containing the name of the enumeration item (string)
 
@@ -48,7 +48,7 @@ Output Parameters:
 .N MPI_T_ERR_INVALID_HANDLE
 .N MPI_T_ERR_INVALID_ITEM
 @*/
-int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name, int *name_len)
+int MPI_T_enum_get_item(MPI_T_enum enumtype, int indx, int *value, char *name, int *name_len)
 {
     int mpi_errno = MPI_SUCCESS;
     enum_item_t *item;
@@ -64,7 +64,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name, 
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_ENUM_HANDLE(enumtype, mpi_errno);
-            MPIR_ERRTEST_ENUM_ITEM(enumtype, index, mpi_errno);
+            MPIR_ERRTEST_ENUM_ITEM(enumtype, indx, mpi_errno);
             MPIR_ERRTEST_ARGNULL(value, "value", mpi_errno);
             /* Do not do TEST_ARGNULL for name or name_len, since this is
              * permitted per MPI_T standard.
@@ -76,7 +76,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name, 
 
     /* ... body of routine ...  */
 
-    item = (enum_item_t *) utarray_eltptr(enumtype->items, index);
+    item = (enum_item_t *) utarray_eltptr(enumtype->items, indx);
     *value = item->value;
     MPIR_T_strncpy(name, item->name, name_len);
 
@@ -96,7 +96,7 @@ int MPI_T_enum_get_item(MPI_T_enum enumtype, int index, int *value, char *name, 
         mpi_errno =
             MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
                                  "**mpi_t_enum_get_item", "**mpi_t_enum_get_item %p %d %p %p %p",
-                                 enumtype, index, value, name, name_len);
+                                 enumtype, indx, value, name, name_len);
     }
     mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
     goto fn_exit;

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -1106,7 +1106,7 @@ int MPID_nem_tcp_ckpt_cleanup(void)
 static int state_tc_c_cnting_handler(struct pollfd *const plfd, sockconn_t * const sc)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPID_NEM_TCP_SOCK_STATUS_t status;
+    int status;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_STATE_TC_C_CNTING_HANDLER);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_STATE_TC_C_CNTING_HANDLER);
@@ -1292,7 +1292,7 @@ static int state_c_tmpvcsent_handler(struct pollfd *const plfd, sockconn_t * con
 static int state_l_cntd_handler(struct pollfd *const plfd, sockconn_t * const sc)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPID_NEM_TCP_SOCK_STATUS_t status;
+    int status;
     int got_sc_eof = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_STATE_L_CNTD_HANDLER);
 
@@ -1378,7 +1378,7 @@ static int state_l_rankrcvd_handler(struct pollfd *const plfd, sockconn_t * cons
     MPIDI_VC_t *const sc_vc = sc->vc;
     MPID_nem_tcp_vc_area *const sc_vc_tcp = VC_TCP(sc_vc);
     int mpi_errno = MPI_SUCCESS;
-    MPID_NEM_TCP_SOCK_STATUS_t status;
+    int status;
     sockconn_t *fnd_sc = NULL;
     int snd_nak = FALSE;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_STATE_L_RANKRCVD_HANDLER);
@@ -1453,7 +1453,7 @@ static int state_l_tmpvcrcvd_handler(struct pollfd *const plfd, sockconn_t * con
     MPIDI_VC_t *const sc_vc = sc->vc;
     MPID_nem_tcp_vc_area *const sc_vc_tcp = VC_TCP(sc_vc);
     int mpi_errno = MPI_SUCCESS;
-    MPID_NEM_TCP_SOCK_STATUS_t status;
+    int status;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_STATE_L_TMPVCRCVD_HANDLER);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_STATE_L_TMPVCRCVD_HANDLER);

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_impl.h
@@ -81,7 +81,7 @@ int MPID_nem_tcp_connpoll(int in_blocking_poll);
 int MPID_nem_tcp_sm_init(void);
 int MPID_nem_tcp_sm_finalize(void);
 int MPID_nem_tcp_set_sockopts(int fd);
-MPID_NEM_TCP_SOCK_STATUS_t MPID_nem_tcp_check_sock_status(const struct pollfd *const plfd);
+int MPID_nem_tcp_check_sock_status(const struct pollfd *const plfd);
 int MPID_nem_tcp_send_finalize(void);
 int MPID_nem_tcp_bind(int sockfd);
 int MPID_nem_tcp_conn_est(MPIDI_VC_t * vc);

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
@@ -123,7 +123,7 @@ FIXME : Above comments are inconsistent now with the changes. No check for EOF i
 actually done now in this function.
 */
 
-MPID_NEM_TCP_SOCK_STATUS_t MPID_nem_tcp_check_sock_status(const struct pollfd *const plfd)
+int MPID_nem_tcp_check_sock_status(const struct pollfd *const plfd)
 {
     int rc = MPID_NEM_TCP_SOCK_NOEVENT;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
@@ -473,7 +473,7 @@ static int lmt_shm_send_progress(MPIDI_VC_t *vc, MPIR_Request *req, int *done)
         last = (data_sz - first <= copy_limit) ? data_sz : first + copy_limit;
 	MPIR_Segment_pack(req->dev.segment_ptr, first, &last, (void *)copy_buf->buf[buf_num]); /* cast away volatile */
         OPA_write_barrier();
-        MPIR_Assign_trunc(copy_buf->len[buf_num].val, (last - first), volatile int);
+        MPIR_Assign_trunc(copy_buf->len[buf_num].val, (last - first), int);
 
         first = last;
         buf_num = (buf_num+1) % NUM_BUFS;

--- a/src/mpid/ch3/channels/sock/src/ch3_init.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_init.c
@@ -80,14 +80,12 @@ int MPIDI_CH3_VC_Init(MPIDI_VC_t * vc)
     return 0;
 }
 
+#ifdef MPL_USE_DBG_LOGGING
 const char *MPIDI_CH3_VC_GetStateString(struct MPIDI_VC *vc)
 {
-#ifdef MPL_USE_DBG_LOGGING
     return MPIDI_CH3_VC_SockGetStateString(vc);
-#else
-    return "unknown";
-#endif
 }
+#endif
 
 /* Select the routine that uses sockets to connect two communicators
    using a socket */

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -2183,6 +2183,8 @@ int MPIDI_CH3I_Sock_post_close(struct MPIDI_CH3I_Sock *sock)
     if (pollinfo->type == MPIDI_CH3I_SOCKI_TYPE_COMMUNICATION) {
         if (MPIDI_CH3I_SOCKI_POLLFD_OP_ISSET(pollfd, pollinfo, POLLIN | POLLOUT)) {
             /* --BEGIN ERROR HANDLING-- */
+            /* comment out unused code. FIXME: understand original intention, then delete. */
+            /*
             int event_mpi_errno;
 
             event_mpi_errno =
@@ -2190,6 +2192,7 @@ int MPIDI_CH3I_Sock_post_close(struct MPIDI_CH3I_Sock *sock)
                                      MPIDI_CH3I_SOCK_ERR_SOCK_CLOSED, "**sock|close_cancel",
                                      "**sock|close_cancel %d %d", pollinfo->sock_set->id,
                                      pollinfo->sock_id);
+            */
 
             if (MPIDI_CH3I_SOCKI_POLLFD_OP_ISSET(pollfd, pollinfo, POLLIN)) {
                 MPIDI_CH3I_SOCKI_EVENT_ENQUEUE(pollinfo, MPIDI_CH3I_SOCK_OP_READ, pollinfo->read_nb,
@@ -2664,7 +2667,6 @@ int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size
 
 int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t * num_written)
 {
-    struct pollfd *pollfd;
     struct pollinfo *pollinfo;
     ssize_t nb;
     int mpi_errno = MPI_SUCCESS;
@@ -2676,12 +2678,15 @@ int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t 
     MPIDI_CH3I_SOCKI_VERIFY_INIT(mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VALIDATE_SOCK(sock, mpi_errno, fn_exit);
 
-    pollfd = MPIDI_CH3I_Socki_sock_get_pollfd(sock);
     pollinfo = MPIDI_CH3I_Socki_sock_get_pollinfo(sock);
 
+#ifdef USE_SOCK_VERIFY  /* necessary for -Wunused-but-set-variable */
+    struct pollfd *pollfd;
+    pollfd = MPIDI_CH3I_Socki_sock_get_pollfd(sock);
     MPIDI_CH3I_SOCKI_VERIFY_CONNECTED_WRITABLE(pollinfo, mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VALIDATE_FD(pollinfo, mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VERIFY_NO_POSTED_WRITE(pollfd, pollinfo, mpi_errno, fn_exit);
+#endif
 
     /* FIXME: multiple passes should be made if len > SSIZE_MAX and nb == SSIZE_MAX */
     if (len > SSIZE_MAX) {
@@ -2738,7 +2743,6 @@ int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t 
 
 int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size_t * num_written)
 {
-    struct pollfd *pollfd;
     struct pollinfo *pollinfo;
     ssize_t nb;
     int mpi_errno = MPI_SUCCESS;
@@ -2750,12 +2754,15 @@ int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, siz
     MPIDI_CH3I_SOCKI_VERIFY_INIT(mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VALIDATE_SOCK(sock, mpi_errno, fn_exit);
 
-    pollfd = MPIDI_CH3I_Socki_sock_get_pollfd(sock);
     pollinfo = MPIDI_CH3I_Socki_sock_get_pollinfo(sock);
 
+#ifdef USE_SOCK_VERIFY 
+    struct pollfd *pollfd;
+    pollfd = MPIDI_CH3I_Socki_sock_get_pollfd(sock);
     MPIDI_CH3I_SOCKI_VALIDATE_FD(pollinfo, mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VERIFY_CONNECTED_WRITABLE(pollinfo, mpi_errno, fn_exit);
     MPIDI_CH3I_SOCKI_VERIFY_NO_POSTED_WRITE(pollfd, pollinfo, mpi_errno, fn_exit);
+#endif
 
     /*
      * FIXME: The IEEE 1003.1 standard says that if the sum of the iov_len
@@ -3276,7 +3283,6 @@ int MPIDI_CH3I_Sock_wait(struct MPIDI_CH3I_Sock_set *sock_set, int millisecond_t
 
                     if (n_fds == 0 && millisecond_timeout != 0) {
                         int pollfds_active_elems = sock_set->poll_array_elems;
-                        int err;
 
                         /* The abstraction here is a shared (blocking) resource that
                          * the threads must coordinate.  That means not holding

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -2183,17 +2183,6 @@ int MPIDI_CH3I_Sock_post_close(struct MPIDI_CH3I_Sock *sock)
     if (pollinfo->type == MPIDI_CH3I_SOCKI_TYPE_COMMUNICATION) {
         if (MPIDI_CH3I_SOCKI_POLLFD_OP_ISSET(pollfd, pollinfo, POLLIN | POLLOUT)) {
             /* --BEGIN ERROR HANDLING-- */
-            /* comment out unused code. FIXME: understand original intention, then delete. */
-            /*
-            int event_mpi_errno;
-
-            event_mpi_errno =
-                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                     MPIDI_CH3I_SOCK_ERR_SOCK_CLOSED, "**sock|close_cancel",
-                                     "**sock|close_cancel %d %d", pollinfo->sock_set->id,
-                                     pollinfo->sock_id);
-            */
-
             if (MPIDI_CH3I_SOCKI_POLLFD_OP_ISSET(pollfd, pollinfo, POLLIN)) {
                 MPIDI_CH3I_SOCKI_EVENT_ENQUEUE(pollinfo, MPIDI_CH3I_SOCK_OP_READ, pollinfo->read_nb,
                                                pollinfo->user_ptr, MPI_SUCCESS, mpi_errno, fn_exit);

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -60,7 +60,7 @@ static inline int immed_copy(void *src, void *dest, size_t len)
 /* =========================================================== */
 
 /* Set extended header for ACC operation and return its real size. */
-static int init_stream_dtype_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
+static int init_stream_dtype_ext_pkt(int pkt_flags,
                               MPIR_Datatype* target_dtp, intptr_t stream_offset,
                               void **ext_hdr_ptr, MPI_Aint * ext_hdr_sz, int *flattened_type_size)
 {
@@ -80,7 +80,7 @@ static int init_stream_dtype_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
      *  2. Flattened datatype: if the target is a derived datatype.
      */
 
-    if ((flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM))
+    if ((pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM))
         stream_hdr_sz = sizeof(MPIDI_CH3_Ext_pkt_stream_t);
     else
         stream_hdr_sz = 0;
@@ -103,7 +103,7 @@ static int init_stream_dtype_ext_pkt(MPIDI_CH3_Pkt_flags_t flags,
         total_hdr = NULL;
     }
 
-    if ((flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM)) {
+    if ((pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM)) {
         ((MPIDI_CH3_Ext_pkt_stream_t *) total_hdr)->stream_offset = stream_offset;
     }
     if (target_dtp != NULL) {
@@ -142,7 +142,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     int iovcnt = 0;
     MPIR_Request *req = NULL;
     MPI_Aint dt_true_lb;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     int is_empty_origin = FALSE;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_ISSUE_FROM_ORIGIN_BUFFER);
@@ -184,8 +184,8 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
     iov[iovcnt].MPL_IOV_LEN = sizeof(rma_op->pkt);
     iovcnt++;
 
-    MPIDI_CH3_PKT_RMA_GET_FLAGS(rma_op->pkt, flags, mpi_errno);
-    if (!(flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) && target_dtp == NULL && is_origin_contig) {
+    MPIDI_CH3_PKT_RMA_GET_FLAGS(rma_op->pkt, pkt_flags, mpi_errno);
+    if (!(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) && target_dtp == NULL && is_origin_contig) {
         /* Fast path --- use iStartMsgv() to issue the data, which does not need a request
          * to be passed in:
          * (1) non-streamed op (do not need to send extended packet header);
@@ -302,7 +302,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
 
 /* issue_put_op() issues PUT packet header and data. */
 static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
-                        MPIDI_RMA_Target_t * target_ptr, MPIDI_CH3_Pkt_flags_t flags)
+                        MPIDI_RMA_Target_t * target_ptr, int pkt_flags)
 {
     MPIDI_VC_t *vc = NULL;
     MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
@@ -315,7 +315,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
     MPIR_FUNC_VERBOSE_RMA_ENTER(MPID_STATE_ISSUE_PUT_OP);
 
-    put_pkt->flags |= flags;
+    put_pkt->pkt_flags |= pkt_flags;
 
     MPIDI_Comm_get_vc_set_active(comm_ptr, rma_op->target_rank, &vc);
 
@@ -376,7 +376,7 @@ static int issue_put_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
 /* issue_acc_op() send ACC packet header and data. */
 static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
-                        MPIDI_RMA_Target_t * target_ptr, MPIDI_CH3_Pkt_flags_t flags)
+                        MPIDI_RMA_Target_t * target_ptr, int pkt_flags)
 {
     MPIDI_VC_t *vc = NULL;
     MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
@@ -400,7 +400,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     if (rma_op->pkt.type == MPIDI_CH3_PKT_ACCUMULATE_IMMED) {
         MPIR_Request *curr_req = NULL;
 
-        accum_pkt->flags |= flags;
+        accum_pkt->pkt_flags |= pkt_flags;
 
         /* All origin data is in packet header, issue the header. */
         MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
@@ -445,7 +445,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     /* If there are more than one stream unit, mark the current packet
      * as stream packet */
     if (stream_unit_count > 1)
-        flags |= MPIDI_CH3_PKT_FLAG_RMA_STREAM;
+        pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_STREAM;
 
     /* Get target datatype */
     if (!MPIR_DATATYPE_IS_PREDEFINED(accum_pkt->datatype))
@@ -460,16 +460,16 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         if (j < rma_op->issued_stream_count)
             continue;
 
-        accum_pkt->flags |= flags;
+        accum_pkt->pkt_flags |= pkt_flags;
 
         if (j != 0) {
-            accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
-            accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
+            accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
+            accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
         }
         if (j != stream_unit_count - 1) {
-            accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_UNLOCK;
-            accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_FLUSH;
-            accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER;
+            accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_UNLOCK;
+            accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_FLUSH;
+            accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER;
         }
 
         stream_offset = j * stream_elem_count * predefined_dtp_size;
@@ -477,7 +477,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_stream_dtype_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+        init_stream_dtype_ext_pkt(pkt_flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
                            &accum_pkt->info.flattened_type_size);
 
         mpi_errno = issue_from_origin_buffer(rma_op, vc, ext_hdr_ptr, ext_hdr_sz,
@@ -506,8 +506,8 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
         rma_op->issued_stream_count++;
 
-        if (accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
+        if (accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
             /* if piggybacked with LOCK flag, we
              * only issue the first streaming unit */
             MPIR_Assert(j == 0);
@@ -538,7 +538,7 @@ static int issue_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
 /* issue_get_acc_op() send GACC packet header and data. */
 static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
-                            MPIDI_RMA_Target_t * target_ptr, MPIDI_CH3_Pkt_flags_t flags)
+                            MPIDI_RMA_Target_t * target_ptr, int pkt_flags)
 {
     MPIDI_VC_t *vc = NULL;
     MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
@@ -562,7 +562,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         MPIR_Request *resp_req = NULL;
         MPIR_Request *curr_req = NULL;
 
-        get_accum_pkt->flags |= flags;
+        get_accum_pkt->pkt_flags |= pkt_flags;
 
         rma_op->reqs_size = 1;
 
@@ -626,7 +626,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
     /* If there are more than one stream unit, mark the current packet
      * as stream packet */
     if (stream_unit_count > 1)
-        flags |= MPIDI_CH3_PKT_FLAG_RMA_STREAM;
+        pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_STREAM;
 
     rest_len = total_len;
 
@@ -649,16 +649,16 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         if (j < rma_op->issued_stream_count)
             continue;
 
-        get_accum_pkt->flags |= flags;
+        get_accum_pkt->pkt_flags |= pkt_flags;
 
         if (j != 0) {
-            get_accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
-            get_accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
+            get_accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
+            get_accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
         }
         if (j != stream_unit_count - 1) {
-            get_accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_UNLOCK;
-            get_accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_FLUSH;
-            get_accum_pkt->flags &= ~MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER;
+            get_accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_UNLOCK;
+            get_accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_FLUSH;
+            get_accum_pkt->pkt_flags &= ~MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER;
         }
 
         /* Create a request for the GACC response.  Store the response buf, count, and
@@ -674,7 +674,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         resp_req->dev.datatype = rma_op->result_datatype;
         resp_req->dev.target_win_handle = MPI_WIN_NULL;
         resp_req->dev.source_win_handle = win_ptr->handle;
-        resp_req->dev.flags = flags;
+        resp_req->dev.pkt_flags = pkt_flags;
 
         if (!MPIR_DATATYPE_IS_PREDEFINED(resp_req->dev.datatype)) {
             MPIR_Datatype*result_dtp = NULL;
@@ -692,7 +692,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         rest_len -= stream_size;
 
         /* Set extended packet header if needed. */
-        init_stream_dtype_ext_pkt(flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
+        init_stream_dtype_ext_pkt(pkt_flags, target_dtp_ptr, stream_offset, &ext_hdr_ptr, &ext_hdr_sz,
                            &get_accum_pkt->info.flattened_type_size);
 
         /* Note: here we need to allocate an extended packet header in response request,
@@ -701,7 +701,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
          * other information. */
         {
             int dummy;
-            init_stream_dtype_ext_pkt(flags, NULL /* target_dtp_ptr */ , stream_offset,
+            init_stream_dtype_ext_pkt(pkt_flags, NULL /* target_dtp_ptr */ , stream_offset,
                                       &(resp_req->dev.ext_hdr_ptr), &(resp_req->dev.ext_hdr_sz),
                                       &dummy);
         }
@@ -722,8 +722,8 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
         rma_op->issued_stream_count++;
 
-        if (get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
+        if (get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
             /* if piggybacked with LOCK flag, we
              * only issue the first streaming unit */
             MPIR_Assert(j == 0);
@@ -770,7 +770,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
 
 static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
-                        MPIDI_RMA_Target_t * target_ptr, MPIDI_CH3_Pkt_flags_t flags)
+                        MPIDI_RMA_Target_t * target_ptr, int pkt_flags)
 {
     MPIDI_CH3_Pkt_get_t *get_pkt = &rma_op->pkt.get;
     int mpi_errno = MPI_SUCCESS;
@@ -812,7 +812,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
     get_pkt->request_handle = curr_req->handle;
 
-    get_pkt->flags |= flags;
+    get_pkt->pkt_flags |= pkt_flags;
 
     comm_ptr = win_ptr->comm_ptr;
     MPIDI_Comm_get_vc_set_active(comm_ptr, rma_op->target_rank, &vc);
@@ -889,7 +889,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
 
 static int issue_cas_op(MPIDI_RMA_Op_t * rma_op,
                         MPIR_Win * win_ptr, MPIDI_RMA_Target_t * target_ptr,
-                        MPIDI_CH3_Pkt_flags_t flags)
+                        int pkt_flags)
 {
     MPIDI_VC_t *vc = NULL;
     MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
@@ -920,7 +920,7 @@ static int issue_cas_op(MPIDI_RMA_Op_t * rma_op,
     curr_req->dev.source_win_handle = win_ptr->handle;
 
     cas_pkt->request_handle = curr_req->handle;
-    cas_pkt->flags |= flags;
+    cas_pkt->pkt_flags |= pkt_flags;
 
     MPIDI_Comm_get_vc_set_active(comm_ptr, rma_op->target_rank, &vc);
     MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
@@ -948,7 +948,7 @@ static int issue_cas_op(MPIDI_RMA_Op_t * rma_op,
 
 static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
                         MPIR_Win * win_ptr, MPIDI_RMA_Target_t * target_ptr,
-                        MPIDI_CH3_Pkt_flags_t flags)
+                        int pkt_flags)
 {
     MPIDI_VC_t *vc = NULL;
     MPIR_Comm *comm_ptr = win_ptr->comm_ptr;
@@ -977,7 +977,7 @@ static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
 
     fop_pkt->request_handle = resp_req->handle;
 
-    fop_pkt->flags |= flags;
+    fop_pkt->pkt_flags |= pkt_flags;
 
     MPIDI_Comm_get_vc_set_active(comm_ptr, rma_op->target_rank, &vc);
 
@@ -1018,7 +1018,7 @@ static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
 /* issue_rma_op() is called by ch3u_rma_progress.c, it triggers
    proper issuing functions according to packet type. */
 static inline int issue_rma_op(MPIDI_RMA_Op_t * op_ptr, MPIR_Win * win_ptr,
-                               MPIDI_RMA_Target_t * target_ptr, MPIDI_CH3_Pkt_flags_t flags)
+                               MPIDI_RMA_Target_t * target_ptr, int pkt_flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_ISSUE_RMA_OP);
@@ -1028,25 +1028,25 @@ static inline int issue_rma_op(MPIDI_RMA_Op_t * op_ptr, MPIR_Win * win_ptr,
     switch (op_ptr->pkt.type) {
     case (MPIDI_CH3_PKT_PUT):
     case (MPIDI_CH3_PKT_PUT_IMMED):
-        mpi_errno = issue_put_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_put_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     case (MPIDI_CH3_PKT_ACCUMULATE):
     case (MPIDI_CH3_PKT_ACCUMULATE_IMMED):
-        mpi_errno = issue_acc_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_acc_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     case (MPIDI_CH3_PKT_GET_ACCUM):
     case (MPIDI_CH3_PKT_GET_ACCUM_IMMED):
-        mpi_errno = issue_get_acc_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_get_acc_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     case (MPIDI_CH3_PKT_GET):
-        mpi_errno = issue_get_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_get_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     case (MPIDI_CH3_PKT_CAS_IMMED):
-        mpi_errno = issue_cas_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_cas_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     case (MPIDI_CH3_PKT_FOP):
     case (MPIDI_CH3_PKT_FOP_IMMED):
-        mpi_errno = issue_fop_op(op_ptr, win_ptr, target_ptr, flags);
+        mpi_errno = issue_fop_op(op_ptr, win_ptr, target_ptr, pkt_flags);
         break;
     default:
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**winInvalidOp");

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -878,7 +878,6 @@ extern MPIDI_CH3U_SRBuf_element_t * MPIDI_CH3U_SRBuf_pool;
 #ifdef MPIDI_CH3_HAS_NO_DYNAMIC_PROCESS
 #define MPIDI_CH3_VC_GetStateString( _c ) "none"
 #else
-/* FIXME: This duplicates a value in util/sock/ch3usock.h */
 const char *MPIDI_CH3_VC_GetStateString(struct MPIDI_VC *);
 const char *MPIDI_CH3_VC_SockGetStateString(struct MPIDI_VC *);
 #endif

--- a/src/mpid/ch3/include/mpidpkt.h
+++ b/src/mpid/ch3/include/mpidpkt.h
@@ -132,7 +132,7 @@ typedef enum {
     MPIDI_CH3_PKT_INVALID = -1  /* forces a signed enum to quash warnings */
 } MPIDI_CH3_Pkt_type_t;
 
-/* These flags can be "OR'ed" together */
+/* These pkt_flags can be "OR'ed" together */
 typedef enum {
     MPIDI_CH3_PKT_FLAG_NONE = 0,
     MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED = 1,
@@ -325,7 +325,7 @@ MPIDI_CH3_PKT_DEFS
 
 #define MPIDI_CH3_PKT_RMA_GET_FLAGS(pkt_, flags_, err_)                 \
     {                                                                   \
-        /* This macro returns flags in RMA operation packets (PUT, GET, \
+        /* This macro returns pkt_flags in RMA operation packets (PUT, GET, \
            ACC, GACC, FOP, CAS), RMA operation response packets         \
            (GET_RESP, GET_ACCUM_RESP, FOP_RESP, CAS_RESP), RMA control  \
            packets (UNLOCK) and RMA control response packets (LOCK_ACK, \
@@ -334,52 +334,52 @@ MPIDI_CH3_PKT_DEFS
         switch((pkt_).type) {                                           \
         case (MPIDI_CH3_PKT_PUT):                                       \
         case (MPIDI_CH3_PKT_PUT_IMMED):                                 \
-            flags_ = (pkt_).put.flags;                                  \
+            flags_ = (pkt_).put.pkt_flags;                                  \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET):                                       \
-            flags_ = (pkt_).get.flags;                                  \
+            flags_ = (pkt_).get.pkt_flags;                                  \
             break;                                                      \
         case (MPIDI_CH3_PKT_ACCUMULATE):                                \
         case (MPIDI_CH3_PKT_ACCUMULATE_IMMED):                          \
-            flags_ = (pkt_).accum.flags;                                \
+            flags_ = (pkt_).accum.pkt_flags;                                \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_ACCUM):                                 \
         case (MPIDI_CH3_PKT_GET_ACCUM_IMMED):                           \
-            flags_ = (pkt_).get_accum.flags;                            \
+            flags_ = (pkt_).get_accum.pkt_flags;                            \
             break;                                                      \
         case (MPIDI_CH3_PKT_CAS_IMMED):                                 \
-            flags_ = (pkt_).cas.flags;                                  \
+            flags_ = (pkt_).cas.pkt_flags;                                  \
             break;                                                      \
         case (MPIDI_CH3_PKT_FOP):                                       \
         case (MPIDI_CH3_PKT_FOP_IMMED):                                 \
-            flags_ = (pkt_).fop.flags;                                  \
+            flags_ = (pkt_).fop.pkt_flags;                                  \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_RESP):                                  \
         case (MPIDI_CH3_PKT_GET_RESP_IMMED):                            \
-            flags_ = (pkt_).get_resp.flags;                             \
+            flags_ = (pkt_).get_resp.pkt_flags;                             \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_ACCUM_RESP):                            \
         case (MPIDI_CH3_PKT_GET_ACCUM_RESP_IMMED):                      \
-            flags_ = (pkt_).get_accum_resp.flags;                       \
+            flags_ = (pkt_).get_accum_resp.pkt_flags;                       \
             break;                                                      \
         case (MPIDI_CH3_PKT_FOP_RESP):                                  \
         case (MPIDI_CH3_PKT_FOP_RESP_IMMED):                            \
-            flags_ = (pkt_).fop_resp.flags;                             \
+            flags_ = (pkt_).fop_resp.pkt_flags;                             \
             break;                                                      \
         case (MPIDI_CH3_PKT_CAS_RESP_IMMED):                            \
-            flags_ = (pkt_).cas_resp.flags;                             \
+            flags_ = (pkt_).cas_resp.pkt_flags;                             \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK):                                      \
-            flags_ = (pkt_).lock.flags;                                 \
+            flags_ = (pkt_).lock.pkt_flags;                                 \
             break;                                                      \
         case (MPIDI_CH3_PKT_UNLOCK):                                    \
-            flags_ = (pkt_).unlock.flags;                               \
+            flags_ = (pkt_).unlock.pkt_flags;                               \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK_ACK):                                  \
-            flags_ = (pkt_).lock_ack.flags;                             \
+            flags_ = (pkt_).lock_ack.pkt_flags;                             \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK_OP_ACK):                               \
-            flags_ = (pkt_).lock_op_ack.flags;                          \
+            flags_ = (pkt_).lock_op_ack.pkt_flags;                          \
             break;                                                      \
         default:                                                        \
             MPIR_ERR_SETANDJUMP1(err_, MPI_ERR_OTHER, "**invalidpkt", "**invalidpkt %d", (pkt_).type); \
@@ -411,7 +411,7 @@ MPIDI_CH3_PKT_DEFS
 
 #define MPIDI_CH3_PKT_RMA_ERASE_FLAGS(pkt_, err_)                       \
     {                                                                   \
-        /* This macro erases flags in RMA operation packets (PUT, GET,  \
+        /* This macro erases pkt_flags in RMA operation packets (PUT, GET,  \
            ACC, GACC, FOP, CAS), RMA operation response packets         \
            (GET_RESP, GET_ACCUM_RESP, FOP_RESP, CAS_RESP), RMA control  \
            packets (UNLOCK) and RMA control response packets (LOCK_ACK, \
@@ -420,52 +420,52 @@ MPIDI_CH3_PKT_DEFS
         switch((pkt_).type) {                                           \
         case (MPIDI_CH3_PKT_PUT):                                       \
         case (MPIDI_CH3_PKT_PUT_IMMED):                                 \
-            (pkt_).put.flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
+            (pkt_).put.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET):                                       \
-            (pkt_).get.flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
+            (pkt_).get.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
             break;                                                      \
         case (MPIDI_CH3_PKT_ACCUMULATE):                                \
         case (MPIDI_CH3_PKT_ACCUMULATE_IMMED):                          \
-            (pkt_).accum.flags = MPIDI_CH3_PKT_FLAG_NONE;               \
+            (pkt_).accum.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;               \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_ACCUM):                                 \
         case (MPIDI_CH3_PKT_GET_ACCUM_IMMED):                           \
-            (pkt_).get_accum.flags = MPIDI_CH3_PKT_FLAG_NONE;           \
+            (pkt_).get_accum.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;           \
             break;                                                      \
         case (MPIDI_CH3_PKT_CAS_IMMED):                                 \
-            (pkt_).cas.flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
+            (pkt_).cas.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
             break;                                                      \
         case (MPIDI_CH3_PKT_FOP):                                       \
         case (MPIDI_CH3_PKT_FOP_IMMED):                                 \
-            (pkt_).fop.flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
+            (pkt_).fop.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;                 \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_RESP):                                  \
         case (MPIDI_CH3_PKT_GET_RESP_IMMED):                            \
-            (pkt_).get_resp.flags = MPIDI_CH3_PKT_FLAG_NONE;            \
+            (pkt_).get_resp.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;            \
             break;                                                      \
         case (MPIDI_CH3_PKT_GET_ACCUM_RESP):                            \
         case (MPIDI_CH3_PKT_GET_ACCUM_RESP_IMMED):                      \
-            (pkt_).get_accum_resp.flags = MPIDI_CH3_PKT_FLAG_NONE;      \
+            (pkt_).get_accum_resp.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;      \
             break;                                                      \
         case (MPIDI_CH3_PKT_FOP_RESP):                                  \
         case (MPIDI_CH3_PKT_FOP_RESP_IMMED):                            \
-            (pkt_).fop_resp.flags = MPIDI_CH3_PKT_FLAG_NONE;            \
+            (pkt_).fop_resp.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;            \
             break;                                                      \
         case (MPIDI_CH3_PKT_CAS_RESP_IMMED):                            \
-            (pkt_).cas_resp.flags = MPIDI_CH3_PKT_FLAG_NONE;            \
+            (pkt_).cas_resp.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;            \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK):                                      \
-            (pkt_).lock.flags = MPIDI_CH3_PKT_FLAG_NONE;                \
+            (pkt_).lock.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;                \
             break;                                                      \
         case (MPIDI_CH3_PKT_UNLOCK):                                    \
-            (pkt_).unlock.flags = MPIDI_CH3_PKT_FLAG_NONE;              \
+            (pkt_).unlock.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;              \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK_ACK):                                  \
-            (pkt_).lock_ack.flags = MPIDI_CH3_PKT_FLAG_NONE;            \
+            (pkt_).lock_ack.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;            \
             break;                                                      \
         case (MPIDI_CH3_PKT_LOCK_OP_ACK):                               \
-            (pkt_).lock_op_ack.flags = MPIDI_CH3_PKT_FLAG_NONE;         \
+            (pkt_).lock_op_ack.pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;         \
             break;                                                      \
         default:                                                        \
             MPIR_ERR_SETANDJUMP1(err_, MPI_ERR_OTHER, "**invalidpkt", "**invalidpkt %d", (pkt_).type); \
@@ -627,7 +627,7 @@ MPIDI_CH3_PKT_DEFS
 
 typedef struct MPIDI_CH3_Pkt_put {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     void *addr;
     int count;
     MPI_Datatype datatype;
@@ -641,7 +641,7 @@ typedef struct MPIDI_CH3_Pkt_put {
 
 typedef struct MPIDI_CH3_Pkt_get {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     void *addr;
     int count;
     MPI_Datatype datatype;
@@ -657,7 +657,7 @@ typedef struct MPIDI_CH3_Pkt_get_resp {
     MPI_Request request_handle;
     /* followings are used to decrement ack_counter at origin */
     int target_rank;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     /* Followings are to piggyback IMMED data */
     struct {
         /* note that we use struct here in order
@@ -669,7 +669,7 @@ typedef struct MPIDI_CH3_Pkt_get_resp {
 
 typedef struct MPIDI_CH3_Pkt_accum {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     void *addr;
     int count;
     MPI_Datatype datatype;
@@ -684,7 +684,7 @@ typedef struct MPIDI_CH3_Pkt_accum {
 
 typedef struct MPIDI_CH3_Pkt_get_accum {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     MPI_Request request_handle; /* For get_accumulate response */
     void *addr;
     int count;
@@ -702,7 +702,7 @@ typedef struct MPIDI_CH3_Pkt_get_accum_resp {
     MPI_Request request_handle;
     /* followings are used to decrement ack_counter at origin */
     int target_rank;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     /* Followings are to piggyback IMMED data */
     struct {
         /* note that we use struct here in order
@@ -714,7 +714,7 @@ typedef struct MPIDI_CH3_Pkt_get_accum_resp {
 
 typedef struct MPIDI_CH3_Pkt_cas {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     MPI_Datatype datatype;
     void *addr;
     MPI_Request request_handle;
@@ -734,12 +734,12 @@ typedef struct MPIDI_CH3_Pkt_cas_resp {
     } info;
     /* followings are used to decrement ack_counter at orign */
     int target_rank;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
 } MPIDI_CH3_Pkt_cas_resp_t;
 
 typedef struct MPIDI_CH3_Pkt_fop {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     MPI_Datatype datatype;
     void *addr;
     MPI_Op op;
@@ -764,12 +764,12 @@ typedef struct MPIDI_CH3_Pkt_fop_resp {
     } info;
     /* followings are used to decrement ack_counter at orign */
     int target_rank;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
 } MPIDI_CH3_Pkt_fop_resp_t;
 
 typedef struct MPIDI_CH3_Pkt_lock {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     MPI_Win target_win_handle;
     /* Note that either source_win_handle
      * or request_handle will be used. Here
@@ -785,7 +785,7 @@ typedef struct MPIDI_CH3_Pkt_unlock {
     MPIDI_CH3_Pkt_type_t type;
     MPI_Win target_win_handle;
     MPI_Win source_win_handle;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
 } MPIDI_CH3_Pkt_unlock_t;
 
 typedef struct MPIDI_CH3_Pkt_flush {
@@ -796,7 +796,7 @@ typedef struct MPIDI_CH3_Pkt_flush {
 
 typedef struct MPIDI_CH3_Pkt_lock_ack {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     /* note that either source_win_handle
      * or request_handle is used. */
     MPI_Win source_win_handle;
@@ -806,7 +806,7 @@ typedef struct MPIDI_CH3_Pkt_lock_ack {
 
 typedef struct MPIDI_CH3_Pkt_lock_op_ack {
     MPIDI_CH3_Pkt_type_t type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     /* note that either source_win_handle
      * or request_handle is used. */
     MPI_Win source_win_handle;
@@ -821,14 +821,14 @@ typedef struct MPIDI_CH3_Pkt_ack {
     MPIDI_CH3_Pkt_type_t type;
     MPI_Win source_win_handle;
     int target_rank;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
 } MPIDI_CH3_Pkt_ack_t;
 
 typedef struct MPIDI_CH3_Pkt_decr_at_counter {
     MPIDI_CH3_Pkt_type_t type;
     MPI_Win target_win_handle;
     MPI_Win source_win_handle;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
 } MPIDI_CH3_Pkt_decr_at_counter_t;
 
 typedef struct MPIDI_CH3_Pkt_close {

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -450,7 +450,7 @@ typedef struct MPIDI_Request {
     MPI_Request request_handle;
     MPI_Win     target_win_handle;
     MPI_Win     source_win_handle;
-    MPIDI_CH3_Pkt_flags_t flags; /* flags that were included in the original RMA packet header */
+    int pkt_flags; /* pkt_flags that were included in the original RMA packet header */
     struct MPIDI_RMA_Target_lock_entry *target_lock_queue_entry;
     MPI_Request resp_request_handle; /* Handle for get_accumulate response */
 

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -29,12 +29,12 @@ static inline int send_lock_msg(int dest, int lock_type, MPIR_Win * win_ptr)
     lock_pkt->target_win_handle = win_ptr->basic_info_table[dest].win_handle;
     lock_pkt->source_win_handle = win_ptr->handle;
     lock_pkt->request_handle = MPI_REQUEST_NULL;
-    lock_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+    lock_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
     if (lock_type == MPI_LOCK_SHARED)
-        lock_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
+        lock_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
     else {
         MPIR_Assert(lock_type == MPI_LOCK_EXCLUSIVE);
-        lock_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
+        lock_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
     }
 
     MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
@@ -56,7 +56,7 @@ static inline int send_lock_msg(int dest, int lock_type, MPIR_Win * win_ptr)
     /* --END ERROR HANDLING-- */
 }
 
-static inline int send_unlock_msg(int dest, MPIR_Win * win_ptr, MPIDI_CH3_Pkt_flags_t flags)
+static inline int send_unlock_msg(int dest, MPIR_Win * win_ptr, int pkt_flags)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3_Pkt_t upkt;
@@ -74,7 +74,7 @@ static inline int send_unlock_msg(int dest, MPIR_Win * win_ptr, MPIDI_CH3_Pkt_fl
     MPIDI_Pkt_init(unlock_pkt, MPIDI_CH3_PKT_UNLOCK);
     unlock_pkt->target_win_handle = win_ptr->basic_info_table[dest].win_handle;
     unlock_pkt->source_win_handle = win_ptr->handle;
-    unlock_pkt->flags = flags;
+    unlock_pkt->pkt_flags = pkt_flags;
 
     MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
     mpi_errno = MPIDI_CH3_iStartMsg(vc, unlock_pkt, sizeof(*unlock_pkt), &req);
@@ -97,7 +97,7 @@ static inline int send_unlock_msg(int dest, MPIR_Win * win_ptr, MPIDI_CH3_Pkt_fl
 
 
 static inline int MPIDI_CH3I_Send_lock_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * win_ptr,
-                                               MPIDI_CH3_Pkt_flags_t flags,
+                                               int pkt_flags,
                                                MPI_Win source_win_handle,
                                                MPI_Request request_handle)
 {
@@ -116,7 +116,7 @@ static inline int MPIDI_CH3I_Send_lock_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * win_p
     lock_ack_pkt->source_win_handle = source_win_handle;
     lock_ack_pkt->request_handle = request_handle;
     lock_ack_pkt->target_rank = win_ptr->comm_ptr->rank;
-    lock_ack_pkt->flags = flags;
+    lock_ack_pkt->pkt_flags = pkt_flags;
 
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER, VERBOSE,
                      (MPL_DBG_FDEST, "sending lock ack pkt on vc=%p, source_win_handle=%#08x",
@@ -140,7 +140,7 @@ static inline int MPIDI_CH3I_Send_lock_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * win_p
 }
 
 static inline int MPIDI_CH3I_Send_lock_op_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * win_ptr,
-                                                  MPIDI_CH3_Pkt_flags_t flags,
+                                                  int pkt_flags,
                                                   MPI_Win source_win_handle,
                                                   MPI_Request request_handle)
 {
@@ -159,7 +159,7 @@ static inline int MPIDI_CH3I_Send_lock_op_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * wi
     lock_op_ack_pkt->source_win_handle = source_win_handle;
     lock_op_ack_pkt->request_handle = request_handle;
     lock_op_ack_pkt->target_rank = win_ptr->comm_ptr->rank;
-    lock_op_ack_pkt->flags = flags;
+    lock_op_ack_pkt->pkt_flags = pkt_flags;
 
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER, VERBOSE,
                      (MPL_DBG_FDEST, "sending lock op ack pkt on vc=%p, source_win_handle=%#08x",
@@ -215,7 +215,7 @@ static inline int MPIDI_CH3I_Send_ack_pkt(MPIDI_VC_t * vc, MPIR_Win * win_ptr,
 }
 
 
-static inline int send_decr_at_cnt_msg(int dst, MPIR_Win * win_ptr, MPIDI_CH3_Pkt_flags_t flags)
+static inline int send_decr_at_cnt_msg(int dst, MPIR_Win * win_ptr, int pkt_flags)
 {
     MPIDI_CH3_Pkt_t upkt;
     MPIDI_CH3_Pkt_decr_at_counter_t *decr_at_cnt_pkt = &upkt.decr_at_cnt;
@@ -228,7 +228,7 @@ static inline int send_decr_at_cnt_msg(int dst, MPIR_Win * win_ptr, MPIDI_CH3_Pk
     MPIDI_Pkt_init(decr_at_cnt_pkt, MPIDI_CH3_PKT_DECR_AT_COUNTER);
     decr_at_cnt_pkt->target_win_handle = win_ptr->basic_info_table[dst].win_handle;
     decr_at_cnt_pkt->source_win_handle = win_ptr->handle;
-    decr_at_cnt_pkt->flags = flags;
+    decr_at_cnt_pkt->pkt_flags = pkt_flags;
 
     MPIDI_Comm_get_vc_set_active(win_ptr->comm_ptr, dst, &vc);
 
@@ -295,7 +295,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
                                       intptr_t * buflen, MPIR_Request ** reqp)
 {
     MPIDI_RMA_Target_lock_entry_t *new_ptr = NULL;
-    MPIDI_CH3_Pkt_flags_t flag;
+    int flag;
     MPI_Win source_win_handle;
     MPI_Request request_handle;
     int lock_discarded = 0, data_discarded = 0;
@@ -334,13 +334,13 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
         int target_count;
         int complete = 0;
         intptr_t data_len;
-        MPIDI_CH3_Pkt_flags_t flags;
+        int pkt_flags;
 
         /* This is PUT, ACC, GACC, FOP */
 
         MPIDI_CH3_PKT_RMA_GET_TARGET_DATATYPE((*pkt), target_dtp, mpi_errno);
         MPIDI_CH3_PKT_RMA_GET_TARGET_COUNT((*pkt), target_count, mpi_errno);
-        MPIDI_CH3_PKT_RMA_GET_FLAGS((*pkt), flags, mpi_errno);
+        MPIDI_CH3_PKT_RMA_GET_FLAGS((*pkt), pkt_flags, mpi_errno);
 
         MPIR_Datatype_get_extent_macro(target_dtp, type_extent);
         MPIR_Datatype_get_size_macro(target_dtp, type_size);
@@ -363,7 +363,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
             }
         }
 
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
             MPIR_Assert(pkt->type == MPIDI_CH3_PKT_ACCUMULATE ||
                         pkt->type == MPIDI_CH3_PKT_GET_ACCUM);
 
@@ -403,7 +403,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
                 lock_pkt->target_win_handle = target_win_handle;
                 lock_pkt->source_win_handle = source_win_handle;
                 lock_pkt->request_handle = request_handle;
-                lock_pkt->flags = flags;
+                lock_pkt->pkt_flags = pkt_flags;
 
                 /* replace original pkt with lock pkt */
                 new_ptr->pkt = new_pkt;
@@ -512,7 +512,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
 }
 
 
-static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3_Pkt_flags_t flags)
+static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, int pkt_flags)
 {
     MPIDI_RMA_Target_t *t = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -527,11 +527,11 @@ static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3
         MPIDI_Comm_get_vc(win_ptr->comm_ptr, target_rank, &target_vc);
         if (win_ptr->comm_ptr->rank == target_rank ||
             (win_ptr->shm_allocated == TRUE && orig_vc->node_id == target_vc->node_id)) {
-            if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+            if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
                 win_ptr->outstanding_locks--;
                 MPIR_Assert(win_ptr->outstanding_locks >= 0);
             }
-            else if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
+            else if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
                 /* re-send lock request message. */
                 mpi_errno = send_lock_msg(target_rank, MPI_LOCK_SHARED, win_ptr);
                 if (mpi_errno != MPI_SUCCESS)
@@ -541,7 +541,7 @@ static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3
         }
     }
     else if (win_ptr->states.access_state == MPIDI_RMA_LOCK_ALL_ISSUED) {
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
             win_ptr->outstanding_locks--;
             MPIR_Assert(win_ptr->outstanding_locks >= 0);
             if (win_ptr->outstanding_locks == 0) {
@@ -555,7 +555,7 @@ static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3
                 }
             }
         }
-        else if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
+        else if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
             /* re-send lock request message. */
             mpi_errno = send_lock_msg(target_rank, MPI_LOCK_SHARED, win_ptr);
             if (mpi_errno != MPI_SUCCESS)
@@ -569,7 +569,7 @@ static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3
         MPIR_ERR_POP(mpi_errno);
     MPIR_Assert(t != NULL);
 
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
         t->access_state = MPIDI_RMA_LOCK_GRANTED;
         if (t->pending_net_ops_list_head)
             MPIDI_CH3I_Win_set_active(win_ptr);
@@ -587,7 +587,7 @@ static inline int handle_lock_ack(MPIR_Win * win_ptr, int target_rank, MPIDI_CH3
         }
     }
 
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED)
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED)
         t->access_state = MPIDI_RMA_LOCK_CALLED;
 
   fn_exit:
@@ -671,11 +671,11 @@ static inline int check_and_set_req_completion(MPIR_Win * win_ptr, MPIDI_RMA_Tar
 
 
 static inline int handle_lock_ack_with_op(MPIR_Win * win_ptr,
-                                          int target_rank, MPIDI_CH3_Pkt_flags_t flags)
+                                          int target_rank, int pkt_flags)
 {
     MPIDI_RMA_Target_t *target = NULL;
     MPIDI_RMA_Op_t *op = NULL;
-    MPIDI_CH3_Pkt_flags_t op_flags = MPIDI_CH3_PKT_FLAG_NONE;
+    int op_flags = MPIDI_CH3_PKT_FLAG_NONE;
     int op_completed ATTRIBUTE((unused)) = FALSE;
     int mpi_errno = MPI_SUCCESS;
 
@@ -693,7 +693,7 @@ static inline int handle_lock_ack_with_op(MPIR_Win * win_ptr,
     MPIR_Assert(op_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
                 op_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE);
 
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
 
         if ((op->pkt.type == MPIDI_CH3_PKT_ACCUMULATE || op->pkt.type == MPIDI_CH3_PKT_GET_ACCUM)
             && op->issued_stream_count != ALL_STREAM_UNITS_ISSUED) {
@@ -719,10 +719,10 @@ static inline int handle_lock_ack_with_op(MPIR_Win * win_ptr,
 
         check_and_set_req_completion(win_ptr, target, op, &op_completed);
     }
-    else if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_QUEUED_DATA_DISCARDED ||
-             flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
+    else if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_QUEUED_DATA_DISCARDED ||
+             pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_DISCARDED) {
         /* We need to re-transmit this operation, so we destroy
-         * the internal request and erase all flags in current
+         * the internal request and erase all pkt_flags in current
          * operation. */
         if (op->reqs_size == 1) {
             MPIR_Assert(op->single_req != NULL);
@@ -774,12 +774,12 @@ static inline int acquire_local_lock(MPIR_Win * win_ptr, int lock_type)
             (MPIDI_RMA_Target_lock_entry_t **) (&(win_ptr->target_lock_queue_head));
 
         MPIDI_Pkt_init(lock_pkt, MPIDI_CH3_PKT_LOCK);
-        lock_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        lock_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (lock_type == MPI_LOCK_SHARED)
-            lock_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
+            lock_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED;
         else {
             MPIR_Assert(lock_type == MPI_LOCK_EXCLUSIVE);
-            lock_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
+            lock_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE;
         }
 
         new_ptr = MPIDI_CH3I_Win_target_lock_entry_alloc(win_ptr, &pkt);
@@ -991,19 +991,19 @@ static inline int check_piggyback_lock(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
                                        int *acquire_lock_fail, MPIR_Request ** reqp)
 {
     int lock_type;
-    MPIDI_CH3_Pkt_flags_t flags;
+    int pkt_flags;
     int mpi_errno = MPI_SUCCESS;
 
     (*acquire_lock_fail) = 0;
     (*reqp) = NULL;
 
-    MPIDI_CH3_PKT_RMA_GET_FLAGS((*pkt), flags, mpi_errno);
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED || flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
+    MPIDI_CH3_PKT_RMA_GET_FLAGS((*pkt), pkt_flags, mpi_errno);
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED || pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
 
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED)
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED)
             lock_type = MPI_LOCK_SHARED;
         else {
-            MPIR_Assert(flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE);
+            MPIR_Assert(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE);
             lock_type = MPI_LOCK_EXCLUSIVE;
         }
 
@@ -1024,28 +1024,29 @@ static inline int check_piggyback_lock(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
 
 static inline int finish_op_on_target(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
                                       int has_response_data,
-                                      MPIDI_CH3_Pkt_flags_t flags, MPI_Win source_win_handle)
+                                      int pkt_flags, MPI_Win source_win_handle)
 {
     int mpi_errno = MPI_SUCCESS;
 
     if (!has_response_data) {
         /* This is PUT or ACC */
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
-            MPIDI_CH3_Pkt_flags_t pkt_flags = MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
-            if ((flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) || (flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
-                pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE) {
+            int flags = MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
+            if ((pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
+                (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK)) {
+                flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+            }
             MPIR_Assert(source_win_handle != MPI_WIN_NULL);
-            mpi_errno = MPIDI_CH3I_Send_lock_op_ack_pkt(vc, win_ptr,
-                                                        pkt_flags,
+            mpi_errno = MPIDI_CH3I_Send_lock_op_ack_pkt(vc, win_ptr, flags,
                                                         source_win_handle, MPI_REQUEST_NULL);
             if (mpi_errno != MPI_SUCCESS)
                 MPIR_ERR_POP(mpi_errno);
             MPIDI_CH3_Progress_signal_completion();
         }
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) {
-            if (!(flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-                  flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) {
+            if (!(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+                  pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)) {
                 /* If op is piggybacked with both LOCK and FLUSH,
                  * we only send LOCK ACK back, do not send FLUSH ACK. */
                 mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, source_win_handle);
@@ -1054,16 +1055,16 @@ static inline int finish_op_on_target(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
             }
             MPIDI_CH3_Progress_signal_completion();
         }
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER) {
             win_ptr->at_completion_counter--;
             MPIR_Assert(win_ptr->at_completion_counter >= 0);
             /* Signal the local process when the op counter reaches 0. */
             if (win_ptr->at_completion_counter == 0)
                 MPIDI_CH3_Progress_signal_completion();
         }
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK) {
-            if (!(flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-                  flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK) {
+            if (!(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+                  pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)) {
                 /* If op is piggybacked with both LOCK and UNLOCK,
                  * we only send LOCK ACK back, do not send FLUSH (UNLOCK) ACK. */
                 mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, source_win_handle);
@@ -1079,14 +1080,14 @@ static inline int finish_op_on_target(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
     else {
         /* This is GACC / GET / CAS / FOP */
 
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK) {
             mpi_errno = MPIDI_CH3I_Release_lock(win_ptr);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
             MPIDI_CH3_Progress_signal_completion();
         }
 
-        if (flags & MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER) {
+        if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_DECR_AT_COUNTER) {
             win_ptr->at_completion_counter--;
             MPIR_Assert(win_ptr->at_completion_counter >= 0);
             /* Signal the local process when the op counter reaches 0. */
@@ -1178,23 +1179,23 @@ static inline int poke_progress_engine(void)
     goto fn_exit;
 }
 
-static inline void MPIDI_CH3_ExtPkt_Accum_get_stream(MPIDI_CH3_Pkt_flags_t flags,
+static inline void MPIDI_CH3_ExtPkt_Accum_get_stream(int pkt_flags,
                                                      int is_derived_dt, void *ext_hdr_ptr,
                                                      MPI_Aint * stream_offset)
 {
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
         MPIR_Assert(ext_hdr_ptr != NULL);
         (*stream_offset) = ((MPIDI_CH3_Ext_pkt_stream_t *) ext_hdr_ptr)->stream_offset;
     }
 }
 
-static inline void MPIDI_CH3_ExtPkt_Gaccum_get_stream(MPIDI_CH3_Pkt_flags_t flags,
+static inline void MPIDI_CH3_ExtPkt_Gaccum_get_stream(int pkt_flags,
                                                       int is_derived_dt, void *ext_hdr_ptr,
                                                       MPI_Aint * stream_offset)
 {
     /* We do not check packet match here, because error must have already been
      * reported at header init time (on origin) and at packet receive time (on target).  */
-    MPIDI_CH3_ExtPkt_Accum_get_stream(flags, is_derived_dt, ext_hdr_ptr, stream_offset);
+    MPIDI_CH3_ExtPkt_Accum_get_stream(pkt_flags, is_derived_dt, ext_hdr_ptr, stream_offset);
 }
 
 #endif /* MPIDRMA_H_INCLUDED */

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -188,15 +188,17 @@ int MPIDI_CH3_ReqHandler_AccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq,
                                       (!MPIR_DATATYPE_IS_PREDEFINED(rreq->dev.datatype)),
                                       rreq->dev.ext_hdr_ptr, &stream_offset);
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
     /* accumulate data from tmp_buf into user_buf */
     MPIR_Assert(predef_count == (int) predef_count);
     mpi_errno = do_accumulate_op(rreq->dev.user_buf, (int) predef_count, basic_type,
                                  rreq->dev.real_user_buf, rreq->dev.user_count, rreq->dev.datatype,
                                  stream_offset, rreq->dev.op, MPIDI_RMA_ACC_SRCBUF_DEFAULT);
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
     if (mpi_errno) {
         MPIR_ERR_POP(mpi_errno);
     }
@@ -309,8 +311,9 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     /* Copy data from target window to temporary buffer */
 
@@ -326,8 +329,9 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
 
         seg = MPIR_Segment_alloc(rreq->dev.real_user_buf, rreq->dev.user_count, rreq->dev.datatype);
         if (seg == NULL) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
         }
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                              "MPIR_Segment");
@@ -341,8 +345,9 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
                                  rreq->dev.real_user_buf, rreq->dev.user_count, rreq->dev.datatype,
                                  stream_offset, rreq->dev.op, MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -448,8 +453,9 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     /* Copy data into a temporary buffer in response request */
     if (is_contig) {
@@ -461,8 +467,9 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 
         seg = MPIR_Segment_alloc(rreq->dev.real_user_buf, 1, rreq->dev.datatype);
         if (seg == NULL) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
         }
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                              "MPIR_Segment");
@@ -475,8 +482,9 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
                                  rreq->dev.real_user_buf, 1, rreq->dev.datatype, 0, rreq->dev.op,
                                  MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -1174,8 +1182,9 @@ static inline int perform_acc_in_lock_queue(MPIR_Win * win_ptr,
     /* Piggyback candidate should have basic datatype for target datatype. */
     MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(acc_pkt->datatype));
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     if (acc_pkt->type == MPIDI_CH3_PKT_ACCUMULATE_IMMED) {
         /* All data fits in packet header */
@@ -1203,8 +1212,9 @@ static inline int perform_acc_in_lock_queue(MPIR_Win * win_ptr,
                                      0, acc_pkt->op, MPIDI_RMA_ACC_SRCBUF_DEFAULT);
     }
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -1279,8 +1289,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
 
         /* NOTE: copy 'data + ACC' needs to be atomic */
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+        }
 
         /* Copy data from target window to response packet header */
 
@@ -1288,8 +1299,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
             (void *) &(get_accum_resp_pkt->info.data);
         mpi_errno = immed_copy(src, dest, len);
         if (mpi_errno != MPI_SUCCESS) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
             MPIR_ERR_POP(mpi_errno);
         }
 
@@ -1302,8 +1314,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
                              get_accum_pkt->datatype, 0, get_accum_pkt->op,
                              MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+        }
 
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
@@ -1340,8 +1353,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     /* Copy data from target window to temporary buffer */
 
@@ -1358,8 +1372,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
 
         seg = MPIR_Segment_alloc(get_accum_pkt->addr, get_accum_pkt->count, get_accum_pkt->datatype);
         if (seg == NULL) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
         }
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                              "MPIR_Segment");
@@ -1374,8 +1389,9 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
                                  get_accum_pkt->addr, get_accum_pkt->count, get_accum_pkt->datatype,
                                  0, get_accum_pkt->op, MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -1479,8 +1495,9 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     /* Copy data from target window to temporary buffer / response packet header */
 
@@ -1489,8 +1506,9 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
         void *src = fop_pkt->addr, *dest = (void *) &fop_resp_pkt->info.data;
         mpi_errno = immed_copy(src, dest, type_size);
         if (mpi_errno != MPI_SUCCESS) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
             MPIR_ERR_POP(mpi_errno);
         }
     }
@@ -1503,8 +1521,9 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
 
         seg = MPIR_Segment_alloc(fop_pkt->addr, 1, fop_pkt->datatype);
         if (seg == NULL) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
         }
         MPIR_ERR_CHKANDJUMP1(seg == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                              "MPIR_Segment");
@@ -1524,8 +1543,9 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
                                      MPIDI_RMA_ACC_SRCBUF_DEFAULT);
     }
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -1618,8 +1638,9 @@ static inline int perform_cas_in_lock_queue(MPIR_Win * win_ptr,
     MPIR_Datatype_get_size_macro(cas_pkt->datatype, len);
     MPIR_Assert(len <= sizeof(MPIDI_CH3_CAS_Immed_u));
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     MPIR_Memcpy((void *) &cas_resp_pkt->info.data, cas_pkt->addr, len);
 
@@ -1628,8 +1649,9 @@ static inline int perform_cas_in_lock_queue(MPIR_Win * win_ptr,
         MPIR_Memcpy(cas_pkt->addr, &cas_pkt->origin_data, len);
     }
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     /* Send the response packet */
     MPID_THREAD_CS_ENTER(POBJ, target_lock_entry->vc->pobj_mutex);

--- a/src/mpid/ch3/src/ch3u_handle_send_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_send_req.c
@@ -49,7 +49,7 @@ int MPIDI_CH3_ReqHandler_GetSendComplete(MPIDI_VC_t * vc ATTRIBUTE((unused)),
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win_ptr;
-    MPIDI_CH3_Pkt_flags_t flags = sreq->dev.flags;
+    int pkt_flags = sreq->dev.pkt_flags;
 
     /* NOTE: It is possible that this request is already completed before
      * entering this handler. This happens when this req handler is called
@@ -87,7 +87,7 @@ int MPIDI_CH3_ReqHandler_GetSendComplete(MPIDI_VC_t * vc ATTRIBUTE((unused)),
      * on the same request again (in release_lock()). Marking this request as
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                    flags, MPI_WIN_NULL);
+                                    pkt_flags, MPI_WIN_NULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -103,7 +103,7 @@ int MPIDI_CH3_ReqHandler_GaccumSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win_ptr;
-    MPIDI_CH3_Pkt_flags_t flags = rreq->dev.flags;
+    int pkt_flags = rreq->dev.pkt_flags;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_REQHANDLER_GACCUMSENDCOMPLETE);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_REQHANDLER_GACCUMSENDCOMPLETE);
@@ -148,7 +148,7 @@ int MPIDI_CH3_ReqHandler_GaccumSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
      * on the same request again (in release_lock()). Marking this request as
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                    flags, MPI_WIN_NULL);
+                                    pkt_flags, MPI_WIN_NULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -167,7 +167,7 @@ int MPIDI_CH3_ReqHandler_CASSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win_ptr;
-    MPIDI_CH3_Pkt_flags_t flags = rreq->dev.flags;
+    int pkt_flags = rreq->dev.pkt_flags;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_REQHANDLER_CASSENDCOMPLETE);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_REQHANDLER_CASSENDCOMPLETE);
@@ -212,7 +212,7 @@ int MPIDI_CH3_ReqHandler_CASSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
      * on the same request again (in release_lock()). Marking this request as
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                    flags, MPI_WIN_NULL);
+                                    pkt_flags, MPI_WIN_NULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -230,7 +230,7 @@ int MPIDI_CH3_ReqHandler_FOPSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win_ptr;
-    MPIDI_CH3_Pkt_flags_t flags = rreq->dev.flags;
+    int pkt_flags = rreq->dev.pkt_flags;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_REQHANDLER_FOPSENDCOMPLETE);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_REQHANDLER_FOPSENDCOMPLETE);
@@ -275,7 +275,7 @@ int MPIDI_CH3_ReqHandler_FOPSendComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
      * on the same request again (in release_lock()). Marking this request as
      * completed will prevent us from processing the same request twice. */
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                    flags, MPI_WIN_NULL);
+                                    pkt_flags, MPI_WIN_NULL);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 

--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -32,7 +32,7 @@ void MPID_Request_create_hook(MPIR_Request *req)
     
     req->dev.datatype_ptr	   = NULL;
     req->dev.segment_ptr	   = NULL;
-    /* Masks and flags for channel device state in an MPIR_Request */
+    /* Masks and pkt_flags for channel device state in an MPIR_Request */
     req->dev.state		   = 0;
     req->dev.cancel_pending	   = FALSE;
     /* FIXME: RMA ops shouldn't need to be set except when creating a
@@ -42,7 +42,7 @@ void MPID_Request_create_hook(MPIR_Request *req)
     req->dev.target_lock_queue_entry = NULL;
     req->dev.flattened_type = NULL;
     req->dev.iov_offset        = 0;
-    req->dev.flags             = MPIDI_CH3_PKT_FLAG_NONE;
+    req->dev.pkt_flags             = MPIDI_CH3_PKT_FLAG_NONE;
     req->dev.resp_request_handle = MPI_REQUEST_NULL;
     req->dev.user_buf          = NULL;
     req->dev.OnDataAvail       = NULL;

--- a/src/mpid/ch3/src/ch3u_rma_ops.c
+++ b/src/mpid/ch3/src/ch3u_rma_ops.c
@@ -169,7 +169,7 @@ int MPIDI_CH3I_Put(const void *origin_addr, int origin_count, MPI_Datatype
         put_pkt->info.flattened_type_size = 0;
         put_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         put_pkt->source_win_handle = win_ptr->handle;
-        put_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        put_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(put_pkt->info.data);
             mpi_errno = immed_copy(src, dest, data_sz);
@@ -338,9 +338,9 @@ int MPIDI_CH3I_Get(void *origin_addr, int origin_count, MPI_Datatype
         get_pkt->datatype = target_datatype;
         get_pkt->info.flattened_type_size = 0;
         get_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
-        get_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        get_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_resp_pkt)
-            get_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP;
+            get_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP;
 
         MPIR_T_PVAR_TIMER_END(RMA, rma_rmaqueue_set);
 
@@ -541,7 +541,7 @@ int MPIDI_CH3I_Accumulate(const void *origin_addr, int origin_count, MPI_Datatyp
         accum_pkt->op = op;
         accum_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
         accum_pkt->source_win_handle = win_ptr->handle;
-        accum_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        accum_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(accum_pkt->info.data);
             mpi_errno = immed_copy(src, dest, data_sz);
@@ -789,7 +789,7 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, int origin_count,
         get_accum_pkt->info.flattened_type_size = 0;
         get_accum_pkt->op = op;
         get_accum_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
-        get_accum_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        get_accum_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(get_accum_pkt->info.data);
             mpi_errno = immed_copy(src, dest, orig_data_sz);
@@ -1007,7 +1007,7 @@ int MPID_Compare_and_swap(const void *origin_addr, const void *compare_addr,
             win_ptr->basic_info_table[target_rank].disp_unit * target_disp;
         cas_pkt->datatype = datatype;
         cas_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
-        cas_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        cas_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
 
         /* REQUIRE: All datatype arguments must be of the same, builtin
          * type and counts must be 1. */
@@ -1154,7 +1154,7 @@ int MPID_Fetch_and_op(const void *origin_addr, void *result_addr,
         fop_pkt->datatype = datatype;
         fop_pkt->op = op;
         fop_pkt->target_win_handle = win_ptr->basic_info_table[target_rank].win_handle;
-        fop_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
+        fop_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
         if (use_immed_pkt) {
             void *src = (void *) origin_addr, *dest = (void *) &(fop_pkt->info.data);
             mpi_errno = immed_copy(src, dest, type_size);

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -178,7 +178,7 @@ void MPIDI_CH3_RMA_Init_pkthandler_pvars(void)
 /*                  extended packet functions                  */
 /* =========================================================== */
 
-static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
+static int MPIDI_CH3_ExtPktHandler_Accumulate(int pkt_flags,
                                               int is_derived_dt, void **ext_hdr_ptr,
                                               MPI_Aint * ext_hdr_sz)
 {
@@ -187,7 +187,7 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_EXTPKTHANDLER_ACCUMULATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3_EXTPKTHANDLER_ACCUMULATE);
 
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
         (*ext_hdr_sz) = sizeof(MPIDI_CH3_Ext_pkt_stream_t);
         (*ext_hdr_ptr) = MPL_malloc(sizeof(MPIDI_CH3_Ext_pkt_stream_t), MPL_MEM_BUFFER);
         if ((*ext_hdr_ptr) == NULL) {
@@ -210,11 +210,11 @@ static int MPIDI_CH3_ExtPktHandler_Accumulate(MPIDI_CH3_Pkt_flags_t flags,
     goto fn_exit;
 }
 
-static int MPIDI_CH3_ExtPktHandler_GetAccumulate(MPIDI_CH3_Pkt_flags_t flags,
+static int MPIDI_CH3_ExtPktHandler_GetAccumulate(int pkt_flags,
                                                  int is_derived_dt, void **ext_hdr_ptr,
                                                  MPI_Aint * ext_hdr_sz)
 {
-    return MPIDI_CH3_ExtPktHandler_Accumulate(flags, is_derived_dt, ext_hdr_ptr, ext_hdr_sz);
+    return MPIDI_CH3_ExtPktHandler_Accumulate(pkt_flags, is_derived_dt, ext_hdr_ptr, ext_hdr_sz);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -268,7 +268,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         /* trigger final action */
         mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
-                                        put_pkt->flags, put_pkt->source_win_handle);
+                                        put_pkt->pkt_flags, put_pkt->source_win_handle);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
@@ -289,7 +289,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         req->dev.user_count = put_pkt->count;
         req->dev.target_win_handle = put_pkt->target_win_handle;
         req->dev.source_win_handle = put_pkt->source_win_handle;
-        req->dev.flags = put_pkt->flags;
+        req->dev.pkt_flags = put_pkt->pkt_flags;
         req->dev.OnFinal = MPIDI_CH3_ReqHandler_PutRecvComplete;
 
         if (MPIR_DATATYPE_IS_PREDEFINED(put_pkt->datatype)) {
@@ -418,7 +418,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
     req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
     req->dev.target_win_handle = get_pkt->target_win_handle;
-    req->dev.flags = get_pkt->flags;
+    req->dev.pkt_flags = get_pkt->pkt_flags;
 
     /* get start location of data and length of data */
     data_len = *buflen;
@@ -428,7 +428,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
      * operation are completed when counter reaches zero. */
     win_ptr->at_completion_counter++;
 
-    if (get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
+    if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
         MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(get_pkt->datatype));
     }
 
@@ -445,20 +445,20 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         req->dev.OnFinal = MPIDI_CH3_ReqHandler_GetSendComplete;
         req->kind = MPIR_REQUEST_KIND__SEND;
 
-        if (get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
+        if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
             MPIDI_Pkt_init(get_resp_pkt, MPIDI_CH3_PKT_GET_RESP_IMMED);
         }
         else {
             MPIDI_Pkt_init(get_resp_pkt, MPIDI_CH3_PKT_GET_RESP);
         }
         get_resp_pkt->request_handle = get_pkt->request_handle;
-        get_resp_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
-        if (get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
-            get_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
-        if ((get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
-            (get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
-            get_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+        get_resp_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
+        if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
+            get_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
+        if ((get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
+            (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
+            get_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
         get_resp_pkt->target_rank = win_ptr->comm_ptr->rank;
 
         /* length of target data */
@@ -466,7 +466,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         MPIR_Datatype_is_contig(get_pkt->datatype, &is_contig);
 
-        if (get_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
+        if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
             MPIR_Assign_trunc(len, get_pkt->count * type_size, size_t);
             void *src = (void *) (get_pkt->addr), *dest = (void *) &(get_resp_pkt->info.data);
             mpi_errno = immed_copy(src, dest, len);
@@ -635,7 +635,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
 
         /* trigger final action */
         mpi_errno = finish_op_on_target(win_ptr, vc, FALSE /* has no response data */ ,
-                                        accum_pkt->flags, accum_pkt->source_win_handle);
+                                        accum_pkt->pkt_flags, accum_pkt->source_win_handle);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
 
@@ -654,7 +654,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
         req->dev.real_user_buf = accum_pkt->addr;
         req->dev.target_win_handle = accum_pkt->target_win_handle;
         req->dev.source_win_handle = accum_pkt->source_win_handle;
-        req->dev.flags = accum_pkt->flags;
+        req->dev.pkt_flags = accum_pkt->pkt_flags;
 
         req->dev.resp_request_handle = MPI_REQUEST_NULL;
 
@@ -664,7 +664,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
 
         /* allocate extended header in the request,
          * only including fixed-length variables defined in packet type. */
-        mpi_errno = MPIDI_CH3_ExtPktHandler_Accumulate(req->dev.flags,
+        mpi_errno = MPIDI_CH3_ExtPktHandler_Accumulate(req->dev.pkt_flags,
                                                        (!MPIR_DATATYPE_IS_PREDEFINED
                                                         (accum_pkt->datatype)),
                                                        &req->dev.ext_hdr_ptr, &req->dev.ext_hdr_sz);
@@ -675,7 +675,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
             MPIDI_Request_set_type(req, MPIDI_REQUEST_TYPE_ACCUM_RECV);
             req->dev.datatype = accum_pkt->datatype;
 
-            if (req->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+            if (req->dev.pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
                 req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_AccumMetadataRecvComplete;
 
                 /* if this is a streamed op pkt, set iov to receive extended pkt header. */
@@ -849,7 +849,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
         resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
         resp_req->dev.target_win_handle = get_accum_pkt->target_win_handle;
-        resp_req->dev.flags = get_accum_pkt->flags;
+        resp_req->dev.pkt_flags = get_accum_pkt->pkt_flags;
 
         MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_GET_ACCUM_RESP);
         resp_req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_GaccumSendComplete;
@@ -867,13 +867,13 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         MPIDI_Pkt_init(get_accum_resp_pkt, MPIDI_CH3_PKT_GET_ACCUM_RESP_IMMED);
         get_accum_resp_pkt->request_handle = get_accum_pkt->request_handle;
         get_accum_resp_pkt->target_rank = win_ptr->comm_ptr->rank;
-        get_accum_resp_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
-        if (get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
-            get_accum_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
-        if ((get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
-            (get_accum_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
-            get_accum_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+        get_accum_resp_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
+        if (get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
+            get_accum_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
+        if ((get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
+            (get_accum_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
+            get_accum_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
 
         /* NOTE: 'copy data + ACC' needs to be atomic */
 
@@ -931,7 +931,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         req->dev.op = get_accum_pkt->op;
         req->dev.real_user_buf = get_accum_pkt->addr;
         req->dev.target_win_handle = get_accum_pkt->target_win_handle;
-        req->dev.flags = get_accum_pkt->flags;
+        req->dev.pkt_flags = get_accum_pkt->pkt_flags;
 
         req->dev.resp_request_handle = get_accum_pkt->request_handle;
 
@@ -942,7 +942,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         /* allocate extended header in the request,
          * only including fixed-length variables defined in packet type. */
         is_derived_dt = !MPIR_DATATYPE_IS_PREDEFINED(get_accum_pkt->datatype);
-        mpi_errno = MPIDI_CH3_ExtPktHandler_GetAccumulate(req->dev.flags, is_derived_dt,
+        mpi_errno = MPIDI_CH3_ExtPktHandler_GetAccumulate(req->dev.pkt_flags, is_derived_dt,
                                                           &req->dev.ext_hdr_ptr,
                                                           &req->dev.ext_hdr_sz);
         if (mpi_errno != MPI_SUCCESS)
@@ -954,7 +954,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
             MPIDI_Request_set_type(req, MPIDI_REQUEST_TYPE_GET_ACCUM_RECV);
             req->dev.datatype = get_accum_pkt->datatype;
 
-            if (req->dev.flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
+            if (req->dev.pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_STREAM) {
                 req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete;
 
                 /* if this is a streamed op pkt, set iov to receive extended pkt header. */
@@ -1133,13 +1133,13 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIDI_Pkt_init(cas_resp_pkt, MPIDI_CH3_PKT_CAS_RESP_IMMED);
     cas_resp_pkt->request_handle = cas_pkt->request_handle;
     cas_resp_pkt->target_rank = win_ptr->comm_ptr->rank;
-    cas_resp_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
-    if (cas_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-        cas_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
-        cas_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
-    if ((cas_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
-        (cas_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
-        cas_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+    cas_resp_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
+    if (cas_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+        cas_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
+        cas_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
+    if ((cas_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
+        (cas_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
+        cas_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
 
     /* Copy old value into the response packet */
     MPIR_Datatype_get_size_macro(cas_pkt->datatype, len);
@@ -1172,7 +1172,7 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
             /* sending process is not completed, set proper OnDataAvail
              * (it is initialized to NULL by lower layer) */
             req->dev.target_win_handle = cas_pkt->target_win_handle;
-            req->dev.flags = cas_pkt->flags;
+            req->dev.pkt_flags = cas_pkt->pkt_flags;
             req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_CASSendComplete;
 
             /* here we increment the Active Target counter to guarantee the GET-like
@@ -1187,7 +1187,7 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     }
 
     mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                    cas_pkt->flags, MPI_WIN_NULL);
+                                    cas_pkt->pkt_flags, MPI_WIN_NULL);
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
@@ -1223,16 +1223,16 @@ int MPIDI_CH3_PktHandler_CASResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     MPIR_Win_get_ptr(req->dev.source_win_handle, win_ptr);
 
     /* decrement ack_counter on this target */
-    if (cas_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
-        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, cas_resp_pkt->flags);
+    if (cas_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, cas_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = handle_lock_ack(win_ptr, target_rank, cas_resp_pkt->flags);
+        mpi_errno = handle_lock_ack(win_ptr, target_rank, cas_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
-    if (cas_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
+    if (cas_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
@@ -1300,13 +1300,13 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         MPIDI_Pkt_init(fop_resp_pkt, MPIDI_CH3_PKT_FOP_RESP_IMMED);
         fop_resp_pkt->request_handle = fop_pkt->request_handle;
         fop_resp_pkt->target_rank = win_ptr->comm_ptr->rank;
-        fop_resp_pkt->flags = MPIDI_CH3_PKT_FLAG_NONE;
-        if (fop_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
-            fop_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
-            fop_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
-        if ((fop_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
-            (fop_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
-            fop_resp_pkt->flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
+        fop_resp_pkt->pkt_flags = MPIDI_CH3_PKT_FLAG_NONE;
+        if (fop_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED ||
+            fop_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE)
+            fop_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED;
+        if ((fop_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) ||
+            (fop_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK))
+            fop_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
 
         /* NOTE: 'copy data + ACC' needs to be atomic */
 
@@ -1347,7 +1347,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
                 /* sending process is not completed, set proper OnDataAvail
                  * (it is initialized to NULL by lower layer) */
                 resp_req->dev.target_win_handle = fop_pkt->target_win_handle;
-                resp_req->dev.flags = fop_pkt->flags;
+                resp_req->dev.pkt_flags = fop_pkt->pkt_flags;
                 resp_req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_FOPSendComplete;
 
                 /* here we increment the Active Target counter to guarantee the GET-like
@@ -1363,7 +1363,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         }
 
         mpi_errno = finish_op_on_target(win_ptr, vc, TRUE /* has response data */ ,
-                                        fop_pkt->flags, MPI_WIN_NULL);
+                                        fop_pkt->pkt_flags, MPI_WIN_NULL);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -1388,7 +1388,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         req->dev.op = fop_pkt->op;
         req->dev.real_user_buf = fop_pkt->addr;
         req->dev.target_win_handle = fop_pkt->target_win_handle;
-        req->dev.flags = fop_pkt->flags;
+        req->dev.pkt_flags = fop_pkt->pkt_flags;
         req->dev.resp_request_handle = fop_pkt->request_handle;
         req->dev.OnDataAvail = MPIDI_CH3_ReqHandler_FOPRecvComplete;
         req->dev.OnFinal = MPIDI_CH3_ReqHandler_FOPRecvComplete;
@@ -1469,16 +1469,16 @@ int MPIDI_CH3_PktHandler_FOPResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     MPIR_Win_get_ptr(req->dev.source_win_handle, win_ptr);
 
     /* decrement ack_counter */
-    if (fop_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
-        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, fop_resp_pkt->flags);
+    if (fop_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, fop_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = handle_lock_ack(win_ptr, target_rank, fop_resp_pkt->flags);
+        mpi_errno = handle_lock_ack(win_ptr, target_rank, fop_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
-    if (fop_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
+    if (fop_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1552,15 +1552,15 @@ int MPIDI_CH3_PktHandler_Get_AccumResp(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
     MPIR_Win_get_ptr(req->dev.source_win_handle, win_ptr);
 
     /* decrement ack_counter on target */
-    if (get_accum_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
-        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_accum_resp_pkt->flags);
+    if (get_accum_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_accum_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
-        mpi_errno = handle_lock_ack(win_ptr, target_rank, get_accum_resp_pkt->flags);
+        mpi_errno = handle_lock_ack(win_ptr, target_rank, get_accum_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
-    if (get_accum_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
+    if (get_accum_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1607,7 +1607,7 @@ int MPIDI_CH3_PktHandler_Get_AccumResp(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
          * Note that this extended packet header only contains stream_offset and
          * does not contain datatype info, so here we pass 0 to is_derived_dt
          * flag. */
-        MPIDI_CH3_ExtPkt_Gaccum_get_stream(req->dev.flags, 0 /* is_derived_dt */ ,
+        MPIDI_CH3_ExtPkt_Gaccum_get_stream(req->dev.pkt_flags, 0 /* is_derived_dt */ ,
                                            req->dev.ext_hdr_ptr, &contig_stream_offset);
 
         total_len = type_size * req->dev.user_count;
@@ -1680,10 +1680,10 @@ int MPIDI_CH3_PktHandler_Lock(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data
 
     MPIR_Win_get_ptr(lock_pkt->target_win_handle, win_ptr);
 
-    if (lock_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED)
+    if (lock_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_SHARED)
         lock_type = MPI_LOCK_SHARED;
     else {
-        MPIR_Assert(lock_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE);
+        MPIR_Assert(lock_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_EXCLUSIVE);
         lock_type = MPI_LOCK_EXCLUSIVE;
     }
 
@@ -1736,16 +1736,16 @@ int MPIDI_CH3_PktHandler_GetResp(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     MPIR_Win_get_ptr(req->dev.source_win_handle, win_ptr);
 
     /* decrement ack_counter on target */
-    if (get_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
-        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_resp_pkt->flags);
+    if (get_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED) {
+        mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, get_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
-        mpi_errno = handle_lock_ack(win_ptr, target_rank, get_resp_pkt->flags);
+        mpi_errno = handle_lock_ack(win_ptr, target_rank, get_resp_pkt->pkt_flags);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
-    if (get_resp_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
+    if (get_resp_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1823,7 +1823,7 @@ int MPIDI_CH3_PktHandler_LockAck(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
         MPIR_Win_get_ptr(req_ptr->dev.source_win_handle, win_ptr);
     }
 
-    mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_ack_pkt->flags);
+    mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_ack_pkt->pkt_flags);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -1845,7 +1845,7 @@ int MPIDI_CH3_PktHandler_LockOpAck(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
     MPIDI_CH3_Pkt_lock_op_ack_t *lock_op_ack_pkt = &pkt->lock_op_ack;
     MPIR_Win *win_ptr = NULL;
     int target_rank = lock_op_ack_pkt->target_rank;
-    MPIDI_CH3_Pkt_flags_t flags = lock_op_ack_pkt->flags;
+    int pkt_flags = lock_op_ack_pkt->pkt_flags;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3_PKTHANDLER_LOCKOPACK);
 
@@ -1865,16 +1865,16 @@ int MPIDI_CH3_PktHandler_LockOpAck(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt,
         MPIR_Win_get_ptr(req_ptr->dev.source_win_handle, win_ptr);
     }
 
-    mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, lock_op_ack_pkt->flags);
+    mpi_errno = handle_lock_ack_with_op(win_ptr, target_rank, lock_op_ack_pkt->pkt_flags);
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
-    mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_op_ack_pkt->flags);
+    mpi_errno = handle_lock_ack(win_ptr, target_rank, lock_op_ack_pkt->pkt_flags);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
-    if (flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
-        MPIR_Assert(flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED);
+    if (pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_ACK) {
+        MPIR_Assert(pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_LOCK_GRANTED);
         mpi_errno = MPIDI_CH3I_RMA_Handle_ack(win_ptr, target_rank);
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);
@@ -1948,7 +1948,7 @@ int MPIDI_CH3_PktHandler_DecrAtCnt(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     *buflen = 0;
     *rreqp = NULL;
 
-    if (decr_at_cnt_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) {
+    if (decr_at_cnt_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_FLUSH) {
         mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, decr_at_cnt_pkt->source_win_handle);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1986,7 +1986,7 @@ int MPIDI_CH3_PktHandler_Unlock(MPIDI_VC_t * vc ATTRIBUTE((unused)),
     mpi_errno = MPIDI_CH3I_Release_lock(win_ptr);
     MPIR_ERR_CHKANDJUMP(mpi_errno != MPI_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**ch3|rma_msg");
 
-    if (!(unlock_pkt->flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK_NO_ACK)) {
+    if (!(unlock_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_UNLOCK_NO_ACK)) {
         mpi_errno = MPIDI_CH3I_Send_ack_pkt(vc, win_ptr, unlock_pkt->source_win_handle);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -619,14 +619,16 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
         /* Immed packet type is used when target datatype is predefined datatype. */
         MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(accum_pkt->datatype));
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+        }
         mpi_errno = do_accumulate_op((void *) &accum_pkt->info.data, accum_pkt->count,
                                      accum_pkt->datatype, accum_pkt->addr, accum_pkt->count,
                                      accum_pkt->datatype, 0, accum_pkt->op,
                                      MPIDI_RMA_ACC_SRCBUF_DEFAULT);
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+        }
         if (mpi_errno) {
             MPIR_ERR_POP(mpi_errno);
         }
@@ -875,15 +877,17 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
         /* NOTE: 'copy data + ACC' needs to be atomic */
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+        }
 
         /* copy data from target buffer to response packet header */
         src = (void *) (get_accum_pkt->addr), dest = (void *) &(get_accum_resp_pkt->info.data);
         mpi_errno = immed_copy(src, dest, len);
         if (mpi_errno != MPI_SUCCESS) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
             MPIR_ERR_POP(mpi_errno);
         }
 
@@ -893,8 +897,9 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
                              get_accum_pkt->datatype, get_accum_pkt->addr, get_accum_pkt->count,
                              get_accum_pkt->datatype, 0, get_accum_pkt->op, MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+        }
 
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
@@ -1140,8 +1145,9 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
     MPIR_Datatype_get_size_macro(cas_pkt->datatype, len);
     MPIR_Assert(len <= sizeof(MPIDI_CH3_CAS_Immed_u));
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+    }
 
     MPIR_Memcpy((void *) &cas_resp_pkt->info.data, cas_pkt->addr, len);
 
@@ -1150,8 +1156,9 @@ int MPIDI_CH3_PktHandler_CAS(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         MPIR_Memcpy(cas_pkt->addr, &cas_pkt->origin_data, len);
     }
 
-    if (win_ptr->shm_allocated == TRUE)
+    if (win_ptr->shm_allocated == TRUE) {
         MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+    }
 
     /* Send the response packet */
     MPID_THREAD_CS_ENTER(POBJ, vc->pobj_mutex);
@@ -1303,15 +1310,17 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
 
         /* NOTE: 'copy data + ACC' needs to be atomic */
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_LOCK(win_ptr);
+        }
 
         /* copy data to resp pkt header */
         void *src = fop_pkt->addr, *dest = (void *) &fop_resp_pkt->info.data;
         mpi_errno = immed_copy(src, dest, type_size);
         if (mpi_errno != MPI_SUCCESS) {
-            if (win_ptr->shm_allocated == TRUE)
+            if (win_ptr->shm_allocated == TRUE) {
                 MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+            }
             MPIR_ERR_POP(mpi_errno);
         }
 
@@ -1320,8 +1329,9 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
                                      fop_pkt->addr, 1, fop_pkt->datatype, 0, fop_pkt->op,
                                      MPIDI_RMA_ACC_SRCBUF_DEFAULT);
 
-        if (win_ptr->shm_allocated == TRUE)
+        if (win_ptr->shm_allocated == TRUE) {
             MPIDI_CH3I_SHM_MUTEX_UNLOCK(win_ptr);
+        }
 
         if (mpi_errno != MPI_SUCCESS)
             MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -14,7 +14,7 @@
 /* Generates a bitarray based on orig_comm where all procs in group are marked with 1 */
 static void group_to_bitarray(MPIR_Group *group, MPIR_Comm *orig_comm, int **bitarray, int *bitarray_size) {
     int mask;
-    int *group_ranks, *comm_ranks, i, index;
+    int *group_ranks, *comm_ranks, i;
 
     /* Calculate the bitarray size in ints and allocate space */
     *bitarray_size = (orig_comm->local_size / (8 * sizeof(int)) + (orig_comm->local_size % (8 * sizeof(int)) ? 1 : 0));
@@ -40,9 +40,9 @@ static void group_to_bitarray(MPIR_Group *group, MPIR_Comm *orig_comm, int **bit
      * add it to the bitarray. */
     for (i = 0; i < group->size ; i++) {
         if (comm_ranks[i] == MPI_UNDEFINED) continue;
-        index = comm_ranks[i] / (sizeof(int) * 8);
+        int idx = comm_ranks[i] / (sizeof(int) * 8);
         mask = 0x1 << comm_ranks[i] % (sizeof(int) * 8);
-        (*bitarray)[index] |= mask;
+        (*bitarray)[idx] |= mask;
     }
 
     MPL_free(group_ranks);

--- a/src/mpid/ch3/src/mpid_irsend.c
+++ b/src/mpid/ch3/src/mpid_irsend.c
@@ -56,14 +56,14 @@ int MPID_Irsend(const void * buf, int count, MPI_Datatype datatype, int rank, in
             goto fn_exit;
         }
 #endif
-    }
-    
-    MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
-    MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
-    MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
-    
-    if (rank == MPI_PROC_NULL)
-    {
+        MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
+        MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
+        MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
+    } else {
+        /* sreq creation code is duplicated here, but it is better than add separate branch later. */
+        MPIDI_Request_create_sreq(sreq, mpi_errno, goto fn_exit);
+        MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
+        MPIDI_Request_set_msg_type(sreq, MPIDI_REQUEST_EAGER_MSG);
 	MPIR_Object_set_ref(sreq, 1);
         MPIR_cc_set(&sreq->cc, 0);
 	goto fn_exit;

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -411,7 +411,9 @@ int MPIDI_CH3U_Get_business_card_sock(int myRank,
     int str_errno = MPL_STR_SUCCESS;
     MPIDI_CH3I_Sock_ifaddr_t ifaddr;
     char ifnamestr[MAX_HOST_DESCRIPTION_LEN];
+#ifdef MPL_USE_DBG_LOGGING
     char *bc_orig = *bc_val_p;
+#endif
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3U_GET_BUSINESS_CARD_SOCK);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3U_GET_BUSINESS_CARD_SOCK);

--- a/src/mpid/ch3/util/sock/ch3usock.h
+++ b/src/mpid/ch3/util/sock/ch3usock.h
@@ -60,12 +60,6 @@ void MPIDI_CH3I_Connection_free(MPIDI_CH3I_Connection_t *);
 /* Routines to get the socket address */
 int MPIDU_CH3U_GetSockInterfaceAddr( int, char *, int, MPIDI_CH3I_Sock_ifaddr_t * );
 
-/* Return a string for the connection state */
-#ifdef MPL_USE_DBG_LOGGING
-const char * MPIDI_Conn_GetStateString(int);
-const char * MPIDI_CH3_VC_GetStateString( struct MPIDI_VC * );
-#endif
-
 int MPIDI_CH3I_Sock_get_conninfo_from_bc( const char *bc,
 				     char *host_description, int maxlen,
 				     int *port, MPIDI_CH3I_Sock_ifaddr_t *ifaddr,

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -84,7 +84,15 @@ static inline int MPIDIG_handle_unexpected(void *buf, MPI_Aint count, MPI_Dataty
             rreq->status.MPI_ERROR = mpi_errno;
         }
     } else {
-        MPIR_Memcpy((char *) buf + dt_true_lb, MPIDIG_REQUEST(rreq, buffer), nbytes);
+        /* Note: buf could be NULL.  In one case it is a zero size message such as
+         * the one used in MPI_Barrier.  In another case, the datatype can specify
+         * the absolute address of the buffer (e.g. buf == MPI_BOTTOM).
+         */
+        if (nbytes > 0) {
+            char *addr = (char *) buf + dt_true_lb;
+            assert(addr);       /* to supress gcc-8 warning: -Wnonnull */
+            MPIR_Memcpy(addr, MPIDIG_REQUEST(rreq, buffer), nbytes);
+        }
     }
 
     MPIDIG_REQUEST(rreq, req->status) &= ~MPIDIG_REQ_UNEXPECTED;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -280,8 +280,8 @@ static int init_hints(struct fi_info *hints);
 static struct fi_info *pick_provider(struct fi_info *hints, const char *provname,
                                      struct fi_info *prov_list);
 static int set_eagain(MPIR_Comm * comm_ptr, MPIR_Info * info, void *state);
-static int conn_manager_init();
-static int conn_manager_destroy();
+static int conn_manager_init(void);
+static int conn_manager_destroy(void);
 static int dynproc_send_disconnect(int conn_id);
 
 static int set_eagain(MPIR_Comm * comm_ptr, MPIR_Info * info, void *state)

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -113,7 +113,12 @@ typedef struct {
     MPIDI_OFI_am_header_t msg_hdr;
     uint8_t am_hdr_buf[MPIDI_OFI_MAX_AM_HDR_SIZE];
     /* FI_ASYNC_IOV requires an iov storage to be alive until a request completes */
+#if MPIDI_OFI_IOVEC_ALIGN <= SIZEOF_VOID_P
+    struct iovec iov[3];
+#else
+    /* need bigger alignment */
     struct iovec iov[3] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+#endif
 } MPIDI_OFI_am_request_header_t;
 
 typedef struct {
@@ -139,9 +144,11 @@ typedef struct {
         struct iovec *nopack;
     } noncontig;
     union {
-#if defined (MPL_HAVE_VAR_ATTRIBUTE_ALIGNED)
-        struct iovec iov MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+#if MPIDI_OFI_IOVEC_ALIGN <= SIZEOF_VOID_P
+        struct iovec iov;
 #else
+        /* Enforce larger alignment. */
+        /*   icc complains alignment attribute without packed struct */
         char iov_store[sizeof(struct iovec) + MPIDI_OFI_IOVEC_ALIGN - 1];
 #endif
         void *inject_buf;       /* Internal buffer for inject emulation */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -346,7 +346,12 @@ typedef struct {
     UT_array *rma_sep_idx_array;        /* Array of available indexes of transmit contexts on sep */
 
     /* Active Message Globals */
+#if MPIDI_OFI_IOVEC_ALIGN <= SIZEOF_VOID_P
+    struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
+#else
+    /* need bigger alignment */
     struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS] MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
+#endif
     struct fi_msg am_msg[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     void *am_bufs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDI_OFI_am_repost_request_t am_reqs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];

--- a/src/mpid/ch4/netmod/ucx/globals.c
+++ b/src/mpid/ch4/netmod/ucx/globals.c
@@ -10,6 +10,4 @@
 #include "ucx_impl.h"
 #include "ucx_types.h"
 
-/* *INDENT-OFF* */
 MPIDI_UCX_global_t MPIDI_UCX_global;
-/* *INDENT-ON* */

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -110,7 +110,7 @@ int MPIDI_UCX_mpi_type_free_hook(MPIR_Datatype * datatype_p)
         ucp_dt_destroy(datatype_p->dev.netmod.ucx.ucp_datatype);
         datatype_p->dev.netmod.ucx.ucp_datatype = -1;
     }
-#if HAVE_LIBHCOLL
+#ifdef HAVE_LIBHCOLL
     hcoll_type_free_hook(datatype_p);
 #endif
 
@@ -141,7 +141,7 @@ int MPIDI_UCX_mpi_type_commit_hook(MPIR_Datatype * datatype_p)
         datatype_p->dev.netmod.ucx.ucp_datatype = ucp_datatype;
 
     }
-#if HAVE_LIBHCOLL
+#ifdef HAVE_LIBHCOLL
     hcoll_type_commit_hook(datatype_p);
 #endif
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -209,25 +209,6 @@ int MPIDI_UCX_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-/* -Wmissing-prototypes, `git grep` not find usage, comment-out for now. */
-/*
-int MPIDI_UCX_comm_get_lpid(MPIR_Comm * comm_ptr, int idx, int *lpid_ptr, bool is_remote)
-{
-    int avtid = 0, lpid = 0;
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
-        MPIDIU_comm_rank_to_pid(comm_ptr, idx, &lpid, &avtid);
-    } else if (is_remote) {
-        MPIDIU_comm_rank_to_pid(comm_ptr, idx, &lpid, &avtid);
-    } else {
-        MPIDIU_comm_rank_to_pid_local(comm_ptr, idx, &lpid, &avtid);
-    }
-
-    *lpid_ptr = MPIDIU_LUPID_CREATE(avtid, lpid);
-    return MPI_SUCCESS;
-
-}
-*/
-
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
 {
     MPIR_Assert(0);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -209,6 +209,8 @@ int MPIDI_UCX_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
+/* -Wmissing-prototypes, `git grep` not find usage, comment-out for now. */
+/*
 int MPIDI_UCX_comm_get_lpid(MPIR_Comm * comm_ptr, int idx, int *lpid_ptr, bool is_remote)
 {
     int avtid = 0, lpid = 0;
@@ -224,6 +226,7 @@ int MPIDI_UCX_comm_get_lpid(MPIR_Comm * comm_ptr, int idx, int *lpid_ptr, bool i
     return MPI_SUCCESS;
 
 }
+*/
 
 int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
 {

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -84,9 +84,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_am_handler(void *msg, size_t msg_sz)
 MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_Handle_am_recv(void *request, ucs_status_t status,
                                                        ucp_tag_recv_info_t * info)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-
     return;
 }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -200,7 +200,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     MPIDI_UCX_CHK_REQUEST(ucp_request);
 
     if (ucp_request->req) {
-        if (unlikely((ucs_status_t) ucp_request->req == UCS_ERR_MESSAGE_TRUNCATED)) {
+        if (unlikely((uint64_t) ucp_request->req == (uint64_t) UCS_ERR_MESSAGE_TRUNCATED)) {
             message->status.MPI_ERROR = MPI_ERR_TRUNCATE;
         } else {
             ucp_tag_recv_info_t *info = ucp_request->req;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -41,7 +41,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
     uint64_t base;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    MPIR_Comm *comm = win->comm_ptr;
     ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
 
     base = win_info->addr;
@@ -107,7 +106,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
     ucs_status_t status;
     struct MPIR_Segment *segment_ptr;
     char *buffer = NULL;
-    MPIR_Comm *comm = win->comm_ptr;
     ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
 
     segment_ptr = MPIR_Segment_alloc(origin_addr, origin_count, origin_datatype);
@@ -150,7 +148,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
     size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    MPIR_Comm *comm = win->comm_ptr;
     ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
 
     base = win_info->addr;

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -76,18 +76,16 @@ void MPIDI_sigusr1_handler(int sig)
 
 int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error_msg)
 {
-    char sys_str[MPI_MAX_ERROR_STRING + 5] = "";
-    char comm_str[MPI_MAX_ERROR_STRING] = "";
-    char world_str[MPI_MAX_ERROR_STRING] = "";
-    char error_str[2 * MPI_MAX_ERROR_STRING + 128];
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ABORT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ABORT);
 
+    char world_str[MPI_MAX_ERROR_STRING] = "";
     if (MPIR_Process.comm_world) {
         int rank = MPIR_Process.comm_world->rank;
         snprintf(world_str, sizeof(world_str), " on node %d", rank);
     }
 
+    char comm_str[MPI_MAX_ERROR_STRING] = "";
     if (comm) {
         int rank = comm->rank;
         int context_id = comm->context_id;
@@ -97,11 +95,14 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code, const char *error
     if (!error_msg)
         error_msg = "Internal error";
 
+    char sys_str[MPI_MAX_ERROR_STRING + 5] = "";
     if (mpi_errno != MPI_SUCCESS) {
         char msg[MPI_MAX_ERROR_STRING] = "";
         MPIR_Err_get_string(mpi_errno, msg, MPI_MAX_ERROR_STRING, NULL);
-        snprintf(sys_str, sizeof(msg), " (%s)", msg);
+        snprintf(sys_str, sizeof(sys_str), " (%s)", msg);
     }
+
+    char error_str[3 * MPI_MAX_ERROR_STRING + 128];
     MPL_snprintf(error_str, sizeof(error_str), "Abort(%d)%s%s: %s%s\n",
                  exit_code, world_str, comm_str, error_msg, sys_str);
     MPL_error_printf("%s", error_str);

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -281,10 +281,10 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     win->base = NULL;
     win->size = length;
     win->disp_unit = disp_unit;
-    win->create_flavor = (MPIR_Win_flavor_t) create_flavor;
-    win->model = (MPIR_Win_model_t) model;
-    win->copyCreateFlavor = (MPIR_Win_flavor_t) 0;
-    win->copyModel = (MPIR_Win_model_t) 0;
+    win->create_flavor = create_flavor;
+    win->model = model;
+    win->copyCreateFlavor = 0;
+    win->copyModel = 0;
     win->attributes = NULL;
     win->comm_ptr = win_comm_ptr;
     win->copyDispUnit = 0;

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -372,7 +372,7 @@ M*/
 #endif /* MPICH_IS_THREADED */
 
 /* Stateful non-recursive version of CS_EXIT.
- * It takes a MPIDU_thread_state_t variable to pass the state between
+ * It takes a MPIDU_thread_mutex_state_t variable to pass the state between
  * ENTER and EXIT. */
 
 #define MPIDU_THREAD_CS_EXIT_ST(name, mutex, st) MPIDUI_THREAD_CS_EXIT_ST_##name(mutex,st)
@@ -392,7 +392,11 @@ M*/
             mutex.count = 0;                                            \
             MPIDU_Thread_mutex_unlock(&mutex, &err_);                   \
             MPIR_Assert(err_ == 0);                                     \
-        }                                                               \
+        } else {                                                        \
+            /* silence warnings: -Wmaybe-uninitialized */               \
+            st.owner = 0;                                               \
+            st.count = 0;                                               \
+        } \
     } while (0)
 
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__GLOBAL

--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -724,7 +724,7 @@ int PMI_Spawn_multiple(int count,
 /* FIXME: This mixes init with get maxes */
 static int PMII_getmaxes(int *kvsname_max, int *keylen_max, int *vallen_max)
 {
-    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE], errmsg[PMIU_MAXLINE];
+    char buf[PMIU_MAXLINE], cmd[PMIU_MAXLINE];
     int err, rc;
 
     rc = MPL_snprintf(buf, PMIU_MAXLINE,
@@ -748,8 +748,10 @@ static int PMII_getmaxes(int *kvsname_max, int *keylen_max, int *vallen_max)
     PMIU_parse_keyvals(buf);
     cmd[0] = 0;
     PMIU_getval("cmd", cmd, PMIU_MAXLINE);
+
     if (strncmp(cmd, "response_to_init", PMIU_MAXLINE) != 0) {
-        MPL_snprintf(errmsg, PMIU_MAXLINE,
+        char errmsg[PMIU_MAXLINE * 2 + 100];
+        MPL_snprintf(errmsg, sizeof(errmsg),
                      "got unexpected response to init :%s: (full line = %s)", cmd, buf);
         PMI_Abort(-1, errmsg);
     } else {
@@ -758,7 +760,9 @@ static int PMII_getmaxes(int *kvsname_max, int *keylen_max, int *vallen_max)
         if (strncmp(buf, "0", PMIU_MAXLINE) != 0) {
             PMIU_getval("pmi_version", buf, PMIU_MAXLINE);
             PMIU_getval("pmi_subversion", buf1, PMIU_MAXLINE);
-            MPL_snprintf(errmsg, PMIU_MAXLINE,
+
+            char errmsg[PMIU_MAXLINE * 2 + 100];
+            MPL_snprintf(errmsg, sizeof(errmsg),
                          "pmi_version mismatch; client=%d.%d mgr=%s.%s",
                          PMI_VERSION, PMI_SUBVERSION, buf, buf1);
             PMI_Abort(-1, errmsg);

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -626,6 +626,13 @@ sub RunList {
 	}
 	else {
 	    $total_run++;
+            my $save_dir;
+            if ($programname =~/^(\S+)\/(\S+)$/) {
+                $save_dir = `pwd`;
+                chomp $save_dir;
+                $programname = $2;
+                chdir $1 or warn "Can't chdir $1\n";
+            }
 	    if (&BuildMPIProgram( $programname, $xfail ) == 0) {
 		if ($batchRun == 1) {
 		    &AddMPIProgram( $programname, $np, $ResultTest, 
@@ -647,6 +654,9 @@ sub RunList {
 	    if ($batchRun == 0) {
 		&CleanUpAfterRun( $programname );
 	    }
+            if ($save_dir) {
+                chdir $save_dir;
+            }
 	}
     }
     close( $LIST );


### PR DESCRIPTION
This is a split commit from #3747. If we are serious at squashing warnings, then we need -Werror tests.

We need a test e.g. `test:jenkins/warnings` that runs both ch3 and ch4 tests with `--enable-strict=error`.
