### PR TITLE
hwloc: use exported LDFLAGS from HWLOC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1311,6 +1311,7 @@ elif test "$with_hwloc_prefix" = "embedded" ; then
       hwlocsrcdir="src/hwloc"
       hwloclib="$HWLOC_EMBEDDED_LDADD"
       PAC_PREPEND_FLAG([$HWLOC_EMBEDDED_LIBS], [WRAPPER_LIBS])
+      PAC_APPEND_FLAG([$HWLOC_EMBEDDED_LDFLAGS], [WRAPPER_LDFLAGS])
       # if possible, do not expose hwloc symbols in libmpi.so
       PAC_PREPEND_FLAG([$VISIBILITY_CFLAGS], [HWLOC_CFLAGS])
    fi


### PR DESCRIPTION
## Pull Request Description

Without the LDFLAGS detected by hwloc, we might miss out on external
library flags that are necessary for the build.  This showed up on Mac
OS, when OpenCL was detected by hwloc, but the corresponding flags
were not added to mpich's wrapper scripts.

Fixes #3449.

## Expected Performance Changes

None.

## Known Issues

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
