### PR TITLE
test: disable gather_big on all platforms

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -29,14 +29,14 @@
 #
 
 ################################################################################
-# gather_big uses around 15GB of memory for the user buffers.  Our
-# FreeBSD nodes have lesser memory than that, so we unconditionally
-# xfail that test on those machines.  We also xfail ch4 ofi/ucx builds
-# because of known bugs in mpich.
-* * * * freebsd64 sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
-* * * * freebsd32 sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
-* * * ch4:ucx * sed -i "s+\(^gather_big .*\)+\1 xfail=issue3770+g" test/mpi/coll/testlist
-* * * ch4:ofi * sed -i "s+\(^gather_big .*\)+\1 xfail=issue3770+g" test/mpi/coll/testlist
+
+# gather_big uses around 16GB of memory for the user buffers.  That
+# already puts the test outside of the memory capacity of our FreeBSD
+# nodes.  It is technically with the memory capacity of our remaining
+# nodes, but the MPICH algorithm for large Gathers allocates too much
+# temporary buffer space causing the remaining configurations to
+# intermittently fail too (see issue 3770 for more details).
+* * * * * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 
 ################################################################################
 # other failures on FreeBSD because of memory limits in our jenkins


### PR DESCRIPTION
## Pull Request Description

The gather_big test requires 1GB of send buffer on each process and 8
GB of receive buffer on the root process.  When running on a single
node, that'd mean we need 16GB of buffer space just for the user
buffers.  On top of that, we use a binomial algorithm within MPICH for
large Gathers, and each intermediate process allocates temporary
buffers for the entire incoming message.  That's an additional 1GB for
4 processes, and 3GB for 2 processes.  That'd put us at a total of
24GB memory requirement.  That's the maximum amount of memory
available on our nodes, making this test somewhat unreliable.

This PR disables that test on all platforms.

## Expected Performance Changes

None.

## Known Issues

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
