### PR TITLE
romio: warnings fix

### DIFF
--- a/src/mpi/romio/adio/common/ad_coll_exch_new.c
+++ b/src/mpi/romio/adio/common/ad_coll_exch_new.c
@@ -108,7 +108,7 @@ void ADIOI_Exch_file_views(int myrank, int nprocs, int file_ptr_type,
     }
 
     MPI_Type_extent(fd->filetype, &filetype_extent);
-    MPI_Type_size_x(fd->filetype, &filetype_sz);
+    MPI_Type_size_x(fd->filetype, (MPI_Count *)&filetype_sz);
     flat_file_p = ADIOI_Flatten_and_find(fd->filetype);
     if (filetype_extent == filetype_sz) {
         flat_file_p->blocklens[0] = memtype_sz * count;

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -1050,7 +1050,7 @@ static void ADIOI_R_Iexchange_data_recv(ADIOI_NBC_Request * nbc_req, int *error_
                 others_req[i].lens[k] = partial_send[i];
             }
             ADIOI_Type_create_hindexed_x(count[i],
-                                         &(others_req[i].lens[start_pos[i]]),
+                                         (MPI_Count *)&(others_req[i].lens[start_pos[i]]),
                                          &(others_req[i].mem_ptrs[start_pos[i]]),
                                          MPI_BYTE, &send_type);
             /* absolute displacement; use MPI_BOTTOM in send */

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -1047,7 +1047,7 @@ static void ADIOI_W_Iexchange_data_hole(ADIOI_NBC_Request * nbc_req, int *error_
                 others_req[i].lens[k] = partial_recv[i];
             }
             ADIOI_Type_create_hindexed_x(count[i],
-                                         &(others_req[i].lens[start_pos[i]]),
+                                         (MPI_Count *)&(others_req[i].lens[start_pos[i]]),
                                          &(others_req[i].mem_ptrs[start_pos[i]]),
                                          MPI_BYTE, recv_types + j);
             /* absolute displacements; use MPI_BOTTOM in recv */

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -843,7 +843,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
                 others_req[i].lens[k] = partial_send[i];
             }
             ADIOI_Type_create_hindexed_x(count[i],
-                                         &(others_req[i].lens[start_pos[i]]),
+                                         (MPI_Count *)&(others_req[i].lens[start_pos[i]]),
                                          &(others_req[i].mem_ptrs[start_pos[i]]),
                                          MPI_BYTE, &send_type);
             /* absolute displacement; use MPI_BOTTOM in send */

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -574,7 +574,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
                 others_req[i].lens[k] = partial_recv[i];
             }
             ADIOI_Type_create_hindexed_x(count[i],
-                                         &(others_req[i].lens[start_pos[i]]),
+                                         (MPI_Count *)&(others_req[i].lens[start_pos[i]]),
                                          &(others_req[i].mem_ptrs[start_pos[i]]),
                                          MPI_BYTE, recv_types + j);
             /* absolute displacements; use MPI_BOTTOM in recv */

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -74,7 +74,7 @@ ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)
     /* flatten and add to datatype */
     flat = flatlist_node_new(datatype, flat_count);
     if (is_contig) {
-        MPI_Type_size_x(datatype, &(flat->blocklens[0]));
+        MPI_Type_size_x(datatype, (MPI_Count *)&(flat->blocklens[0]));
         flat->indices[0] = 0;
     } else {
 

--- a/src/mpi/romio/mpi-io/get_bytoff.c
+++ b/src/mpi/romio/mpi-io/get_bytoff.c
@@ -62,7 +62,7 @@ int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset * disp)
     MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
-    ADIOI_Get_byte_offset(adio_fh, offset, disp);
+    ADIOI_Get_byte_offset(adio_fh, offset, (ADIO_Offset *)disp);
 
   fn_exit:
 

--- a/src/mpi/romio/mpi-io/get_posn.c
+++ b/src/mpi/romio/mpi-io/get_posn.c
@@ -53,7 +53,7 @@ int MPI_File_get_position(MPI_File fh, MPI_Offset * offset)
     MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
-    ADIOI_Get_position(adio_fh, offset);
+    ADIOI_Get_position(adio_fh, (ADIO_Offset *)offset);
 
   fn_exit:
     return MPI_SUCCESS;

--- a/src/mpi/romio/mpi-io/get_posn_sh.c
+++ b/src/mpi/romio/mpi-io/get_posn_sh.c
@@ -54,7 +54,7 @@ int MPI_File_get_position_shared(MPI_File fh, MPI_Offset * offset)
 
     ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
 
-    ADIO_Get_shared_fp(adio_fh, 0, offset, &error_code);
+    ADIO_Get_shared_fp(adio_fh, 0, (ADIO_Offset *)offset, &error_code);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);

--- a/src/mpi/romio/mpi-io/seek.c
+++ b/src/mpi/romio/mpi-io/seek.c
@@ -73,7 +73,7 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
             break;
         case MPI_SEEK_CUR:
             /* find offset corr. to current location of file pointer */
-            ADIOI_Get_position(adio_fh, &curr_offset);
+            ADIOI_Get_position(adio_fh, (ADIO_Offset *)&curr_offset);
             offset += curr_offset;
 
             /* --BEGIN ERROR HANDLING-- */
@@ -93,7 +93,7 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
             ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_seek", &error_code);
 
             /* find offset corr. to end of file */
-            ADIOI_Get_eof_offset(adio_fh, &eof_offset);
+            ADIOI_Get_eof_offset(adio_fh, (ADIO_Offset *)&eof_offset);
             offset += eof_offset;
 
             /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/seek_sh.c
+++ b/src/mpi/romio/mpi-io/seek_sh.c
@@ -94,7 +94,7 @@ int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
                 break;
             case MPI_SEEK_CUR:
                 /* get current location of shared file pointer */
-                ADIO_Get_shared_fp(adio_fh, 0, &curr_offset, &error_code);
+                ADIO_Get_shared_fp(adio_fh, 0, (ADIO_Offset *)&curr_offset, &error_code);
                 /* --BEGIN ERROR HANDLING-- */
                 if (error_code != MPI_SUCCESS) {
                     error_code = MPIO_Err_create_code(MPI_SUCCESS,
@@ -119,7 +119,7 @@ int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
                 break;
             case MPI_SEEK_END:
                 /* find offset corr. to end of file */
-                ADIOI_Get_eof_offset(adio_fh, &eof_offset);
+                ADIOI_Get_eof_offset(adio_fh, (ADIO_Offset *)&eof_offset);
                 offset += eof_offset;
                 /* --BEGIN ERROR HANDLING-- */
                 if (offset < 0) {


### PR DESCRIPTION
## Pull Request Description

Incompatible pointer types between
    ADIO_Offset * and MPI_Offset *
    ADIO_Offset * and MPI_Count *
One is `long long *`, and the other is `long *`, however, on 64bit os, both are 64-bit int -- Maybe a proper fix is to typedef both to `int64_t`?

## Expected Performance Changes

None.

## Known Issues

The typecast (used in the PR) is bad fix as it hides away the warning of "incompatibility" between the cast.
Soliciting discussions.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
