### PR TITLE
config: refactor configure for MPI_Aint and MPI_Offset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4812,52 +4812,21 @@ if test "$with_aint_size" -gt 0 ; then
         AC_MSG_RESULT([Overriding MPI_Aint to be $aint_size bytes])
    fi
 fi
+
+MPI_SIZEOF_AINT=$aint_size
+# export for subconfigure (e.g. test/mpi/configure)
+export MPI_SIZEOF_AINT
+
 MPI_AINT=int
 for type in int long long_long short ; do
     eval len=\$ac_cv_sizeof_$type
     if test "$len" = "$aint_size" ; then
         MPI_AINT=`echo $type | sed -e 's/_/ /'`
-        # Make the sizeof AINT available to other configures
-        MPI_SIZEOF_AINT=$len
-        export MPI_SIZEOF_AINT
-        case $type in
-            int)
-                MPI_AINT_FMT_DEC_SPEC="%d"
-                MPI_AINT_FMT_HEX_SPEC="%x"
-                MPIR_AINT_MAX="INT_MAX"
-                ;;
-            long)
-                MPI_AINT_FMT_DEC_SPEC="%ld"
-                MPI_AINT_FMT_HEX_SPEC="%lx"
-                MPIR_AINT_MAX="LONG_MAX"
-                ;;
-            long_long)
-                MPI_AINT_FMT_DEC_SPEC="%lld"
-                MPI_AINT_FMT_HEX_SPEC="%llx"
-                # tt#1776: if LLONG_MAX is missing, we fix it up in C, b/c it's
-                # easier there.  See mpiiimpl.h.
-                MPIR_AINT_MAX="LLONG_MAX"
-                ;;
-            short)
-                MPI_AINT_FMT_DEC_SPEC="%hd"
-                MPI_AINT_FMT_HEX_SPEC="%hx"
-                MPIR_AINT_MAX="SHRT_MAX"
-                ;;
-            *)
-                AC_MSG_WARN([unable to determine format specifiers for MPI_Aint, defaulting to int])
-                MPI_AINT_FMT_DEC_SPEC="%d"
-                MPI_AINT_FMT_HEX_SPEC="%x"
-                MPIR_AINT_MAX="INT_MAX"
-            ;;
-        esac
-        export MPI_AINT_FMT_DEC_SPEC MPI_AINT_FMT_HEX_SPEC
         break
     fi
 done
 AC_SUBST(MPI_AINT)
-AC_SUBST(MPI_AINT_FMT_DEC_SPEC)
-AC_SUBST(MPI_AINT_FMT_HEX_SPEC)
-AC_DEFINE_UNQUOTED([MPIR_AINT_MAX],[$MPIR_AINT_MAX],[limits.h _MAX constant for MPI_Aint])
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_AINT],[$aint_size], [Define size of MPI_Aint in bytes])
 
 # ----------------------------------------------------------------------------
 # MPI_AINT datatype

--- a/configure.ac
+++ b/configure.ac
@@ -5079,14 +5079,6 @@ AS_CASE([$MPI_OFFSET],
         [AC_MSG_ERROR([unable to determine MPIR_OFFSET_MAX for MPI_Offset])])
 AC_DEFINE_UNQUOTED([MPIR_OFFSET_MAX],[$MPIR_OFFSET_MAX],[limits.h _MAX constant for MPI_Offset])
 
-# FIXME: we need an explanation of why we need both MPI_OFFSET and
-# MPI_OFFSET_TYPEDEF.   Why is MPI_OFFSET_TYPEDEF necessary?
-# This appears to be used by the Windows "winconfigure.wsf" which is used
-# to create a multiline definition using an #ifdef check on USE_GCC
-# We may wish to use a different approach
-MPI_OFFSET_TYPEDEF="typedef $MPI_OFFSET MPI_Offset;"
-AC_SUBST(MPI_OFFSET_TYPEDEF)
-#
 # Fortran type for an Offset type (needed to define MPI_DISPLACEMENT_CURRENT
 # The value for this comes from ROMIO, and is needed in mpif.h.in
 # First, we check that this works with both Fortran compilers (if

--- a/configure.ac
+++ b/configure.ac
@@ -4243,9 +4243,8 @@ dnl     len_doublecplx=$hexlen
     # not yet support it.
     PAC_F77_LOGICALS_IN_C([$MPI_FINT])
 
-    # Get the INTEGER_KIND, ADDRESS_KIND and OFFSET_KIND if possible
+    # Get the INTEGER_KIND if possible
     #
-    # For Fortran 90, we'll also need MPI_ADDRESS_KIND and MPI_OFFSET_KIND
     # Since our compiler might BE a Fortran 90 compiler, try and determine the
     # values.
     if test "$FC" = "no" ; then
@@ -4257,48 +4256,12 @@ dnl     len_doublecplx=$hexlen
         ])
     fi
     if test "$FC" != "no" ; then
-        # Offset kind should be for 8 bytes if possible (Romio prefers that)
-        # address should be sizeof void * (unless --with-aint-size has
-        # been set)
-        # FIXME in the current configure implementation OFFSET_KIND and
-        # MPI_Offset won't always agree, but generally will.  The MPI Standard
-        # implies that these types must have identical size, so this is a bug
-        # waiting to happen.
-	if test "$with_aint_size" -gt 0 -a \
-	        "$with_aint_size" -gt "$ac_cv_sizeof_void_p" ; then
-	    testsize=$with_aint_size
-        else
-            testsize=$ac_cv_sizeof_void_p
-        fi
-        if test "$testsize" = 0 ; then
-            # Set a default
-            testsize=4
-        fi
-        dnl Using the {} around testsize helps the comments work correctly
-        PAC_PROG_FC_INT_KIND(ADDRESS_KIND,${testsize},$CROSS_F90_ADDRESS_KIND)
-        if test "$testsize" = 8 ; then
-            OFFSET_KIND=$ADDRESS_KIND
-        else
-            PAC_PROG_FC_INT_KIND(OFFSET_KIND,8,$CROSS_F90_OFFSET_KIND)
-        fi
-        #
         PAC_PROG_FC_INT_KIND(INTEGER_KIND,$pac_cv_f77_sizeof_integer,$CROSS_F90_INTEGER_KIND)
         if test "$INTEGER_KIND" = "-1" ; then
 	    # In our experience, this usually means that there is some
 	    # problem building and/or running the f90 program.  Fail
 	    # in this case rather than attempt to continue
 	    AC_MSG_ERROR([Unable to determine Fortran 90 KIND values for either address-sized integers or offset-sized integers.])
-        fi
-	#
-        # Some compilers won't allow a -1 kind (e.g., absoft).  In this case,
-        # use a fallback (sizeof(int) kind)
-        if test "$ADDRESS_KIND" = "-1" -o "$OFFSET_KIND" = "-1" ; then
-            if test "$ADDRESS_KIND" = "-1" ; then
-	        ADDRESS_KIND=$INTEGER_KIND
-            fi
-            if test "$OFFSET_KIND" = "-1" ; then
-	        OFFSET_KIND=$INTEGER_KIND
-            fi
         fi
 	AC_LANG_PUSH([Fortran])
         AC_CACHE_CHECK([if real*8 is supported in Fortran 90],
@@ -4320,26 +4283,6 @@ dnl     len_doublecplx=$hexlen
 	# WTIME_DOUBLE_TYPE is substituted into mpi_base.f90
 	AC_SUBST(WTIME_DOUBLE_TYPE)
     fi
-    # Make sure that address kind and offset kind have values.
-    if test -z "$ADDRESS_KIND" ; then
-        ADDRESS_KIND=0
-    fi
-    if test -z "$OFFSET_KIND" ; then
-        OFFSET_KIND=0
-    fi
-    # Note, however, that zero value are (in all practical case) invalid
-    # for Fortran 90, and indicate a failure.  Test and fail if Fortran 90
-    # enabled.
-    if test "$enable_fc" = "yes" ; then
-        if test "$ADDRESS_KIND" -le 0 -o "$OFFSET_KIND" -le 0 ; then
-	    AC_MSG_ERROR([Unable to determine Fortran 90 integer kinds for MPI types.  If you do not need Fortran 90, add --disable-fc to the configure options.])
-	    # If the above is converted to a warning, you need to change
-	    # enable_fc and remote f90 from the bindings
-	    enable_fc=no
-        fi
-    fi
-    AC_SUBST(ADDRESS_KIND)
-    AC_SUBST(OFFSET_KIND)
     AC_SUBST(INTEGER_KIND)
 
     # Some compilers may require special directives to handle the common
@@ -4803,6 +4746,12 @@ if test "$NEEDSPLIB" = "yes" ; then
 fi
 AC_SUBST(LPMPILIBNAME)
 
+#----------------------------------------------------------------- 
+#   **** MPI_Aint, MPI_Offset, MPI_Count ****
+#----------------------------------------------------------------- 
+#---------------------------------------- 
+# **** SIZES: export MPI_SIZEOF_xxx and define SIZEOF_MPI_xxx 
+# ---- MPI_Aint ----
 # Note that aint_size must be used instead of void_p where the desired check
 # is on the size of MPI_Aint
 aint_size=$ac_cv_sizeof_void_p
@@ -4814,7 +4763,6 @@ if test "$with_aint_size" -gt 0 ; then
 fi
 
 MPI_SIZEOF_AINT=$aint_size
-# export for subconfigure (e.g. test/mpi/configure)
 export MPI_SIZEOF_AINT
 
 MPI_AINT=int
@@ -4828,19 +4776,50 @@ done
 AC_SUBST(MPI_AINT)
 AC_DEFINE_UNQUOTED([SIZEOF_MPI_AINT],[$aint_size], [Define size of MPI_Aint in bytes])
 
-# ----------------------------------------------------------------------------
-# MPI_AINT datatype
-# ----------------------------------------------------------------------------
-# Must be done after MPI_Aint type determination but before subconfigures.
+# ---- MPI_Offset ----
+# Use 8-byte integer for MPI_Offset. We could use a config option
+# --with-offset_size=#, similar to --with-aint-size.
+MPI_SIZEOF_OFFSET=8
+export MPI_SIZEOF_OFFSET
 
-# convert to 2-char hex size
+MPI_OFFSET=int
+for type in int long long_long short ; do
+    eval len=\$ac_cv_sizeof_$type
+    if test "$len" = "$MPI_SIZEOF_OFFSET" ; then
+        MPI_OFFSET=`echo $type | sed -e 's/_/ /'`
+        break
+    fi
+done
+AC_SUBST(MPI_OFFSET)
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_OFFSET],[$MPI_SIZEOF_OFFSET], [Define size of MPI_Offset in bytes])
+
+# ---- MPI_Count ----
+# quick sanity checking to avoid a bad test immediately below
+AS_IF([test -z "$MPI_SIZEOF_AINT"],
+      [AC_MSG_ERROR([size of MPI_Aint is unknown at this stage])])
+AS_IF([test -z "$MPI_SIZEOF_OFFSET"],
+      [AC_MSG_ERROR([size of MPI_Offset is unknown at this stage])])
+
+AS_IF([test "$MPI_SIZEOF_AINT" -gt "$MPI_SIZEOF_OFFSET"],
+      [# an unlikely case, but I suppose it's theoretically possible
+       MPI_COUNT="$MPI_AINT"
+       MPI_SIZEOF_COUNT="$MPI_SIZEOF_AINT"],
+      [# don't bother checking whether Aint or Offset are larger than int, they
+       # surely will be
+       MPI_COUNT="$MPI_OFFSET"
+       MPI_SIZEOF_COUNT="$MPI_SIZEOF_OFFSET"])
+AC_SUBST([MPI_COUNT])
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_COUNT],[$MPI_SIZEOF_COUNT], [Define size of MPI_Count in bytes])
+
+#---------------------------------------- 
+# **** MPI datatype: AC_SUBST(MPI_xxx_DATATYPE)
+# ---- MPI_AINT ----
 case "$MPI_SIZEOF_AINT" in
     4)    len_mpi_aint=04 ;;
     8)    len_mpi_aint=08 ;;
     16)   len_mpi_aint=10 ;;
     *)    AC_MSG_ERROR([Unable to convert MPI_SIZEOF_AINT to a hex string.  This is either because we are building on a very strange platform or there is a bug somewhere in configure.]) ;;
 esac
-# MPI_AINT and MPI_OFFSET are already taken, appending a _DATATYPE suffix
 MPI_AINT_DATATYPE=0x4c00${len_mpi_aint}43
 AC_SUBST(MPI_AINT_DATATYPE)
 export MPI_AINT_DATATYPE
@@ -4850,8 +4829,85 @@ export MPI_AINT_DATATYPE
 MPI_F77_AINT=`expr 1275068483 '+' '(' 256 '*' $MPI_SIZEOF_AINT ')'`
 AC_SUBST(MPI_F77_AINT)
 export MPI_F77_AINT
-# ----------------------------------------------------------------------------
 
+# ---- MPI_OFFSET ----
+case "$MPI_SIZEOF_OFFSET" in
+    4)    len_mpi_offset=04 ;;
+    8)    len_mpi_offset=08 ;;
+    16)   len_mpi_offset=10 ;;
+    *)    AC_MSG_ERROR([Unable to convert MPI_SIZEOF_OFFSET to a hex string.  This is either because we are building on a very strange platform or there is a bug somewhere in configure.]) ;;
+esac
+MPI_OFFSET_DATATYPE=0x4c00${len_mpi_offset}44
+AC_SUBST(MPI_OFFSET_DATATYPE)
+export MPI_OFFSET_DATATYPE
+
+# 0x4c000044 is 1275068484 in decimal, add ($MPI_SIZEOF_OFFSET * 256) and you get
+# the decimal equivalent of the hex number
+MPI_F77_OFFSET=`expr 1275068484 '+' '(' 256 '*' $MPI_SIZEOF_OFFSET ')'`
+AC_SUBST(MPI_F77_OFFSET)
+export MPI_F77_OFFSET
+
+# ---- MPI_COUNT ----
+AS_CASE([$MPI_SIZEOF_COUNT],
+        [4], [len_mpi_count=04],
+        [8], [len_mpi_count=08],
+        [16],[len_mpi_count=10],
+        [AC_MSG_ERROR([Unable to convert MPI_SIZEOF_COUNT to a hex string!])])
+MPI_COUNT_DATATYPE=0x4c00${len_mpi_count}45
+AC_SUBST([MPI_COUNT_DATATYPE])
+
+# 0x4c000045 is 1275068485 in decimal, add ($MPI_SIZEOF_COUNT * 256) and you get
+# the decimal equivalent of the hex number
+MPI_F77_COUNT=`expr 1275068485 '+' '(' 256 '*' $MPI_SIZEOF_OFFSET ')'`
+AC_SUBST([MPI_F77_COUNT])
+
+#---------------------------------------- 
+# **** Fortran F90 KIND:
+if test "$enable_f77" = yes ; then
+    if test "$FC" != "no" ; then
+        PAC_PROG_FC_INT_KIND(ADDRESS_KIND,$MPI_SIZEOF_AINT,$CROSS_F90_ADDRESS_KIND)
+        PAC_PROG_FC_INT_KIND(OFFSET_KIND,$MPI_SIZEOF_OFFSET,$CROSS_F90_OFFSET_KIND)
+        if test "$ADDRESS_KIND" -le 0 -o "$OFFSET_KIND" -le 0 ; then
+            AC_MSG_ERROR([Unable to determine Fortran 90 integer kinds for MPI types.  If you do not need Fortran 90, add --disable-fc to the configure options.])
+            # If the above is converted to a warning, you need to change
+            # enable_fc and remote f90 from the bindings
+            enable_fc=no
+        fi
+    fi
+    # Make sure that address kind and offset kind have values.
+    if test -z "$ADDRESS_KIND" ; then
+        ADDRESS_KIND=0
+    fi
+    if test -z "$OFFSET_KIND" ; then
+        OFFSET_KIND=0
+    fi
+
+    AS_IF([test "$MPI_SIZEOF_AINT" -gt "$MPI_SIZEOF_OFFSET"],
+      [COUNT_KIND="$ADDRESS_KIND"],
+      [COUNT_KIND="$OFFSET_KIND"])
+
+    AC_SUBST(ADDRESS_KIND)
+    AC_SUBST(OFFSET_KIND)
+    AC_SUBST(COUNT_KIND)
+fi
+
+#---------------------------------------- 
+# **** Fortran F77 type:
+if test "$enable_f77" = yes ; then
+    if test $MPI_SIZEOF_OFFSET = $pac_cv_f77_sizeof_integer ; then
+        FORTRAN_MPI_OFFSET="integer"
+    elif test $MPI_SIZEOF_OFFSET = 4 -a $pac_cv_fort_integer4 = yes ; then
+        FORTRAN_MPI_OFFSET="integer*8"
+    elif test $MPI_SIZEOF_OFFSET = 8 -a $pac_cv_fort_integer8 = yes ; then
+        FORTRAN_MPI_OFFSET="integer*8"
+    else
+        AC_MSG_ERROR([Can't find F77 integer type for MPI_Offset.])
+    fi
+    export FORTRAN_MPI_OFFSET
+    AC_SUBST(FORTRAN_MPI_OFFSET)
+fi
+
+#---------------------------------------- 
 if test "$ac_cv_sizeof_void_p" -lt "$aint_size" ; then
     AC_DEFINE(USE_AINT_FOR_ATTRVAL,1,[Define if MPI_Aint should be used instead of void * for storing attribute values])
 fi
@@ -4880,6 +4936,9 @@ BSEND_OVERHEAD=$ac_cv_sizeof_MPII_Bsend_data_t
 export BSEND_OVERHEAD
 AC_SUBST(BSEND_OVERHEAD)
 
+AC_DEFINE_UNQUOTED(MPIR_Ucount,unsigned $MPI_COUNT,[MPIR_Ucount is an unsigned MPI_Count-sized integer])
+
+# ----------------------------------------------------------------------------
 dnl Configure any subdirectories.  Note that config.status will *not*
 dnl reexecute these!
 dnl
@@ -5029,23 +5088,7 @@ dnl AC_SUBST(MPI_2COMPLEX)
 dnl AC_SUBST(MPI_2DOUBLE_COMPLEX)
 AC_SUBST(MPI_FINT)
 
-#---- MPI_Offset ---- 
-# Use 8-byte integer for MPI_Offset. We could use a config option
-# --with-offset_size=#, similar to --with-aint-size.
-MPI_SIZEOF_OFFSET=8
-export MPI_SIZEOF_OFFSET
-
-MPI_OFFSET=int
-for type in int long long_long short ; do
-    eval len=\$ac_cv_sizeof_$type
-    if test "$len" = "$MPI_SIZEOF_OFFSET" ; then
-        MPI_OFFSET=`echo $type | sed -e 's/_/ /'`
-        break
-    fi
-done
-AC_SUBST(MPI_OFFSET)
-AC_DEFINE_UNQUOTED([SIZEOF_MPI_OFFSET],[$MPI_SIZEOF_OFFSET], [Define size of MPI_Offset in bytes])
-
+#---- FORTRAN_MPI_OFFSET ---- 
 # Fortran type for an Offset type (needed to define MPI_DISPLACEMENT_CURRENT
 # The value for this comes from ROMIO, and is needed in mpif.h.in
 # First, we check that this works with both Fortran compilers (if
@@ -5081,64 +5124,6 @@ AC_SUBST(FORTRAN_MPI_OFFSET)
 #
 
 # ----------------------------------------------------------------------------
-# MPI_OFFSET datatype
-# ----------------------------------------------------------------------------
-# must be done after ROMIO configure step
-case "$MPI_SIZEOF_OFFSET" in
-    4)    len_mpi_offset=04 ;;
-    8)    len_mpi_offset=08 ;;
-    16)   len_mpi_offset=10 ;;
-    *)    AC_MSG_ERROR([Unable to convert MPI_SIZEOF_OFFSET to a hex string.  This is either because we are building on a very strange platform or there is a bug somewhere in configure.]) ;;
-esac
-MPI_OFFSET_DATATYPE=0x4c00${len_mpi_offset}44
-AC_SUBST(MPI_OFFSET_DATATYPE)
-export MPI_OFFSET_DATATYPE
-
-# 0x4c000044 is 1275068484 in decimal, add ($MPI_SIZEOF_OFFSET * 256) and you get
-# the decimal equivalent of the hex number
-MPI_F77_OFFSET=`expr 1275068484 '+' '(' 256 '*' $MPI_SIZEOF_OFFSET ')'`
-AC_SUBST(MPI_F77_OFFSET)
-export MPI_F77_OFFSET
-
-# ----------------------------------------------------------------------------
-# MPI_COUNT datatype
-# ----------------------------------------------------------------------------
-# quick sanity checking to avoid a bad test immediately below
-AS_IF([test -z "$MPI_SIZEOF_AINT"],
-      [AC_MSG_ERROR([size of MPI_Aint is unknown at this stage])])
-AS_IF([test -z "$MPI_SIZEOF_OFFSET"],
-      [AC_MSG_ERROR([size of MPI_Offset is unknown at this stage])])
-
-AS_IF([test "$MPI_SIZEOF_AINT" -gt "$MPI_SIZEOF_OFFSET"],
-      [# an unlikely case, but I suppose it's theoretically possible
-       MPI_COUNT="$MPI_AINT"
-       COUNT_KIND="$ADDRESS_KIND"
-       MPI_SIZEOF_COUNT="$MPI_SIZEOF_AINT"],
-      [# don't bother checking whether Aint or Offset are larger than int, they
-       # surely will be
-       MPI_COUNT="$MPI_OFFSET"
-       COUNT_KIND="$OFFSET_KIND"
-       MPI_SIZEOF_COUNT="$MPI_SIZEOF_OFFSET"])
-AC_SUBST([MPI_COUNT])
-AC_SUBST([COUNT_KIND])
-AC_DEFINE_UNQUOTED([SIZEOF_MPI_COUNT],[$MPI_SIZEOF_COUNT], [Define size of MPI_Count in bytes])
-AC_DEFINE_UNQUOTED(MPIR_Ucount,unsigned $MPI_COUNT,[MPIR_Ucount is an unsigned MPI_Count-sized integer])
-
-AS_CASE([$MPI_SIZEOF_COUNT],
-        [4], [len_mpi_count=04],
-        [8], [len_mpi_count=08],
-        [16],[len_mpi_count=10],
-        [AC_MSG_ERROR([Unable to convert MPI_SIZEOF_COUNT to a hex string!])])
-MPI_COUNT_DATATYPE=0x4c00${len_mpi_count}45
-AC_SUBST([MPI_COUNT_DATATYPE])
-
-# 0x4c000045 is 1275068485 in decimal, add ($MPI_SIZEOF_COUNT * 256) and you get
-# the decimal equivalent of the hex number
-MPI_F77_COUNT=`expr 1275068485 '+' '(' 256 '*' $MPI_SIZEOF_OFFSET ')'`
-AC_SUBST([MPI_F77_COUNT])
-
-# ----------------------------------------------------------------------------
-
 #
 # Set size of MPI_Status.  Must come after MPI_Count determination.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -5029,55 +5029,22 @@ dnl AC_SUBST(MPI_2COMPLEX)
 dnl AC_SUBST(MPI_2DOUBLE_COMPLEX)
 AC_SUBST(MPI_FINT)
 
-# If ROMIO was successfully configured, then ROMIO will have exported the
-# definition of MPI_OFFSET_TYPE through its localdefs file (created by the
-# ROMIO configure in src/mpi/romio/localdefs).  If MPI_OFFSET_TYPE was not
-# defined, this code attempts to find a good choice for MPI_OFFSET_TYPE
-# (As the offset type is used for File operations, the specific type
-# really doesn't matter if ROMIO doesn't provide it).
-if test -n "$MPI_OFFSET_TYPE" ; then
-    # We got the value from the ROMIO configure
-    MPI_OFFSET="$MPI_OFFSET_TYPE"
-    # Get and export the size of this type if possible
-    if test -z "$MPI_SIZEOF_OFFSET" ; then
-        # set a default
-        AC_CACHE_CHECK([the sizeof MPI_Offset],ac_cv_sizeof_MPI_Offset,[
-            ac_cv_sizeof_MPI_Offset=unknown
-            AC_COMPUTE_INT([ac_cv_sizeof_MPI_Offset],[sizeof($MPI_OFFSET)],[],[
-                AC_MSG_WARN([Unable to determine the size of MPI_Offset])
-            ])
-	])
-	if test "$ac_cv_sizeof_MPI_Offset" != "unknown" ; then
-  	    MPI_SIZEOF_OFFSET=$ac_cv_sizeof_MPI_Offset
-        fi
-    fi
-    export MPI_SIZEOF_OFFSET
-else
-    # Make a guess at the appropriate definition for offset.  Try to
-    # find a 64bit type.
-    if test "$ac_cv_sizeof_long" = 8 ; then
-        MPI_OFFSET="long"
-	# Make the size of this type available to other configures
-	MPI_SIZEOF_OFFSET=8
-    elif test "$ac_cv_sizeof_long_long" = 8 ; then
-        MPI_OFFSET="long long"
-	# Make the size of this type available to other configures
-	MPI_SIZEOF_OFFSET=8
-    else
-        MPI_OFFSET=long
-        MPI_SIZEOF_OFFSET=$ac_cv_sizeof_long
-    fi
-    export MPI_SIZEOF_OFFSET
-fi
-AC_SUBST(MPI_OFFSET)
+#---- MPI_Offset ---- 
+# Use 8-byte integer for MPI_Offset. We could use a config option
+# --with-offset_size=#, similar to --with-aint-size.
+MPI_SIZEOF_OFFSET=8
+export MPI_SIZEOF_OFFSET
 
-AS_CASE([$MPI_OFFSET],
-        [int],         [MPIR_OFFSET_MAX="INT_MAX"],
-        [long],        [MPIR_OFFSET_MAX="LONG_MAX"],
-        ['long long'], [MPIR_OFFSET_MAX="LLONG_MAX"],
-        [short],       [MPIR_OFFSET_MAX="SHRT_MAX"],
-        [AC_MSG_ERROR([unable to determine MPIR_OFFSET_MAX for MPI_Offset])])
-AC_DEFINE_UNQUOTED([MPIR_OFFSET_MAX],[$MPIR_OFFSET_MAX],[limits.h _MAX constant for MPI_Offset])
+MPI_OFFSET=int
+for type in int long long_long short ; do
+    eval len=\$ac_cv_sizeof_$type
+    if test "$len" = "$MPI_SIZEOF_OFFSET" ; then
+        MPI_OFFSET=`echo $type | sed -e 's/_/ /'`
+        break
+    fi
+done
+AC_SUBST(MPI_OFFSET)
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_OFFSET],[$MPI_SIZEOF_OFFSET], [Define size of MPI_Offset in bytes])
 
 # Fortran type for an Offset type (needed to define MPI_DISPLACEMENT_CURRENT
 # The value for this comes from ROMIO, and is needed in mpif.h.in
@@ -5146,17 +5113,15 @@ AS_IF([test "$MPI_SIZEOF_AINT" -gt "$MPI_SIZEOF_OFFSET"],
       [# an unlikely case, but I suppose it's theoretically possible
        MPI_COUNT="$MPI_AINT"
        COUNT_KIND="$ADDRESS_KIND"
-       MPIR_COUNT_MAX="$MPIR_AINT_MAX"
        MPI_SIZEOF_COUNT="$MPI_SIZEOF_AINT"],
       [# don't bother checking whether Aint or Offset are larger than int, they
        # surely will be
        MPI_COUNT="$MPI_OFFSET"
        COUNT_KIND="$OFFSET_KIND"
-       MPIR_COUNT_MAX="$MPIR_OFFSET_MAX"
        MPI_SIZEOF_COUNT="$MPI_SIZEOF_OFFSET"])
 AC_SUBST([MPI_COUNT])
 AC_SUBST([COUNT_KIND])
-AC_DEFINE_UNQUOTED([MPIR_COUNT_MAX],[$MPIR_COUNT_MAX],[limits.h _MAX constant for MPI_Count])
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_COUNT],[$MPI_SIZEOF_COUNT], [Define size of MPI_Count in bytes])
 AC_DEFINE_UNQUOTED(MPIR_Ucount,unsigned $MPI_COUNT,[MPIR_Ucount is an unsigned MPI_Count-sized integer])
 
 AS_CASE([$MPI_SIZEOF_COUNT],

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -567,10 +567,7 @@ static const MPI_Datatype mpich_mpi_aint   MPICH_ATTR_TYPE_TAG(MPI_Aint)   = MPI
 
 /* Let ROMIO know that MPI_Offset is already defined */
 #define HAVE_MPI_OFFSET
-/* MPI_OFFSET_TYPEDEF is set in configure and is 
-      typedef $MPI_OFFSET MPI_Offset;
-   where $MPI_OFFSET is the correct C type */
-@MPI_OFFSET_TYPEDEF@
+typedef @MPI_OFFSET@ MPI_Offset;
 
 #ifdef MPICH_DEFINE_ATTR_TYPE_TYPES
 static const MPI_Datatype mpich_mpi_offset MPICH_ATTR_TYPE_TAG(MPI_Offset) = MPI_OFFSET;

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -565,12 +565,6 @@ typedef @MPI_COUNT@ MPI_Count;
 static const MPI_Datatype mpich_mpi_aint   MPICH_ATTR_TYPE_TAG(MPI_Aint)   = MPI_AINT;
 #endif
 
-/* FIXME: The following two definition are not defined by MPI and must not be
-   included in the mpi.h file, as the MPI namespace is reserved to the MPI 
-   standard */
-#define MPI_AINT_FMT_DEC_SPEC "@MPI_AINT_FMT_DEC_SPEC@"
-#define MPI_AINT_FMT_HEX_SPEC "@MPI_AINT_FMT_HEX_SPEC@"
-
 /* Let ROMIO know that MPI_Offset is already defined */
 #define HAVE_MPI_OFFSET
 /* MPI_OFFSET_TYPEDEF is set in configure and is 

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -102,6 +102,18 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #define __func__ "__func__"
 #endif
 
+#if SIZEOF_MPI_AINT == 4
+#define MPI_AINT_FMT_DEC_SPEC PRId32
+#define MPI_AINT_FMT_HEX_SPEC PRIx32
+#define MPIR_AINT_MAX 2147483647
+#elif SIZEOF_MPI_AINT == 8
+#define MPI_AINT_FMT_DEC_SPEC PRId64
+#define MPI_AINT_FMT_HEX_SPEC PRIx64
+#define MPIR_AINT_MAX 9223372036854775807
+#else
+#error "Size of MPI_Aint is neither 4 or 8 bytes."
+#endif
+
 /*****************************************************************************
  * We use the following ordering of information in this file:
  *

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -103,12 +103,12 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #endif
 
 #if SIZEOF_MPI_AINT == 4
-#define MPI_AINT_FMT_DEC_SPEC PRId32
-#define MPI_AINT_FMT_HEX_SPEC PRIx32
+#define MPIR_FMT_AINT_d PRId32
+#define MPIR_FMT_AINT_x PRIx32
 #define MPIR_AINT_MAX 2147483647
 #elif SIZEOF_MPI_AINT == 8
-#define MPI_AINT_FMT_DEC_SPEC PRId64
-#define MPI_AINT_FMT_HEX_SPEC PRIx64
+#define MPIR_FMT_AINT_d PRId64
+#define MPIR_FMT_AINT_x PRIx64
 #define MPIR_AINT_MAX 9223372036854775807
 #else
 #error "Size of MPI_Aint is neither 4 or 8 bytes."

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -114,6 +114,30 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #error "Size of MPI_Aint is neither 4 or 8 bytes."
 #endif
 
+#if SIZEOF_MPI_OFFSET == 4
+#define MPIR_FMT_OFFSET_d PRId32
+#define MPIR_FMT_OFFSET_x PRIx32
+#define MPIR_OFFSET_MAX 2147483647
+#elif SIZEOF_MPI_OFFSET == 8
+#define MPIR_FMT_OFFSET_d PRId64
+#define MPIR_FMT_OFFSET_x PRIx64
+#define MPIR_OFFSET_MAX 9223372036854775807
+#else
+#error "Size of MPI_Offset is neither 4 or 8 bytes."
+#endif
+
+#if SIZEOF_MPI_COUNT == 4
+#define MPIR_FMT_COUNT_d PRId32
+#define MPIR_FMT_COUNT_x PRIx32
+#define MPIR_COUNT_MAX 2147483647
+#elif SIZEOF_MPI_COUNT == 8
+#define MPIR_FMT_COUNT_d PRId64
+#define MPIR_FMT_COUNT_x PRIx64
+#define MPIR_COUNT_MAX 9223372036854775807
+#else
+#error "Size of MPI_Count is neither 4 or 8 bytes."
+#endif
+
 /*****************************************************************************
  * We use the following ordering of information in this file:
  *

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -79,10 +79,10 @@ void MPII_Datatype_printf(MPI_Datatype type,
     }
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE,
                     (MPL_DBG_FDEST,
-                     "%5d  %21s  %11d  " MPI_AINT_FMT_DEC_SPEC "  " MPI_AINT_FMT_DEC_SPEC "  "
-                     MPI_AINT_FMT_DEC_SPEC "  " MPI_AINT_FMT_DEC_SPEC "(" MPI_AINT_FMT_DEC_SPEC
-                     ")  " MPI_AINT_FMT_DEC_SPEC "(" MPI_AINT_FMT_DEC_SPEC ")  "
-                     MPI_AINT_FMT_DEC_SPEC "  %11d", depth, string, (int) size, (MPI_Aint) extent,
+                     "%5d  %21s  %11d  " MPIR_FMT_AINT_d "  " MPIR_FMT_AINT_d "  "
+                     MPIR_FMT_AINT_d "  " MPIR_FMT_AINT_d "(" MPIR_FMT_AINT_d
+                     ")  " MPIR_FMT_AINT_d "(" MPIR_FMT_AINT_d ")  "
+                     MPIR_FMT_AINT_d "  %11d", depth, string, (int) size, (MPI_Aint) extent,
                      (MPI_Aint) true_lb, (MPI_Aint) true_ub, (MPI_Aint) lb, (MPI_Aint) sticky_lb,
                      (MPI_Aint) ub, (MPI_Aint) sticky_ub, (MPI_Aint) displacement,
                      (int) blocklength));
@@ -337,11 +337,11 @@ void MPIR_Datatype_debug(MPI_Datatype type, int array_ct)
     MPIR_Assert(string != NULL);
 
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                        "# Size = " MPI_AINT_FMT_DEC_SPEC ", Extent = "
-                                        MPI_AINT_FMT_DEC_SPEC ", LB = " MPI_AINT_FMT_DEC_SPEC
-                                        "%s, UB = " MPI_AINT_FMT_DEC_SPEC "%s, Extent = "
-                                        MPI_AINT_FMT_DEC_SPEC ", Element Size = "
-                                        MPI_AINT_FMT_DEC_SPEC " (%s), %s", (MPI_Aint) dtp->size,
+                                        "# Size = " MPIR_FMT_AINT_d ", Extent = "
+                                        MPIR_FMT_AINT_d ", LB = " MPIR_FMT_AINT_d
+                                        "%s, UB = " MPIR_FMT_AINT_d "%s, Extent = "
+                                        MPIR_FMT_AINT_d ", Element Size = "
+                                        MPIR_FMT_AINT_d " (%s), %s", (MPI_Aint) dtp->size,
                                         (MPI_Aint) dtp->extent, (MPI_Aint) dtp->lb,
                                         (dtp->has_sticky_lb) ? "(sticky)" : "", (MPI_Aint) dtp->ub,
                                         (dtp->has_sticky_ub) ? "(sticky)" : "",
@@ -468,7 +468,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
             MPIR_Assert((ints != NULL) && (aints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                 "# %shvector ct = %d, blk = %d, str = "
-                                                MPI_AINT_FMT_DEC_SPEC "\n",
+                                                MPIR_FMT_AINT_d "\n",
                                                 depth_spacing(depth), ints[0],
                                                 ints[1], (MPI_Aint) aints[0]));
             contents_printf(*types, depth + 1, acount);
@@ -493,7 +493,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
             for (i = 0; i < acount && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  hindexed [%d]: blk = %d, disp = "
-                                                    MPI_AINT_FMT_DEC_SPEC "\n",
+                                                    MPIR_FMT_AINT_d "\n",
                                                     depth_spacing(depth), i,
                                                     (int) ints[i + 1], (MPI_Aint) aints[i]));
                 contents_printf(*types, depth + 1, acount);
@@ -506,7 +506,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
             for (i = 0; i < acount && i < ints[0]; i++) {
                 MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                     "# %s  struct[%d]: blk = %d, disp = "
-                                                    MPI_AINT_FMT_DEC_SPEC "\n",
+                                                    MPIR_FMT_AINT_d "\n",
                                                     depth_spacing(depth), i,
                                                     (int) ints[i + 1], (MPI_Aint) aints[i]));
                 contents_printf(types[i], depth + 1, acount);
@@ -531,8 +531,8 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
             MPIR_Assert((aints != NULL) && (types != NULL));
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE,
                             (MPL_DBG_FDEST,
-                             "# %sresized lb = " MPI_AINT_FMT_DEC_SPEC " extent = "
-                             MPI_AINT_FMT_DEC_SPEC "\n", depth_spacing(depth), aints[0], aints[1]));
+                             "# %sresized lb = " MPIR_FMT_AINT_d " extent = "
+                             MPIR_FMT_AINT_d "\n", depth_spacing(depth), aints[0], aints[1]));
             contents_printf(*types, depth + 1, acount);
             MPII_DATATYPE_FREE_AND_RETURN;
         default:

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -565,7 +565,7 @@ MPII_Dataloop_stream_size(MPII_Dataloop * dl_p, MPI_Aint(*sizefn) (MPI_Datatype 
                 MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                                 (MPL_DBG_FDEST,
                                  "stream_size: contig: ct = %d; new tot_ct = "
-                                 MPI_AINT_FMT_DEC_SPEC "\n", (int) dl_p->loop_params.c_t.count,
+                                 MPIR_FMT_AINT_d "\n", (int) dl_p->loop_params.c_t.count,
                                  (MPI_Aint) tmp_ct));
 #endif
                 break;
@@ -576,7 +576,7 @@ MPII_Dataloop_stream_size(MPII_Dataloop * dl_p, MPI_Aint(*sizefn) (MPI_Datatype 
                 MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                                 (MPL_DBG_FDEST,
                                  "stream_size: vector: ct = %d; blk = %d; new tot_ct = "
-                                 MPI_AINT_FMT_DEC_SPEC "\n", (int) dl_p->loop_params.v_t.count,
+                                 MPIR_FMT_AINT_d "\n", (int) dl_p->loop_params.v_t.count,
                                  (int) dl_p->loop_params.v_t.blocksize, (MPI_Aint) tmp_ct));
 #endif
                 break;
@@ -587,7 +587,7 @@ MPII_Dataloop_stream_size(MPII_Dataloop * dl_p, MPI_Aint(*sizefn) (MPI_Datatype 
                 MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                                 (MPL_DBG_FDEST,
                                  "stream_size: blkindexed: blks = %d; new tot_ct = "
-                                 MPI_AINT_FMT_DEC_SPEC "\n",
+                                 MPIR_FMT_AINT_d "\n",
                                  (int) dl_p->loop_params.bi_t.count *
                                  (int) dl_p->loop_params.bi_t.blocksize, (MPI_Aint) tmp_ct));
 #endif
@@ -598,7 +598,7 @@ MPII_Dataloop_stream_size(MPII_Dataloop * dl_p, MPI_Aint(*sizefn) (MPI_Datatype 
                 MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                                 (MPL_DBG_FDEST,
                                  "stream_size: contig: blks = %d; new tot_ct = "
-                                 MPI_AINT_FMT_DEC_SPEC "\n",
+                                 MPIR_FMT_AINT_d "\n",
                                  (int) dl_p->loop_params.i_t.total_blocks, (MPI_Aint) tmp_ct));
 #endif
                 break;

--- a/src/mpi/datatype/typerep/dataloop/dataloop_create_struct.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_create_struct.c
@@ -383,7 +383,7 @@ static int create_flattened_struct(MPI_Aint count,
         MPL_DBG_OUT(MPIR_DBG_DATATYPE, "--- start of flattened type ---");
         for (i = 0; i < nr_blks; i++) {
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                "a[%d] = (%d, " MPI_AINT_FMT_DEC_SPEC ")", i,
+                                                "a[%d] = (%d, " MPIR_FMT_AINT_d ")", i,
                                                 tmp_blklens[i], tmp_disps[i]));
         }
         MPL_DBG_OUT(MPIR_DBG_DATATYPE, "--- end of flattened type ---");

--- a/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
@@ -39,8 +39,8 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
         case MPII_DATALOOP_KIND_CONTIG:
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                 "      dl%d [shape = record, label = \"contig |{ ct = %d; el_sz = "
-                                                MPI_AINT_FMT_DEC_SPEC "; el_ext = "
-                                                MPI_AINT_FMT_DEC_SPEC " }\"];", depth,
+                                                MPIR_FMT_AINT_d "; el_ext = "
+                                                MPIR_FMT_AINT_d " }\"];", depth,
                                                 (int) loop_p->loop_params.c_t.count,
                                                 (MPI_Aint) loop_p->el_size,
                                                 (MPI_Aint) loop_p->el_extent));
@@ -48,9 +48,9 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
         case MPII_DATALOOP_KIND_VECTOR:
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                                 "      dl%d [shape = record, label = \"vector |{ ct = %d; blk = %d; str = "
-                                                MPI_AINT_FMT_DEC_SPEC "; el_sz = "
-                                                MPI_AINT_FMT_DEC_SPEC "; el_ext =  "
-                                                MPI_AINT_FMT_DEC_SPEC " }\"];", depth,
+                                                MPIR_FMT_AINT_d "; el_sz = "
+                                                MPIR_FMT_AINT_d "; el_ext =  "
+                                                MPIR_FMT_AINT_d " }\"];", depth,
                                                 (int) loop_p->loop_params.v_t.count,
                                                 (int) loop_p->loop_params.v_t.blocksize,
                                                 (MPI_Aint) loop_p->loop_params.v_t.stride,
@@ -68,14 +68,14 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
                 if (i + 1 < loop_p->loop_params.i_t.count) {
                     /* more regions after this one */
                     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                        "\\n(" MPI_AINT_FMT_DEC_SPEC ", %d), ",
+                                                        "\\n(" MPIR_FMT_AINT_d ", %d), ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         i_t.offset_array[i],
                                                         (int) loop_p->loop_params.
                                                         i_t.blocksize_array[i]));
                 } else {
                     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                        "\\n(" MPI_AINT_FMT_DEC_SPEC ", %d); ",
+                                                        "\\n(" MPIR_FMT_AINT_d ", %d); ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         i_t.offset_array[i],
                                                         (int) loop_p->loop_params.
@@ -87,8 +87,8 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
             }
 
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                "\\nel_sz = " MPI_AINT_FMT_DEC_SPEC "; el_ext = "
-                                                MPI_AINT_FMT_DEC_SPEC " }\"];\n",
+                                                "\\nel_sz = " MPIR_FMT_AINT_d "; el_ext = "
+                                                MPIR_FMT_AINT_d " }\"];\n",
                                                 (MPI_Aint) loop_p->el_size,
                                                 (MPI_Aint) loop_p->el_extent));
             break;
@@ -103,12 +103,12 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
                 if (i + 1 < loop_p->loop_params.bi_t.count) {
                     /* more regions after this one */
                     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                        MPI_AINT_FMT_DEC_SPEC ",\\n ",
+                                                        MPIR_FMT_AINT_d ",\\n ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         bi_t.offset_array[i]));
                 } else {
                     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                        MPI_AINT_FMT_DEC_SPEC "; ",
+                                                        MPIR_FMT_AINT_d "; ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         bi_t.offset_array[i]));
                 }
@@ -118,8 +118,8 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
             }
 
             MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
-                                                "\\nel_sz = " MPI_AINT_FMT_DEC_SPEC "; el_ext = "
-                                                MPI_AINT_FMT_DEC_SPEC " }\"];",
+                                                "\\nel_sz = " MPIR_FMT_AINT_d "; el_ext = "
+                                                MPIR_FMT_AINT_d " }\"];",
                                                 (MPI_Aint) loop_p->el_size,
                                                 (MPI_Aint) loop_p->el_extent));
             break;
@@ -146,11 +146,11 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
 
             for (i = 0; i < NR_TYPE_CUTOFF && i < loop_p->loop_params.s_t.count; i++) {
                 if (i + 1 < loop_p->loop_params.s_t.count) {
-                    MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, MPI_AINT_FMT_DEC_SPEC ", ",
+                    MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, MPIR_FMT_AINT_d ", ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         s_t.offset_array[i]));
                 } else {
-                    MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, MPI_AINT_FMT_DEC_SPEC "; ",
+                    MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, MPIR_FMT_AINT_d "; ",
                                                         (MPI_Aint) loop_p->loop_params.
                                                         s_t.offset_array[i]));
                 }

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -435,8 +435,8 @@ static int contig_m2m(MPI_Aint * blocks_p,
     DBG_SEGMENT(printf("element type = %lx\n", (long) el_type));
     DBG_SEGMENT(printf("contig m2m: elsize = %d, size = %d\n", (int) el_size, (int) size));
 #ifdef MPID_SU_VERBOSE
-    dbg_printf("\t[contig unpack: do=" MPI_AINT_FMT_DEC_SPEC ", dp=%x, bp=%x, sz="
-               MPI_AINT_FMT_DEC_SPEC ", blksz=" MPI_AINT_FMT_DEC_SPEC "]\n", rel_off,
+    dbg_printf("\t[contig unpack: do=" MPIR_FMT_AINT_d ", dp=%x, bp=%x, sz="
+               MPIR_FMT_AINT_d ", blksz=" MPIR_FMT_AINT_d "]\n", rel_off,
                (unsigned) bufp, (unsigned) paramp->u.unpack.unpack_buffer, el_size, *blocks_p);
 #endif
 
@@ -884,9 +884,9 @@ static int contig_pack_to_iov(MPI_Aint * blocks_p,
     size = *blocks_p * (MPI_Aint) el_size;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE, (MPL_DBG_FDEST,
-                                                 "    contig to vec: do=" MPI_AINT_FMT_DEC_SPEC
+                                                 "    contig to vec: do=" MPIR_FMT_AINT_d
                                                  ", dp=%p, ind=%d, sz=%d, blksz="
-                                                 MPI_AINT_FMT_DEC_SPEC, (MPI_Aint) rel_off, bufp,
+                                                 MPIR_FMT_AINT_d, (MPI_Aint) rel_off, bufp,
                                                  paramp->u.pack_vector.index, el_size,
                                                  (MPI_Aint) * blocks_p));
 
@@ -944,14 +944,14 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blks
     blocks_left = *blocks_p;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE, (MPL_DBG_FDEST,
-                                                 "    vector to vec: do=" MPI_AINT_FMT_DEC_SPEC
+                                                 "    vector to vec: do=" MPIR_FMT_AINT_d
                                                  ", dp=%p"
-                                                 ", len=" MPI_AINT_FMT_DEC_SPEC
-                                                 ", ind=" MPI_AINT_FMT_DEC_SPEC
-                                                 ", ct=" MPI_AINT_FMT_DEC_SPEC
-                                                 ", blksz=" MPI_AINT_FMT_DEC_SPEC
-                                                 ", str=" MPI_AINT_FMT_DEC_SPEC
-                                                 ", blks=" MPI_AINT_FMT_DEC_SPEC,
+                                                 ", len=" MPIR_FMT_AINT_d
+                                                 ", ind=" MPIR_FMT_AINT_d
+                                                 ", ct=" MPIR_FMT_AINT_d
+                                                 ", blksz=" MPIR_FMT_AINT_d
+                                                 ", str=" MPIR_FMT_AINT_d
+                                                 ", blks=" MPIR_FMT_AINT_d,
                                                  (MPI_Aint) rel_off,
                                                  bufp,
                                                  (MPI_Aint) paramp->u.pack_vector.length,
@@ -987,7 +987,7 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blks
 #ifdef MPID_SP_VERBOSE
             MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "\t[vector to vec exiting (1): next ind = %d, " MPI_AINT_FMT_DEC_SPEC
+                             "\t[vector to vec exiting (1): next ind = %d, " MPIR_FMT_AINT_d
                              " blocks processed.\n", paramp->u.pack_vector.index,
                              (MPI_Aint) * blocks_p));
 #endif
@@ -1009,7 +1009,7 @@ static int vector_pack_to_iov(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint blks
 #ifdef MPID_SP_VERBOSE
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                     (MPL_DBG_FDEST,
-                     "\t[vector to vec exiting (2): next ind = %d, " MPI_AINT_FMT_DEC_SPEC
+                     "\t[vector to vec exiting (2): next ind = %d, " MPIR_FMT_AINT_d
                      " blocks processed.\n", paramp->u.pack_vector.index, (MPI_Aint) * blocks_p));
 #endif
 

--- a/src/mpi/datatype/typerep/dataloop/segment.c
+++ b/src/mpi/datatype/typerep/dataloop/segment.c
@@ -497,7 +497,7 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
         MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                         (MPL_DBG_FDEST,
                          "dloop_segment_manipulate: warning: first == last ("
-                         MPI_AINT_FMT_DEC_SPEC ")\n", first));
+                         MPIR_FMT_AINT_d ")\n", first));
         return;
     }
 
@@ -506,8 +506,8 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
         MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                         (MPL_DBG_FDEST,
-                         "first=" MPI_AINT_FMT_DEC_SPEC "; stream_off="
-                         MPI_AINT_FMT_DEC_SPEC "; resetting.\n", first, stream_off));
+                         "first=" MPIR_FMT_AINT_d "; stream_off="
+                         MPIR_FMT_AINT_d "; resetting.\n", first, stream_off));
 #endif
 
         if (first < stream_off) {
@@ -524,9 +524,9 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
         MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                         (MPL_DBG_FDEST,
-                         "done repositioning stream_off; first=" MPI_AINT_FMT_DEC_SPEC
-                         ", stream_off=" MPI_AINT_FMT_DEC_SPEC ", last="
-                         MPI_AINT_FMT_DEC_SPEC "\n", first, stream_off, last));
+                         "done repositioning stream_off; first=" MPIR_FMT_AINT_d
+                         ", stream_off=" MPIR_FMT_AINT_d ", last="
+                         MPIR_FMT_AINT_d "\n", first, stream_off, last));
 #endif
     }
 
@@ -611,7 +611,7 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
             MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "\thit leaf; cur_sp=%d, elmp=%x, piece_sz=" MPI_AINT_FMT_DEC_SPEC
+                             "\thit leaf; cur_sp=%d, elmp=%x, piece_sz=" MPIR_FMT_AINT_d
                              "\n", cur_sp, (unsigned) cur_elmp, myblocks * local_el_size));
 #endif
 
@@ -622,9 +622,8 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
                 MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                                 (MPL_DBG_FDEST,
-                                 "\tpartial block count=" MPI_AINT_FMT_DEC_SPEC " ("
-                                 MPI_AINT_FMT_DEC_SPEC " bytes)\n", myblocks,
-                                 myblocks * stream_el_size));
+                                 "\tpartial block count=" MPIR_FMT_AINT_d " ("
+                                 MPIR_FMT_AINT_d " bytes)\n", myblocks, myblocks * stream_el_size));
 #endif
                 if (myblocks == 0) {
                     SEGMENT_SAVE_LOCAL_VALUES;
@@ -904,8 +903,8 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
             MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "\tstep 1: next orig_offset = " MPI_AINT_FMT_DEC_SPEC " (0x"
-                             MPI_AINT_FMT_HEX_SPEC ")\n", next_elmp->orig_offset,
+                             "\tstep 1: next orig_offset = " MPIR_FMT_AINT_d " (0x"
+                             MPIR_FMT_AINT_x ")\n", next_elmp->orig_offset,
                              next_elmp->orig_offset));
 #endif
 
@@ -944,9 +943,8 @@ void MPII_Segment_manipulate(struct MPIR_Segment *segp,
 #ifdef MPII_DATALOOP_DEBUG_MANIPULATE
             MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "\tstep 2: next curoffset = " MPI_AINT_FMT_DEC_SPEC " (0x"
-                             MPI_AINT_FMT_HEX_SPEC ")\n", next_elmp->curoffset,
-                             next_elmp->curoffset));
+                             "\tstep 2: next curoffset = " MPIR_FMT_AINT_d " (0x"
+                             MPIR_FMT_AINT_x ")\n", next_elmp->curoffset, next_elmp->curoffset));
 #endif
 
             cur_elmp->curblock--;
@@ -1044,7 +1042,7 @@ MPI_Aint MPII_Dataloop_stackelm_offset(struct MPII_Dataloop_stackelm * elmp)
  * the rest are filled in at processing time.
  */
 void MPII_Dataloop_stackelm_load(struct MPII_Dataloop_stackelm *elmp,
-                                 MPII_Dataloop *dlp, int branch_flag)
+                                 MPII_Dataloop * dlp, int branch_flag)
 {
     elmp->loop_p = dlp;
 

--- a/src/mpi/datatype/typerep/dataloop/segment_count.c
+++ b/src/mpi/datatype/typerep/dataloop/segment_count.c
@@ -88,7 +88,7 @@ static int leaf_contig_count_block(MPI_Aint * blocks_p,
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                     (MPL_DBG_FDEST,
                      "contig count block: count = %d, buf+off = %d, lastloc = "
-                     MPI_AINT_FMT_DEC_SPEC "\n", (int) paramp->count,
+                     MPIR_FMT_AINT_d "\n", (int) paramp->count,
                      (int) ((char *) bufp + rel_off), paramp->last_loc));
 #endif
 

--- a/src/mpi/datatype/typerep/dataloop/segment_flatten.c
+++ b/src/mpi/datatype/typerep/dataloop/segment_flatten.c
@@ -189,7 +189,7 @@ static int leaf_vector_mpi_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint
             MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                             (MPL_DBG_FDEST,
                              "\t[vector to vec exiting (1): next ind = %d, "
-                             MPI_AINT_FMT_DEC_SPEC " blocks processed.\n",
+                             MPIR_FMT_AINT_d " blocks processed.\n",
                              paramp->u.pack_vector.index, *blocks_p));
 #endif
             return 1;
@@ -208,7 +208,7 @@ static int leaf_vector_mpi_flatten(MPI_Aint * blocks_p, MPI_Aint count, MPI_Aint
 #ifdef MPID_SP_VERBOSE
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                     (MPL_DBG_FDEST,
-                     "\t[vector to vec exiting (2): next ind = %d, " MPI_AINT_FMT_DEC_SPEC
+                     "\t[vector to vec exiting (2): next ind = %d, " MPIR_FMT_AINT_d
                      " blocks processed.\n", paramp->u.pack_vector.index, *blocks_p));
 #endif
 

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -235,8 +235,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
     else
         packsize = count;
 
-    MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL, "looking for buffer of size " MPI_AINT_FMT_DEC_SPEC,
-                  packsize);
+    MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL, "looking for buffer of size " MPIR_FMT_AINT_d, packsize);
     /*
      * Use two passes.  Each pass is the same; between the two passes,
      * attempt to complete any active requests, and start any pending
@@ -248,7 +247,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
         p = MPIR_Bsend_find_buffer(packsize);
         if (p) {
             MPL_DBG_MSG_FMT(MPIR_DBG_BSEND, TYPICAL, (MPL_DBG_FDEST,
-                                                      "found buffer of size " MPI_AINT_FMT_DEC_SPEC
+                                                      "found buffer of size " MPIR_FMT_AINT_d
                                                       " with address %p", packsize, p));
             /* Found a segment */
 

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -135,7 +135,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
         DBG_FPRINTF(stderr, "ADIOI_Flatten:: ints[%lld]=%#X\n", i, ints[i]);
     }
     for (i = 0; i < nadds; ++i) {
-        DBG_FPRINTF(stderr, "ADIOI_Flatten:: adds[%lld]=" MPI_AINT_FMT_HEX_SPEC "\n", i, adds[i]);
+        DBG_FPRINTF(stderr, "ADIOI_Flatten:: adds[%lld]=" MPIR_FMT_AINT_x "\n", i, adds[i]);
     }
     for (i = 0; i < ntypes; ++i) {
         DBG_FPRINTF(stderr, "ADIOI_Flatten:: types[%lld]=%#llX\n", i,
@@ -695,7 +695,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                             flat->ub_idx = j;
 #ifdef FLATTEN_DEBUG
                         DBG_FPRINTF(stderr,
-                                    "ADIOI_Flatten:: simple adds[%#X] " MPI_AINT_FMT_HEX_SPEC
+                                    "ADIOI_Flatten:: simple adds[%#X] " MPIR_FMT_AINT_x
                                     ", flat->indices[%#llX] %#llX, flat->blocklens[%#llX] %#llX\n",
                                     n, adds[n], j, flat->indices[j], j, flat->blocklens[j]);
 #endif
@@ -719,7 +719,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
                             flat->blocklens[j] = flat->blocklens[j - num];
 #ifdef FLATTEN_DEBUG
                             DBG_FPRINTF(stderr,
-                                        "ADIOI_Flatten:: simple old_extent " MPI_AINT_FMT_HEX_SPEC
+                                        "ADIOI_Flatten:: simple old_extent " MPIR_FMT_AINT_x
                                         ", flat->indices[%#llX] %#llX, flat->blocklens[%#llX] %#llX\n",
                                         old_extent, j, flat->indices[j], j, flat->blocklens[j]);
 #endif
@@ -756,7 +756,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
 
 #ifdef FLATTEN_DEBUG
                 DBG_FPRINTF(stderr,
-                            "ADIOI_Flatten:: simple adds[%#X] " MPI_AINT_FMT_HEX_SPEC
+                            "ADIOI_Flatten:: simple adds[%#X] " MPIR_FMT_AINT_x
                             ", flat->indices[%#llX] %#llX, flat->blocklens[%#llX] %#llX\n", 0,
                             adds[0], j, flat->indices[j], j, flat->blocklens[j]);
 #endif
@@ -785,7 +785,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
 
 #ifdef FLATTEN_DEBUG
                 DBG_FPRINTF(stderr,
-                            "ADIOI_Flatten:: simple adds[%#X] " MPI_AINT_FMT_HEX_SPEC
+                            "ADIOI_Flatten:: simple adds[%#X] " MPIR_FMT_AINT_x
                             ", flat->indices[%#llX] %#llX, flat->blocklens[%#llX] %#llX\n", 0,
                             adds[0], j, flat->indices[j], j, flat->blocklens[j]);
 #endif
@@ -811,7 +811,7 @@ void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
 
 #ifdef FLATTEN_DEBUG
             DBG_FPRINTF(stderr,
-                        "ADIOI_Flatten:: simple adds[%#X] " MPI_AINT_FMT_HEX_SPEC
+                        "ADIOI_Flatten:: simple adds[%#X] " MPIR_FMT_AINT_x
                         ", flat->indices[%#llX] %#llX, flat->blocklens[%#llX] %#llX\n", 1, adds[1],
                         j, flat->indices[j], j, flat->blocklens[j]);
 #endif

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -88,24 +88,9 @@
 #define FDTYPE int
 #endif
 
-#ifdef MPI_OFFSET_IS_INT
-typedef int ADIO_Offset;
-#define ADIO_OFFSET MPI_INT
-#elif defined(HAVE_LONG_LONG_64)
-typedef long long ADIO_Offset;
-#ifdef HAVE_MPI_LONG_LONG_INT
-#define ADIO_OFFSET MPI_LONG_LONG_INT
-#else
-#define ADIO_OFFSET MPI_DOUBLE
-#endif
-#elif defined(HAVE_INT64)
-typedef __int64 ADIO_Offset;
-#define ADIO_OFFSET MPI_DOUBLE
-#else
-typedef long ADIO_Offset;
-#define ADIO_OFFSET MPI_LONG
-#endif
-
+/* Let mpi.h figure out the offset type */
+typedef MPI_Offset ADIO_Offset;
+#define ADIO_OFFSET MPI_OFFSET
 #define ADIO_Status MPI_Status
 
 #ifndef MPIO_INCLUDE

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -175,10 +175,7 @@ F77GETARG="call getarg(i,str)"
 F77IARGC="iargc()"
 F77MPIOINC=""
 FTESTDEFINE=""
-FORTRAN_MPI_OFFSET=""
 MPIOF_H_INCLUDED=0
-MPI_OFFSET_KIND1="!"
-MPI_OFFSET_KIND2="!"
 TEST_CC=""
 TEST_F77=""
 #
@@ -525,43 +522,49 @@ if test "$pac_cv_int_hold_pointer" != yes ; then
     AC_DEFINE(HAVE_INT_LT_POINTER,1,[Define if int smaller than pointer])
 fi
 
+AC_ARG_VAR(MPI_SIZEOF_OFFSET, [Size of MPI_Offset in bytes.])
+AC_ARG_VAR(MPI_OFFSET, [C type for MPI_Offset.])
+AC_ARG_VAR(FORTRAN_MPI_OFFSET, [Fortran type for MPI_Offset.])
+
+if test -z $MPI_SIZEOF_OFFSET ; then
+    MPI_SIZEOF_OFFSET=8
+fi
+AC_DEFINE_UNQUOTED([SIZEOF_MPI_OFFSET],[$MPI_SIZEOF_OFFSET],[Define size of MPI_Offset in bytes.])
+
+if test -z $MPI_OFFSET ; then
+    MPI_OFFSET=int
+    AC_CHECK_SIZEOF([long])
+    AC_CHECK_SIZEOF([long long])
+    for type in int long long_long ; do
+        eval len=\$ac_cv_sizeof_$type
+        if test "$len" = "$MPI_SIZEOF_OFFSET" ; then
+            MPI_OFFSET=`echo $type | sed -e 's/_/ /'`
+            break
+        fi
+    done
+fi
+
+if test -z $FORTRAN_MPI_OFFSET ; then
+    # When not build from MPICH, use a simplistic default.
+    FORTRAN_MPI_OFFSET="integer*8"
+fi
+
+MPI_OFFSET_KIND1="!"
+MPI_OFFSET_KIND2="!"
+
+# FIXME: Use preprocessor to get correct format, xref: mpiimpl.h
 # LL is the printf-style format name for output of a MPI_Offset.
 # We have to match this to the type that we use for MPI_Offset.
 AC_CHECK_SIZEOF(long long)
 if test "$ac_cv_sizeof_long_long" != 0 ; then
     if test "$ac_cv_sizeof_long_long" = "8" ; then
-       AC_DEFINE(HAVE_LONG_LONG_64,1,[Define if long long is 64 bits])
-       MPI_OFFSET_TYPE="long long"
-       DEFINE_MPI_OFFSET="typedef long long MPI_Offset;"
-       FORTRAN_MPI_OFFSET="integer*8"
        LL="lld"
-    elif test "$ac_cv_sizeof_long_long" = "$ac_cv_sizeof_int" ; then
-       MPI_OFFSET_TYPE="int"
-       DEFINE_MPI_OFFSET="typedef int MPI_Offset;"
-       FORTRAN_MPI_OFFSET="integer"
-       AC_DEFINE(MPI_OFFSET_IS_INT,1,[Define if MPI_Offset is int])
-       LL="d"
-       MPI_OFFSET_KIND1="!"
-       MPI_OFFSET_KIND2="!"
     else
-       echo "defining MPI_Offset as long in C and integer in Fortran" 
-       MPI_OFFSET_TYPE="long"
-       DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
-       FORTRAN_MPI_OFFSET="integer"
        LL="ld"
-       MPI_OFFSET_KIND1="!"
-       MPI_OFFSET_KIND2="!"
     fi
 else
-    echo "defining MPI_Offset as long in C and integer in Fortran" 
-    MPI_OFFSET_TYPE="long"
-    DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
-    FORTRAN_MPI_OFFSET="integer"
     LL="ld"
-    MPI_OFFSET_KIND1="!"
-    MPI_OFFSET_KIND2="!"
 fi
-
 
 #
 if test -n "$ac_cv_sizeof_long_long"; then
@@ -718,7 +721,7 @@ AM_CONDITIONAL([BUILD_F77_TESTS],[test "x$NOF77" != "x1"])
 AC_MSG_CHECKING([whether struct flock compatible with MPI_Offset])
 AC_TRY_COMPILE([#include <fcntl.h>],
 [struct flock l;
- $MPI_OFFSET_TYPE a=1;
+ $MPI_OFFSET a=1;
  l.l_start = a; 
  l.l_len   = a;
 ],pac_cv_struct_flock_and_mpi_offset=yes,pac_cv_struct_flock_and_mpi_offset=no)
@@ -1701,9 +1704,7 @@ AC_SUBST(HAVE_MPI_INFO)
 AC_SUBST(BUILD_MPI_INFO)
 AC_SUBST(HAVE_MPI_DARRAY_SUBARRAY)
 AC_SUBST(BUILD_MPI_ARRAY)
-AC_SUBST(DEFINE_MPI_OFFSET)
 AC_SUBST(DEFINE_HAVE_MPI_GREQUEST)
-AC_SUBST(MPI_OFFSET_TYPE)
 AC_SUBST(MPI_FINFO1)
 AC_SUBST(MPI_FINFO2)
 AC_SUBST(MPI_FINFO3)

--- a/src/mpi/romio/include/mpio.h.in
+++ b/src/mpi/romio/include/mpio.h.in
@@ -47,9 +47,7 @@ typedef struct ADIOI_RequestD *MPIO_Request;
 #define MPIO_REQUEST_DEFINED
 
 #ifndef HAVE_MPI_OFFSET
-/* *INDENT-OFF* */
-@DEFINE_MPI_OFFSET@
-/* *INDENT-ON* */
+typedef @MPI_OFFSET@ MPI_Offset;
 /* If we needed to define MPI_Offset, then we also need to make
    this definition. */
 #ifndef HAVE_MPI_DATAREP_FUNCTIONS

--- a/src/mpi/romio/localdefs.in
+++ b/src/mpi/romio/localdefs.in
@@ -3,5 +3,3 @@
 # Append ROMIO library dependencies to the global list
 WRAPPER_LIBS="$WRAPPER_LIBS @LIBS@"
 
-MPI_OFFSET_TYPE="@MPI_OFFSET_TYPE@"
-FORTRAN_MPI_OFFSET="@FORTRAN_MPI_OFFSET@"

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -15,6 +15,18 @@
 #include "adio.h"
 #include "mpio.h"
 
+#if SIZEOF_MPI_OFFSET == 4
+#define MPIR_FMT_OFFSET_d PRId32
+#define MPIR_FMT_OFFSET_x PRIx32
+#define MPIR_OFFSET_MAX 2147483647
+#elif SIZEOF_MPI_OFFSET == 8
+#define MPIR_FMT_OFFSET_d PRId64
+#define MPIR_FMT_OFFSET_x PRIx64
+#define MPIR_OFFSET_MAX 9223372036854775807
+#else
+#error "Size of MPI_Offset is neither 4 or 8 bytes."
+#endif
+
 #ifdef ROMIO_INSIDE_MPICH
 #include "mpir_ext.h"
 

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -177,7 +177,7 @@ extern MPIDI_Process_t MPIDI_Process;
 	MPIR_Datatype_is_contig((datatype_), (&dt_contig_out_));	\
 	(data_sz_out_) = (intptr_t) (count_) * (dt_ptr_)->size;	\
         (dt_true_lb_)    = (dt_ptr_)->true_lb;                          \
-	MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER, TERSE, (MPL_DBG_FDEST, "user defined datatype: dt_contig=%d, dt_sz=" MPI_AINT_FMT_DEC_SPEC ", data_sz=%" PRIdPTR, \
+	MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER, TERSE, (MPL_DBG_FDEST, "user defined datatype: dt_contig=%d, dt_sz=" MPIR_FMT_AINT_d ", data_sz=%" PRIdPTR, \
 			  (dt_contig_out_), (dt_ptr_)->size, (data_sz_out_)));\
     }									\
 }

--- a/src/mpid/ch3/src/ch3u_rndv.c
+++ b/src/mpid/ch3/src/ch3u_rndv.c
@@ -200,7 +200,7 @@ int MPIDI_CH3_PktHandler_RndvClrToSend( MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, vo
     MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"received rndv CTS pkt");
     
     MPIR_Request_get_ptr(cts_pkt->sender_req_id, sreq);
-    MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,TERSE,(MPL_DBG_FDEST,"received cts, count=" MPI_AINT_FMT_DEC_SPEC "\n", sreq->dev.user_count));
+    MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,TERSE,(MPL_DBG_FDEST,"received cts, count=" MPIR_FMT_AINT_d "\n", sreq->dev.user_count));
 
     sreq->dev.OnDataAvail = 0;
     sreq->dev.OnFinal = 0;

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -54,7 +54,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
         case MPIDU_SCHED_ENTRY_SEND:
             {
                 struct MPIDU_Sched_send *s = &(e->u.send);
-                fprintf(fh, "\t\tSend: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", s->count,
+                fprintf(fh, "\t\tSend: " MPIR_FMT_AINT_d " of type %x from %d\n", s->count,
                         s->datatype, s->dest);
                 fprintf(fh, "\t\t from buff: %p\n", s->buf);
             }
@@ -62,7 +62,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
         case MPIDU_SCHED_ENTRY_RECV:
             {
                 struct MPIDU_Sched_recv *r = &(e->u.recv);
-                fprintf(fh, "\t\tRecv: " MPI_AINT_FMT_DEC_SPEC " of type %x from %d\n", r->count,
+                fprintf(fh, "\t\tRecv: " MPIR_FMT_AINT_d " of type %x from %d\n", r->count,
                         r->datatype, r->src);
                 fprintf(fh, "\t\t Into buff: %p\n", r->buf);
             }
@@ -71,7 +71,7 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
             {
                 struct MPIDU_Sched_reduce *rd = &(e->u.reduce);
                 fprintf(fh, "\t\tReduce: %p -> %p\n", rd->inbuf, rd->inoutbuf);
-                fprintf(fh, "\t\t  " MPI_AINT_FMT_DEC_SPEC " elements of type %x\n", rd->count,
+                fprintf(fh, "\t\t  " MPIR_FMT_AINT_d " elements of type %x\n", rd->count,
                         rd->datatype);
                 fprintf(fh, "\t\t Op: %x\n", rd->op);
             }
@@ -79,9 +79,9 @@ static void entry_dump(FILE * fh, struct MPIDU_Sched_entry *e)
         case MPIDU_SCHED_ENTRY_COPY:
             {
                 struct MPIDU_Sched_copy *cp = &(e->u.copy);
-                fprintf(fh, "\t\tFrom: %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->inbuf,
+                fprintf(fh, "\t\tFrom: %p " MPIR_FMT_AINT_d " of type %x\n", cp->inbuf,
                         cp->incount, cp->intype);
-                fprintf(fh, "\t\tTo:   %p " MPI_AINT_FMT_DEC_SPEC " of type %x\n", cp->outbuf,
+                fprintf(fh, "\t\tTo:   %p " MPIR_FMT_AINT_d " of type %x\n", cp->outbuf,
                         cp->outcount, cp->outtype);
             }
             break;
@@ -789,9 +789,9 @@ int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype,
         MPIR_Datatype_get_size_macro(intype, intype_size);
         MPIR_Datatype_get_size_macro(outtype, outtype_size);
         if (incount * intype_size > outcount * outtype_size) {
-            MPL_error_printf("truncation: intype=%#x, intype_size=" MPI_AINT_FMT_DEC_SPEC
-                             ", incount=" MPI_AINT_FMT_DEC_SPEC ", outtype=%#x, outtype_size="
-                             MPI_AINT_FMT_DEC_SPEC " outcount=" MPI_AINT_FMT_DEC_SPEC "\n", intype,
+            MPL_error_printf("truncation: intype=%#x, intype_size=" MPIR_FMT_AINT_d
+                             ", incount=" MPIR_FMT_AINT_d ", outtype=%#x, outtype_size="
+                             MPIR_FMT_AINT_d " outcount=" MPIR_FMT_AINT_d "\n", intype,
                              intype_size, incount, outtype, outtype_size, outcount);
         }
     }


### PR DESCRIPTION
## Pull Request Description

* `MPI_AINT_FMT_..._SPEC` does not belong in `mpi.h`. They are moved to `mpiimpl.h` in this PR.

* In principle, MPI_Aint and MPI_Offset are either 4 bytes or 8 bytes. `configure` should just probe and define the sizes -- SIZEOF_MPI_AINT and SIZEOF_MPI_OFFSET. The reset of the logic should be carried out at the MPIR-layer using C preprocessor.

* Historically we let ROMIO configure the "offset" type and MPICH inherits it. It is more sensible to make it the other way.

Reference: it was originated in fixing a few romio warnings (PR #1811 and PR #1812).

## Expected Performance Changes

It should not affect runtime behavior. 
It may simplify the build time logic.

## Known Issues

There maybe legacy issues (such as third party usage of ROMIO).

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
