### PR TITLE
warning squash

### DIFF
--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -35,9 +35,9 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
 
-    size_t sendtype_extent, sendtype_lb;
-    size_t recvtype_extent, recvtype_lb;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint sendtype_extent, sendtype_lb;
+    MPI_Aint recvtype_extent, recvtype_lb;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     int delta = 1;
     int i_recv = 0;

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -31,9 +31,9 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_RING);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_RING);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -49,9 +49,9 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     int delta = 1;
 
     int is_inplace, rank, size, max;
-    size_t sendtype_extent, sendtype_lb;
-    size_t recvtype_extent, recvtype_lb;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint sendtype_extent, sendtype_lb;
+    MPI_Aint recvtype_extent, recvtype_lb;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
 #ifdef MPL_USE_DBG_LOGGING
     size_t sendtype_size;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -56,7 +56,7 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, int cou
                  int phase, int k, int digitval, int comm_size, int *pupsize,
                  MPIR_TSP_sched_t * sched, int ninvtcs, int *invtcs)
 {
-    size_t type_extent, type_lb, type_true_extent;
+    MPI_Aint type_extent, type_lb, type_true_extent;
     int pow_k_phase, offset, nconsecutive_occurrences, delta;
     int *dtcopy_id;
     int counter;
@@ -134,8 +134,8 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     int nphases = 0, max;
     int p_of_k;                 /* largest power of k that is (strictly) smaller than 'size' */
     int is_inplace;
-    size_t s_extent, s_lb, r_extent, r_lb;
-    size_t s_true_extent, r_true_extent;
+    MPI_Aint s_extent, s_lb, r_extent, r_lb;
+    MPI_Aint s_true_extent, r_true_extent;
     int delta, src, dst;
     void ***tmp_sbuf = NULL, ***tmp_rbuf = NULL;
     int *packids, *sendids = NULL, *recvids = NULL, *unpackids = NULL;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -58,9 +58,9 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
     int rank = MPIR_Comm_rank(comm);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLTOALL_SCHED_INTRA_RING);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLTOALL_SCHED_INTRA_RING);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -38,9 +38,9 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
     int batch_size = MPIR_CVAR_IALLTOALLV_SCATTERED_BATCH_SIZE;
     int bblock = MPIR_CVAR_IALLTOALLV_SCATTERED_OUTSTANDING_TASKS;
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLTOALLV_SCHED_INTRA_SCATTERED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLTOALLV_SCHED_INTRA_SCATTERED);

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -26,8 +26,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int size, rank, lrank;
     int i, j, tag, is_inplace = false;
-    size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
-    size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
+    MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id, *recv_id = NULL;
     void *tmp_buf = NULL;
     const void *data_buf = NULL;

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -22,7 +22,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t extent, true_extent;
+    MPI_Aint extent, true_extent;
     MPI_Aint lb;
     int nranks, rank;
     int is_commutative;

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -29,8 +29,8 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
     int size, rank;
     int i, j, is_inplace = false;
     int lrank;
-    size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
-    size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
+    MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id[2];
     void *tmp_buf = NULL;
     int recv_id;

--- a/src/mpid/ch3/src/ch3u_buffer.c
+++ b/src/mpid/ch3/src/ch3u_buffer.c
@@ -147,7 +147,6 @@ void MPIDI_CH3U_Buffer_copy(
 	for(;;)
 	{
 	    MPI_Aint last;
-	    char * buf_end;
 
 	    if (sdata_sz - sfirst > MPIDI_COPY_BUFFER_SZ)
 	    {
@@ -169,7 +168,6 @@ void MPIDI_CH3U_Buffer_copy(
 	    MPIR_Assert(last > sfirst);
 	    /* --END ERROR HANDLING-- */
 	    
-	    buf_end = buf + last - sfirst;
 	    sfirst = last;
 	    
 	    MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,VERBOSE,(MPL_DBG_FDEST,

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_get_next_recv_seqno(fi_addr_t add
     r = MPIDIU_map_lookup(MPIDI_OFI_global.am_recv_seq_tracker, id);
     if (r == MPIDIU_MAP_NOT_FOUND) {
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "First time adding recv seqno addr=0x%016lx\n", addr));
+                        (MPL_DBG_FDEST, "First time adding recv seqno addr=%" PRIx64 "\n", addr));
         MPIDIU_map_set(MPIDI_OFI_global.am_recv_seq_tracker, id, 0, MPL_MEM_OTHER);
         return 0;
     } else {
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_set_next_recv_seqno(fi_addr_t addr, u
     uint64_t id = addr;
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    (MPL_DBG_FDEST, "Next recv seqno=%d addr=0x%016lx\n", seqno, addr));
+                    (MPL_DBG_FDEST, "Next recv seqno=%d addr=%" PRIx64 "\n", seqno, addr));
 
     MPIDIU_map_update(MPIDI_OFI_global.am_recv_seq_tracker, id, (void *) (uintptr_t) seqno,
                       MPL_MEM_OTHER);
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
         if (uo_msg->am_hdr.fi_src_addr == addr && uo_msg->am_hdr.seqno == seqno) {
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                             (MPL_DBG_FDEST,
-                             "Found unordered message in the queue: addr=0x%016lx, seqno=%d\n",
+                             "Found unordered message in the queue: addr=%" PRIx64 ", seqno=%d\n",
                              addr, seqno));
             DL_DELETE(MPIDI_OFI_global.am_unordered_msgs, uo_msg);
             return uo_msg;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST,
                      "Generated seqno=%d for dest_rank=%d "
-                     "(context_id=0x%08x, src_addr=0x%016lx, dest_addr=0x%016lx)\n",
+                     "(context_id=0x%08x, src_addr=%" PRIx64 ", dest_addr=%" PRIx64 ")\n",
                      old_seq, dest_rank, comm->context_id,
                      MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank),
                      addr));

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -534,7 +534,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_recv_event(struct fi_cq_tagged_entry *
          * Put it in the queue to process it later. */
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                         (MPL_DBG_FDEST,
-                         "Expected seqno=%d but got %d (am_type=%d addr=0x%016lx). "
+                         "Expected seqno=%d but got %d (am_type=%d addr=%" PRIx64 "). "
                          "Enqueueing it to the queue.\n",
                          expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
         mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(am_hdr);

--- a/test/mpi/dtpools/src/dtpools_attr.c
+++ b/test/mpi/dtpools/src/dtpools_attr.c
@@ -8,6 +8,7 @@
 #include "dtpools_internal.h"
 #include <assert.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #define VALUE_FITS_IN_INT(val) ((val) <= INT_MAX)
 #define VALUE_FITS_IN_AINT(val) ((val) <= (((uint64_t) 1 << (sizeof(MPI_Aint) * 8 - 1)) - 1))
@@ -17,7 +18,7 @@
         MPI_Aint type_extent;                                           \
         MPI_Type_extent(type, &type_extent);                            \
         if (type_extent != extent) {                                    \
-            fprintf(stderr, "expected extent of %llu, but got %zd\n", extent, type_extent); \
+            fprintf(stderr, "expected extent of %" PRIu64 ", but got %zd\n", extent, type_extent); \
             fflush(stderr);                                             \
             assert(0);                                                  \
         }                                                               \


### PR DESCRIPTION
## Pull Request Description

Squashes for warnings that show up with clang version:

```
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

## Expected Performance Changes

No performance impact expected.

## Known Issues

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
