### PR TITLE
init: Fix single threaded builds

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -331,6 +331,7 @@ int MPI_Finalize(void)
     }
 #endif
 
+#if defined(MPICH_IS_THREADED)
     /* Finalize the threading library after releasing all synchronization
      * objects (e.g., mutexes) */
     {
@@ -338,6 +339,7 @@ int MPI_Finalize(void)
         MPL_thread_finalize(&thread_err);
         MPIR_Assert(thread_err == 0);
     }
+#endif
 
     /* ... end of body of routine ... */
   fn_exit:

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -346,7 +346,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_Info *info_ptr;
 #if defined(MPICH_IS_THREADED)
     bool cs_initialized = false;
-#endif
 
     /* The threading library must be initialized at the very beginning because
      * it manages all synchronization objects (e.g., mutexes) that will be
@@ -357,6 +356,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
         if (thread_err)
             goto fn_fail;
     }
+#endif
 
 #ifdef HAVE_HWLOC
     MPIR_Process.bindset = hwloc_bitmap_alloc();


### PR DESCRIPTION
Guard thread library initialization and finalization in case it is not
needed. Single thread build configurations with thread package "none"
were broken by [a10bd569f3a7].

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
