### PR TITLE
datatypes: remove unnecessary dataloop_size variable

### DIFF
--- a/src/include/mpir_dataloop.h
+++ b/src/include/mpir_dataloop.h
@@ -17,11 +17,11 @@ typedef struct MPIR_Dataloop MPIR_Dataloop;
 typedef struct MPIR_Segment MPIR_Segment;
 
 /* Dataloop functions */
-void MPIR_Dataloop_dup(MPIR_Dataloop * old_loop, MPI_Aint old_loop_sz, MPIR_Dataloop ** new_loop_p);
+void MPIR_Dataloop_dup(MPIR_Dataloop * old_loop, MPIR_Dataloop ** new_loop_p);
 
 void MPIR_Dataloop_free(MPIR_Dataloop ** dataloop);
 
-void MPIR_Dataloop_create(MPI_Datatype type, MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+void MPIR_Dataloop_create(MPI_Datatype type, MPIR_Dataloop ** dlp_p);
 
 void MPIR_Dataloop_printf(MPI_Datatype type, int depth, int header);
 int MPIR_Dataloop_flatten_size(MPIR_Datatype * dtp, int *flattened_dataloop_size);

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -138,7 +138,6 @@ struct MPIR_Datatype {
      * and a depth used to verify that we can process it (limited stack depth
      */
     struct MPIR_Dataloop *dataloop;     /* might be optimized for homogenous */
-    MPI_Aint dataloop_size;
 
     /* Other, device-specific information */
 #ifdef MPID_DEV_DATATYPE_DECL

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks_algos.h
@@ -35,9 +35,9 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, int sendcount,
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
 
-    size_t sendtype_extent, sendtype_lb;
-    size_t recvtype_extent, recvtype_lb;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint sendtype_extent, sendtype_lb;
+    MPI_Aint recvtype_extent, recvtype_lb;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     int delta = 1;
     int i_recv = 0;

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring_algos.h
@@ -31,9 +31,9 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, int sendcount,
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_RING);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLGATHER_SCHED_INTRA_RING);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -49,9 +49,9 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     int delta = 1;
 
     int is_inplace, rank, size, max;
-    size_t sendtype_extent, sendtype_lb;
-    size_t recvtype_extent, recvtype_lb;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint sendtype_extent, sendtype_lb;
+    MPI_Aint recvtype_extent, recvtype_lb;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
 #ifdef MPL_USE_DBG_LOGGING
     size_t sendtype_size;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -56,7 +56,7 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, int cou
                  int phase, int k, int digitval, int comm_size, int *pupsize,
                  MPIR_TSP_sched_t * sched, int ninvtcs, int *invtcs)
 {
-    size_t type_extent, type_lb, type_true_extent;
+    MPI_Aint type_extent, type_lb, type_true_extent;
     int pow_k_phase, offset, nconsecutive_occurrences, delta;
     int *dtcopy_id;
     int counter;
@@ -134,8 +134,8 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
     int nphases = 0, max;
     int p_of_k;                 /* largest power of k that is (strictly) smaller than 'size' */
     int is_inplace;
-    size_t s_extent, s_lb, r_extent, r_lb;
-    size_t s_true_extent, r_true_extent;
+    MPI_Aint s_extent, s_lb, r_extent, r_lb;
+    MPI_Aint s_true_extent, r_true_extent;
     int delta, src, dst;
     void ***tmp_sbuf = NULL, ***tmp_rbuf = NULL;
     int *packids, *sendids = NULL, *recvids = NULL, *unpackids = NULL;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring_algos.h
@@ -58,9 +58,9 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, int sendcount, MPI_
     int rank = MPIR_Comm_rank(comm);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLTOALL_SCHED_INTRA_RING);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLTOALL_SCHED_INTRA_RING);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered_algos.h
@@ -38,9 +38,9 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const int sen
     int batch_size = MPIR_CVAR_IALLTOALLV_SCATTERED_BATCH_SIZE;
     int bblock = MPIR_CVAR_IALLTOALLV_SCATTERED_OUTSTANDING_TASKS;
 
-    size_t recvtype_lb, recvtype_extent;
-    size_t sendtype_lb, sendtype_extent;
-    size_t sendtype_true_extent, recvtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent;
+    MPI_Aint sendtype_lb, sendtype_extent;
+    MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIR_TSP_IALLTOALLV_SCHED_INTRA_SCATTERED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIR_TSP_IALLTOALLV_SCHED_INTRA_SCATTERED);

--- a/src/mpi/coll/igather/igather_tsp_tree_algos.h
+++ b/src/mpi/coll/igather/igather_tsp_tree_algos.h
@@ -26,8 +26,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int size, rank, lrank;
     int i, j, tag, is_inplace = false;
-    size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
-    size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
+    MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id, *recv_id = NULL;
     void *tmp_buf = NULL;
     const void *data_buf = NULL;

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling_algos.h
@@ -22,7 +22,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t extent, true_extent;
+    MPI_Aint extent, true_extent;
     MPI_Aint lb;
     int nranks, rank;
     int is_commutative;

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree_algos.h
@@ -29,8 +29,8 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, int sendcount,
     int size, rank;
     int i, j, is_inplace = false;
     int lrank;
-    size_t sendtype_lb, sendtype_extent, sendtype_true_extent;
-    size_t recvtype_lb, recvtype_extent, recvtype_true_extent;
+    MPI_Aint sendtype_lb, sendtype_extent, sendtype_true_extent;
+    MPI_Aint recvtype_lb, recvtype_extent, recvtype_true_extent;
     int dtcopy_id[2];
     void *tmp_buf = NULL;
     int recv_id;

--- a/src/mpi/datatype/dataloop/dataloop.h
+++ b/src/mpi/datatype/dataloop/dataloop.h
@@ -48,27 +48,6 @@
     }                                             \
 } while (0)
 
-#define MPII_DATALOOP_GET_LOOPSIZE(a,depth_) do {             \
-    void *ptr;                                                      \
-    switch (HANDLE_GET_KIND(a)) {                                   \
-        case HANDLE_KIND_DIRECT:                                    \
-            MPIR_Assert(HANDLE_INDEX(a) < MPIR_DATATYPE_PREALLOC) ; \
-            ptr = MPIR_Datatype_direct+HANDLE_INDEX(a);             \
-            GET_FIELD(depth_,_size);                  \
-            break;                                                  \
-        case HANDLE_KIND_INDIRECT:                                  \
-            ptr = ((MPIR_Datatype *)                                \
-             MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem));   \
-            GET_FIELD(depth_,_size);                                \
-            break;                                                  \
-        case HANDLE_KIND_INVALID:                                   \
-        case HANDLE_KIND_BUILTIN:                                   \
-        default:                                                    \
-            depth_ = 0;                                             \
-            break;                                                  \
-    }                                                               \
-} while (0)
-
 #define MPII_DATALOOP_SET_LOOPPTR(a,lptr_) do {               \
     void *ptr;                                                      \
     switch (HANDLE_GET_KIND(a)) {                                   \
@@ -86,27 +65,6 @@
         case HANDLE_KIND_BUILTIN:                                   \
         default:                                                    \
             lptr_ = 0;                                              \
-            break;                                                  \
-    }                                                               \
-} while (0)
-
-#define MPII_DATALOOP_SET_LOOPSIZE(a,depth_) do {             \
-    void *ptr;                                                      \
-    switch (HANDLE_GET_KIND(a)) {                                   \
-        case HANDLE_KIND_DIRECT:                                    \
-            MPIR_Assert(HANDLE_INDEX(a) < MPIR_DATATYPE_PREALLOC);  \
-            ptr = MPIR_Datatype_direct+HANDLE_INDEX(a);             \
-            SET_FIELD(depth_,_size);                  \
-            break;                                                  \
-        case HANDLE_KIND_INDIRECT:                                  \
-            ptr = ((MPIR_Datatype *)                                \
-             MPIR_Handle_get_ptr_indirect(a,&MPIR_Datatype_mem));   \
-            SET_FIELD(depth_,_size);                  \
-            break;                                                  \
-        case HANDLE_KIND_INVALID:                                   \
-        case HANDLE_KIND_BUILTIN:                                   \
-        default:                                                    \
-            depth_ = 0;                                             \
             break;                                                  \
     }                                                               \
 } while (0)
@@ -225,7 +183,18 @@ struct MPIR_Dataloop {
     MPI_Aint el_size;
     MPI_Aint el_extent;
     MPI_Datatype el_type;
+
+    MPI_Aint dloop_sz;
 };
+
+static int MPII_Type_dloop_size(MPI_Datatype type)
+{
+    struct MPIR_Dataloop *dloop;
+
+    MPII_DATALOOP_GET_LOOPPTR(type, dloop);
+    return dloop->dloop_sz;
+}
+
 
 /*S
   MPIR_Segment - Description of the Segment datatype
@@ -271,33 +240,27 @@ MPI_Aint MPII_Dataloop_stackelm_offset(struct MPII_Dataloop_stackelm *elmp);
 void MPII_Dataloop_stackelm_load(struct MPII_Dataloop_stackelm *elmp,
                                  struct MPIR_Dataloop *dlp, int branch_flag);
 
-int MPII_Dataloop_create_contiguous(MPI_Aint count,
-                                    MPI_Datatype oldtype,
-                                    MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+int MPII_Dataloop_create_contiguous(MPI_Aint count, MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p);
 int MPII_Dataloop_create_vector(MPI_Aint count,
                                 MPI_Aint blocklength,
                                 MPI_Aint stride,
-                                int strideinbytes,
-                                MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+                                int strideinbytes, MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p);
 int MPII_Dataloop_create_blockindexed(MPI_Aint count,
                                       MPI_Aint blklen,
                                       const void *disp_array,
                                       int dispinbytes,
-                                      MPI_Datatype oldtype,
-                                      MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+                                      MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p);
 /* we bump up the size of the blocklength array because create_struct might use
  * create_indexed in an optimization, and in course of doing so, generate a
  * request of a large blocklength. */
 int MPII_Dataloop_create_indexed(MPI_Aint count,
                                  const MPI_Aint * blocklength_array,
                                  const void *displacement_array,
-                                 int dispinbytes,
-                                 MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+                                 int dispinbytes, MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p);
 int MPII_Dataloop_create_struct(MPI_Aint count,
                                 const int *blklen_array,
                                 const MPI_Aint * disp_array,
-                                const MPI_Datatype * oldtype_array,
-                                MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p);
+                                const MPI_Datatype * oldtype_array, MPIR_Dataloop ** dlp_p);
 
 /* Helper functions for dataloop construction */
 int MPII_Dataloop_convert_subarray(int ndims,
@@ -316,13 +279,10 @@ int MPII_Dataloop_convert_darray(int size,
 
 MPI_Aint MPII_Dataloop_stream_size(MPIR_Dataloop * dl_p, MPI_Aint(*sizefn) (MPI_Datatype el_type));
 
-void MPII_Dataloop_alloc(int kind,
-                         MPI_Aint count, MPIR_Dataloop ** new_loop_p, MPI_Aint * new_loop_sz_p);
+void MPII_Dataloop_alloc(int kind, MPI_Aint count, MPIR_Dataloop ** new_loop_p);
 void MPII_Dataloop_alloc_and_copy(int kind,
                                   MPI_Aint count,
-                                  MPIR_Dataloop * old_loop,
-                                  MPI_Aint old_loop_sz,
-                                  MPIR_Dataloop ** new_loop_p, MPI_Aint * new_loop_sz_p);
+                                  MPIR_Dataloop * old_loop, MPIR_Dataloop ** new_loop_p);
 
 void MPII_Dataloop_segment_flatten(MPIR_Segment * segp,
                                    MPI_Aint first,

--- a/src/mpi/datatype/dataloop/dataloop_create_blockindexed.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_blockindexed.c
@@ -25,7 +25,6 @@ static void blockindexed_array_copy(MPI_Aint count,
 .  int displacement_in_bytes (boolean)
 .  MPI_Datatype old_type
 .  MPIR_Dataloop **output_dataloop_ptr
-.  int output_dataloop_size
 
 .N Errors
 .N Returns 0 on success, -1 on failure.
@@ -33,9 +32,7 @@ static void blockindexed_array_copy(MPI_Aint count,
 int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
                                       MPI_Aint iblklen,
                                       const void *disp_array,
-                                      int dispinbytes,
-                                      MPI_Datatype oldtype,
-                                      MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p)
+                                      int dispinbytes, MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p)
 {
     int err, is_builtin, is_vectorizable = 1;
     int i;
@@ -50,7 +47,7 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
 
     /* if count or blklen are zero, handle with contig code, call it a int */
     if (count == 0 || blklen == 0) {
-        err = MPII_Dataloop_create_contiguous(0, MPI_INT, dlp_p, dlsz_p);
+        err = MPII_Dataloop_create_contiguous(0, MPI_INT, dlp_p);
         return err;
     }
 
@@ -74,7 +71,7 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
     if ((contig_count == 1) &&
         ((!dispinbytes && ((int *) disp_array)[0] == 0) ||
          (dispinbytes && ((MPI_Aint *) disp_array)[0] == 0))) {
-        err = MPII_Dataloop_create_contiguous(icount * iblklen, oldtype, dlp_p, dlsz_p);
+        err = MPII_Dataloop_create_contiguous(icount * iblklen, oldtype, dlp_p);
         return err;
     }
 
@@ -117,7 +114,7 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
         }
         if (is_vectorizable) {
             err = MPII_Dataloop_create_vector(count, blklen, last_stride, 1,    /* strideinbytes */
-                                              oldtype, dlp_p, dlsz_p);
+                                              oldtype, dlp_p);
             return err;
         }
     }
@@ -141,11 +138,12 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
      */
 
     if (is_builtin) {
-        MPII_Dataloop_alloc(MPII_DATALOOP_KIND_BLOCKINDEXED, count, &new_dlp, &new_loop_sz);
+        MPII_Dataloop_alloc(MPII_DATALOOP_KIND_BLOCKINDEXED, count, &new_dlp);
         /* --BEGIN ERROR HANDLING-- */
         if (!new_dlp)
             return -1;
         /* --END ERROR HANDLING-- */
+        new_loop_sz = new_dlp->dloop_sz;
 
         new_dlp->kind = MPII_DATALOOP_KIND_BLOCKINDEXED | MPII_DATALOOP_FINAL_MASK;
 
@@ -154,17 +152,16 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
         new_dlp->el_type = oldtype;
     } else {
         MPIR_Dataloop *old_loop_ptr = NULL;
-        MPI_Aint old_loop_sz = 0;
 
         MPII_DATALOOP_GET_LOOPPTR(oldtype, old_loop_ptr);
-        MPII_DATALOOP_GET_LOOPSIZE(oldtype, old_loop_sz);
 
         MPII_Dataloop_alloc_and_copy(MPII_DATALOOP_KIND_BLOCKINDEXED,
-                                     count, old_loop_ptr, old_loop_sz, &new_dlp, &new_loop_sz);
+                                     count, old_loop_ptr, &new_dlp);
         /* --BEGIN ERROR HANDLING-- */
         if (!new_dlp)
             return -1;
         /* --END ERROR HANDLING-- */
+        new_loop_sz = new_dlp->dloop_sz;
 
         new_dlp->kind = MPII_DATALOOP_KIND_BLOCKINDEXED;
 
@@ -185,7 +182,7 @@ int MPII_Dataloop_create_blockindexed(MPI_Aint icount,
                             new_dlp->loop_params.bi_t.offset_array, dispinbytes, old_extent);
 
     *dlp_p = new_dlp;
-    *dlsz_p = new_loop_sz;
+    new_dlp->dloop_sz = new_loop_sz;
 
     return 0;
 }

--- a/src/mpi/datatype/dataloop/dataloop_create_vector.c
+++ b/src/mpi/datatype/dataloop/dataloop_create_vector.c
@@ -18,7 +18,6 @@
 .  int strideinbytes
 .  MPI_Datatype oldtype
 .  MPIR_Dataloop **dlp_p
-.  int *dlsz_p
 
    Returns 0 on success, -1 on failure.
 
@@ -26,8 +25,7 @@
 int MPII_Dataloop_create_vector(MPI_Aint icount,
                                 MPI_Aint iblocklength,
                                 MPI_Aint astride,
-                                int strideinbytes,
-                                MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p, MPI_Aint * dlsz_p)
+                                int strideinbytes, MPI_Datatype oldtype, MPIR_Dataloop ** dlp_p)
 {
     int err, is_builtin;
     MPI_Aint new_loop_sz;
@@ -45,7 +43,7 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
      */
     if (count == 0 || blocklength == 0) {
 
-        err = MPII_Dataloop_create_contiguous(0, MPI_INT, dlp_p, dlsz_p);
+        err = MPII_Dataloop_create_contiguous(0, MPI_INT, dlp_p);
         return err;
     }
 
@@ -54,7 +52,7 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
      * if count == 1, store as a contiguous rather than a vector dataloop.
      */
     if (count == 1) {
-        err = MPII_Dataloop_create_contiguous(iblocklength, oldtype, dlp_p, dlsz_p);
+        err = MPII_Dataloop_create_contiguous(iblocklength, oldtype, dlp_p);
         return err;
     }
 
@@ -65,7 +63,7 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
     } else {
         MPI_Aint old_loop_sz = 0;
 
-        MPII_DATALOOP_GET_LOOPSIZE(oldtype, old_loop_sz);
+        old_loop_sz = MPII_Type_dloop_size(oldtype);
 
         /* TODO: ACCOUNT FOR PADDING IN LOOP_SZ HERE */
         new_loop_sz = sizeof(MPIR_Dataloop) + old_loop_sz;
@@ -75,11 +73,12 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
     if (is_builtin) {
         MPI_Aint basic_sz = 0;
 
-        MPII_Dataloop_alloc(MPII_DATALOOP_KIND_VECTOR, count, &new_dlp, &new_loop_sz);
+        MPII_Dataloop_alloc(MPII_DATALOOP_KIND_VECTOR, count, &new_dlp);
         /* --BEGIN ERROR HANDLING-- */
         if (!new_dlp)
             return -1;
         /* --END ERROR HANDLING-- */
+        new_loop_sz = new_dlp->dloop_sz;
 
         MPIR_Datatype_get_size_macro(oldtype, basic_sz);
         new_dlp->kind = MPII_DATALOOP_KIND_VECTOR | MPII_DATALOOP_FINAL_MASK;
@@ -90,17 +89,15 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
     } else {    /* user-defined base type (oldtype) */
 
         MPIR_Dataloop *old_loop_ptr;
-        MPI_Aint old_loop_sz = 0;
 
         MPII_DATALOOP_GET_LOOPPTR(oldtype, old_loop_ptr);
-        MPII_DATALOOP_GET_LOOPSIZE(oldtype, old_loop_sz);
 
-        MPII_Dataloop_alloc_and_copy(MPII_DATALOOP_KIND_VECTOR,
-                                     count, old_loop_ptr, old_loop_sz, &new_dlp, &new_loop_sz);
+        MPII_Dataloop_alloc_and_copy(MPII_DATALOOP_KIND_VECTOR, count, old_loop_ptr, &new_dlp);
         /* --BEGIN ERROR HANDLING-- */
         if (!new_dlp)
             return -1;
         /* --END ERROR HANDLING-- */
+        new_loop_sz = new_dlp->dloop_sz;
 
         new_dlp->kind = MPII_DATALOOP_KIND_VECTOR;
         MPIR_Datatype_get_size_macro(oldtype, new_dlp->el_size);
@@ -117,7 +114,6 @@ int MPII_Dataloop_create_vector(MPI_Aint icount,
     new_dlp->loop_params.v_t.stride = (strideinbytes) ? stride : stride * new_dlp->el_extent;
 
     *dlp_p = new_dlp;
-    *dlsz_p = new_loop_sz;
 
     return 0;
 }

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -65,7 +65,6 @@ int MPIR_Type_blockindexed(int count,
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
 

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -48,7 +48,7 @@ int MPIR_Type_commit(MPI_Datatype * datatype_p)
     if (datatype_ptr->is_committed == 0) {
         datatype_ptr->is_committed = 1;
 
-        MPIR_Dataloop_create(*datatype_p, &datatype_ptr->dataloop, &datatype_ptr->dataloop_size);
+        MPIR_Dataloop_create(*datatype_p, &datatype_ptr->dataloop);
 
         MPL_DBG_MSG_D(MPIR_DBG_DATATYPE, TERSE, "# contig blocks = %d\n",
                       (int) datatype_ptr->max_contig_blocks);

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -70,7 +70,6 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
 

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -75,7 +75,6 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     switch (type) {
         case MPI_FLOAT_INT:
@@ -166,7 +165,7 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
      * type and then committing it, then the dataloop will be missing.
      */
 
-    MPIR_Dataloop_create(type, &(new_dtp->dataloop), &(new_dtp->dataloop_size));
+    MPIR_Dataloop_create(type, &(new_dtp->dataloop));
 
     int err = MPID_Type_commit_hook(new_dtp);
 

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -62,7 +62,6 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
     new_dtp->contents = 0;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     /* if oldtype is a basic, we build a contiguous dataloop of count = 1 */
     if (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN) {

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -91,12 +91,11 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
         new_dtp->max_contig_blocks = old_dtp->max_contig_blocks;
 
         new_dtp->dataloop = NULL;
-        new_dtp->dataloop_size = old_dtp->dataloop_size;
         *newtype = new_dtp->handle;
 
         if (old_dtp->is_committed) {
             MPIR_Assert(old_dtp->dataloop != NULL);
-            MPIR_Dataloop_dup(old_dtp->dataloop, old_dtp->dataloop_size, &new_dtp->dataloop);
+            MPIR_Dataloop_dup(old_dtp->dataloop, &new_dtp->dataloop);
             MPID_Type_commit_hook(new_dtp);
         }
     }

--- a/src/mpi/datatype/type_flatten.c
+++ b/src/mpi/datatype/type_flatten.c
@@ -27,12 +27,12 @@ struct flatten_hdr {
  */
 int MPIR_Type_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_size)
 {
-    int flattened_dataloop_size;
+    int flattened_loop_size;
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_Dataloop_flatten_size(datatype_ptr, &flattened_dataloop_size);
+    MPIR_Dataloop_flatten_size(datatype_ptr, &flattened_loop_size);
 
-    *flattened_type_size = flattened_dataloop_size + sizeof(struct flatten_hdr);
+    *flattened_type_size = flattened_loop_size + sizeof(struct flatten_hdr);
 
     return mpi_errno;
 }

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -92,7 +92,6 @@ int MPIR_Type_indexed(int count,
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
 

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -195,7 +195,6 @@ int MPIR_Type_struct(int count,
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     /* check for junk struct with all zero blocks */
     for (i = 0; i < count; i++)

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -79,7 +79,6 @@ int MPIR_Type_vector(int count,
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
 

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -340,7 +340,6 @@ int MPII_Type_zerolen(MPI_Datatype * newtype)
     new_dtp->contents = NULL;
 
     new_dtp->dataloop = NULL;
-    new_dtp->dataloop_size = -1;
 
     new_dtp->size = 0;
     new_dtp->has_sticky_ub = 0;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -21,7 +21,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_get_next_recv_seqno(fi_addr_t add
     r = MPIDIU_map_lookup(MPIDI_OFI_global.am_recv_seq_tracker, id);
     if (r == MPIDIU_MAP_NOT_FOUND) {
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "First time adding recv seqno addr=0x%016lx\n", addr));
+                        (MPL_DBG_FDEST, "First time adding recv seqno addr=%" PRIu64 "\n", addr));
         MPIDIU_map_set(MPIDI_OFI_global.am_recv_seq_tracker, id, 0, MPL_MEM_OTHER);
         return 0;
     } else {
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_am_set_next_recv_seqno(fi_addr_t addr, u
     uint64_t id = addr;
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    (MPL_DBG_FDEST, "Next recv seqno=%d addr=0x%016lx\n", seqno, addr));
+                    (MPL_DBG_FDEST, "Next recv seqno=%d addr=%" PRIu64 "\n", seqno, addr));
 
     MPIDIU_map_update(MPIDI_OFI_global.am_recv_seq_tracker, id, (void *) (uintptr_t) seqno,
                       MPL_MEM_OTHER);
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
         if (uo_msg->am_hdr.fi_src_addr == addr && uo_msg->am_hdr.seqno == seqno) {
             MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                             (MPL_DBG_FDEST,
-                             "Found unordered message in the queue: addr=0x%016lx, seqno=%d\n",
+                             "Found unordered message in the queue: addr=%" PRIu64 ", seqno=%d\n",
                              addr, seqno));
             DL_DELETE(MPIDI_OFI_global.am_unordered_msgs, uo_msg);
             return uo_msg;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST,
                      "Generated seqno=%d for dest_rank=%d "
-                     "(context_id=0x%08x, src_addr=0x%016lx, dest_addr=0x%016lx)\n",
+                     "(context_id=0x%08x, src_addr=%" PRIu64 ", dest_addr=%" PRIu64 ")\n",
                      old_seq, dest_rank, comm->context_id,
                      MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank),
                      addr));

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -534,7 +534,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_recv_event(struct fi_cq_tagged_entry *
          * Put it in the queue to process it later. */
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                         (MPL_DBG_FDEST,
-                         "Expected seqno=%d but got %d (am_type=%d addr=0x%016lx). "
+                         "Expected seqno=%d but got %d (am_type=%d addr=%" PRIu64 "). "
                          "Enqueueing it to the queue.\n",
                          expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
         mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(am_hdr);

--- a/test/mpi/dtpools/src/dtpools_attr.c
+++ b/test/mpi/dtpools/src/dtpools_attr.c
@@ -8,6 +8,7 @@
 #include "dtpools_internal.h"
 #include <assert.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #define VALUE_FITS_IN_INT(val) ((val) <= INT_MAX)
 #define VALUE_FITS_IN_AINT(val) ((val) <= (((uint64_t) 1 << (sizeof(MPI_Aint) * 8 - 1)) - 1))
@@ -17,7 +18,7 @@
         MPI_Aint type_extent;                                           \
         MPI_Type_extent(type, &type_extent);                            \
         if (type_extent != extent) {                                    \
-            fprintf(stderr, "expected extent of %llu, but got %zd\n", extent, type_extent); \
+            fprintf(stderr, "expected extent of %" PRIu64 ", but got %zd\n", extent, type_extent); \
             fflush(stderr);                                             \
             assert(0);                                                  \
         }                                                               \


### PR DESCRIPTION
## Pull Request Description

The dataloop_size is a part of the dataloop infrastructure and should not be maintained outside of the dataloop code.  All external access to the actual dataloop should be done through the flatten/unflatten functions.

## Expected Performance Changes

None.

## Known Issues

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
