### PR TITLE
warning-fix: warnings when enable-g=most

### DIFF
--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -888,6 +888,9 @@ int MPIDI_PrintConnStr( const char *file, int line,
 			const char *label, const char *str );
 int MPIDI_PrintConnStrToFile( FILE *fd, const char *file, int line, 
 			      const char *label, const char *str );
+
+/* Defined and used in sock channel. */
+const char * MPIDI_Conn_GetStateString(int state);
 #endif
 
 /* These macros simplify and unify the debugging of changes in the

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -8,6 +8,7 @@
 #define MPL_DBG_H_INCLUDED
 
 #include "mplconfig.h"
+#include <assert.h>
 
 /*
  * Multilevel debugging and tracing macros.
@@ -70,7 +71,9 @@
     {                                                                   \
         if ((_class & MPL_dbg_active_classes) && MPL_DBG_##_level <= MPL_dbg_max_level) { \
             char _s[MPL_DBG_MAXLINE];                                   \
-            MPL_snprintf _fmatargs ;                                    \
+            int _ret = MPL_snprintf _fmatargs ;                          \
+            /* by checking _ret, we supress -Wformat-trunction in gcc-8 */ \
+            assert(_ret >= 0);                                          \
             MPL_dbg_outevent(__FILE__, __LINE__, _class, 0, "%s", _s);  \
         }                                                               \
     }


### PR DESCRIPTION
## Pull Request Description

Under `--enable-g=most/all`, there are a few new warnings discovered. This PR fixes them.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None expected.

## Known Issues

None known.

## Author Checklist
* [X] Reference appropriate issues (with "Fixes" or "See" as appropriate)
This pr is a spin-off from PR #3735
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
None apply.
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
None apply.
