### PR TITLE
posix:  modify fastbox payload size

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
@@ -19,12 +19,12 @@
 
 typedef struct {
 
-    volatile uint64_t data_ready;
+    volatile uint64_t data_ready;       /*  takes a cache line */
 
     int is_header;
-    size_t payload_sz;
+    unsigned int payload_sz;    /* payload and cell can't be more than 4GB */
 
-    uint8_t payload[MPIDI_POSIX_FBOX_DATA_LEN];
+    uint8_t payload[MPIDI_POSIX_FBOX_DATA_LEN]; /* should be 64-bit aligned */
 
 } MPIDI_POSIX_fastbox_t;
 


### PR DESCRIPTION
modify MPIDI_POSIX_FBOX_DATA_LEN to make size of MPIDI_POSIX_fastbox_t
really 16KB as it intends to. Also account for the compiler inserted
padding.