### PR TITLE
Fix build errors on MacOs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1351,8 +1351,6 @@ HWLOC_DO_AM_CONDITIONALS
 AM_CONDITIONAL([have_hwloc], [test "${have_hwloc}" = "yes"])
 AM_CONDITIONAL([use_embedded_hwloc], [test "${use_embedded_hwloc}" = "yes"])
 
-AM_CONDITIONAL([HAVE_HWLOC], [test x$have_hwloc = xyes])
-
 # ----------------------------------------------------------------------------
 # NETLOC
 # ----------------------------------------------------------------------------

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -138,7 +138,7 @@ cvars:
 
 #include "mpiimpl.h"
 #include "release_gather.h"
-#ifdef HAVE_HWLOC
+#ifdef BUILD_TOPOTREES
 #include "topotree.h"
 #include "topotree_util.h"
 #endif
@@ -305,7 +305,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
         release_gather_info_ptr->flags_shm_size = flags_shm_size;
 
-#ifdef HAVE_HWLOC
+#ifdef BUILD_TOPOTREES
         /* Create bcast_tree and reduce_tree with root of the tree as 0 */
         if (MPIR_CVAR_ENABLE_INTRANODE_TOPOLOGY_AWARE_TREES &&
             getenv("HYDRA_USER_PROVIDED_BINDING")) {

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -196,7 +196,11 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
     const long pg_sz = sysconf(_SC_PAGESIZE);
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     bool mapfail_flag = false;
-    int topotree_fail[2] = { 0, 0 };
+    int topotree_fail[2] = { -1, -1 };  /* -1 means topo trees not created due to reasons like not
+                                         * specifying binding, no hwloc etc. 0 means topo trees were
+                                         * created successfully. 1 means topo trees were created
+                                         * but there was a failure, so the tree needs to be freed
+                                         * before creating the non-topo tree */
 
     rank = MPIR_Comm_rank(comm_ptr);
     num_ranks = MPIR_Comm_size(comm_ptr);
@@ -309,6 +313,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
         /* Create bcast_tree and reduce_tree with root of the tree as 0 */
         if (MPIR_CVAR_ENABLE_INTRANODE_TOPOLOGY_AWARE_TREES &&
             getenv("HYDRA_USER_PROVIDED_BINDING")) {
+            /* Topology aware trees are created only when the user has specified process binding */
             if (hwloc_topology_load(MPIR_Process.hwloc_topology) == 0) {
                 mpi_errno =
                     MPIDI_SHM_topology_tree_init(comm_ptr, 0, MPIR_CVAR_BCAST_INTRANODE_TREE_KVAL,

--- a/src/mpid/ch4/shm/src/Makefile.mk
+++ b/src/mpid/ch4/shm/src/Makefile.mk
@@ -27,7 +27,7 @@ mpi_core_sources   += src/mpid/ch4/shm/src/func_table.c \
                       src/mpid/ch4/shm/src/shm_rma.c \
                       src/mpid/ch4/shm/src/shm_impl.c
 
-if HAVE_HWLOC
+if BUILD_TOPOTREES
 noinst_HEADERS += src/mpid/ch4/shm/src/topotree_util.h \
                   src/mpid/ch4/shm/src/topotree_types.h\
                   src/mpid/ch4/shm/src/topotree.h

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -514,6 +514,16 @@ src/mpid/ch4/src/ch4_coll_globals_default.c
 AM_CONDITIONAL([BUILD_CH4_SHM],[test "$enable_ch4_direct" = "auto"])
 AM_CONDITIONAL([BUILD_CH4_COLL_TUNING],[test -e "$srcdir/src/mpid/ch4/src/ch4_coll_globals.c"])
 
+# Test for the cpu process set type
+AC_CACHE_CHECK([whether cpu_set_t available],pac_cv_have_cpu_set_t,[
+                AC_TRY_COMPILE( [
+                                 #include <sched.h>],[ cpu_set_t t; ],pac_cv_have_cpu_set_t=yes,pac_cv_have_cpu_set_t=no)])
+if test "${have_hwloc}" = "yes" -a "${pac_cv_have_cpu_set_t}" = "yes" ; then
+   AC_DEFINE(BUILD_TOPOTREES,1,[Define if hwloc, cpu_set and GNU extensions are available])
+fi
+
+AM_CONDITIONAL([BUILD_TOPOTREES], [test x${have_hwloc} = x"yes" -a x${pac_cv_have_cpu_set_t} = x"yes" ])
+
 ])dnl end _BODY
 
 [#] end of __file__


### PR DESCRIPTION
## Pull Request Description
This PR fixes the build issues on MacOs which were caused due to Intra-node Topology aware trees.

The Linux-only header, sched.h, is also needed to be able to use the needed features in HWLOC.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
