### PR TITLE
maint: perl script use single quote to protect string literal

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -42,9 +42,11 @@ my $alt_ns = "MPIR_PARAM";
 my $dep_ns = "MPICH";
 
 # Default :output source files
-my $header_file = "@abs_srcdir@/../src/include/mpir_cvars.h";
-my $c_file      = "@abs_srcdir@/../src/util/cvar/mpir_cvars.c";
-my $readme_file = "@abs_srcdir@/../README.envvar";
+# NOTE: it's important to use single quote. abs_srcdir may contain sigils
+#   e.g. /var/lib/jenkins-slave/workspace/hzhou-custom@2/config/ch3-sock/label/centos64
+my $header_file = '@abs_srcdir@/../src/include/mpir_cvars.h';
+my $c_file      = '@abs_srcdir@/../src/util/cvar/mpir_cvars.c';
+my $readme_file = '@abs_srcdir@/../README.envvar';
 
 sub Usage {
     print <<EOT;


### PR DESCRIPTION
When multiple Jenkins tests (of the same config) gets run on the same node -- our new Jenkins server is setup that way -- the workspace path contains '@' which will be interpolated away by `Perl`. This PR fixes it by using single quotes.