### PR TITLE
ch4/ofi: Update submodule to pmodels/libfabric fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/pmodels/izem
 [submodule "src/mpid/ch4/netmod/ofi/libfabric"]
 	path = src/mpid/ch4/netmod/ofi/libfabric
-	url = https://github.com/ofiwg/libfabric
+	url = https://github.com/pmodels/libfabric
 [submodule "src/hwloc"]
 	path = src/hwloc
 	url = https://github.com/pmodels/hwloc


### PR DESCRIPTION
## Pull Request Description

Use pmodels fork of libfabric to carry patches not yet in upstream. Similar to how to maintain ucx and hwloc submodules. Add warning squashes from Pavan to v1.7.1 tagged release. PRs have been submitted to upstream libfabric for v1.7.2 and v1.8.x.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None

## Known Issues

None

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design