### PR TITLE
test: disable gather_big on all platforms. (cherry-picked for 3.3.x)

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -30,9 +30,20 @@
 portals4 * * ch3:portals4 * sed -i "s+\(^alltoall .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
 portals4 * * ch3:portals4 * sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
 portals4 * * ch3:portals4 * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-# gather_big is running out of memory on FreeBSD, xfailed until more memory is
-# added to FreeBSD nodes
-* * * * freebsd64 sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
+
+################################################################################
+
+# gather_big uses around 16GB of memory for the user buffers.  That
+# already puts the test outside of the memory capacity of our FreeBSD
+# nodes.  It is technically with the memory capacity of our remaining
+# nodes, but the MPICH algorithm for large Gathers allocates too much
+# temporary buffer space causing the remaining configurations to
+# intermittently fail too (see issue 3770 for more details).
+* * * * * sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
+
+################################################################################
+# other failures on FreeBSD because of memory limits in our jenkins
+# infrastructure
 * * * * freebsd64 sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
 * * * * freebsd32 sed -i "s+\(^gather_big .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 ################################################################################


### PR DESCRIPTION
The gather_big test requires 1GB of send buffer on each process and 8
GB of receive buffer on the root process.  When running on a single
node, that'd mean we need 16GB of buffer space just for the user
buffers.  On top of that, we use a binomial algorithm within MPICH for
large Gathers, and each intermediate process allocates temporary
buffers for the entire incoming message.  That's an additional 1GB for
4 processes, and 3GB for 2 processes.  That'd put us at a total of
24GB memory requirement.  That's the maximum amount of memory
available on our nodes, making this test somewhat unreliable.

Also see issue#3770.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
