### PR TITLE
refactor: replace all internal use of size_t with MPI_Aint

### DIFF
--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos.h
@@ -18,8 +18,9 @@
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                           int log_pofk, int T, void *recvbuf,
-                                                          MPI_Datatype recvtype, size_t recv_extent,
-                                                          int recvcount, int tag, MPIR_Comm * comm,
+                                                          MPI_Datatype recvtype,
+                                                          MPI_Aint recv_extent, int recvcount,
+                                                          int tag, MPIR_Comm * comm,
                                                           MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -61,7 +62,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int is_inplace, int rank,
                                                   int tag, const void *sendbuf, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  MPI_Aint recv_extent, int recvcount,
                                                   MPI_Datatype recvtype, int n_invtcs, int *invtx,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
@@ -99,7 +100,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int step2_np
                                                   int **step2_nbrs, int rank, int nranks, int k,
                                                   int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                   int **recv_id_, int tag, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  MPI_Aint recv_extent, int recvcount,
                                                   MPI_Datatype recvtype, int is_dist_halving,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched)
 {
@@ -212,7 +213,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int is_inplace, i;
     int nranks, rank;
-    size_t recv_extent;
+    MPI_Aint recv_extent;
     MPI_Aint recv_lb, true_extent;
     int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0, p_of_k, T;
     int dtcopy_id, n_invtcs = 0, invtx;

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch_algos_prototypes.h
@@ -30,15 +30,15 @@
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                           int log_pofk, int T, void *recvbuf,
-                                                          MPI_Datatype recvtype, size_t recv_extent,
-                                                          int recvcount, int tag,
-                                                          MPIR_Comm * comm,
+                                                          MPI_Datatype recvtype,
+                                                          MPI_Aint recv_extent, int recvcount,
+                                                          int tag, MPIR_Comm * comm,
                                                           MPIR_TSP_sched_t * sched);
 
 int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                   int step1_nrecvs, int is_inplace, int rank,
                                                   int tag, const void *sendbuf, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  MPI_Aint recv_extent, int recvcount,
                                                   MPI_Datatype recvtype, int n_invtcs, int *invtx,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
 
@@ -46,7 +46,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int step2_np
                                                   int **step2_nbrs, int rank, int nranks, int k,
                                                   int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                   int **recv_id_, int tag, void *recvbuf,
-                                                  size_t recv_extent, int recvcount,
+                                                  MPI_Aint recv_extent, int recvcount,
                                                   MPI_Datatype recvtype, int is_dist_halving,
                                                   MPIR_Comm * comm, MPIR_TSP_sched_t * sched);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks_algos.h
@@ -54,7 +54,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_
     MPI_Aint sendtype_true_extent, recvtype_true_extent;
 
 #ifdef MPL_USE_DBG_LOGGING
-    size_t sendtype_size;
+    MPI_Aint sendtype_size;
 #endif
 
     int tag;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos.h
@@ -19,7 +19,7 @@
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                            int log_pofk, int T, void *recvbuf,
                                                            MPI_Datatype recvtype,
-                                                           size_t recv_extent,
+                                                           MPI_Aint recv_extent,
                                                            const int *recvcounts, const int *displs,
                                                            int tag, MPIR_Comm * comm,
                                                            MPIR_TSP_sched_t * sched)
@@ -72,7 +72,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks,
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int is_inplace, int rank,
                                                    int tag, const void *sendbuf, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
+                                                   MPI_Aint recv_extent, const int *recvcounts,
                                                    const int *displs, MPI_Datatype recvtype,
                                                    int n_invtcs, int *invtx, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched)
@@ -111,7 +111,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    int **step2_nbrs, int rank, int nranks, int k,
                                                    int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                    int **recv_id_, int tag, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
+                                                   MPI_Aint recv_extent, const int *recvcounts,
                                                    const int *displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched)
@@ -229,7 +229,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, int sendcount,
     int mpi_errno = MPI_SUCCESS;
     int is_inplace, i;
     int nranks, rank;
-    size_t recv_extent;
+    MPI_Aint recv_extent;
     MPI_Aint recv_lb, true_extent;
     int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0, p_of_k, T;
     int dtcopy_id, n_invtcs = 0, invtx;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch_algos_prototypes.h
@@ -31,7 +31,7 @@
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks, int k, int p_of_k,
                                                            int log_pofk, int T, void *recvbuf,
                                                            MPI_Datatype recvtype,
-                                                           size_t recv_extent,
+                                                           MPI_Aint recv_extent,
                                                            const int *recvcounts, const int *displs,
                                                            int tag, MPIR_Comm * comm,
                                                            MPIR_TSP_sched_t * sched);
@@ -39,7 +39,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int nranks,
 int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int *step1_recvfrom,
                                                    int step1_nrecvs, int is_inplace, int rank,
                                                    int tag, const void *sendbuf, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
+                                                   MPI_Aint recv_extent, const int *recvcounts,
                                                    const int *displs, MPI_Datatype recvtype,
                                                    int n_invtcs, int *invtx, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);
@@ -48,7 +48,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    int **step2_nbrs, int rank, int nranks, int k,
                                                    int p_of_k, int log_pofk, int T, int *nrecvs_,
                                                    int **recv_id_, int tag, void *recvbuf,
-                                                   size_t recv_extent, const int *recvcounts,
+                                                   MPI_Aint recv_extent, const int *recvcounts,
                                                    const int *displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
                                                    MPIR_TSP_sched_t * sched);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring_algos.h
@@ -23,7 +23,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, int sendcount,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
                                           MPIR_TSP_sched_t * sched)
 {
-    size_t extent;
+    MPI_Aint extent;
     MPI_Aint lb, true_extent;
     int mpi_errno = MPI_SUCCESS;
     int i, src, dst;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_algos.h
@@ -26,7 +26,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     int mpi_errno = MPI_SUCCESS;
     int is_inplace, i, j;
     int dtcopy_id = -1;
-    size_t extent;
+    MPI_Aint extent;
     MPI_Aint lb, true_extent;
     int is_commutative;
     int nranks, rank;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree_algos.h
@@ -27,7 +27,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int
     int i, j, t;
     int num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
-    size_t extent, type_size;
+    MPI_Aint extent, type_size;
     MPI_Aint type_lb, true_extent;
     int is_commutative;
     int size;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks_algos.h
@@ -203,7 +203,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, int sendcount, MPI_Da
 
 #ifdef MPL_USE_DBG_LOGGING
     {
-        size_t s_type_size;
+        MPI_Aint s_type_size;
         MPIR_Datatype_get_size_macro(sendtype, s_type_size);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                         (MPL_DBG_FDEST,

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -274,7 +274,7 @@ int MPIR_Ibcast_impl(void *buffer, int count, MPI_Datatype datatype, int root,
     int mpi_errno = MPI_SUCCESS;
     int tag = -1;
     MPIR_Sched_t s = MPIR_SCHED_NULL;
-    size_t type_size, nbytes;
+    MPI_Aint type_size, nbytes;
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
     nbytes = type_size * count;

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatter_recexch_allgather_algos.h
@@ -25,12 +25,12 @@ int MPIR_TSP_Ibcast_sched_intra_scatter_recexch_allgather(void *buffer, int coun
                                                           MPIR_TSP_sched_t * sched)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t extent, type_size;
+    MPI_Aint extent, type_size;
     MPI_Aint true_lb, true_extent;
     int size, rank;
     int is_contig;
     void *tmp_buf = NULL;
-    size_t nbytes;
+    MPI_Aint nbytes;
     int scatter_k = MPIR_CVAR_IBCAST_SCATTER_KVAL;
     int allgather_k = MPIR_CVAR_IBCAST_ALLGATHER_RECEXCH_KVAL;
 

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree_algos.h
@@ -26,7 +26,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, int count, MPI_Datatype datat
     int i;
     int num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
-    size_t extent, type_size;
+    MPI_Aint extent, type_size;
     MPI_Aint lb, true_extent;
     int size;
     int rank;

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree_algos.h
@@ -27,7 +27,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, int co
     int i, j, t;
     int num_chunks, chunk_size_floor, chunk_size_ceil;
     int offset = 0;
-    size_t extent, type_size;
+    MPI_Aint extent, type_size;
     MPI_Aint type_lb, true_extent;
     int is_commutative;
     int size;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch_algos.h
@@ -25,7 +25,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
 {
     int mpi_errno = MPI_SUCCESS;
     int is_inplace;
-    size_t extent;
+    MPI_Aint extent;
     MPI_Aint lb, true_extent;
     int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0;
     int in_step2;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch_algos.h
@@ -25,7 +25,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
 {
     int mpi_errno = MPI_SUCCESS;
     int is_inplace;
-    size_t extent;
+    MPI_Aint extent;
     MPI_Aint lb, true_extent;
     int step1_sendto = -1, step2_nphases = 0, step1_nrecvs = 0;
     int in_step2;

--- a/src/mpi/coll/iscatter/iscatter_intra_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_binomial.c
@@ -24,7 +24,7 @@ static int get_count(MPIR_Comm * comm, int tag, void *state)
 static int calc_send_count_root(MPIR_Comm * comm, int tag, void *state, void *state2)
 {
     struct shared_state *ss = state;
-    int mask = (int) (size_t) state2;
+    int mask = (int) (MPI_Aint) state2;
     ss->send_subtree_count = ss->curr_count - ss->sendcount * mask;
     return MPI_SUCCESS;
 }
@@ -32,7 +32,7 @@ static int calc_send_count_root(MPIR_Comm * comm, int tag, void *state, void *st
 static int calc_send_count_non_root(MPIR_Comm * comm, int tag, void *state, void *state2)
 {
     struct shared_state *ss = state;
-    int mask = (int) (size_t) state2;
+    int mask = (int) (MPI_Aint) state2;
     ss->send_subtree_count = ss->curr_count - ss->nbytes * mask;
     return MPI_SUCCESS;
 }
@@ -205,7 +205,8 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
                  * is it always true the (curr_cnt/2==sendcount*mask)? */
                 send_subtree_cnt = curr_cnt - sendcount * mask;
 #endif
-                mpi_errno = MPIR_Sched_cb2(&calc_send_count_root, ss, ((void *) (size_t) mask), s);
+                mpi_errno =
+                    MPIR_Sched_cb2(&calc_send_count_root, ss, ((void *) (MPI_Aint) mask), s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
@@ -220,7 +221,7 @@ int MPIR_Iscatter_sched_intra_binomial(const void *sendbuf, int sendcount, MPI_D
             } else {
                 /* non-zero root and others */
                 mpi_errno =
-                    MPIR_Sched_cb2(&calc_send_count_non_root, ss, ((void *) (size_t) mask), s);
+                    MPIR_Sched_cb2(&calc_send_count_non_root, ss, ((void *) (MPI_Aint) mask), s);
                 if (mpi_errno)
                     MPIR_ERR_POP(mpi_errno);
                 MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -272,7 +272,7 @@ int MPII_Genutil_sched_selective_sink(MPII_Genutil_sched_t * sched, int n_in_vtc
 
 }
 
-void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched)
+void *MPII_Genutil_sched_malloc(MPI_Aint size, MPII_Genutil_sched_t * sched)
 {
     void *addr = MPL_malloc(size, MPL_MEM_COLL);
     utarray_push_back(sched->buffers, &addr, MPL_MEM_COLL);

--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -101,7 +101,7 @@ int MPII_Genutil_sched_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Da
 int MPII_Genutil_sched_selective_sink(MPII_Genutil_sched_t * sched, int n_in_vtcs, int *invtcs);
 
 /* Transport function to allocate memory required for schedule execution */
-void *MPII_Genutil_sched_malloc(size_t size, MPII_Genutil_sched_t * sched);
+void *MPII_Genutil_sched_malloc(MPI_Aint size, MPII_Genutil_sched_t * sched);
 
 /* Transport function to enqueue and kick start a non-blocking
  * collective */

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.c
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.c
@@ -57,7 +57,7 @@ int MPII_Stubutil_sched_selective_sink(MPII_Stubutil_sched_t * sched, int n_in_v
     return MPI_SUCCESS;
 }
 
-void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched)
+void *MPII_Stubutil_sched_malloc(MPI_Aint size, MPII_Stubutil_sched_t * sched)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.h
@@ -67,7 +67,7 @@ int MPII_Stubutil_sched_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_D
 int MPII_Stubutil_sched_selective_sink(MPII_Stubutil_sched_t * sched, int n_in_vtcs, int *invtcs);
 int MPII_Genutil_sched_sink(MPII_Genutil_sched_t * sched);
 void MPII_Genutil_sched_fence(MPII_Genutil_sched_t * sched);
-void *MPII_Stubutil_sched_malloc(size_t size, MPII_Stubutil_sched_t * sched);
+void *MPII_Stubutil_sched_malloc(MPI_Aint size, MPII_Stubutil_sched_t * sched);
 int MPII_Stubutil_sched_start(MPII_Stubutil_sched_t * sched, MPIR_Comm * comm,
                               MPII_Coll_req_t ** request);
 

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -165,7 +165,7 @@ static void dloop_copy(void *dest, void *src, MPI_Aint size)
 #ifdef DEBUG_MEMORY
     MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE,
                     (MPL_DBG_FDEST, "dloop_copy: copying from %x to %x (%z bytes).\n",
-                     (int) src, (int) dest, (size_t) size));
+                     (int) src, (int) dest, (MPI_Aint) size));
 #endif
 
     /* copy region first */

--- a/src/mpi/debugger/mpi_interface.h
+++ b/src/mpi/debugger/mpi_interface.h
@@ -339,7 +339,7 @@ typedef int (*mqs_get_process_identity_ft) (mqs_job *);
 #endif
 
 /* Allocate store */
-typedef void *(*mqs_malloc_ft) (size_t);
+typedef void *(*mqs_malloc_ft) (MPI_Aint);
 /* Free it again */
 typedef void (*mqs_free_ft) (void *);
 

--- a/src/mpi/debugger/tvtest.c
+++ b/src/mpi/debugger/tvtest.c
@@ -311,7 +311,7 @@ static int dbgrI_find_function(mqs_image * image, char *name, mqs_lang_code lang
 /* Simulate requesting the debugger to fetch data from within this process */
 static int dbgrI_fetch_data(mqs_process * proc, mqs_taddr_t addr, int asize, void *data)
 {
-    MPIR_Memcpy(data, (void *) addr, (size_t) asize);
+    MPIR_Memcpy(data, (void *) addr, (MPI_Aint) asize);
     return mqs_ok;
 }
 

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -109,7 +109,7 @@ Input Parameters:
 int MPIR_Err_set_msg(int code, const char *msg_string)
 {
     int errcode, errclass;
-    size_t msg_len;
+    MPI_Aint msg_len;
     char *str;
 
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -765,7 +765,7 @@ static const char *ErrcodeInvalidReasonStr(int);
 #define NEEDS_FIND_GENERIC_MSG_INDEX
 static int FindGenericMsgIndex(const char[]);
 static int FindSpecificMsgIndex(const char[]);
-static int vsnprintf_mpi(char *str, size_t maxlen, const char *fmt_orig, va_list list);
+static int vsnprintf_mpi(char *str, MPI_Aint maxlen, const char *fmt_orig, va_list list);
 static void ErrcodeCreateID(int error_class, int generic_idx, const char *msg, int *id, int *seq);
 static int convertErrcodeToIndexes(int errcode, int *ring_idx, int *ring_id, int *generic_idx);
 static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen);
@@ -1309,8 +1309,8 @@ static const char *GetAssertString(int d)
 {
     static char str[ASSERT_STR_MAXLEN] = "";
     char *cur;
-    size_t len = ASSERT_STR_MAXLEN;
-    size_t n;
+    MPI_Aint len = ASSERT_STR_MAXLEN;
+    MPI_Aint n;
 
     if (d == 0) {
         MPL_strncpy(str, "assert=0", ASSERT_STR_MAXLEN);
@@ -1464,10 +1464,10 @@ static const char *GetMPIOpString(MPI_Op o)
    will replace these. */
 /* ------------------------------------------------------------------------ */
 
-static int vsnprintf_mpi(char *str, size_t maxlen, const char *fmt_orig, va_list list)
+static int vsnprintf_mpi(char *str, MPI_Aint maxlen, const char *fmt_orig, va_list list)
 {
     char *begin, *end, *fmt;
-    size_t len;
+    MPI_Aint len;
     MPI_Comm C;
     MPI_Info info;
     MPI_Datatype D;
@@ -1493,8 +1493,8 @@ static int vsnprintf_mpi(char *str, size_t maxlen, const char *fmt_orig, va_list
     end = strchr(fmt, '%');
     while (end) {
         len = maxlen;
-        if (len > (size_t) (end - begin)) {
-            len = (size_t) (end - begin);
+        if (len > (MPI_Aint) (end - begin)) {
+            len = (MPI_Aint) (end - begin);
         }
         if (len) {
             MPIR_Memcpy(str, begin, len);

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -57,10 +57,10 @@ static void MPIR_Bsend_dump(void);
 static struct BsendBuffer {
     void *buffer;               /* Pointer to the begining of the user-
                                  * provided buffer */
-    size_t buffer_size;         /* Size of the user-provided buffer */
+    MPI_Aint buffer_size;       /* Size of the user-provided buffer */
     void *origbuffer;           /* Pointer to the buffer provided by
                                  * the user */
-    size_t origbuffer_size;     /* Size of the buffer as provided
+    MPI_Aint origbuffer_size;   /* Size of the buffer as provided
                                  * by the user */
     MPII_Bsend_data_t *avail;   /* Pointer to the first available block
                                  * of space */
@@ -79,8 +79,8 @@ static int initialized = 0;     /* keep track of the first call to any
 /* Forward references */
 static void MPIR_Bsend_retry_pending(void);
 static int MPIR_Bsend_check_active(void);
-static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(size_t);
-static void MPIR_Bsend_take_buffer(MPII_Bsend_data_t *, size_t);
+static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(MPI_Aint);
+static void MPIR_Bsend_take_buffer(MPII_Bsend_data_t *, MPI_Aint);
 static int MPIR_Bsend_finalize(void *);
 static void MPIR_Bsend_free_segment(MPII_Bsend_data_t *);
 
@@ -91,7 +91,7 @@ static void MPIR_Bsend_free_segment(MPII_Bsend_data_t *);
 int MPIR_Bsend_attach(void *buffer, int buffer_size)
 {
     MPII_Bsend_data_t *p;
-    size_t offset, align_sz;
+    MPI_Aint offset, align_sz;
 
 #ifdef HAVE_ERROR_CHECKING
     {
@@ -133,7 +133,7 @@ int MPIR_Bsend_attach(void *buffer, int buffer_size)
      * Further, GCC 4.5.1 generates bad code on 32-bit platforms when this is
      * only 4-byte aligned (see #1149). */
     align_sz = MPL_MAX(sizeof(void *), sizeof(double));
-    offset = ((size_t) buffer) % align_sz;
+    offset = ((MPI_Aint) buffer) % align_sz;
     if (offset) {
         offset = align_sz - offset;
         buffer = (char *) buffer + offset;
@@ -520,7 +520,7 @@ static void MPIR_Bsend_retry_pending(void)
  * Find a slot in the avail buffer that can hold size bytes.  Does *not*
  * remove the slot from the avail buffer (see MPIR_Bsend_take_buffer)
  */
-static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(size_t size)
+static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(MPI_Aint size)
 {
     MPII_Bsend_data_t *p = BsendBuffer.avail;
 
@@ -542,10 +542,10 @@ static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(size_t size)
  * If there isn't enough left of p, remove the entire segment from
  * the avail list.
  */
-static void MPIR_Bsend_take_buffer(MPII_Bsend_data_t * p, size_t size)
+static void MPIR_Bsend_take_buffer(MPII_Bsend_data_t * p, MPI_Aint size)
 {
     MPII_Bsend_data_t *prev;
-    size_t alloc_size;
+    MPI_Aint alloc_size;
 
     /* Compute the remaining size.  This must include any padding
      * that must be added to make the new block properly aligned */

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -732,7 +732,8 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
             tmp_buf = (char *) ADIOI_Malloc(for_next_iter);
             ADIOI_Assert((((ADIO_Offset) (uintptr_t) read_buf) + real_size - for_next_iter) ==
                          (ADIO_Offset) (uintptr_t) (read_buf + real_size - for_next_iter));
-            ADIOI_Assert((for_next_iter + coll_bufsize) == (size_t) (for_next_iter + coll_bufsize));
+            ADIOI_Assert((for_next_iter + coll_bufsize) ==
+                         (MPI_Aint) (for_next_iter + coll_bufsize));
             memcpy(tmp_buf, read_buf + real_size - for_next_iter, for_next_iter);
             ADIOI_Free(fd->io_buf);
             fd->io_buf = (char *) ADIOI_Malloc(for_next_iter + coll_bufsize);
@@ -957,10 +958,10 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
         while (size) {                                                  \
             size_in_buf = MPL_MIN(size, flat_buf_sz);                   \
             ADIOI_Assert((((ADIO_Offset)(uintptr_t)buf) + user_buf_idx) == (ADIO_Offset)(uintptr_t)(buf + user_buf_idx)); \
-            ADIOI_Assert(size_in_buf == (size_t)size_in_buf);           \
+            ADIOI_Assert(size_in_buf == (MPI_Aint)size_in_buf);           \
             memcpy(((char *) buf) + user_buf_idx,                       \
                    &(recv_buf[p][recv_buf_idx[p]]), size_in_buf);       \
-            recv_buf_idx[p] += size_in_buf; /* already tested (size_t)size_in_buf*/ \
+            recv_buf_idx[p] += size_in_buf; /* already tested (MPI_Aint)size_in_buf*/ \
             user_buf_idx += size_in_buf;                                \
             flat_buf_sz -= size_in_buf;                                 \
             if (!flat_buf_sz) {                                         \

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c
@@ -1127,7 +1127,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
             }
     } else if (nprocs_send) {
         /* buftype is not contig */
-        size_t msgLen = 0;
+        MPI_Aint msgLen = 0;
         for (i = 0; i < nprocs; i++)
             msgLen += send_size[i];
         send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
@@ -1234,7 +1234,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, const void *buf, char *write_buf
     while (size) { \
         size_in_buf = MPL_MIN(size, flat_buf_sz); \
   ADIOI_Assert((((ADIO_Offset)(uintptr_t)buf) + user_buf_idx) == (ADIO_Offset)(uintptr_t)((uintptr_t)buf + user_buf_idx)); \
-  ADIOI_Assert(size_in_buf == (size_t)size_in_buf); \
+  ADIOI_Assert(size_in_buf == (MPI_Aint)size_in_buf); \
         memcpy(&(send_buf[p][send_buf_idx[p]]), \
                ((char *) buf) + user_buf_idx, size_in_buf); \
         send_buf_idx[p] += size_in_buf; \

--- a/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_pset.c
+++ b/src/mpi/romio/adio/ad_gpfs/bg/ad_bg_pset.c
@@ -399,9 +399,9 @@ ADIOI_BG_persInfo_init(ADIOI_BG_ConfInfo_t * conf,
 /*    if (conf->aggRatio > 1) conf->aggRatio = 1.; */
         TRACE_ERR
             ("n_aggrs %zd, conf->nProcs %zu, conf->ioMaxSize %zu, ADIOI_BG_NAGG_PSET_DFLT %zu,conf->numBridgeRanks %zu,conf->nAggrs %zu\n",
-             (size_t) n_aggrs, (size_t) conf->nProcs, (size_t) conf->ioMaxSize,
-             (size_t) ADIOI_BG_NAGG_PSET_DFLT, (size_t) conf->numBridgeRanks,
-             (size_t) conf->nAggrs);
+             (MPI_Aint) n_aggrs, (MPI_Aint) conf->nProcs, (MPI_Aint) conf->ioMaxSize,
+             (MPI_Aint) ADIOI_BG_NAGG_PSET_DFLT, (MPI_Aint) conf->numBridgeRanks,
+             (MPI_Aint) conf->nAggrs);
         TRACE_ERR
             ("Maximum ranks under a bridge rank: %d, minimum: %d, nAggrs: %d, numBridgeRanks: %d pset dflt: %d naggrs: %d ratio: %f\n",
              maxcompute, mincompute, conf->nAggrs, conf->numBridgeRanks, ADIOI_BG_NAGG_PSET_DFLT,

--- a/src/mpi/romio/adio/ad_ime/ad_ime_common.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_common.c
@@ -66,7 +66,7 @@ void ADIOI_IME_Init(int rank, int *error_code)
 char *ADIOI_IME_Add_prefix(const char *filename)
 {
     static char myname[] = "ADIOI_IME_ADD_PREFIX";
-    size_t f_len = strlen(filename) + 1;
+    MPI_Aint f_len = strlen(filename) + 1;
     char *ime_filename = ADIOI_Malloc(f_len + ADIOI_IME_PREFIX_LEN);
 
     if (!ime_filename) {

--- a/src/mpi/romio/adio/ad_ime/ad_ime_io.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_io.c
@@ -26,7 +26,7 @@ static void IME_IOContig(ADIO_File fd,
 {
     ssize_t ret;
     MPI_Count datatype_size;
-    size_t mem_len;
+    MPI_Aint mem_len;
     uint64_t file_offset = offset;
     static char myname[] = "ADIOI_IME_IOCONTIG";
 

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_aggregate.c
@@ -139,7 +139,7 @@ void ADIOI_LUSTRE_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list,
      * ADIOI_Lustre_Calc_aggregator() instead of the old one */
     int *count_my_req_per_proc, count_my_req_procs;
     int i, l, proc;
-    size_t memLen;
+    MPI_Aint memLen;
     ADIO_Offset avail_len, rem_len, curr_idx, off, **buf_idx, *ptr;
     ADIOI_Access *my_req;
 

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
@@ -25,7 +25,7 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
     struct lov_user_md *lum = NULL;
     char *value;
     ADIO_Offset str_factor = -1, str_unit = 0, start_iodev = -1;
-    size_t value_sz = (MPI_MAX_INFO_VAL + 1) * sizeof(char);
+    MPI_Aint value_sz = (MPI_MAX_INFO_VAL + 1) * sizeof(char);
 
 #if defined(MPICH) || !defined(PRINT_ERR_MSG)
     static char myname[] = "ADIOI_LUSTRE_OPEN";

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -151,7 +151,7 @@ static void ADIOI_LUSTRE_IOContig(ADIO_File fd, const void *buf, int count,
                                   int io_mode, int *error_code)
 {
     ssize_t err = 0;
-    size_t rw_count;
+    MPI_Aint rw_count;
     ADIO_Offset bytes_xfered = 0;
     MPI_Count datatype_size, len;
     static char myname[] = "ADIOI_LUSTRE_IOCONTIG";

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -711,8 +711,8 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
     MPI_Status *statuses, status;
     int sum_recv;
     int data_sieving = *hole;
-    static size_t malloc_srt_num = 0;
-    size_t send_total_size;
+    static MPI_Aint malloc_srt_num = 0;
+    MPI_Aint send_total_size;
     static char myname[] = "ADIOI_W_EXCHANGE_DATA";
 
     /* create derived datatypes for recv */
@@ -935,7 +935,7 @@ static void ADIOI_LUSTRE_W_Exchange_data(ADIO_File fd, const void *buf,
     while (size) { \
         size_in_buf = MPL_MIN(size, flat_buf_sz); \
         ADIOI_Assert((((ADIO_Offset)(uintptr_t)buf) + user_buf_idx) == (ADIO_Offset)(uintptr_t)((uintptr_t)buf + user_buf_idx)); \
-        ADIOI_Assert(size_in_buf == (size_t)size_in_buf);               \
+        ADIOI_Assert(size_in_buf == (MPI_Aint)size_in_buf);               \
         memcpy(&(send_buf[p][send_buf_idx[p]]), \
                ((char *) buf) + user_buf_idx, size_in_buf); \
         send_buf_idx[p] += size_in_buf; \

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
@@ -18,7 +18,7 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
     ssize_t err = -1;
     MPI_Count datatype_size, len;
     ADIO_Offset bytes_xfered = 0;
-    size_t rd_count;
+    MPI_Aint rd_count;
     static char myname[] = "ADIOI_NFS_READCONTIG";
     char *p;
 

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
@@ -18,7 +18,7 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
     ssize_t err = -1;
     MPI_Count datatype_size, len;
     ADIO_Offset bytes_xfered = 0;
-    size_t wr_count;
+    MPI_Aint wr_count;
     static char myname[] = "ADIOI_NFS_WRITECONTIG";
     char *p;
 

--- a/src/mpi/romio/adio/common/ad_aggregate.c
+++ b/src/mpi/romio/adio/common/ad_aggregate.c
@@ -259,7 +259,7 @@ void ADIOI_Calc_my_req(ADIO_File fd, ADIO_Offset * offset_list, ADIO_Offset * le
     int *count_my_req_per_proc, count_my_req_procs;
     MPI_Aint *buf_idx;
     int i, l, proc;
-    size_t memLen;
+    MPI_Aint memLen;
     ADIO_Offset fd_len, rem_len, curr_idx, off, *ptr;
     ADIOI_Access *my_req;
 
@@ -439,7 +439,7 @@ void ADIOI_Calc_others_req(ADIO_File fd, int count_my_req_procs,
     int i, j;
     MPI_Request *requests;
     ADIOI_Access *others_req;
-    size_t memLen;
+    MPI_Aint memLen;
     ADIO_Offset *ptr;
     MPI_Aint *mem_ptrs;
 
@@ -569,7 +569,7 @@ void ADIOI_Icalc_others_req_main(ADIOI_NBC_Request * nbc_req, int *error_code)
     int count_others_req_procs;
     int i, j;
     ADIOI_Access *others_req;
-    size_t memLen;
+    MPI_Aint memLen;
     ADIO_Offset *ptr;
     MPI_Aint *mem_ptrs;
 

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -848,7 +848,7 @@ static void ADIOI_Iread_and_exch_l1_end(ADIOI_NBC_Request * nbc_req, int *error_
         ADIOI_Assert((((ADIO_Offset) (uintptr_t) read_buf) + real_size - for_next_iter) ==
                      (ADIO_Offset) (uintptr_t) (read_buf + real_size - for_next_iter));
         ADIOI_Assert((for_next_iter + vars->coll_bufsize) ==
-                     (size_t) (for_next_iter + vars->coll_bufsize));
+                     (MPI_Aint) (for_next_iter + vars->coll_bufsize));
         memcpy(tmp_buf, read_buf + real_size - for_next_iter, for_next_iter);
         ADIOI_Free(fd->io_buf);
         fd->io_buf = (char *) ADIOI_Malloc(for_next_iter + vars->coll_bufsize);

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -1185,7 +1185,7 @@ static void ADIOI_W_Iexchange_data_send(ADIOI_NBC_Request * nbc_req, int *error_
             }
     } else if (nprocs_send) {
         /* buftype is not contig */
-        size_t msgLen = 0;
+        MPI_Aint msgLen = 0;
         for (i = 0; i < nprocs; i++)
             msgLen += send_size[i];
         send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));

--- a/src/mpi/romio/adio/common/ad_read.c
+++ b/src/mpi/romio/adio/common/ad_read.c
@@ -27,7 +27,7 @@ void ADIOI_GEN_ReadContig(ADIO_File fd, void *buf, int count,
     ssize_t err = -1;
     MPI_Count datatype_size;
     ADIO_Offset len, bytes_xfered = 0;
-    size_t rd_count;
+    MPI_Aint rd_count;
     static char myname[] = "ADIOI_GEN_READCONTIG";
 #ifdef ROMIO_GPFS
     double io_time = 0;

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -726,7 +726,8 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
             tmp_buf = (char *) ADIOI_Malloc(for_next_iter);
             ADIOI_Assert((((ADIO_Offset) (uintptr_t) read_buf) + real_size - for_next_iter) ==
                          (ADIO_Offset) (uintptr_t) (read_buf + real_size - for_next_iter));
-            ADIOI_Assert((for_next_iter + coll_bufsize) == (size_t) (for_next_iter + coll_bufsize));
+            ADIOI_Assert((for_next_iter + coll_bufsize) ==
+                         (MPI_Aint) (for_next_iter + coll_bufsize));
             memcpy(tmp_buf, read_buf + real_size - for_next_iter, for_next_iter);
             ADIOI_Free(fd->io_buf);
             fd->io_buf = (char *) ADIOI_Malloc(for_next_iter + coll_bufsize);
@@ -768,7 +769,7 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
 {
     int i, j, k = 0, tmp = 0, nprocs_recv, nprocs_send;
     char **recv_buf = NULL;
-    size_t memLen;
+    MPI_Aint memLen;
     MPI_Request *requests;
     MPI_Datatype send_type;
     MPI_Status *statuses;
@@ -928,10 +929,10 @@ static void ADIOI_R_Exchange_data(ADIO_File fd, void *buf, ADIOI_Flatlist_node
         while (size) {                                                  \
             size_in_buf = MPL_MIN(size, flat_buf_sz);                   \
             ADIOI_Assert((((ADIO_Offset)(uintptr_t)buf) + user_buf_idx) == (ADIO_Offset)(uintptr_t)((uintptr_t)buf + user_buf_idx)); \
-            ADIOI_Assert(size_in_buf == (size_t)size_in_buf);           \
+            ADIOI_Assert(size_in_buf == (MPI_Aint)size_in_buf);           \
             memcpy(((char *) buf) + user_buf_idx,                       \
                    &(recv_buf[p][recv_buf_idx[p]]), size_in_buf);       \
-            recv_buf_idx[p] += size_in_buf; /* already tested (size_t)size_in_buf*/ \
+            recv_buf_idx[p] += size_in_buf; /* already tested (MPI_Aint)size_in_buf*/ \
             user_buf_idx += size_in_buf;                                \
             flat_buf_sz -= size_in_buf;                                 \
             if (!flat_buf_sz) {                                         \

--- a/src/mpi/romio/adio/common/ad_read_str.c
+++ b/src/mpi/romio/adio/common/ad_read_str.c
@@ -34,7 +34,7 @@
                             &status1, error_code);                      \
             if (*error_code != MPI_SUCCESS) return;                     \
         }                                                               \
-        ADIOI_Assert(req_len == (size_t)req_len);                       \
+        ADIOI_Assert(req_len == (MPI_Aint)req_len);                       \
         memcpy((char *)buf + userbuf_off, readbuf+req_off-readbuf_off, req_len); \
     }
 

--- a/src/mpi/romio/adio/common/ad_write.c
+++ b/src/mpi/romio/adio/common/ad_write.c
@@ -29,7 +29,7 @@ void ADIOI_GEN_WriteContig(ADIO_File fd, const void *buf, int count,
     ssize_t err = -1;
     MPI_Count datatype_size;
     ADIO_Offset len, bytes_xfered = 0;
-    size_t wr_count;
+    MPI_Aint wr_count;
     static char myname[] = "ADIOI_GEN_WRITECONTIG";
 #ifdef ROMIO_GPFS
     double io_time = 0;

--- a/src/mpi/romio/adio/common/ad_write_coll.c
+++ b/src/mpi/romio/adio/common/ad_write_coll.c
@@ -687,7 +687,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
             }
     } else if (nprocs_send) {
         /* buftype is not contig */
-        size_t msgLen = 0;
+        MPI_Aint msgLen = 0;
         for (i = 0; i < nprocs; i++)
             msgLen += send_size[i];
         send_buf = (char **) ADIOI_Malloc(nprocs * sizeof(char *));
@@ -793,7 +793,7 @@ static void ADIOI_W_Exchange_data(ADIO_File fd, void *buf, char *write_buf,
     while (size) { \
         size_in_buf = MPL_MIN(size, flat_buf_sz); \
   ADIOI_Assert((((ADIO_Offset)(uintptr_t)buf) + user_buf_idx) == (ADIO_Offset)(uintptr_t)((uintptr_t)buf + user_buf_idx)); \
-  ADIOI_Assert(size_in_buf == (size_t)size_in_buf); \
+  ADIOI_Assert(size_in_buf == (MPI_Aint)size_in_buf); \
         memcpy(&(send_buf[p][send_buf_idx[p]]), \
                ((char *) buf) + user_buf_idx, size_in_buf); \
         send_buf_idx[p] += size_in_buf; \

--- a/src/mpi/romio/adio/common/ad_write_nolock.c
+++ b/src/mpi/romio/adio/common/ad_write_nolock.c
@@ -337,7 +337,7 @@ void ADIOI_NOLOCK_WriteStrided(ADIO_File fd, const void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
                     MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);
 #endif
-                    ADIOI_Assert(size == (size_t) size);
+                    ADIOI_Assert(size == (MPI_Aint) size);
                     ADIOI_Assert(off == (off_t) off);
                     err = write(fd->fd_sys, ((char *) buf) + indx, size);
 #ifdef ADIOI_MPE_LOGGING

--- a/src/mpi/romio/adio/common/hint_fns.c
+++ b/src/mpi/romio/adio/common/hint_fns.c
@@ -133,7 +133,7 @@ int ADIOI_Info_check_and_install_str(ADIO_File fd, MPI_Info info, const char *ke
                                      char **local_cache, char *funcname, int *error_code)
 {
     int flag, ret = 0;
-    size_t len;
+    MPI_Aint len;
     char *value;
 
     value = (char *) ADIOI_Malloc((MPI_MAX_INFO_VAL + 1) * sizeof(char));

--- a/src/mpi/romio/adio/common/malloc.c
+++ b/src/mpi/romio/adio/common/malloc.c
@@ -28,12 +28,12 @@
 
 #define FPRINTF fprintf
 
-void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname);
-void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname);
-void *ADIOI_Realloc_fn(void *ptr, size_t size, int lineno, const char *fname);
+void *ADIOI_Malloc_fn(MPI_Aint size, int lineno, const char *fname);
+void *ADIOI_Calloc_fn(MPI_Aint nelem, MPI_Aint elsize, int lineno, const char *fname);
+void *ADIOI_Realloc_fn(void *ptr, MPI_Aint size, int lineno, const char *fname);
 void ADIOI_Free_fn(void *ptr, int lineno, const char *fname);
 
-void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname)
+void *ADIOI_Malloc_fn(MPI_Aint size, int lineno, const char *fname)
 {
     void *new;
 
@@ -52,7 +52,7 @@ void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname)
 }
 
 
-void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname)
+void *ADIOI_Calloc_fn(MPI_Aint nelem, MPI_Aint elsize, int lineno, const char *fname)
 {
     void *new;
 
@@ -66,7 +66,7 @@ void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname
 }
 
 
-void *ADIOI_Realloc_fn(void *ptr, size_t size, int lineno, const char *fname)
+void *ADIOI_Realloc_fn(void *ptr, MPI_Aint size, int lineno, const char *fname)
 {
     void *new;
 

--- a/src/mpi/romio/adio/common/strfns.c
+++ b/src/mpi/romio/adio/common/strfns.c
@@ -45,7 +45,7 @@ Output Parameters:
   Module:
   Utility
   @*/
-int ADIOI_Strncpy(char *dest, const char *src, size_t n)
+int ADIOI_Strncpy(char *dest, const char *src, MPI_Aint n)
 {
     char *restrict d_ptr = dest;
     const char *restrict s_ptr = src;

--- a/src/mpi/romio/adio/common/utils.c
+++ b/src/mpi/romio/adio/common/utils.c
@@ -113,10 +113,10 @@ int ADIOI_Type_create_hindexed_x(int count,
 #include <sys/types.h>
 #include <unistd.h>
 
-ssize_t pread(int fd, void *buf, size_t count, off_t offset);
-ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+ssize_t pread(int fd, void *buf, MPI_Aint count, off_t offset);
+ssize_t pwrite(int fd, const void *buf, MPI_Aint count, off_t offset);
 
-ssize_t pread(int fd, void *buf, size_t count, off_t offset)
+ssize_t pread(int fd, void *buf, MPI_Aint count, off_t offset)
 {
     off_t lseek_ret;
     off_t old_offset;
@@ -136,7 +136,7 @@ ssize_t pread(int fd, void *buf, size_t count, off_t offset)
     return read_ret;
 }
 
-ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset)
+ssize_t pwrite(int fd, const void *buf, MPI_Aint count, off_t offset)
 {
     off_t lseek_ret;
     off_t old_offset;

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -160,7 +160,7 @@ MPI_Info PMPI_Info_f2c(MPI_Fint info);
 char *strdup(const char *s);
 #endif
 #if defined(HAVE_READLINK) && defined(NEEDS_READLINK_DECL) && !defined(readlink)
-ssize_t readlink(const char *path, char *buf, size_t bufsiz);
+ssize_t readlink(const char *path, char *buf, MPI_Aint bufsiz);
 #endif
 #if defined(HAVE_LSTAT) && defined(NEEDS_LSTAT_DECL) && !defined(lstat)
 int lstat(const char *file_name, struct stat *buf);

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -355,9 +355,9 @@ int ADIOI_Flattened_type_delete(MPI_Datatype datatype,
 ADIOI_Flatlist_node *ADIOI_Flatten_and_find(MPI_Datatype);
 MPI_Count ADIOI_Count_contiguous_blocks(MPI_Datatype type, MPI_Count * curr_index);
 void ADIOI_Complete_async(int *error_code);
-void *ADIOI_Malloc_fn(size_t size, int lineno, const char *fname);
-void *ADIOI_Calloc_fn(size_t nelem, size_t elsize, int lineno, const char *fname);
-void *ADIOI_Realloc_fn(void *ptr, size_t size, int lineno, const char *fname);
+void *ADIOI_Malloc_fn(MPI_Aint size, int lineno, const char *fname);
+void *ADIOI_Calloc_fn(MPI_Aint nelem, MPI_Aint elsize, int lineno, const char *fname);
+void *ADIOI_Realloc_fn(void *ptr, MPI_Aint size, int lineno, const char *fname);
 void ADIOI_Free_fn(void *ptr, int lineno, const char *fname);
 void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag);
 void ADIOI_Get_position(ADIO_File fd, ADIO_Offset * offset);
@@ -847,7 +847,7 @@ int ADIOI_Set_lock64(FDTYPE fd_sys, int cmd, int type, ADIO_Offset offset, int w
 #define ADIOI_Realloc(a,b) ADIOI_Realloc_fn(a,b,__LINE__,__FILE__)
 #define ADIOI_Free(a) ADIOI_Free_fn(a,__LINE__,__FILE__)
 
-int ADIOI_Strncpy(char *outstr, const char *instr, size_t maxlen);
+int ADIOI_Strncpy(char *outstr, const char *instr, MPI_Aint maxlen);
 char *ADIOI_Strdup(const char *);
 
 /* the current MPI standard is not const-correct, and modern compilers warn
@@ -988,8 +988,8 @@ void *ADIOI_IO_Thread_Func(void *vptr_args);
 #if (HAVE_DECL_PWRITE == 0)
 #include <sys/types.h>
 #include <unistd.h>
-ssize_t pread(int fd, void *buf, size_t count, off_t offset);
-ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
+ssize_t pread(int fd, void *buf, MPI_Aint count, off_t offset);
+ssize_t pwrite(int fd, const void *buf, MPI_Aint count, off_t offset);
 
 #endif
 

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -265,7 +265,7 @@ MPID_nem_mpich_sendv (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *again)
     
     while (*n_iov && payload_len >= (*iov)->MPL_IOV_LEN)
     {
-	size_t _iov_len = (*iov)->MPL_IOV_LEN;
+	MPI_Aint _iov_len = (*iov)->MPL_IOV_LEN;
 	MPIR_Memcpy (cell_buf, (*iov)->MPL_IOV_BUF, _iov_len);
 	payload_len -= _iov_len;
 	cell_buf += _iov_len;
@@ -398,7 +398,7 @@ MPID_nem_mpich_sendv_header (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *aga
     payload_len = MPID_NEM_MPICH_DATA_LEN - buf_offset;
     while (*n_iov && payload_len >= (*iov)->MPL_IOV_LEN)
     {
-	size_t _iov_len = (*iov)->MPL_IOV_LEN;
+	MPI_Aint _iov_len = (*iov)->MPL_IOV_LEN;
 	MPIR_Memcpy (cell_buf, (*iov)->MPL_IOV_BUF, _iov_len);
 	payload_len -= _iov_len;
 	cell_buf += _iov_len;

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_cm.c
@@ -123,7 +123,7 @@ static inline int MPID_nem_ofi_conn_req_callback(cq_tagged_entry_t * wc, MPIR_Re
     MPIDI_CH3I_NM_OFI_RC(MPIDI_GetTagFromPort(bc, &vc->port_name_tag));
     ret = MPL_str_get_binary_arg(bc, "OFI", addr, gl_data.bound_addrlen, &len);
     MPIR_ERR_CHKANDJUMP((ret != MPL_STR_SUCCESS && ret != MPL_STR_NOMEM) ||
-                        (size_t) len != gl_data.bound_addrlen,
+                        (MPI_Aint) len != gl_data.bound_addrlen,
                         mpi_errno, MPI_ERR_OTHER, "**business_card");
 
     FI_RC(fi_av_insert(gl_data.av, addr, 1, &direct_addr, 0ULL, NULL), avmap);
@@ -205,7 +205,7 @@ static inline int MPID_nem_ofi_cts_send_callback(cq_tagged_entry_t * wc, MPIR_Re
 static inline int MPID_nem_ofi_preposted_callback(cq_tagged_entry_t * wc, MPIR_Request * rreq)
 {
     int c, mpi_errno = MPI_SUCCESS;
-    size_t pkt_len;
+    MPI_Aint pkt_len;
     char *pack_buffer = NULL;
     MPIDI_VC_t *vc;
     MPIR_Request *new_rreq, *sreq;
@@ -418,7 +418,7 @@ int MPID_nem_ofi_vc_connect(MPIDI_VC_t * vc)
     MPIDI_CH3I_NM_OFI_RC(vc->pg->getConnInfo(vc->pg_rank, bc, MPIDI_OFI_KVSAPPSTRLEN, vc->pg));
     ret = MPL_str_get_binary_arg(bc, "OFI", addr, gl_data.bound_addrlen, &len);
     MPIR_ERR_CHKANDJUMP((ret != MPL_STR_SUCCESS && ret != MPL_STR_NOMEM) ||
-                        (size_t) len != gl_data.bound_addrlen,
+                        (MPI_Aint) len != gl_data.bound_addrlen,
                         mpi_errno, MPI_ERR_OTHER, "**business_card");
     FI_RC(fi_av_insert(gl_data.av, addr, 1, &(VC_OFI(vc)->direct_addr), 0ULL, NULL), avmap);
     VC_OFI(vc)->ready = 1;
@@ -544,7 +544,7 @@ int MPID_nem_ofi_connect_to_root(const char *business_card, MPIDI_VC_t * new_vc)
     MPIDI_CH3I_NM_OFI_RC(MPIDI_GetTagFromPort(business_card, &new_vc->port_name_tag));
     ret = MPL_str_get_binary_arg(business_card, "OFI", addr, gl_data.bound_addrlen, &len);
     MPIR_ERR_CHKANDJUMP((ret != MPL_STR_SUCCESS && ret != MPL_STR_NOMEM) ||
-                        (size_t) len != gl_data.bound_addrlen,
+                        (MPI_Aint) len != gl_data.bound_addrlen,
                         mpi_errno, MPI_ERR_OTHER, "**business_card");
     FI_RC(fi_av_insert(gl_data.av, addr, 1, &(VC_OFI(new_vc)->direct_addr), 0ULL, NULL), avmap);
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -71,15 +71,15 @@ typedef int (*req_fn) (MPIDI_VC_t *, MPIR_Request *, int *);
 /* ******************************** */
 typedef struct {
     char bound_addr[OFI_MAX_ADDR_LEN];  /* This ranks bound address    */
-    size_t bound_addrlen;       /* length of the bound address */
+    MPI_Aint bound_addrlen;       /* length of the bound address */
     struct fid_fabric *fabric;  /* fabric object               */
     struct fid_domain *domain;  /* domain object               */
     struct fid_ep *endpoint;    /* endpoint object             */
     struct fid_cq *cq;          /* completion queue            */
     struct fid_av *av;          /* address vector              */
     struct fid_mr *mr;          /* memory region               */
-    size_t iov_limit;           /* Max send iovec limit        */
-    size_t max_buffered_send;   /* Buffered send threshold     */
+    MPI_Aint iov_limit;           /* Max send iovec limit        */
+    MPI_Aint max_buffered_send;   /* Buffered send threshold     */
     int rts_cts_in_flight;      /* Count of incompleted        */
     /*   RTS-CTS-DATA exchanges    */
     int api_set;                /* Used OFI API for send       */
@@ -111,8 +111,8 @@ typedef struct {
     void *addr;                 /* OFI Address                 */
     event_callback_fn event_callback;   /* Callback Event      */
     char *pack_buffer;          /* MPI Pack Buffer             */
-    size_t pack_buffer_size;    /* Pack buffer size            */
-    size_t msg_bytes;           /* msg api bytes               */
+    MPI_Aint pack_buffer_size;    /* Pack buffer size            */
+    MPI_Aint msg_bytes;           /* msg api bytes               */
     int iov_count;              /* Number of iovecs            */
     void *real_hdr;             /* Extended header             */
     int match_state;            /* State of the match          */

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
@@ -255,7 +255,7 @@ int MPID_nem_ofi_init(MPIDI_PG_t * pg_p, int pg_rank, char **bc_val_p, int *val_
                                      (char *) &addrs[i * gl_data.bound_addrlen],
                                      gl_data.bound_addrlen, &len);
         MPIR_ERR_CHKANDJUMP((ret != MPL_STR_SUCCESS && ret != MPL_STR_NOMEM) ||
-                            (size_t) len != gl_data.bound_addrlen,
+                            (MPI_Aint) len != gl_data.bound_addrlen,
                             mpi_errno, MPI_ERR_OTHER, "**business_card");
     }
 

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_msg.c
@@ -223,7 +223,7 @@ int MPID_nem_ofi_iSendContig(MPIDI_VC_t * vc,
     uint64_t match_bits;
     MPIR_Request *cts_req;
     intptr_t buf_offset = 0;
-    size_t pkt_len;
+    MPI_Aint pkt_len;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISENDCONTIG);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISENDCONTIG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));
@@ -263,7 +263,7 @@ int MPID_nem_ofi_iSendIov(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intpt
     uint64_t match_bits;
     MPIR_Request *cts_req;
     intptr_t buf_offset = 0;
-    size_t pkt_len;
+    MPI_Aint pkt_len;
     int i;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISENDIOV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISENDIOV);
@@ -306,7 +306,7 @@ int MPID_nem_ofi_SendNoncontig(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, 
     MPIR_Request *cts_req;
     intptr_t buf_offset = 0;
     void *data = NULL;
-    size_t pkt_len;
+    MPI_Aint pkt_len;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_SENDNONCONTIG);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_SENDNONCONTIG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));
@@ -359,7 +359,7 @@ int MPID_nem_ofi_iStartContigMsg(MPIDI_VC_t * vc,
     MPIR_Request *cts_req;
     char *pack_buffer = NULL;
     uint64_t match_bits;
-    size_t pkt_len;
+    MPI_Aint pkt_len;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_ISTARTCONTIGMSG);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_OFI_ISTARTCONTIGMSG);
     MPIR_Assert(hdr_sz <= (intptr_t) sizeof(MPIDI_CH3_Pkt_t));

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_probe_template.c
@@ -41,7 +41,7 @@ int ADD_SUFFIX(MPID_nem_ofi_iprobe_impl) (struct MPIDI_VC * vc,
     int ret, mpi_errno = MPI_SUCCESS;
     fi_addr_t remote_proc = 0;
     uint64_t match_bits, mask_bits;
-    size_t len;
+    MPI_Aint len;
     MPIR_Request rreq_s, *rreq;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_NEM_OFI_IPROBE_IMPL);

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -427,7 +427,7 @@ static int send_id_info(const sockconn_t * const sc)
     struct iovec iov[3];
     int buf_size, iov_cnt = 2;
     ssize_t offset;
-    size_t pg_id_len = 0;
+    MPI_Aint pg_id_len = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_SEND_ID_INFO);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_SEND_ID_INFO);
@@ -542,7 +542,7 @@ static int recv_id_or_tmpvc_info(sockconn_t * const sc, int *got_sc_eof)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_nem_tcp_header_t hdr;
     int iov_cnt = 1;
-    size_t pg_id_len = 0;
+    MPI_Aint pg_id_len = 0;
     ssize_t nread;
     int hdr_len = sizeof(MPIDI_nem_tcp_header_t);
     struct iovec iov[2];

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -11,7 +11,7 @@
 
 typedef struct MPID_nem_tcp_send_q_element {
     struct MPID_nem_tcp_send_q_element *next;
-    size_t len;                 /* number of bytes left to send */
+    MPI_Aint len;                 /* number of bytes left to send */
     char *start;                /* pointer to next byte to send */
     MPID_nem_cell_ptr_t cell;
     /*     char buf[MPID_NEM_MAX_PACKET_LEN]; *//* data to be sent */

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_utility.c
@@ -157,7 +157,7 @@ int MPID_nem_tcp_is_sock_connected(int fd)
     int rc = FALSE;
     char buf[1];
     int buf_len = sizeof(buf) / sizeof(buf[0]), error = 0;
-    size_t ret_recv;
+    MPI_Aint ret_recv;
     socklen_t n = sizeof(error);
 
     n = sizeof(error);

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -832,7 +832,7 @@ int MPID_nem_handle_pkt(MPIDI_VC_t *vc, char *buf, intptr_t buflen)
 		
             while (n_iov && buflen >= iov->MPL_IOV_LEN)
             {
-                size_t iov_len = iov->MPL_IOV_LEN;
+                MPI_Aint iov_len = iov->MPL_IOV_LEN;
 		MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "        %d", (int)iov_len);
                 if (rreq->dev.drop_data == FALSE) {
                     MPIR_Memcpy (iov->MPL_IOV_BUF, buf, iov_len);

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
@@ -274,7 +274,7 @@ static int restore_env(pid_t parent_pid, int rank)
     CHECK_ERR(ret, MPIR_Strerror (errno));
 
     while (fgets(var_val, MAX_STR_LEN, f)) {
-        size_t len = strlen(var_val);
+        MPI_Aint len = strlen(var_val);
         /* remove newline */
         if (var_val[len-1] == '\n')
             var_val[len-1] = '\0';

--- a/src/mpid/ch3/channels/sock/include/mpidu_sock.h
+++ b/src/mpid/ch3/channels/sock/include/mpidu_sock.h
@@ -99,7 +99,7 @@ Utility-Sock
 S*/
 typedef struct MPIDI_CH3I_Sock_event {
     MPIDI_CH3I_Sock_op_t op_type;
-    size_t num_bytes;
+    MPI_Aint num_bytes;
     void *user_ptr;
     int error;
 } MPIDI_CH3I_Sock_event_t;
@@ -560,7 +560,7 @@ internal progress engine could block on an application routine.
 Module:
 Utility-Sock
 E*/
-typedef int (*MPIDI_CH3I_Sock_progress_update_func_t) (size_t num_bytes, void *user_ptr);
+typedef int (*MPIDI_CH3I_Sock_progress_update_func_t) (MPI_Aint num_bytes, void *user_ptr);
 
 
 /*@
@@ -619,7 +619,7 @@ one thread is not attempting to post a new operation while another thread is att
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_post_read(MPIDI_CH3I_Sock_t sock, void *buf, size_t minbr, size_t maxbr,
+int MPIDI_CH3I_Sock_post_read(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint minbr, MPI_Aint maxbr,
                               MPIDI_CH3I_Sock_progress_update_func_t fn);
 
 
@@ -739,7 +739,7 @@ need this flexibility?
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_post_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t min, size_t max,
+int MPIDI_CH3I_Sock_post_write(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint min, MPI_Aint max,
                                MPIDI_CH3I_Sock_progress_update_func_t fn);
 
 
@@ -909,7 +909,7 @@ not attempting to perform an immediate read while another thread is attempting t
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t * num_read);
+int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint len, MPI_Aint * num_read);
 
 
 /*@
@@ -959,7 +959,7 @@ not attempting to perform an immediate read while another thread is attempting t
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size_t * num_read);
+int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, MPI_Aint * num_read);
 
 
 /*@
@@ -1008,7 +1008,7 @@ not attempting to perform an immediate write while another thread is attempting 
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t * num_written);
+int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint len, MPI_Aint * num_written);
 
 
 /*@
@@ -1057,7 +1057,7 @@ not attempting to perform an immediate write while another thread is attempting 
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size_t * num_written);
+int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, MPI_Aint * num_written);
 
 
 /*@
@@ -1121,7 +1121,7 @@ The returned string is the generic error message for the supplied error code.
 Module:
 Utility-Sock
 @*/
-int MPIDI_CH3I_Sock_get_error_class_string(int error, char *error_string, size_t length);
+int MPIDI_CH3I_Sock_get_error_class_string(int error, char *error_string, MPI_Aint length);
 
 
 CPLUSPLUS_END

--- a/src/mpid/ch3/channels/sock/include/mpidu_socki.h
+++ b/src/mpid/ch3/channels/sock/include/mpidu_socki.h
@@ -21,7 +21,7 @@
 #endif
 
 #if defined(HAVE_GETHOSTNAME) && defined(NEEDS_GETHOSTNAME_DECL) && !defined(gethostname)
-int gethostname(char *name, size_t len);
+int gethostname(char *name, MPI_Aint len);
 #endif
 
 #ifndef SSIZE_MAX
@@ -39,7 +39,7 @@ int gethostname(char *name, size_t len);
 
 typedef struct MPIDI_CH3I_Sock_set *MPIDI_CH3I_Sock_set_t;
 typedef struct MPIDI_CH3I_Sock *MPIDI_CH3I_Sock_t;
-typedef size_t MPIDI_CH3I_Sock_size_t;
+typedef MPI_Aint MPIDI_CH3I_Sock_size_t;
 
 #define MPIDI_CH3I_SOCKI_STATE_LIST \
 MPID_STATE_MPIDI_CH3I_SOCKI_READ, \

--- a/src/mpid/ch3/channels/sock/src/ch3_isend.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isend.c
@@ -6,7 +6,7 @@
 
 #include "mpidi_ch3_impl.h"
 
-static void update_request(MPIR_Request * sreq, void *hdr, intptr_t hdr_sz, size_t nb)
+static void update_request(MPIR_Request * sreq, void *hdr, intptr_t hdr_sz, MPI_Aint nb)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_UPDATE_REQUEST);
 
@@ -39,7 +39,7 @@ int MPIDI_CH3_iSend(MPIDI_VC_t * vc, MPIR_Request * sreq, void *hdr, intptr_t hd
         /* Connection already formed.  If send queue is empty attempt to send
          * data, queuing any unsent data. */
         if (MPIDI_CH3I_SendQ_empty(vcch)) {     /* MT */
-            size_t nb;
+            MPI_Aint nb;
             int rc;
 
             MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "send queue empty, attempting to write");

--- a/src/mpid/ch3/channels/sock/src/ch3_isendv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_isendv.c
@@ -7,7 +7,7 @@
 #include "mpidi_ch3_impl.h"
 
 static void update_request(MPIR_Request * sreq, MPL_IOV * iov, int iov_count,
-                           int iov_offset, size_t nb)
+                           int iov_offset, MPI_Aint nb)
 {
     int i;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_UPDATE_REQUEST);
@@ -52,7 +52,7 @@ int MPIDI_CH3_iSendv(MPIDI_VC_t * vc, MPIR_Request * sreq, MPL_IOV * iov, int n_
         /* Connection already formed.  If send queue is empty attempt to send
          * data, queuing any unsent data. */
         if (MPIDI_CH3I_SendQ_empty(vcch)) {     /* MT */
-            size_t nb;
+            MPI_Aint nb;
             int rc;
 
             MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "send queue empty, attempting to write");

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
@@ -6,7 +6,7 @@
 
 #include "mpidi_ch3_impl.h"
 
-static MPIR_Request *create_request(void *hdr, intptr_t hdr_sz, size_t nb)
+static MPIR_Request *create_request(void *hdr, intptr_t hdr_sz, MPI_Aint nb)
 {
     MPIR_Request *sreq;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CREATE_REQUEST);
@@ -59,7 +59,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
         /* Connection already formed.  If send queue is empty attempt to send
          * data, queuing any unsent data. */
         if (MPIDI_CH3I_SendQ_empty(vcch)) {     /* MT */
-            size_t nb;
+            MPI_Aint nb;
             int rc;
 
             MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "send queue empty, attempting to write");

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
@@ -6,7 +6,7 @@
 
 #include "mpidi_ch3_impl.h"
 
-static MPIR_Request *create_request(MPL_IOV * iov, int iov_count, int iov_offset, size_t nb)
+static MPIR_Request *create_request(MPL_IOV * iov, int iov_count, int iov_offset, MPI_Aint nb)
 {
     MPIR_Request *sreq;
     int i;
@@ -84,7 +84,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, MPL_IOV * iov, int n_iov, MPIR_Request
          * data, queuing any unsent data. */
         if (MPIDI_CH3I_SendQ_empty(vcch)) {     /* MT */
             int rc;
-            size_t nb;
+            MPI_Aint nb;
 
             MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "send queue empty, attempting to write");
             MPL_DBG_PKT(vcch->conn, (MPIDI_CH3_Pkt_t *) iov[0].MPL_IOV_BUF, "isend");

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -43,7 +43,7 @@ static int MPIDI_CH3I_Progress_handle_sock_event(MPIDI_CH3I_Sock_event_t * event
 static inline int connection_pop_sendq_req(MPIDI_CH3I_Connection_t * conn);
 static inline int connection_post_recv_pkt(MPIDI_CH3I_Connection_t * conn);
 
-static int adjust_iov(MPL_IOV ** iovp, int *countp, size_t nb);
+static int adjust_iov(MPL_IOV ** iovp, int *countp, MPI_Aint nb);
 
 #define MAX_PROGRESS_HOOKS 4
 typedef int (*progress_func_ptr_t) (int *made_progress);
@@ -569,7 +569,7 @@ static int MPIDI_CH3I_Progress_handle_sock_event(MPIDI_CH3I_Sock_event_t * event
 
                         for (;;) {
                             MPL_IOV *iovp;
-                            size_t nb;
+                            MPI_Aint nb;
 
                             iovp = sreq->dev.iov;
 
@@ -803,7 +803,7 @@ static inline int connection_post_recv_pkt(MPIDI_CH3I_Connection_t * conn)
 }
 
 /* FIXME: What is this routine for? */
-static int adjust_iov(MPL_IOV ** iovp, int *countp, size_t nb)
+static int adjust_iov(MPL_IOV ** iovp, int *countp, MPI_Aint nb)
 {
     MPL_IOV *const iov = *iovp;
     const int count = *countp;
@@ -835,7 +835,7 @@ static int ReadMoreData(MPIDI_CH3I_Connection_t * conn, MPIR_Request * rreq)
 
     while (1) {
         MPL_IOV *iovp;
-        size_t nb;
+        MPI_Aint nb;
 
         iovp = rreq->dev.iov;
 

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -105,12 +105,12 @@ struct pollinfo {
         } iov;
         struct {
             char *ptr;
-            size_t min;
-            size_t max;
+            MPI_Aint min;
+            MPI_Aint max;
         } buf;
     } read;
     int read_iov_flag;
-    size_t read_nb;
+    MPI_Aint read_nb;
     MPIDI_CH3I_Sock_progress_update_func_t read_progress_update_fn;
     union {
         struct {
@@ -120,12 +120,12 @@ struct pollinfo {
         } iov;
         struct {
             char *ptr;
-            size_t min;
-            size_t max;
+            MPI_Aint min;
+            MPI_Aint max;
         } buf;
     } write;
     int write_iov_flag;
-    size_t write_nb;
+    MPI_Aint write_nb;
     MPIDI_CH3I_Sock_progress_update_func_t write_progress_update_fn;
 };
 
@@ -218,7 +218,7 @@ static void MPIDI_CH3I_Socki_sock_free(struct MPIDI_CH3I_Sock *sock);
 
 static int MPIDI_CH3I_Socki_event_enqueue(struct pollinfo *pollinfo,
                                           enum MPIDI_CH3I_Sock_op op,
-                                          size_t num_bytes, void *user_ptr, int error);
+                                          MPI_Aint num_bytes, void *user_ptr, int error);
 static inline int MPIDI_CH3I_Socki_event_dequeue(struct MPIDI_CH3I_Sock_set *sock_set,
                                                  int *set_elem,
                                                  struct MPIDI_CH3I_Sock_event *eventp);
@@ -981,7 +981,7 @@ static void MPIDI_CH3I_Socki_sock_free(struct MPIDI_CH3I_Sock *sock)
 
 
 static int MPIDI_CH3I_Socki_event_enqueue(struct pollinfo *pollinfo, MPIDI_CH3I_Sock_op_t op,
-                                          size_t num_bytes, void *user_ptr, int error)
+                                          MPI_Aint num_bytes, void *user_ptr, int error)
 {
     struct MPIDI_CH3I_Sock_set *sock_set = pollinfo->sock_set;
     struct MPIDI_CH3I_Socki_eventq_elem *eventq_elem;
@@ -1960,7 +1960,7 @@ int MPIDI_CH3I_Sock_listen(struct MPIDI_CH3I_Sock_set *sock_set, void *user_ptr,
 
 
 /* FIXME: What does this function do? */
-int MPIDI_CH3I_Sock_post_read(struct MPIDI_CH3I_Sock *sock, void *buf, size_t minlen, size_t maxlen,
+int MPIDI_CH3I_Sock_post_read(struct MPIDI_CH3I_Sock *sock, void *buf, MPI_Aint minlen, MPI_Aint maxlen,
                               MPIDI_CH3I_Sock_progress_update_func_t fn)
 {
     struct pollfd *pollfd;
@@ -2056,8 +2056,8 @@ int MPIDI_CH3I_Sock_post_readv(struct MPIDI_CH3I_Sock *sock, MPL_IOV * iov, int 
 /* end MPIDI_CH3I_Sock_post_readv() */
 
 
-int MPIDI_CH3I_Sock_post_write(struct MPIDI_CH3I_Sock *sock, void *buf, size_t minlen,
-                               size_t maxlen, MPIDI_CH3I_Sock_progress_update_func_t fn)
+int MPIDI_CH3I_Sock_post_write(struct MPIDI_CH3I_Sock *sock, void *buf, MPI_Aint minlen,
+                               MPI_Aint maxlen, MPIDI_CH3I_Sock_progress_update_func_t fn)
 {
     struct pollfd *pollfd;
     struct pollinfo *pollinfo;
@@ -2455,11 +2455,11 @@ int MPIDI_CH3I_Sock_accept(struct MPIDI_CH3I_Sock *listener,
 /* end MPIDI_CH3I_Sock_accept() */
 
 
-int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t * num_read)
+int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint len, MPI_Aint * num_read)
 {
     struct pollfd *pollfd;
     struct pollinfo *pollinfo;
-    size_t nb;
+    MPI_Aint nb;
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_READ);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_SOCK_READ);
@@ -2495,7 +2495,7 @@ int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t *
     while (nb == -1 && errno == EINTR);
 
     if (nb > 0) {
-        *num_read = (size_t) nb;
+        *num_read = (MPI_Aint) nb;
     }
     /* --BEGIN ERROR HANDLING-- */
     else if (nb == 0) {
@@ -2557,7 +2557,7 @@ int MPIDI_CH3I_Sock_read(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t *
 /* end MPIDI_CH3I_Sock_read() */
 
 
-int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size_t * num_read)
+int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, MPI_Aint * num_read)
 {
     struct pollfd *pollfd;
     struct pollinfo *pollinfo;
@@ -2592,7 +2592,7 @@ int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size
     while (nb == -1 && errno == EINTR);
 
     if (nb > 0) {
-        *num_read = (size_t) nb;
+        *num_read = (MPI_Aint) nb;
     }
     /* --BEGIN ERROR HANDLING-- */
     else if (nb == 0) {
@@ -2655,7 +2655,7 @@ int MPIDI_CH3I_Sock_readv(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size
 /* end MPIDI_CH3I_Sock_readv() */
 
 
-int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t * num_written)
+int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, MPI_Aint len, MPI_Aint * num_written)
 {
     struct pollinfo *pollinfo;
     ssize_t nb;
@@ -2731,7 +2731,7 @@ int MPIDI_CH3I_Sock_write(MPIDI_CH3I_Sock_t sock, void *buf, size_t len, size_t 
 /* end MPIDI_CH3I_Sock_write() */
 
 
-int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, size_t * num_written)
+int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, MPI_Aint * num_written)
 {
     struct pollinfo *pollinfo;
     ssize_t nb;
@@ -2768,7 +2768,7 @@ int MPIDI_CH3I_Sock_writev(MPIDI_CH3I_Sock_t sock, MPL_IOV * iov, int iov_n, siz
     while (nb == -1 && errno == EINTR);
 
     if (nb >= 0) {
-        *num_written = (size_t) nb;
+        *num_written = (MPI_Aint) nb;
     }
     /* --BEGIN ERROR HANDLING-- */
     else if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -2890,7 +2890,7 @@ int MPIDI_CH3I_Sock_get_host_description(int myRank, char *host_description, int
     }
 
     if (env_hostname != NULL) {
-        rc = MPL_strncpy(host_description, env_hostname, (size_t) len);
+        rc = MPL_strncpy(host_description, env_hostname, (MPI_Aint) len);
         /* --BEGIN ERROR HANDLING-- */
         if (rc != 0) {
             mpi_errno =
@@ -3081,7 +3081,7 @@ int MPIDI_CH3I_Sock_get_sock_set_id(struct MPIDI_CH3I_Sock_set *sock_set)
    existing MPI-2 features to extend MPI error classes and code, of to export
    messages to non-MPI application */
 /* --BEGIN ERROR HANDLING-- */
-int MPIDI_CH3I_Sock_get_error_class_string(int error, char *error_string, size_t length)
+int MPIDI_CH3I_Sock_get_error_class_string(int error, char *error_string, MPI_Aint length)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3I_SOCK_GET_ERROR_CLASS_STRING);
 

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -16,7 +16,7 @@
 
 /* immed_copy() copys data from origin buffer to
    IMMED packet header. */
-static inline int immed_copy(void *src, void *dest, size_t len)
+static inline int immed_copy(void *src, void *dest, MPI_Aint len)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_IMMED_COPY);

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -30,7 +30,7 @@
 
 #if defined(HAVE_GETHOSTNAME) && defined(NEEDS_GETHOSTNAME_DECL) && \
    !defined(gethostname)
-int gethostname(char *name, size_t len);
+int gethostname(char *name, MPI_Aint len);
 # endif
 
 /* Default PMI version to use */
@@ -1108,7 +1108,7 @@ int MPIDI_CH3U_Win_gather_info(void *, MPI_Aint, int, MPIR_Info *, MPIR_Comm *,
 
 
 #ifdef MPIDI_CH3I_HAS_ALLOC_MEM
-void* MPIDI_CH3I_Alloc_mem(size_t size, MPIR_Info *info_ptr);
+void* MPIDI_CH3I_Alloc_mem(MPI_Aint size, MPIR_Info *info_ptr);
 /* fallback to MPL_malloc if channel does not have its own RMA memory allocator */
 #else
 #define MPIDI_CH3I_Alloc_mem(size, info_ptr)    MPL_malloc(size, MPL_MEM_USER)

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -396,7 +396,7 @@ typedef struct MPIDI_Request {
        iov_offset points to the current head element in the IOV */
     MPL_IOV iov[MPL_IOV_LIMIT];
     int iov_count;
-    size_t iov_offset;
+    MPI_Aint iov_offset;
 
     /* OnDataAvail is the action to take when data is now available.
        For example, when an operation described by an iov has 
@@ -725,7 +725,7 @@ void MPID_Request_free_hook(MPIR_Request *);
 void MPID_Request_destroy_hook(MPIR_Request *);
 int MPID_Request_complete(MPIR_Request *);
 
-void *MPID_Alloc_mem( size_t size, MPIR_Info *info );
+void *MPID_Alloc_mem( MPI_Aint size, MPIR_Info *info );
 int MPID_Free_mem( void *ptr );
 
 /* Prototypes and definitions for the node ID code.  This is used to support

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -1025,7 +1025,7 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
     MPIDI_CH3_Pkt_get_t *get_pkt = &((target_lock_entry->pkt).get);
     MPIR_Request *sreq = NULL;
     MPI_Aint type_size;
-    size_t len;
+    MPI_Aint len;
     int iovcnt;
     MPL_IOV iov[MPL_IOV_LIMIT];
     int is_contig;
@@ -1073,7 +1073,7 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
 
     /* length of target data */
     MPIR_Datatype_get_size_macro(get_pkt->datatype, type_size);
-    MPIR_Assign_trunc(len, get_pkt->count * type_size, size_t);
+    MPIR_Assign_trunc(len, get_pkt->count * type_size, MPI_Aint);
 
     MPIR_Datatype_is_contig(get_pkt->datatype, &is_contig);
 
@@ -1199,7 +1199,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     MPIDI_CH3_Pkt_get_accum_t *get_accum_pkt = &((target_lock_entry->pkt).get_accum);
     MPIR_Request *sreq = NULL;
     MPI_Aint type_size;
-    size_t len;
+    MPI_Aint len;
     int iovcnt;
     MPL_IOV iov[MPL_IOV_LIMIT];
     int is_contig;
@@ -1231,7 +1231,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     MPIR_Datatype_get_size_macro(get_accum_pkt->datatype, type_size);
 
     /* length of target data */
-    MPIR_Assign_trunc(len, get_accum_pkt->count * type_size, size_t);
+    MPIR_Assign_trunc(len, get_accum_pkt->count * type_size, MPI_Aint);
 
     if (get_accum_pkt->type == MPIDI_CH3_PKT_GET_ACCUM_IMMED) {
         MPIDI_Pkt_init(get_accum_resp_pkt, MPIDI_CH3_PKT_GET_ACCUM_RESP_IMMED);

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -436,7 +436,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         /* basic datatype. send the data. */
         MPIDI_CH3_Pkt_t upkt;
         MPIDI_CH3_Pkt_get_resp_t *get_resp_pkt = &upkt.get_resp;
-        size_t len;
+        MPI_Aint len;
         int iovcnt;
         int is_contig;
 
@@ -467,7 +467,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         MPIR_Datatype_is_contig(get_pkt->datatype, &is_contig);
 
         if (get_pkt->pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP) {
-            MPIR_Assign_trunc(len, get_pkt->count * type_size, size_t);
+            MPIR_Assign_trunc(len, get_pkt->count * type_size, MPI_Aint);
             void *src = (void *) (get_pkt->addr), *dest = (void *) &(get_resp_pkt->info.data);
             mpi_errno = immed_copy(src, dest, len);
             if (mpi_errno != MPI_SUCCESS)
@@ -830,7 +830,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
     }
 
     if (pkt->type == MPIDI_CH3_PKT_GET_ACCUM_IMMED) {
-        size_t len;
+        MPI_Aint len;
         void *src = NULL, *dest = NULL;
         MPIR_Request *resp_req = NULL;
         MPIDI_CH3_Pkt_t upkt;
@@ -860,7 +860,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
         /* Calculate the length of reponse data, ensure that it fits into immed packet. */
         MPIR_Datatype_get_size_macro(get_accum_pkt->datatype, type_size);
-        MPIR_Assign_trunc(len, get_accum_pkt->count * type_size, size_t);
+        MPIR_Assign_trunc(len, get_accum_pkt->count * type_size, MPI_Aint);
 
         MPIDI_Pkt_init(get_accum_resp_pkt, MPIDI_CH3_PKT_GET_ACCUM_RESP_IMMED);
         get_accum_resp_pkt->request_handle = get_accum_pkt->request_handle;

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -140,7 +140,7 @@ int MPID_Win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm_ptr, MPIR_Win ** 
 
 
 /* The memory allocation functions */
-void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ap = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -682,7 +682,7 @@ static int connToStringKVS( char **buf_p, int *slen, MPIDI_PG_t *pg )
 					     the pg id is a string */
     char   buf[MPIDI_MAX_KVS_VALUE_LEN];
     int    i, j, rc, mpi_errno = MPI_SUCCESS, len;
-    size_t vallen, curSlen;
+    MPI_Aint vallen, curSlen;
 
     /* Make an initial allocation of a string with an estimate of the
        needed space */

--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -22,7 +22,7 @@ typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 /* for short cases, output arguments are NULL */
 typedef int (*MPIDIG_am_target_msg_cb)
  (int handler_id, void *am_hdr, void **data,    /* data should be iovs if *is_contig is false */
-  size_t * data_sz, int is_local,       /* SHM or NM directly specifies locality */
+  MPI_Aint * data_sz, int is_local,     /* SHM or NM directly specifies locality */
   int *is_contig, MPIDIG_am_target_cmpl_cb * target_cmpl_cb,    /* completion handler */
   MPIR_Request ** req);         /* if allocated, need pointer to completion function */
 

--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -43,7 +43,7 @@ static inline int MPIDIG_handle_unexpected(void *buf, MPI_Aint count, MPI_Dataty
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
-    size_t in_data_sz, dt_sz, nbytes;
+    MPI_Aint in_data_sz, dt_sz, nbytes;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_HANDLE_UNEXPECTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_HANDLE_UNEXPECTED);

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -141,7 +141,7 @@ MPIDI_CH4I_API(int, Win_flush_all, MPIR_Win *);
 MPIDI_CH4I_API(int, Get_accumulate, const void *, int, MPI_Datatype, void *, int, MPI_Datatype, int,
                MPI_Aint, int, MPI_Datatype, MPI_Op, MPIR_Win *);
 MPIDI_CH4I_API(int, Win_lock_all, int, MPIR_Win *);
-MPIDI_CH4I_API_NOINLINE(void *, Alloc_mem, size_t, MPIR_Info *);
+MPIDI_CH4I_API_NOINLINE(void *, Alloc_mem, MPI_Aint, MPIR_Info *);
 MPIDI_CH4I_API_NOINLINE(int, Free_mem, void *);
 MPIDI_CH4I_API_NOINLINE(int, Get_node_id, MPIR_Comm *, int rank, int *);
 MPIDI_CH4I_API_NOINLINE(int, Get_max_node_id, MPIR_Comm *, int *);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -144,7 +144,7 @@ typedef struct MPIDIG_acc_req_t {
     void *target_addr;
     void *dt_iov;
     void *data;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Op op;
     void *result_addr;
     int result_count;
@@ -233,7 +233,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_destroy_hook(struct MPIR_Request *req
 
 typedef struct MPIDIG_win_shared_info {
     uint32_t disp_unit;
-    size_t size;
+    MPI_Aint size;
     void *shm_base_addr;
 } MPIDIG_win_shared_info_t;
 

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -31,27 +31,28 @@ typedef int (*MPIDI_NM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_NM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info, int root,
                                            MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_NM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz);
+                                       const void *am_hdr, MPI_Aint am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
-                                    size_t am_hdr_sz, const void *data, MPI_Count count,
+                                    MPI_Aint am_hdr_sz, const void *data, MPI_Count count,
                                     MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_NM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                     struct iovec * am_hdrs, size_t iov_len, const void *data,
+                                     struct iovec * am_hdrs, MPI_Aint iov_len, const void *data,
                                      MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_NM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz);
+                                             int handler_id, const void *am_hdr,
+                                             MPI_Aint am_hdr_sz);
 typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                          int handler_id, const void *am_hdr, size_t am_hdr_sz,
+                                          int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz,
                                           const void *data, MPI_Count count, MPI_Datatype datatype,
                                           MPIR_Request * sreq);
-typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
+typedef MPI_Aint(*MPIDI_NM_am_hdr_max_sz_t) (void);
 typedef int (*MPIDI_NM_am_recv_t) (MPIR_Request * req);
 typedef int (*MPIDI_NM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx, int *lpid_ptr,
                                          bool is_remote);
-typedef int (*MPIDI_NM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
+typedef int (*MPIDI_NM_get_local_upids_t) (MPIR_Comm * comm, MPI_Aint ** local_upid_size,
                                            char **local_upids);
-typedef int (*MPIDI_NM_upids_to_lupids_t) (int size, size_t * remote_upid_size, char *remote_upids,
-                                           int **remote_lupids);
+typedef int (*MPIDI_NM_upids_to_lupids_t) (int size, MPI_Aint * remote_upid_size,
+                                           char *remote_upids, int **remote_lupids);
 typedef int (*MPIDI_NM_create_intercomm_from_lpids_t) (MPIR_Comm * newcomm_ptr, int size,
                                                        const int lpids[]);
 typedef int (*MPIDI_NM_mpi_comm_create_hook_t) (MPIR_Comm * comm);
@@ -109,7 +110,7 @@ typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype dat
 typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       MPIR_Request * message);
 typedef int (*MPIDI_NM_mpi_cancel_recv_t) (MPIR_Request * rreq);
-typedef void *(*MPIDI_NM_mpi_alloc_mem_t) (size_t size, MPIR_Info * info_ptr);
+typedef void *(*MPIDI_NM_mpi_alloc_mem_t) (MPI_Aint size, MPIR_Info * info_ptr);
 typedef int (*MPIDI_NM_mpi_free_mem_t) (void *ptr);
 typedef int (*MPIDI_NM_mpi_improbe_t) (int source, int tag, MPIR_Comm * comm, int context_offset,
                                        MPIDI_av_entry_t * addr, int *flag, MPIR_Request ** message,
@@ -669,32 +670,33 @@ int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root, 
                              MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                   const void *am_hdr,
-                                                  size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                  MPI_Aint am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                               const void *am_hdr, size_t am_hdr_sz,
+                                               const void *am_hdr, MPI_Aint am_hdr_sz,
                                                const void *data, MPI_Count count,
                                                MPI_Datatype datatype,
                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                struct iovec *am_hdrs, size_t iov_len,
+                                                struct iovec *am_hdrs, MPI_Aint iov_len,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype,
                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                        MPI_Aint am_hdr_sz)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                      int handler_id, const void *am_hdr,
-                                                     size_t am_hdr_sz, const void *data,
+                                                     MPI_Aint am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_recv(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr,
                                                     bool is_remote) MPL_STATIC_INLINE_SUFFIX;
-int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_NM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_NM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                              int **remote_lupids);
 int MPIDI_NM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 int MPIDI_NM_mpi_comm_create_hook(MPIR_Comm * comm);
@@ -784,7 +786,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_D
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;
-void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_NM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_NM_mpi_free_mem(void *ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
                                                   int context_offset, MPIDI_av_entry_t * addr,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -30,7 +30,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz)
+                                                  const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -44,7 +44,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                               const void *am_hdr, size_t am_hdr_sz,
+                                               const void *am_hdr, MPI_Aint am_hdr_sz,
                                                const void *data, MPI_Count count,
                                                MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -61,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                struct iovec *am_hdrs, size_t iov_len,
+                                                struct iovec *am_hdrs, MPI_Aint iov_len,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -79,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int 
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                         int src_rank, int handler_id,
-                                                        const void *am_hdr, size_t am_hdr_sz)
+                                                        const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -94,7 +94,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                      int handler_id, const void *am_hdr,
-                                                     size_t am_hdr_sz, const void *data,
+                                                     MPI_Aint am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
                                                      MPIR_Request * sreq)
 {
@@ -110,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     int ret;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -30,7 +30,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     MPIR_Comm * comm,
                                     int handler_id,
                                     const void *am_hdr,
-                                    size_t am_hdr_sz,
+                                    MPI_Aint am_hdr_sz,
                                     const void *data,
                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -52,12 +52,12 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      MPIR_Comm * comm,
                                      int handler_id,
                                      struct iovec *am_hdr,
-                                     size_t iov_len,
+                                     MPI_Aint iov_len,
                                      const void *data,
                                      MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
-    size_t am_hdr_sz = 0, i;
+    MPI_Aint am_hdr_sz = 0, i;
     char *am_hdr_buf;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_SEND_AMV);
@@ -99,7 +99,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
                                           int src_rank,
                                           int handler_id,
                                           const void *am_hdr,
-                                          size_t am_hdr_sz,
+                                          MPI_Aint am_hdr_sz,
                                           const void *data,
                                           MPI_Count count,
                                           MPI_Datatype datatype, MPIR_Request * sreq)
@@ -118,20 +118,20 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
     return mpi_errno;
 }
 
-static inline size_t MPIDI_NM_am_hdr_max_sz(void)
+static inline MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     /* Maximum size that fits in short send */
-    size_t max_shortsend = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE -
+    MPI_Aint max_shortsend = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE -
         (sizeof(MPIDI_OFI_am_header_t) + sizeof(MPIDI_OFI_lmt_msg_payload_t));
     /* Maximum payload size representable by MPIDI_OFI_am_header_t::am_hdr_sz field */
-    size_t max_representable = (1 << MPIDI_OFI_AM_HDR_SZ_BITS) - 1;
+    MPI_Aint max_representable = (1 << MPIDI_OFI_AM_HDR_SZ_BITS) - 1;
 
     return MPL_MIN(max_shortsend, max_representable);
 }
 
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
-                                       int handler_id, const void *am_hdr, size_t am_hdr_sz)
+                                       int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
@@ -150,7 +150,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
 
 static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                              int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz)
+                                             int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -44,7 +44,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_enqueue_unordered_msg(const MPIDI_OFI_
                                                                 am_hdr)
 {
     MPIDI_OFI_am_unordered_msg_t *uo_msg;
-    size_t uo_msg_len, packet_len;
+    MPI_Aint uo_msg_len, packet_len;
     /* Essentially, uo_msg_len == packet_len + sizeof(next,prev pointers) */
 
     uo_msg_len = sizeof(*uo_msg) + am_hdr->am_hdr_sz + am_hdr->data_sz;
@@ -97,11 +97,11 @@ static inline int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr)
     void *p_data;
     void *in_data;
 
-    size_t data_sz, in_data_sz;
+    MPI_Aint data_sz, in_data_sz;
     MPIDIG_am_target_cmpl_cb target_cmpl_cb = NULL;
     struct iovec *iov;
     int i, is_contig, iov_len;
-    size_t done, curr_len, rem;
+    MPI_Aint done, curr_len, rem;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_HANDLE_SHORT_AM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_SHORT_AM);
@@ -193,12 +193,12 @@ static inline int MPIDI_OFI_handle_short_am_hdr(MPIDI_OFI_am_header_t * msg_hdr,
 
 static inline int MPIDI_OFI_do_rdma_read(void *dst,
                                          uint64_t src,
-                                         size_t data_sz,
+                                         MPI_Aint data_sz,
                                          MPIR_Context_id_t context_id,
                                          int src_rank, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t done = 0, curr_len, rem = 0;
+    MPI_Aint done = 0, curr_len, rem = 0;
     MPIDI_OFI_am_request_t *am_req;
     MPIR_Comm *comm;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_RDMA_READ);
@@ -259,7 +259,7 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
     int num_reads, i, iov_len, c, mpi_errno = MPI_SUCCESS, is_contig = 0;
     MPIR_Request *rreq = NULL;
     void *p_data;
-    size_t data_sz, rem, done, curr_len, in_data_sz;
+    MPI_Aint data_sz, rem, done, curr_len, in_data_sz;
     MPIDIG_am_target_cmpl_cb target_cmpl_cb = NULL;
     struct iovec *iov;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -97,7 +97,7 @@ static inline void MPIDI_OFI_am_clear_request(MPIR_Request * sreq)
 }
 
 static inline int MPIDI_OFI_am_init_request(const void *am_hdr,
-                                            size_t am_hdr_sz, MPIR_Request * sreq)
+                                            MPI_Aint am_hdr_sz, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_request_header_t *req_hdr;
@@ -199,7 +199,8 @@ static inline int MPIDI_OFI_do_am_isend_header(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz, MPIR_Request * sreq, int is_reply)
+                                               MPI_Aint am_hdr_sz, MPIR_Request * sreq,
+                                               int is_reply)
 {
     struct iovec *iov;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -254,9 +255,9 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
                                           MPIR_Comm * comm,
                                           int handler_id,
                                           const void *am_hdr,
-                                          size_t am_hdr_sz,
+                                          MPI_Aint am_hdr_sz,
                                           const void *data,
-                                          size_t data_sz, MPIR_Request * sreq, int need_lock)
+                                          MPI_Aint data_sz, MPIR_Request * sreq, int need_lock)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -345,7 +346,7 @@ static inline int MPIDI_OFI_am_isend_short(int rank,
                                            MPIR_Comm * comm,
                                            int handler_id,
                                            const void *am_hdr,
-                                           size_t am_hdr_sz,
+                                           MPI_Aint am_hdr_sz,
                                            const void *data,
                                            MPI_Count count, MPIR_Request * sreq, int need_lock)
 {
@@ -398,14 +399,14 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
                                         MPIR_Comm * comm,
                                         int handler_id,
                                         const void *am_hdr,
-                                        size_t am_hdr_sz,
+                                        MPI_Aint am_hdr_sz,
                                         const void *buf,
-                                        size_t count,
+                                        MPI_Aint count,
                                         MPI_Datatype datatype, MPIR_Request * sreq, int is_reply)
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb, last;
     MPIR_Datatype *dt_ptr;
     int need_lock = !is_reply;
@@ -477,12 +478,12 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
                                                           const MPIDI_OFI_am_header_t * msg_hdrp,
                                                           const void *am_hdr,
-                                                          size_t am_hdr_sz, int need_lock)
+                                                          MPI_Aint am_hdr_sz, int need_lock)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
     char *ibuf;
-    size_t len;
+    MPI_Aint len;
 
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
@@ -509,14 +510,14 @@ static inline int MPIDI_OFI_do_inject(int rank,
                                       MPIR_Comm * comm,
                                       int handler_id,
                                       const void *am_hdr,
-                                      size_t am_hdr_sz,
+                                      MPI_Aint am_hdr_sz,
                                       int is_reply, int use_comm_table, int need_lock)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t msg_hdr;
     fi_addr_t addr;
     char *buff;
-    size_t buff_len;
+    MPI_Aint buff_len;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_INJECT);

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -36,7 +36,7 @@ int MPIDI_OFI_mpi_comm_create_hook(MPIR_Comm * comm)
     if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
         void *table;
         fi_addr_t *mapped_table;
-        size_t rem_bcs, num_nodes = MPIDI_global.max_node_id + 1;
+        MPI_Aint rem_bcs, num_nodes = MPIDI_global.max_node_id + 1;
         int i, curr, node;
 
         MPIR_Assert(MPII_Comm_is_node_consecutive(comm));

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -15,7 +15,7 @@
 
 static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
                                             char *send_buf,
-                                            size_t msgsize,
+                                            MPI_Aint msgsize,
                                             int rank,
                                             MPIR_Comm * comm_ptr,
                                             MPIR_Request * ackreq, int need_lock)

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -28,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_event(struct fi_cq_tagged_entry *wc,
                                                   MPIR_Request * rreq)
 {
-    size_t count;
+    MPI_Aint count;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PEEK_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PEEK_EVENT);
     MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_FOUND;
@@ -72,7 +72,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
                                                   MPIR_Request * rreq, int event_id)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t count;
+    MPI_Aint count;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_RECV_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_RECV_EVENT);
 
@@ -357,10 +357,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry 
                                                                  * receive already and we'll be able to find the
                                                                  * struct describing the transfer. */
         /* Subtract one max_msg_size because we send the first chunk via a regular message instead of the memory region */
-        size_t bytesSent = recv_elem->cur_offset - MPIDI_OFI_global.max_msg_size;
-        size_t bytesLeft =
+        MPI_Aint bytesSent = recv_elem->cur_offset - MPIDI_OFI_global.max_msg_size;
+        MPI_Aint bytesLeft =
             recv_elem->remote_info.msgsize - bytesSent - MPIDI_OFI_global.max_msg_size;
-        size_t bytesToGet =
+        MPI_Aint bytesToGet =
             (bytesLeft <=
              MPIDI_OFI_global.max_msg_size) ? bytesLeft : MPIDI_OFI_global.max_msg_size;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -484,7 +484,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     struct fi_cntr_attr cntr_attr;
     fi_addr_t *mapped_table;
     struct fi_av_attr av_attr;
-    size_t optlen;
+    MPI_Aint optlen;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_INIT);
@@ -1111,7 +1111,7 @@ int MPIDI_OFI_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_OFI_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
 
     void *ap;
@@ -1127,7 +1127,7 @@ int MPIDI_OFI_mpi_free_mem(void *ptr)
     return mpi_errno;
 }
 
-int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_size = 0;
@@ -1136,7 +1136,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     MPIR_CHKPMEM_DECL(2);
     MPIR_CHKLMEM_DECL(1);
 
-    MPIR_CHKPMEM_MALLOC((*local_upid_size), size_t *, comm->local_size * sizeof(size_t),
+    MPIR_CHKPMEM_MALLOC((*local_upid_size), MPI_Aint *, comm->local_size * sizeof(MPI_Aint),
                         mpi_errno, "local_upid_size", MPL_MEM_ADDRESS);
     MPIR_CHKLMEM_MALLOC(temp_buf, char *, comm->local_size * MPIDI_OFI_global.addrnamelen,
                         mpi_errno, "temp_buf", MPL_MEM_BUFFER);
@@ -1166,7 +1166,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     goto fn_exit;
 }
 
-int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_OFI_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids)
 {
     int i, mpi_errno = MPI_SUCCESS;
@@ -1184,7 +1184,7 @@ int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_
         int j, k;
         char tbladdr[FI_NAME_MAX];
         int found = 0;
-        size_t sz = 0;
+        MPI_Aint sz = 0;
 
         for (k = 0; k < max_n_avts; k++) {
             if (MPIDIU_get_av_table(k) == NULL) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -665,16 +665,17 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPIDI_OFI_global.prov_use = fi_dupinfo(prov_use);
     MPIR_Assert(MPIDI_OFI_global.prov_use);
 
-    MPIDI_OFI_global.max_buffered_send = prov_use->tx_attr->inject_size;
-    MPIDI_OFI_global.max_buffered_write = prov_use->tx_attr->inject_size;
-    MPIDI_OFI_global.max_msg_size = prov_use->ep_attr->max_msg_size;
-    MPIDI_OFI_global.max_order_raw = prov_use->ep_attr->max_order_raw_size;
-    MPIDI_OFI_global.max_order_war = prov_use->ep_attr->max_order_war_size;
-    MPIDI_OFI_global.max_order_waw = prov_use->ep_attr->max_order_waw_size;
+    /* Queryable limits - they may be bigger than MPIR_AINT_MAX */
+    MPIDI_OFI_global.max_buffered_send = MIN(prov_use->tx_attr->inject_size, MPIR_AINT_MAX);
+    MPIDI_OFI_global.max_buffered_write = MIN(prov_use->tx_attr->inject_size, MPIR_AINT_MAX);
+    MPIDI_OFI_global.max_msg_size = MIN(prov_use->ep_attr->max_msg_size, MPIR_AINT_MAX);
+    MPIDI_OFI_global.max_order_raw = MIN(prov_use->ep_attr->max_order_raw_size, MPIR_AINT_MAX);
+    MPIDI_OFI_global.max_order_war = MIN(prov_use->ep_attr->max_order_war_size, MPIR_AINT_MAX);
+    MPIDI_OFI_global.max_order_waw = MIN(prov_use->ep_attr->max_order_waw_size, MPIR_AINT_MAX);
     MPIDI_OFI_global.tx_iov_limit = MIN(prov_use->tx_attr->iov_limit, MPIDI_OFI_IOV_MAX);
     MPIDI_OFI_global.rx_iov_limit = MIN(prov_use->rx_attr->iov_limit, MPIDI_OFI_IOV_MAX);
     MPIDI_OFI_global.rma_iov_limit = MIN(prov_use->tx_attr->rma_iov_limit, MPIDI_OFI_IOV_MAX);
-    MPIDI_OFI_global.max_mr_key_size = prov_use->domain_attr->mr_key_size;
+    MPIDI_OFI_global.max_mr_key_size = MIN(prov_use->domain_attr->mr_key_size, MPIR_AINT_MAX);
 
     /* ------------------------------------------------------------------------ */
     /* Open fabric                                                              */

--- a/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
@@ -190,13 +190,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state(MPIDI_OFI_seg_state_t * s
                                                        MPI_Datatype origin_type,
                                                        MPI_Datatype target_type)
 {
-    /* `seg_state->buflimit` is `MPI_Aint` == `MPI_Aint` (typically, long or other signed types)
-     * and its maximum value is likely to be smaller than that of `buf_limit` of `size_t`.
-     * So round down to the maximum of MPI_Aint if necessary.
-     * For instance, as of libfabric 1.6.2, sockets provider has (SIZE_MAX-4K) as buf_limit. */
-    MPL_COMPILE_TIME_ASSERT(sizeof(seg_state->buf_limit) == sizeof(MPI_Aint));
-    if (likely(buf_limit > MPIR_AINT_MAX))
-        buf_limit = MPIR_AINT_MAX;
     seg_state->buf_limit = buf_limit;
     seg_state->buf_limit_left = buf_limit;
 
@@ -239,13 +232,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state2(MPIDI_OFI_seg_state_t * 
                                                         MPI_Aint result_bytes,
                                                         MPI_Aint target_bytes)
 {
-    /* `seg_state->buflimit` is `MPI_Aint` == `MPI_Aint` (typically, long or other signed types)
-     * and its maximum value is likely to be smaller than that of `buf_limit` of `size_t`.
-     * So round down to the maximum of MPI_Aint if necessary.
-     * For instance, as of libfabric 1.6.2, sockets provider has (SIZE_MAX-4K) as buf_limit. */
-    MPL_COMPILE_TIME_ASSERT(sizeof(seg_state->buf_limit) == sizeof(MPI_Aint));
-    if (likely(buf_limit > MPIR_AINT_MAX))
-        buf_limit = MPIR_AINT_MAX;
     seg_state->buf_limit = buf_limit;
     seg_state->buf_limit_left = buf_limit;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_iovec_util.h
@@ -121,10 +121,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_segment_next(MPIDI_OFI_seg_state_t * stat
 {
     MPL_IOV typerep_vec;
     MPI_Aint last;
-    size_t *cursor;
+    MPI_Aint *cursor;
     int num_contig = 1;
     const void *buf;
-    size_t count;
+    MPI_Aint count;
     MPI_Datatype type;
 
     switch (side) {
@@ -182,11 +182,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_segment_next(MPIDI_OFI_seg_state_t * stat
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state(MPIDI_OFI_seg_state_t * seg_state,
                                                        const void *origin,
                                                        const MPI_Aint target,
-                                                       size_t origin_count,
-                                                       size_t target_count,
-                                                       size_t origin_bytes,
-                                                       size_t target_bytes,
-                                                       size_t buf_limit,
+                                                       MPI_Aint origin_count,
+                                                       MPI_Aint target_count,
+                                                       MPI_Aint origin_bytes,
+                                                       MPI_Aint target_bytes,
+                                                       MPI_Aint buf_limit,
                                                        MPI_Datatype origin_type,
                                                        MPI_Datatype target_type)
 {
@@ -228,15 +228,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_init_seg_state2(MPIDI_OFI_seg_state_t * 
                                                         const void *origin,
                                                         const void *result,
                                                         const MPI_Aint target,
-                                                        size_t origin_count,
-                                                        size_t result_count,
-                                                        size_t target_count,
-                                                        size_t buf_limit,
+                                                        MPI_Aint origin_count,
+                                                        MPI_Aint result_count,
+                                                        MPI_Aint target_count,
+                                                        MPI_Aint buf_limit,
                                                         MPI_Datatype origin_type,
                                                         MPI_Datatype result_type,
                                                         MPI_Datatype target_type,
-                                                        size_t origin_bytes,
-                                                        size_t result_bytes, size_t target_bytes)
+                                                        MPI_Aint origin_bytes,
+                                                        MPI_Aint result_bytes,
+                                                        MPI_Aint target_bytes)
 {
     /* `seg_state->buflimit` is `MPI_Aint` == `MPI_Aint` (typically, long or other signed types)
      * and its maximum value is likely to be smaller than that of `buf_limit` of `size_t`.
@@ -278,7 +279,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_finalize_seg_state2(MPIDI_OFI_seg_state_
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state(MPIDI_OFI_seg_state_t * seg_state,
                                                       uintptr_t * origin_addr_next,
                                                       uintptr_t * target_addr_next,
-                                                      size_t * buf_len)
+                                                      MPI_Aint * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0)) {
         uintptr_t buf_size = MPL_MIN(MPL_MIN(seg_state->target_iov_len, seg_state->origin_iov_len),
@@ -298,7 +299,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state2(MPIDI_OFI_seg_state_t * s
                                                        uintptr_t * origin_addr_next,
                                                        uintptr_t * result_addr_next,
                                                        uintptr_t * target_addr_next,
-                                                       size_t * buf_len)
+                                                       MPI_Aint * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0) &&
         (seg_state->result_iov_len != 0)) {
@@ -326,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_next_seg_state2(MPIDI_OFI_seg_state_t * s
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state(MPIDI_OFI_seg_state_t * seg_state,
                                                       uintptr_t * next_origin_addr,
                                                       uintptr_t * next_target_addr,
-                                                      size_t * buf_len)
+                                                      MPI_Aint * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0)) {
         *next_origin_addr = seg_state->origin_addr;
@@ -351,7 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state2(MPIDI_OFI_seg_state_t * s
                                                        uintptr_t * next_origin_addr,
                                                        uintptr_t * next_result_addr,
                                                        uintptr_t * next_target_addr,
-                                                       size_t * buf_len)
+                                                       MPI_Aint * buf_len)
 {
     if ((seg_state->origin_iov_len != 0) && (seg_state->target_iov_len != 0) &&
         (seg_state->result_iov_len != 0)) {
@@ -372,17 +373,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_peek_seg_state2(MPIDI_OFI_seg_state_t * s
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment(MPIDI_OFI_seg_state_t * seg_state,
                                                      struct iovec *origin_iov,
-                                                     size_t origin_max_iovs,
+                                                     MPI_Aint origin_max_iovs,
                                                      struct fi_rma_iov *target_iov,
-                                                     size_t target_max_iovs,
-                                                     size_t * origin_iovs_nout,
-                                                     size_t * target_iovs_nout)
+                                                     MPI_Aint target_max_iovs,
+                                                     MPI_Aint * origin_iovs_nout,
+                                                     MPI_Aint * target_iovs_nout)
 {
     int rc;
     uintptr_t origin_addr = (uintptr_t) NULL, target_addr = (uintptr_t) NULL;
     uintptr_t origin_last_addr = 0, target_last_addr = 0;
     int origin_idx = 0, target_idx = 0;
-    size_t len = 0, last_len = 0;
+    MPI_Aint len = 0, last_len = 0;
 
     MPL_COMPILE_TIME_ASSERT(offsetof(struct iovec, iov_base) == offsetof(struct fi_rma_iov, addr));
     MPL_COMPILE_TIME_ASSERT(offsetof(struct iovec, iov_len) == offsetof(struct fi_rma_iov, len));
@@ -446,21 +447,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment(MPIDI_OFI_seg_state_t * seg
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_merge_segment2(MPIDI_OFI_seg_state_t * seg_state,
                                                       struct iovec *origin_iov,
-                                                      size_t origin_max_iovs,
+                                                      MPI_Aint origin_max_iovs,
                                                       struct iovec *result_iov,
-                                                      size_t result_max_iovs,
+                                                      MPI_Aint result_max_iovs,
                                                       struct fi_rma_iov *target_iov,
-                                                      size_t target_max_iovs,
-                                                      size_t * origin_iovs_nout,
-                                                      size_t * result_iovs_nout,
-                                                      size_t * target_iovs_nout)
+                                                      MPI_Aint target_max_iovs,
+                                                      MPI_Aint * origin_iovs_nout,
+                                                      MPI_Aint * result_iovs_nout,
+                                                      MPI_Aint * target_iovs_nout)
 {
     int rc;
     uintptr_t origin_addr = (uintptr_t) NULL, result_addr = (uintptr_t) NULL, target_addr =
         (uintptr_t) NULL;
     uintptr_t origin_last_addr = 0, result_last_addr = 0, target_last_addr = 0;
     int origin_idx = 0, result_idx = 0, target_idx = 0;
-    size_t len = 0, last_len = 0;
+    MPI_Aint len = 0, last_len = 0;
 
     rc = MPIDI_OFI_next_seg_state2(seg_state, &origin_last_addr, &result_last_addr,
                                    &target_last_addr, &last_len);

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -88,10 +88,10 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                             MPIR_Comm * comm_self, int spawned, int *n_vcis_provided);
 int MPIDI_OFI_mpi_finalize_hook(void);
 int MPIDI_OFI_get_vci_attr(int vci);
-void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_OFI_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_OFI_mpi_free_mem(void *ptr);
-int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_OFI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_OFI_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids);
 int MPIDI_OFI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -130,7 +130,7 @@ typedef struct {
 
 typedef struct {
     void *buf;
-    size_t count;
+    MPI_Aint count;
     MPI_Datatype datatype;
     char pack_buffer[0];
 } MPIDI_OFI_pack_t;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -26,7 +26,7 @@
       due to limitations with iovec. Needs to fall back to the unpack path.
   Other: An error occurred as indicated in the code.
 */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_t data_sz,      /* data_sz passed in here for reusing */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, MPI_Aint data_sz,    /* data_sz passed in here for reusing */
                                                 int rank, uint64_t match_bits, uint64_t mask_bits,
                                                 MPIR_Comm * comm, MPIR_Context_id_t context_id,
                                                 MPIDI_av_entry_t * addr, MPIR_Request * rreq,
@@ -34,19 +34,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL, *originv_huge = NULL;
-    size_t max_pipe = INT64_MAX;
-    size_t omax = MPIDI_OFI_global.rx_iov_limit;
-    size_t countp =
+    MPI_Aint max_pipe = INT64_MAX;
+    MPI_Aint omax = MPIDI_OFI_global.rx_iov_limit;
+    MPI_Aint countp =
         MPIDI_OFI_count_iov(count, MPIDI_OFI_REQUEST(rreq, datatype), data_sz, max_pipe);
-    size_t o_size = sizeof(struct iovec);
+    MPI_Aint o_size = sizeof(struct iovec);
     unsigned map_size;
     int num_contig, size, j = 0, k = 0, huge = 0, length = 0;
-    size_t l = 0;
-    size_t countp_huge = 0;
-    size_t oout = 0;
-    size_t cur_o = 0;
+    MPI_Aint l = 0;
+    MPI_Aint countp_huge = 0;
+    MPI_Aint oout = 0;
+    MPI_Aint cur_o = 0;
     struct fi_msg_tagged msg;
-    size_t iov_align = MPL_MAX(MPIDI_OFI_IOVEC_ALIGN, sizeof(void *));
+    MPI_Aint iov_align = MPL_MAX(MPIDI_OFI_IOVEC_ALIGN, sizeof(void *));
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_RECV_IOV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_RECV_IOV);
 
@@ -184,7 +184,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     MPIR_Request *rreq = *request;
     uint64_t match_bits, mask_bits;
     MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -81,10 +81,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_count_iovecs(int origin_count,
                                                     MPI_Datatype origin_datatype,
                                                     MPI_Datatype target_datatype,
                                                     MPI_Datatype result_datatype,
-                                                    size_t origin_bytes,
-                                                    size_t target_bytes,
-                                                    size_t result_bytes,
-                                                    size_t max_pipe, size_t * countp)
+                                                    MPI_Aint origin_bytes,
+                                                    MPI_Aint target_bytes,
+                                                    MPI_Aint result_bytes,
+                                                    MPI_Aint max_pipe, MPI_Aint * countp)
 {
     /* Count the max number of iovecs that will be generated, given the iovs    */
     /* and maximum data size.  The code adds the iovecs from all three lists    */
@@ -104,8 +104,8 @@ static inline void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query
                                                       MPI_Op op,
                                                       MPIR_Win * win,
                                                       enum fi_datatype *fi_dt,
-                                                      enum fi_op *fi_op, size_t * count,
-                                                      size_t * dtsize)
+                                                      enum fi_op *fi_op, MPI_Aint * count,
+                                                      MPI_Aint * dtsize)
 {
     MPIR_Datatype *dt_ptr;
     int op_index, dt_index;
@@ -160,10 +160,10 @@ static inline void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query
     /* We use the minimal max_count of local op and any possible remote op as the limit
      * to validate dt_size in later check. We assume the limit should be symmetric on
      * all processes as long as the hint correctly contains the local op.*/
-    MPIR_Assert(*count >= (size_t) MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[dt_index]);
+    MPIR_Assert(*count >= (MPI_Aint) MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[dt_index]);
 
     if (MPIDIG_WIN(win, info_args).accumulate_ops == MPIDIG_ACCU_SAME_OP_NO_OP)
-        *count = (size_t) MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[dt_index];
+        *count = (MPI_Aint) MPIDI_OFI_WIN(win).acc_hint->dtypes_max_count[dt_index];
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_QUERY_ACC_ATOMIC_SUPPORT);
 }
@@ -178,16 +178,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
                                                                     int target_rank,
                                                                     MPI_Datatype origin_datatype,
                                                                     MPI_Datatype target_datatype,
-                                                                    size_t origin_bytes,
-                                                                    size_t target_bytes,
-                                                                    size_t max_pipe,
+                                                                    MPI_Aint origin_bytes,
+                                                                    MPI_Aint target_bytes,
+                                                                    MPI_Aint max_pipe,
                                                                     MPIDI_OFI_win_request_t **
                                                                     winreq, uint64_t * flags,
                                                                     struct fid_ep **ep,
                                                                     MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t o_size, t_size, alloc_iovs, alloc_iov_size;
+    MPI_Aint o_size, t_size, alloc_iovs, alloc_iov_size;
     MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_PUT_GET);
@@ -241,16 +241,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
                                                                        int target_rank,
                                                                        MPI_Datatype origin_datatype,
                                                                        MPI_Datatype target_datatype,
-                                                                       size_t origin_bytes,
-                                                                       size_t target_bytes,
-                                                                       size_t max_pipe,
+                                                                       MPI_Aint origin_bytes,
+                                                                       MPI_Aint target_bytes,
+                                                                       MPI_Aint max_pipe,
                                                                        MPIDI_OFI_win_request_t **
                                                                        winreq, uint64_t * flags,
                                                                        struct fid_ep **ep,
                                                                        MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t o_size, t_size, alloc_iovs, alloc_iov_size;
+    MPI_Aint o_size, t_size, alloc_iovs, alloc_iov_size;
     MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_ACCUMULATE);
@@ -306,10 +306,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
                                                                            target_datatype,
                                                                            MPI_Datatype
                                                                            result_datatype,
-                                                                           size_t origin_bytes,
-                                                                           size_t target_bytes,
-                                                                           size_t result_bytes,
-                                                                           size_t max_pipe,
+                                                                           MPI_Aint origin_bytes,
+                                                                           MPI_Aint target_bytes,
+                                                                           MPI_Aint result_bytes,
+                                                                           MPI_Aint max_pipe,
                                                                            MPIDI_OFI_win_request_t
                                                                            ** winreq,
                                                                            uint64_t * flags,
@@ -317,7 +317,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
                                                                            MPIR_Request ** sigreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t o_size, t_size, r_size, alloc_iovs, alloc_rma_iovs, alloc_iov_size;
+    MPI_Aint o_size, t_size, r_size, alloc_iovs, alloc_rma_iovs, alloc_iov_size;
     MPIDI_OFI_win_request_t *req = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_ALLOCATE_WIN_REQUEST_GET_ACCUMULATE);
@@ -380,7 +380,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
 {
     int rc, mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t offset, omax, tmax, tout, oout;
+    MPI_Aint offset, omax, tmax, tout, oout;
     uint64_t flags;
     struct fid_ep *ep = NULL;
     struct fi_msg_rma msg;
@@ -389,7 +389,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     struct fi_rma_iov *targetv;
     MPIDI_OFI_seg_state_t p;
     int target_contig, origin_contig;
-    size_t target_bytes, origin_bytes;
+    MPI_Aint target_bytes, origin_bytes;
     MPI_Aint origin_true_lb, target_true_lb;
     struct iovec iov;
     struct fi_rma_iov riov;
@@ -484,7 +484,7 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
                              MPIDI_OFI_global.max_msg_size, origin_datatype, target_datatype);
     rc = MPIDI_OFI_SEG_EAGAIN;
 
-    size_t cur_o = 0, cur_t = 0;
+    MPI_Aint cur_o = 0, cur_t = 0;
     while (rc == MPIDI_OFI_SEG_EAGAIN) {
         originv = &req->noncontig->iov.put_get.originv[cur_o];
         targetv = &req->noncontig->iov.put_get.targetv[cur_t];
@@ -564,7 +564,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
 {
     int rc, mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t offset, omax, tmax, tout, oout;
+    MPI_Aint offset, omax, tmax, tout, oout;
     uint64_t flags;
     struct fid_ep *ep = NULL;
     struct fi_msg_rma msg;
@@ -574,7 +574,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
     MPIDI_OFI_seg_state_t p;
     int origin_contig, target_contig;
     MPI_Aint origin_true_lb, target_true_lb;
-    size_t origin_bytes, target_bytes;
+    MPI_Aint origin_bytes, target_bytes;
     struct fi_rma_iov riov;
     struct iovec iov;
 
@@ -654,7 +654,7 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
                              MPIDI_OFI_global.max_msg_size, origin_datatype, target_datatype);
     rc = MPIDI_OFI_SEG_EAGAIN;
 
-    size_t cur_o = 0, cur_t = 0;
+    MPI_Aint cur_o = 0, cur_t = 0;
     while (rc == MPIDI_OFI_SEG_EAGAIN) {
         originv = &req->noncontig->iov.put_get.originv[cur_o];
         targetv = &req->noncontig->iov.put_get.targetv[cur_t];
@@ -767,7 +767,7 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t offset, max_count, max_size, dt_size, bytes;
+    MPI_Aint offset, max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb;
     void *buffer, *tbuffer, *rbuffer;
     struct fi_ioc originv MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);
@@ -878,7 +878,8 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     int rc, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t origin_bytes, target_bytes, offset, max_count, max_size, dt_size, omax, tmax, tout, oout;
+    MPI_Aint origin_bytes, target_bytes, offset, max_count, max_size, dt_size, omax, tmax, tout,
+        oout;
     struct fid_ep *ep = NULL;
     MPI_Datatype basic_type;
     enum fi_op fi_op;
@@ -945,7 +946,7 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
     msg.op = fi_op;
     rc = MPIDI_OFI_SEG_EAGAIN;
 
-    size_t cur_o = 0, cur_t = 0;
+    MPI_Aint cur_o = 0, cur_t = 0;
     while (rc == MPIDI_OFI_SEG_EAGAIN) {
         originv = &req->noncontig->iov.accumulate.originv[cur_o];
         targetv = &req->noncontig->iov.accumulate.targetv[cur_t];
@@ -1018,7 +1019,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     int rc, mpi_errno = MPI_SUCCESS;
     uint64_t flags;
     MPIDI_OFI_win_request_t *req = NULL;
-    size_t target_bytes, origin_bytes, result_bytes, offset, max_count, max_size, dt_size, omax,
+    MPI_Aint target_bytes, origin_bytes, result_bytes, offset, max_count, max_size, dt_size, omax,
         rmax, tmax, tout, rout, oout;
     struct fid_ep *ep = NULL;
     MPI_Datatype basic_type;
@@ -1105,7 +1106,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
     msg.op = fi_op;
     rc = MPIDI_OFI_SEG_EAGAIN;
 
-    size_t cur_o = 0, cur_t = 0, cur_r = 0;
+    MPI_Aint cur_o = 0, cur_t = 0, cur_r = 0;
     while (rc == MPIDI_OFI_SEG_EAGAIN) {
         originv = &req->noncontig->iov.get_accumulate.originv[cur_o];
         targetv = &req->noncontig->iov.get_accumulate.targetv[cur_t];
@@ -1292,7 +1293,7 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     int mpi_errno = MPI_SUCCESS;
     enum fi_op fi_op;
     enum fi_datatype fi_dt;
-    size_t offset, max_count, max_size, dt_size, bytes;
+    MPI_Aint offset, max_count, max_size, dt_size, bytes;
     MPI_Aint true_lb ATTRIBUTE((unused));
     void *buffer, *tbuffer, *rbuffer;
     struct fi_ioc originv MPL_ATTR_ALIGNED(MPIDI_OFI_IOVEC_ALIGN);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -15,7 +15,7 @@
 #include <../mpi/pt2pt/bsendutil.h>
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
-                                                        size_t data_sz,
+                                                        MPI_Aint data_sz,
                                                         int rank,
                                                         int tag, MPIR_Comm * comm,
                                                         int context_offset, MPIDI_av_entry_t * addr)
@@ -40,7 +40,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
-                                                                size_t data_sz,
+                                                                MPI_Aint data_sz,
                                                                 int rank,
                                                                 int tag,
                                                                 MPIR_Comm * comm,
@@ -82,26 +82,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
       due to limitations with iovec. Needs to fall back to the pack path.
   Other: An error occurred as indicated in the code.
 */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,        /* data_sz is passed in here for reusing */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, MPI_Aint data_sz,      /* data_sz is passed in here for reusing */
                                                 int rank, uint64_t match_bits, MPIR_Comm * comm,
                                                 MPIDI_av_entry_t * addr, MPIR_Request * sreq,
                                                 MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     struct iovec *originv = NULL, *originv_huge = NULL;
-    size_t countp =
+    MPI_Aint countp =
         MPIDI_OFI_count_iov(count, MPIDI_OFI_REQUEST(sreq, datatype), data_sz, INT64_MAX);
-    size_t omax = MPIDI_OFI_global.tx_iov_limit;
-    size_t o_size = sizeof(struct iovec);
-    size_t cur_o = 0;
+    MPI_Aint omax = MPIDI_OFI_global.tx_iov_limit;
+    MPI_Aint o_size = sizeof(struct iovec);
+    MPI_Aint cur_o = 0;
     struct fi_msg_tagged msg;
     uint64_t flags;
     unsigned map_size;
     int num_contig, size, j = 0, k = 0, huge = 0, length = 0;
-    size_t oout = 0;
-    size_t l = 0;
-    size_t countp_huge = 0;
-    size_t iov_align = MPL_MAX(MPIDI_OFI_IOVEC_ALIGN, sizeof(void *));
+    MPI_Aint oout = 0;
+    MPI_Aint l = 0;
+    MPI_Aint countp_huge = 0;
+    MPI_Aint iov_align = MPL_MAX(MPIDI_OFI_IOVEC_ALIGN, sizeof(void *));
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_IOV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -225,7 +225,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                    MPI_Datatype datatype, int rank, int tag,
                                                    MPIR_Comm * comm, int context_offset,
                                                    MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                   int dt_contig, size_t data_sz,
+                                                   int dt_contig, MPI_Aint data_sz,
                                                    MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
                                                    uint64_t type)
 {
@@ -392,7 +392,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                                             int noreq, uint64_t syncflag)
 {
     int dt_contig, mpi_errno;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -311,13 +311,14 @@ typedef struct {
     struct fid_ep *rma_sep;     /* dedicated scalable EP for RMA */
 
     /* Queryable limits */
-    uint64_t max_buffered_send;
-    uint64_t max_buffered_write;
-    uint64_t max_msg_size;
-    uint64_t max_short_send;
-    uint64_t max_mr_key_size;
-    uint64_t max_rma_key_bits;
-    uint64_t max_huge_rmas;
+    /* FIXME: max_short_send, max_rma_key_bits, max_huge_rmas: where are they used? */
+    MPI_Aint max_buffered_send;
+    MPI_Aint max_buffered_write;
+    MPI_Aint max_msg_size;
+    MPI_Aint max_short_send;
+    MPI_Aint max_mr_key_size;
+    MPI_Aint max_rma_key_bits;
+    MPI_Aint max_huge_rmas;
     int rma_key_type_bits;
     int context_shift;
     MPI_Aint tx_iov_limit;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -320,14 +320,14 @@ typedef struct {
     uint64_t max_huge_rmas;
     int rma_key_type_bits;
     int context_shift;
-    size_t tx_iov_limit;
-    size_t rx_iov_limit;
-    size_t rma_iov_limit;
+    MPI_Aint tx_iov_limit;
+    MPI_Aint rx_iov_limit;
+    MPI_Aint rma_iov_limit;
     int max_ch4_vcis;
     int max_rma_sep_tx_cnt;     /* Max number of transmit context on one RMA scalable EP */
-    size_t max_order_raw;
-    size_t max_order_war;
-    size_t max_order_waw;
+    MPI_Aint max_order_raw;
+    MPI_Aint max_order_war;
+    MPI_Aint max_order_waw;
 
     /* Mutexex and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[4];
@@ -374,7 +374,7 @@ typedef struct {
     int pname_set;
     int pname_len;
     char addrname[FI_NAME_MAX];
-    size_t addrnamelen;
+    MPI_Aint addrnamelen;
     char kvsname[MPIDI_KVSAPPSTRLEN];
     char pname[MPI_MAX_PROCESSOR_NAME];
     int port_name_tag_mask[MPIR_MAX_CONTEXT_MASK];
@@ -398,7 +398,7 @@ typedef struct {
     int origin_rank;
     MPIR_Request *ackreq;
     uintptr_t send_buf;
-    size_t msgsize;
+    MPI_Aint msgsize;
     int comm_id;
     int endpoint_id;
     uint64_t rma_key;
@@ -415,28 +415,28 @@ typedef struct MPIDI_OFI_seg_state {
                                  * This value remains constant once seg_state is initialized. */
     MPI_Aint buf_limit_left;    /* Buffer length left for a single OFI call */
 
-    size_t origin_cursor;       /* First byte to pack */
-    size_t origin_end;          /* Last byte to pack */
+    MPI_Aint origin_cursor;     /* First byte to pack */
+    MPI_Aint origin_end;        /* Last byte to pack */
     const void *origin_buf;
-    size_t origin_count;
+    MPI_Aint origin_count;
     MPI_Datatype origin_type;
     MPI_Aint origin_iov_len;    /* Length of data actually packed */
     MPL_IOV origin_iov;         /* IOVEC returned after pack */
     uintptr_t origin_addr;      /* Address of data actually packed */
 
-    size_t target_cursor;
-    size_t target_end;
+    MPI_Aint target_cursor;
+    MPI_Aint target_end;
     MPI_Aint target_buf;
-    size_t target_count;
+    MPI_Aint target_count;
     MPI_Datatype target_type;
     MPI_Aint target_iov_len;
     MPL_IOV target_iov;
     uintptr_t target_addr;
 
-    size_t result_cursor;
-    size_t result_end;
+    MPI_Aint result_cursor;
+    MPI_Aint result_end;
     const void *result_buf;
-    size_t result_count;
+    MPI_Aint result_count;
     MPI_Datatype result_type;
     MPI_Aint result_iov_len;
     MPL_IOV result_iov;
@@ -509,7 +509,7 @@ typedef struct MPIDI_OFI_huge_recv {
     int event_id;               /* fixed field, do not move */
     int (*done_fn) (struct fi_cq_tagged_entry * wc, MPIR_Request * req, int event_id);
     MPIDI_OFI_send_control_t remote_info;
-    size_t cur_offset;
+    MPI_Aint cur_offset;
     MPIR_Comm *comm_ptr;
     MPIR_Request *localreq;
     struct fi_cq_tagged_entry wc;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -177,7 +177,7 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
 
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
                               void **data,
-                              size_t * data_sz,
+                              MPI_Aint * data_sz,
                               int is_local,
                               int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
@@ -443,7 +443,7 @@ static MPI_Op mpi_ops[] = {
 static inline void create_dt_map()
 {
     int i, j;
-    size_t dtsize[FI_DATATYPE_LAST];
+    MPI_Aint dtsize[FI_DATATYPE_LAST];
     dtsize[FI_INT8] = sizeof(int8_t);
     dtsize[FI_UINT8] = sizeof(uint8_t);
     dtsize[FI_INT16] = sizeof(int16_t);
@@ -478,7 +478,7 @@ static inline void create_dt_map()
             _TBL.max_compare_atomic_count = 0;
             _TBL.mpi_acc_valid = check_mpi_acc_valid(mpi_dtypes[i], mpi_ops[j]);
             ssize_t ret;
-            size_t atomic_count;
+            MPI_Aint atomic_count;
 
             if (fi_dt != FI_DATATYPE_LAST && fi_op != FI_ATOMIC_OP_LAST) {
                 CHECK_ATOMIC(fi_atomicvalid, atomic_valid, max_atomic_count);

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -385,7 +385,7 @@ int MPIDI_NM_get_vci_attr(int vci)
     return ret;
 }
 
-void *MPIDI_NM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_NM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ret;
 
@@ -411,7 +411,7 @@ int MPIDI_NM_mpi_free_mem(void *ptr)
     return ret;
 }
 
-int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_NM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     int ret;
 
@@ -424,7 +424,7 @@ int MPIDI_NM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char *
     return ret;
 }
 
-int MPIDI_NM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_NM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                              int **remote_lupids)
 {
     int ret;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -17,7 +17,7 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     MPIR_Comm * comm,
                                     int handler_id,
                                     const void *am_hdr,
-                                    size_t am_hdr_sz,
+                                    MPI_Aint am_hdr_sz,
                                     const void *data,
                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -29,7 +29,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
                                      MPIR_Comm * comm,
                                      int handler_id,
                                      struct iovec *am_hdr,
-                                     size_t iov_len,
+                                     MPI_Aint iov_len,
                                      const void *data,
                                      MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -40,7 +40,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
 static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                           int handler_id,
                                           const void *am_hdr,
-                                          size_t am_hdr_sz,
+                                          MPI_Aint am_hdr_sz,
                                           const void *data,
                                           MPI_Count count,
                                           MPI_Datatype datatype, MPIR_Request * sreq)
@@ -49,7 +49,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_
     return MPI_SUCCESS;
 }
 
-static inline size_t MPIDI_NM_am_hdr_max_sz(void)
+static inline MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     MPIR_Assert(0);
     return 0;
@@ -57,14 +57,14 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
 
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
-                                       int handler_id, const void *am_hdr, size_t am_hdr_sz)
+                                       int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
 static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz)
+                                             int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -35,13 +35,13 @@ int MPIDI_STUBNM_get_vci_attr(int vci)
     return 0;
 }
 
-int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBNM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_STUBNM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                  int **remote_lupids)
 {
     MPIR_Assert(0);
@@ -59,7 +59,7 @@ int MPIDI_STUBNM_mpi_free_mem(void *ptr)
     return MPIDIG_mpi_free_mem(ptr);
 }
 
-void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_STUBNM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }

--- a/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
@@ -90,10 +90,10 @@ int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
                                int *n_vcis_provided);
 int MPIDI_STUBNM_mpi_finalize_hook(void);
 int MPIDI_STUBNM_get_vci_attr(int vci);
-void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_STUBNM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_STUBNM_mpi_free_mem(void *ptr);
-int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_STUBNM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_STUBNM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_STUBNM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                  int **remote_lupids);
 int MPIDI_STUBNM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -55,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz,
+                                               MPI_Aint am_hdr_sz,
                                                const void *data,
                                                MPI_Count count, MPI_Datatype datatype,
                                                MPIR_Request * sreq)
@@ -65,7 +65,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     ucp_ep_h ep;
     uint64_t ucx_tag;
     char *send_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
     int dt_contig;
@@ -156,18 +156,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
                                                 MPIR_Comm * comm,
                                                 int handler_id,
                                                 struct iovec *am_hdr,
-                                                size_t iov_len,
+                                                MPI_Aint iov_len,
                                                 const void *data,
                                                 MPI_Count count, MPI_Datatype datatype,
                                                 MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t am_hdr_sz = 0, i;
+    MPI_Aint am_hdr_sz = 0, i;
     MPIDI_UCX_ucp_request_t *ucp_request;
     ucp_ep_h ep;
     uint64_t ucx_tag;
     char *send_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
     int dt_contig;
@@ -240,7 +240,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      int src_rank,
                                                      int handler_id,
                                                      const void *am_hdr,
-                                                     size_t am_hdr_sz,
+                                                     MPI_Aint am_hdr_sz,
                                                      const void *data, MPI_Count count,
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -249,7 +249,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     ucp_ep_h ep;
     uint64_t ucx_tag;
     char *send_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
     int dt_contig;
@@ -311,7 +311,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_NM_am_hdr_max_sz(void)
 {
     int ret;
 
@@ -327,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
                                                   MPIR_Comm * comm,
                                                   int handler_id, const void *am_hdr,
-                                                  size_t am_hdr_sz)
+                                                  MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;
@@ -374,7 +374,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                         int src_rank,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz)
+                                                        MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -27,7 +27,7 @@ int MPIDI_UCX_mpi_comm_create_hook(MPIR_Comm * comm)
         ucs_status_t ucx_status;
         ucp_ep_params_t ep_params;
         int i, curr, node;
-        size_t *bc_indices;
+        MPI_Aint *bc_indices;
 
         MPIR_Assert(MPII_Comm_is_node_consecutive(comm));
         MPIDU_bc_allgather(comm, MPIDI_global.node_map[0], MPIDI_UCX_global.if_address,

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -16,18 +16,18 @@
 
 struct pack_state {
     void *buffer;
-    size_t count;
+    MPI_Aint count;
     MPI_Datatype datatype;
 };
 
-static void *start_pack(void *context, const void *buffer, size_t count);
-static void *start_unpack(void *context, void *buffer, size_t count);
-static size_t pack_size(void *state);
-static size_t pack(void *state, size_t offset, void *dest, size_t max_length);
-static ucs_status_t unpack(void *state, size_t offset, const void *src, size_t count);
+static void *start_pack(void *context, const void *buffer, MPI_Aint count);
+static void *start_unpack(void *context, void *buffer, MPI_Aint count);
+static MPI_Aint pack_size(void *state);
+static MPI_Aint pack(void *state, MPI_Aint offset, void *dest, MPI_Aint max_length);
+static ucs_status_t unpack(void *state, MPI_Aint offset, const void *src, MPI_Aint count);
 static void finish_pack(void *state);
 
-static void *start_pack(void *context, const void *buffer, size_t count)
+static void *start_pack(void *context, const void *buffer, MPI_Aint count)
 {
     struct pack_state *state;
 
@@ -41,7 +41,7 @@ static void *start_pack(void *context, const void *buffer, size_t count)
     return (void *) state;
 }
 
-static void *start_unpack(void *context, void *buffer, size_t count)
+static void *start_unpack(void *context, void *buffer, MPI_Aint count)
 {
     struct pack_state *state;
 
@@ -55,17 +55,17 @@ static void *start_unpack(void *context, void *buffer, size_t count)
     return (void *) state;
 }
 
-static size_t pack_size(void *state)
+static MPI_Aint pack_size(void *state)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
     MPI_Aint packsize;
 
     MPIR_Pack_size_impl(pack_state->count, pack_state->datatype, &packsize);
 
-    return (size_t) packsize;
+    return (MPI_Aint) packsize;
 }
 
-static size_t pack(void *state, size_t offset, void *dest, size_t max_length)
+static MPI_Aint pack(void *state, MPI_Aint offset, void *dest, MPI_Aint max_length)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
     MPI_Aint actual_pack_bytes;
@@ -76,7 +76,7 @@ static size_t pack(void *state, size_t offset, void *dest, size_t max_length)
     return actual_pack_bytes;
 }
 
-static ucs_status_t unpack(void *state, size_t offset, const void *src, size_t count)
+static ucs_status_t unpack(void *state, MPI_Aint offset, const void *src, MPI_Aint count)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
     MPI_Aint max_unpack_bytes;

--- a/src/mpid/ch4/netmod/ucx/ucx_datatype.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_datatype.c
@@ -20,14 +20,14 @@ struct pack_state {
     MPI_Datatype datatype;
 };
 
-static void *start_pack(void *context, const void *buffer, MPI_Aint count);
-static void *start_unpack(void *context, void *buffer, MPI_Aint count);
-static MPI_Aint pack_size(void *state);
-static MPI_Aint pack(void *state, MPI_Aint offset, void *dest, MPI_Aint max_length);
-static ucs_status_t unpack(void *state, MPI_Aint offset, const void *src, MPI_Aint count);
+static void *start_pack(void *context, const void *buffer, size_t count);
+static void *start_unpack(void *context, void *buffer, size_t count);
+static size_t pack_size(void *state);
+static size_t pack(void *state, size_t offset, void *dest, size_t max_length);
+static ucs_status_t unpack(void *state, size_t offset, const void *src, size_t count);
 static void finish_pack(void *state);
 
-static void *start_pack(void *context, const void *buffer, MPI_Aint count)
+static void *start_pack(void *context, const void *buffer, size_t count)
 {
     struct pack_state *state;
 
@@ -41,7 +41,7 @@ static void *start_pack(void *context, const void *buffer, MPI_Aint count)
     return (void *) state;
 }
 
-static void *start_unpack(void *context, void *buffer, MPI_Aint count)
+static void *start_unpack(void *context, void *buffer, size_t count)
 {
     struct pack_state *state;
 
@@ -55,20 +55,20 @@ static void *start_unpack(void *context, void *buffer, MPI_Aint count)
     return (void *) state;
 }
 
-static MPI_Aint pack_size(void *state)
+static size_t pack_size(void *state)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
     MPI_Aint packsize;
 
     MPIR_Pack_size_impl(pack_state->count, pack_state->datatype, &packsize);
 
-    return (MPI_Aint) packsize;
+    return (size_t) packsize;
 }
 
-static MPI_Aint pack(void *state, MPI_Aint offset, void *dest, MPI_Aint max_length)
+static size_t pack(void *state, size_t offset, void *dest, size_t max_length)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
-    MPI_Aint actual_pack_bytes;
+    size_t actual_pack_bytes;
 
     MPIR_Typerep_pack(pack_state->buffer, pack_state->count, pack_state->datatype, offset,
                       dest, max_length, &actual_pack_bytes);
@@ -76,7 +76,7 @@ static MPI_Aint pack(void *state, MPI_Aint offset, void *dest, MPI_Aint max_leng
     return actual_pack_bytes;
 }
 
-static ucs_status_t unpack(void *state, MPI_Aint offset, const void *src, MPI_Aint count)
+static ucs_status_t unpack(void *state, size_t offset, const void *src, size_t count)
 {
     struct pack_state *pack_state = (struct pack_state *) state;
     MPI_Aint max_unpack_bytes;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -33,7 +33,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     ucp_params_t ucp_params;
     ucp_worker_params_t worker_params;
     ucp_ep_params_t ep_params;
-    size_t *bc_indices;
+    MPI_Aint *bc_indices;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_INIT_HOOK);
@@ -209,13 +209,13 @@ int MPIDI_UCX_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-int MPIDI_UCX_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_UCX_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids)
 {
     MPIR_Assert(0);
@@ -232,7 +232,7 @@ int MPIDI_UCX_mpi_free_mem(void *ptr)
     return MPIDIG_mpi_free_mem(ptr);
 }
 
-void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_UCX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -88,10 +88,10 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                             MPIR_Comm * comm_self, int spawned, int *n_vcis_provided);
 int MPIDI_UCX_mpi_finalize_hook(void);
 int MPIDI_UCX_get_vci_attr(int vci);
-void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_UCX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_UCX_mpi_free_mem(void *ptr);
-int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_UCX_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_UCX_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids);
 int MPIDI_UCX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -12,17 +12,17 @@
 #include "ucx_impl.h"
 //#include "events.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_am_handler(void *msg, size_t msg_sz)
+MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_am_handler(void *msg, MPI_Aint msg_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
     void *p_data;
     void *in_data;
-    size_t data_sz, in_data_sz;
+    MPI_Aint data_sz, in_data_sz;
     MPIDIG_am_target_cmpl_cb target_cmpl_cb = NULL;
     struct iovec *iov;
     int i, is_contig, iov_len;
-    size_t done, curr_len, rem;
+    MPI_Aint done, curr_len, rem;
     MPIDI_UCX_am_header_t *msg_hdr = (MPIDI_UCX_am_header_t *) msg;
 
     p_data = in_data = (char *) msg_hdr->payload + (msg_sz - msg_hdr->data_sz - sizeof(*msg_hdr));

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -104,7 +104,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
                                             MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
                                                  MPI_Datatype datatype, MPIR_Request * message)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIDI_UCX_ucp_request_t *ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_rma_cmpl_cb(void *request, ucs_status_t 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
-                                                  size_t size,
+                                                  MPI_Aint size,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
-    size_t offset;
+    MPI_Aint offset;
     uint64_t base;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
@@ -94,13 +94,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
                                                      int origin_count, MPI_Datatype origin_datatype,
-                                                     int target_rank, size_t size,
+                                                     int target_rank, MPI_Aint size,
                                                      MPI_Aint target_disp, MPI_Aint true_lb,
                                                      MPIR_Win * win, MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** reqptr ATTRIBUTE((unused)))
 {
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
-    size_t base, offset;
+    MPI_Aint base, offset;
     int mpi_errno = MPI_SUCCESS;
     ucs_status_t status;
     char *buffer = NULL;
@@ -134,7 +134,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
-                                                  size_t size,
+                                                  MPI_Aint size,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
@@ -142,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
-    size_t base, offset;
+    MPI_Aint base, offset;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
     ucp_ep_h ep = MPIDI_UCX_AV_TO_EP(addr);
@@ -199,9 +199,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
 {
     int mpi_errno = MPI_SUCCESS;
     int target_contig, origin_contig;
-    size_t target_bytes, origin_bytes;
+    MPI_Aint target_bytes, origin_bytes;
     MPI_Aint origin_true_lb, target_true_lb;
-    size_t offset;
+    MPI_Aint offset;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_UCX_DO_PUT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_UCX_DO_PUT);
@@ -257,8 +257,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
 {
     int mpi_errno = MPI_SUCCESS;
     int origin_contig, target_contig;
-    size_t origin_bytes, target_bytes ATTRIBUTE((unused));
-    size_t offset;
+    MPI_Aint origin_bytes, target_bytes ATTRIBUTE((unused));
+    MPI_Aint offset;
     MPI_Aint origin_true_lb, target_true_lb;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_UCX_DO_GET);

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -40,7 +40,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
                                             MPIR_Request ** request, int have_request, int is_sync)
 {
     int dt_contig;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -31,7 +31,7 @@ typedef struct {
     ucp_worker_h worker;
     char addrname[UCP_PEER_NAME_MAX];
     char *pmi_addr_table;
-    size_t addrname_len;
+    MPI_Aint addrname_len;
     ucp_address_t *if_address;
     char kvsname[MPIDI_UCX_KVSAPPSTRLEN];
     char pname[MPI_MAX_PROCESSOR_NAME];

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -15,10 +15,10 @@ struct ucx_share {
     MPI_Aint addr;
 };
 
-static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr);
+static int win_allgather(MPIR_Win * win, MPI_Aint length, uint32_t disp_unit, void **base_ptr);
 static int win_init(MPIR_Win * win);
 
-static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void **base_ptr)
+static int win_allgather(MPIR_Win * win, MPI_Aint length, uint32_t disp_unit, void **base_ptr)
 {
 
     MPIR_Errflag_t err = MPIR_ERR_NONE;
@@ -27,7 +27,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     ucs_status_t status;
     ucp_mem_h mem_h;
     int cntr = 0;
-    size_t rkey_size = 0;
+    MPI_Aint rkey_size = 0;
     int *rkey_sizes = NULL, *recv_disps = NULL, i;
     char *rkey_buffer = NULL, *rkey_recv_buff = NULL;
     struct ucx_share *share_data = NULL;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -31,29 +31,29 @@ typedef int (*MPIDI_SHM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_SHM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info,
                                             int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_SHM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                        const void *am_hdr, size_t am_hdr_sz);
+                                        const void *am_hdr, MPI_Aint am_hdr_sz);
 typedef int (*MPIDI_SHM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                     const void *am_hdr, size_t am_hdr_sz,
+                                     const void *am_hdr, MPI_Aint am_hdr_sz,
                                      const void *data, MPI_Count count,
                                      MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_SHM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                      struct iovec * am_hdrs, size_t iov_len,
+                                      struct iovec * am_hdrs, MPI_Aint iov_len,
                                       const void *data, MPI_Count count,
                                       MPI_Datatype datatype, MPIR_Request * sreq);
 typedef int (*MPIDI_SHM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                              int handler_id, const void *am_hdr, size_t am_hdr_sz);
+                                              int handler_id, const void *am_hdr,
+                                              MPI_Aint am_hdr_sz);
 typedef int (*MPIDI_SHM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                           int handler_id, const void *am_hdr,
-                                           size_t am_hdr_sz, const void *data,
-                                           MPI_Count count, MPI_Datatype datatype,
+                                           int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz,
+                                           const void *data, MPI_Count count, MPI_Datatype datatype,
                                            MPIR_Request * sreq);
-typedef size_t(*MPIDI_SHM_am_hdr_max_sz_t) (void);
+typedef MPI_Aint(*MPIDI_SHM_am_hdr_max_sz_t) (void);
 typedef int (*MPIDI_SHM_am_recv_t) (MPIR_Request * req);
 typedef int (*MPIDI_SHM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx,
                                           int *lpid_ptr, bool is_remote);
-typedef int (*MPIDI_SHM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
+typedef int (*MPIDI_SHM_get_local_upids_t) (MPIR_Comm * comm, MPI_Aint ** local_upid_size,
                                             char **local_upids);
-typedef int (*MPIDI_SHM_upids_to_lupids_t) (int size, size_t * remote_upid_size,
+typedef int (*MPIDI_SHM_upids_to_lupids_t) (int size, MPI_Aint * remote_upid_size,
                                             char *remote_upids, int **remote_lupids);
 typedef int (*MPIDI_SHM_create_intercomm_from_lpids_t) (MPIR_Comm * newcomm_ptr,
                                                         int size, const int lpids[]);
@@ -113,7 +113,7 @@ typedef int (*MPIDI_SHM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype da
 typedef int (*MPIDI_SHM_mpi_imrecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype,
                                        MPIR_Request * message);
 typedef int (*MPIDI_SHM_mpi_cancel_recv_t) (MPIR_Request * rreq);
-typedef void *(*MPIDI_SHM_mpi_alloc_mem_t) (size_t size, MPIR_Info * info_ptr);
+typedef void *(*MPIDI_SHM_mpi_alloc_mem_t) (MPI_Aint size, MPIR_Info * info_ptr);
 typedef int (*MPIDI_SHM_mpi_free_mem_t) (void *ptr);
 typedef int (*MPIDI_SHM_mpi_improbe_t) (int source, int tag, MPIR_Comm * comm,
                                         int context_offset, int *flag,
@@ -599,32 +599,33 @@ int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root,
                               MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                    const void *am_hdr,
-                                                   size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                   MPI_Aint am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
+                                                const void *am_hdr, MPI_Aint am_hdr_sz,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype,
                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                 struct iovec *am_hdrs, size_t iov_len,
+                                                 struct iovec *am_hdrs, MPI_Aint iov_len,
                                                  const void *data, MPI_Count count,
                                                  MPI_Datatype datatype,
                                                  MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                          int handler_id, const void *am_hdr,
-                                                         size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                         MPI_Aint am_hdr_sz)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                       int handler_id, const void *am_hdr,
-                                                      size_t am_hdr_sz, const void *data,
+                                                      MPI_Aint am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
                                                       MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_recv(MPIR_Request * req) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr,
                                                      bool is_remote) MPL_STATIC_INLINE_SUFFIX;
-int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_SHM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids);
 int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 int MPIDI_SHM_mpi_comm_create_hook(MPIR_Comm * comm);
@@ -705,7 +706,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI
                                                   MPIR_Request * message) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request *
                                                        rreq) MPL_STATIC_INLINE_SUFFIX;
-void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_SHM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_SHM_mpi_free_mem(void *ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source, int tag, MPIR_Comm * comm,
                                                    int context_offset, int *flag,

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
@@ -125,7 +125,7 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
 
 MPL_STATIC_INLINE_PREFIX void
 MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t * transaction,
-                              void *dst, const void *src, size_t size)
+                              void *dst, const void *src, MPI_Aint size)
 {
     MPIR_Memcpy(dst, src, size);
 }

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
@@ -26,14 +26,14 @@
  */
 MPL_STATIC_INLINE_PREFIX int
 MPIDI_POSIX_eager_send(int grank,
-                       MPIDI_POSIX_am_header_t ** msg_hdr, struct iovec **iov, size_t * iov_num)
+                       MPIDI_POSIX_am_header_t ** msg_hdr, struct iovec **iov, MPI_Aint * iov_num)
 {
     MPIDI_POSIX_fastbox_t *fbox_out;
     int i;
-    size_t iov_done = 0;
+    MPI_Aint iov_done = 0;
     uint8_t *fbox_payload_ptr;
-    size_t fbox_payload_size = MPIDI_POSIX_FBOX_DATA_LEN;
-    size_t fbox_payload_size_left = MPIDI_POSIX_FBOX_DATA_LEN;
+    MPI_Aint fbox_payload_size = MPIDI_POSIX_FBOX_DATA_LEN;
+    MPI_Aint fbox_payload_size_left = MPIDI_POSIX_FBOX_DATA_LEN;
     int ret = MPIDI_POSIX_OK;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_SEND);

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
@@ -22,7 +22,7 @@ typedef struct {
     volatile uint64_t data_ready;
 
     int is_header;
-    size_t payload_sz;
+    MPI_Aint payload_sz;
 
     uint8_t payload[MPIDI_POSIX_FBOX_DATA_LEN];
 

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -19,12 +19,12 @@ typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 
 typedef int (*MPIDI_POSIX_eager_send_t) (int grank,
                                          MPIDI_POSIX_am_header_t ** msg_hdr,
-                                         struct iovec ** iov, size_t * iov_num);
+                                         struct iovec ** iov, MPI_Aint * iov_num);
 
 typedef int (*MPIDI_POSIX_eager_recv_begin_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction);
 
 typedef void (*MPIDI_POSIX_eager_recv_memcpy_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction,
-                                                 void *dst, const void *src, size_t size);
+                                                 void *dst, const void *src, MPI_Aint size);
 
 typedef void (*MPIDI_POSIX_eager_recv_commit_t) (MPIDI_POSIX_eager_recv_transaction_t *
                                                  transaction);
@@ -57,14 +57,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_finalize(void) MPL_STATIC_INLINE_
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
                                                     MPIDI_POSIX_am_header_t ** msg_hdr,
                                                     struct iovec **iov,
-                                                    size_t * iov_num) MPL_STATIC_INLINE_SUFFIX;
+                                                    MPI_Aint * iov_num) MPL_STATIC_INLINE_SUFFIX;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction) MPL_STATIC_INLINE_SUFFIX;
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *
                                                             transaction, void *dst, const void *src,
-                                                            size_t size) MPL_STATIC_INLINE_SUFFIX;
+                                                            MPI_Aint size) MPL_STATIC_INLINE_SUFFIX;
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_commit(MPIDI_POSIX_eager_recv_transaction_t *
                                                             transaction) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_finalize()
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
                                                     MPIDI_POSIX_am_header_t ** msg_hdr,
-                                                    struct iovec **iov, size_t * iov_num)
+                                                    struct iovec **iov, MPI_Aint * iov_num)
 {
     return MPIDI_POSIX_eager_func->send(grank, msg_hdr, iov, iov_num);
 }
@@ -38,7 +38,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *
                                                             transaction, void *dst, const void *src,
-                                                            size_t size)
+                                                            MPI_Aint size)
 {
     return MPIDI_POSIX_eager_func->recv_memcpy(transaction, dst, src, size);
 }

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
@@ -19,7 +19,7 @@ typedef struct MPIDI_POSIX_eager_recv_transaction {
     void *msg_hdr;
 
     void *payload;
-    size_t payload_sz;          /* 2GB limit */
+    MPI_Aint payload_sz;        /* 2GB limit */
 
     int src_grank;
 

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_recv.h
@@ -22,7 +22,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *
                                                             transaction, void *dst, const void *src,
-                                                            size_t size)
+                                                            MPI_Aint size)
 {
     MPIR_Assert(0);
     return;

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_send.h
@@ -15,7 +15,7 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank,
                                                     MPIDI_POSIX_am_header_t ** msg_hdr,
-                                                    struct iovec **iov, size_t * iov_num)
+                                                    struct iovec **iov, MPI_Aint * iov_num)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -15,12 +15,12 @@
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, size_t am_hdr_sz,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             int handler_id, const int grank,
                                                             MPIDI_POSIX_am_header_t msg_hdr,
                                                             MPIDI_POSIX_am_header_t * msg_hdr_p,
                                                             struct iovec *iov_left_ptr,
-                                                            size_t iov_num_left, size_t data_sz,
+                                                            MPI_Aint iov_num_left, MPI_Aint data_sz,
                                                             MPIR_Request * sreq)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
@@ -85,7 +85,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
                                                   MPIR_Comm * comm,
                                                   int handler_id,
                                                   const void *am_hdr,
-                                                  size_t am_hdr_sz,
+                                                  MPI_Aint am_hdr_sz,
                                                   const void *data,
                                                   MPI_Count count,
                                                   MPI_Datatype datatype, MPIR_Request * sreq)
@@ -93,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     int mpi_errno = MPI_SUCCESS;
     int result = MPIDI_POSIX_OK;
     int dt_contig;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPIR_Datatype *dt_ptr;
     MPI_Aint dt_true_lb;
     MPIDI_POSIX_am_header_t msg_hdr;
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     const int grank = MPIDIU_rank_to_lpid(rank, comm);
     struct iovec iov_left[2];
     struct iovec *iov_left_ptr;
-    size_t iov_num_left;
+    MPI_Aint iov_num_left;
 #ifdef POSIX_AM_DEBUG
     static int seq_num = 0;
 #endif /* POSIX_AM_DEBUG */
@@ -224,14 +224,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
                                                    MPIR_Comm * comm,
                                                    int handler_id,
                                                    struct iovec *am_hdr,
-                                                   size_t iov_len,
+                                                   MPI_Aint iov_len,
                                                    const void *data,
                                                    MPI_Count count,
                                                    MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_allocated;
-    size_t am_hdr_sz = 0;
+    MPI_Aint am_hdr_sz = 0;
     int i;
     uint8_t *am_hdr_buf = NULL;
 
@@ -274,7 +274,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                         int handler_id,
                                                         const void *am_hdr,
-                                                        size_t am_hdr_sz,
+                                                        MPI_Aint am_hdr_sz,
                                                         const void *data,
                                                         MPI_Count count,
                                                         MPI_Datatype datatype, MPIR_Request * sreq)
@@ -292,25 +292,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t contex
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_POSIX_am_hdr_max_sz(void)
 {
     /* Maximum size that fits in short send */
 
-    size_t max_shortsend = MPIDI_POSIX_DEFAULT_SHORT_SEND_SIZE - (sizeof(MPIDI_POSIX_am_header_t));
+    MPI_Aint max_shortsend =
+        MPIDI_POSIX_DEFAULT_SHORT_SEND_SIZE - (sizeof(MPIDI_POSIX_am_header_t));
 
     /* Maximum payload size representable by MPIDI_POSIX_am_header_t::am_hdr_sz field */
 
-    size_t max_representable = (1 << MPIDI_POSIX_AM_HDR_SZ_BITS) - 1;
+    MPI_Aint max_representable = (1 << MPIDI_POSIX_AM_HDR_SZ_BITS) - 1;
 
     return MPL_MIN(max_shortsend, max_representable);
 }
 
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, MPI_Aint am_hdr_sz,
                                                             int handler_id, const int grank,
                                                             MPIDI_POSIX_am_header_t msg_hdr,
-                                                            size_t iov_num_left)
+                                                            MPI_Aint iov_num_left)
 {
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -349,7 +350,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
                                                      MPIR_Comm * comm,
                                                      int handler_id,
-                                                     const void *am_hdr, size_t am_hdr_sz)
+                                                     const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     int result = MPIDI_POSIX_OK;
@@ -357,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
     MPIDI_POSIX_am_header_t *msg_hdr_p = &msg_hdr;
     struct iovec iov_left[1];
     struct iovec *iov_left_ptr = iov_left;
-    size_t iov_num_left = 1;
+    MPI_Aint iov_num_left = 1;
     const int grank = MPIDIU_rank_to_lpid(rank, comm);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_POSIX_AM_SEND_HDR);
@@ -409,7 +410,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                            int src_rank, int handler_id,
-                                                           const void *am_hdr, size_t am_hdr_sz)
+                                                           const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -32,7 +32,7 @@ static inline int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_request_header_t
 }
 
 static inline int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
-                                              size_t am_hdr_sz,
+                                              MPI_Aint am_hdr_sz,
                                               MPIDI_POSIX_am_request_header_t ** req_hdr_ptr,
                                               MPIR_Request * sreq)
 {

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -237,7 +237,7 @@ int MPIDI_POSIX_get_vci_attr(int vci)
     return MPIDI_VCI_TX | MPIDI_VCI_RX;
 }
 
-void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_POSIX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     MPIR_Assert(0);
     return NULL;
@@ -249,13 +249,13 @@ int MPIDI_POSIX_mpi_free_mem(void *ptr)
     return MPI_SUCCESS;
 }
 
-int MPIDI_POSIX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_POSIX_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-int MPIDI_POSIX_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_POSIX_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                 int **remote_lupids)
 {
     MPIR_Assert(0);

--- a/src/mpid/ch4/shm/posix/posix_noinline.h
+++ b/src/mpid/ch4/shm/posix/posix_noinline.h
@@ -52,11 +52,11 @@ int MPIDI_POSIX_mpi_win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info,
                                  void *baseptr, MPIR_Win ** win);
 int MPIDI_POSIX_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win);
 
-int MPIDI_POSIX_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_POSIX_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_POSIX_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_POSIX_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                 int **remote_lupids);
 int MPIDI_POSIX_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 
-void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_POSIX_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_POSIX_mpi_free_mem(void *ptr);
 #endif

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -85,12 +85,12 @@ typedef struct MPIDI_POSIX_am_request_header {
 
     struct iovec *iov_ptr;
     struct iovec iov[MPIDI_POSIX_MAX_IOV_NUM];
-    size_t iov_num;
-    size_t iov_num_total;
+    MPI_Aint iov_num;
+    MPI_Aint iov_num_total;
 
     int is_contig;
 
-    size_t in_total_data_sz;
+    MPI_Aint in_total_data_sz;
 
     /* Structure used with POSIX postponed_queue */
     MPIR_Request *request;      /* Store address of MPIR_Request* sreq */
@@ -103,12 +103,12 @@ typedef struct MPIDI_POSIX_am_request {
     int tag;
     int context_id;
     char *user_buf;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int type;
     int user_count;
     MPI_Datatype datatype;
-    size_t segment_first;
-    size_t segment_size;
+    MPI_Aint segment_first;
+    MPI_Aint segment_size;
 
     int eager_recv_posted_hook_grank;
 

--- a/src/mpid/ch4/shm/posix/posix_progress.h
+++ b/src/mpid/ch4/shm/posix/posix_progress.h
@@ -26,15 +26,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_progress_recv(int blocking)
     MPIDIG_am_target_cmpl_cb target_cmpl_cb = NULL;
     MPIDI_POSIX_am_request_header_t *curr_rreq_hdr = NULL;
     void *p_data = NULL;
-    size_t p_data_sz = 0;
-    size_t recv_data_sz = 0;
-    size_t in_total_data_sz = 0;
+    MPI_Aint p_data_sz = 0;
+    MPI_Aint recv_data_sz = 0;
+    MPI_Aint in_total_data_sz = 0;
     int iov_done = 0;
     int is_contig;
     void *am_hdr = NULL;
     MPIDI_POSIX_am_header_t *msg_hdr;
     uint8_t *payload;
-    size_t payload_left;
+    MPI_Aint payload_left;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_PROGRESS_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_PROGRESS_RECV);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -96,7 +96,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
                                                 MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t origin_data_sz = 0, target_data_sz = 0;
+    MPI_Aint origin_data_sz = 0, target_data_sz = 0;
     int disp_unit = 0;
     void *base = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_PUT);
@@ -142,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
                                                 MPIR_Win * win)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t origin_data_sz = 0, target_data_sz = 0;
+    MPI_Aint origin_data_sz = 0, target_data_sz = 0;
     int disp_unit = 0;
     void *base = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_GET);
@@ -192,7 +192,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
-    size_t origin_data_sz = 0, target_data_sz = 0, result_data_sz = 0;
+    MPI_Aint origin_data_sz = 0, target_data_sz = 0, result_data_sz = 0;
     int shm_locked = 0, disp_unit = 0;
     void *base = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_GET_ACCUMULATE);
@@ -258,7 +258,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
-    size_t origin_data_sz = 0, target_data_sz = 0;
+    MPI_Aint origin_data_sz = 0, target_data_sz = 0;
     int disp_unit = 0;
     void *base = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_DO_ACCUMULATE);
@@ -403,7 +403,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
-    size_t data_sz = 0;
+    MPI_Aint data_sz = 0;
     int disp_unit = 0;
     void *base = NULL, *target_addr = NULL;
     MPI_Aint dtype_sz = 0;
@@ -561,7 +561,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
-    size_t data_sz = 0;
+    MPI_Aint data_sz = 0;
     int disp_unit = 0;
     void *base = NULL, *target_addr = NULL;
     MPI_Aint dtype_sz = 0;

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -192,7 +192,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
     int rank, num_ranks;
     bool initialize_flags = false, initialize_bcast_buf = false, initialize_reduce_buf = false;
     int flags_num_pages, fallback = 0;
-    size_t flags_shm_size = 0;
+    MPI_Aint flags_shm_size = 0;
     const long pg_sz = sysconf(_SC_PAGESIZE);
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     bool mapfail_flag = false;
@@ -235,8 +235,8 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
     if (initialize_flags || initialize_bcast_buf || initialize_reduce_buf) {
         /* Calculate the amount of shm to be created */
-        size_t tmp_shm_counter;
-        size_t memory_to_be_allocated = 0;
+        MPI_Aint tmp_shm_counter;
+        MPI_Aint memory_to_be_allocated = 0;
         if (initialize_flags) {
             /* Calculate the amount of memory that would be allocated for flags */
             flags_shm_size = MPIDI_POSIX_RELEASE_GATHER_FLAG_SPACE_PER_RANK * num_ranks;

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -19,7 +19,7 @@
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
                                                    int handler_id, const void *am_hdr,
-                                                   size_t am_hdr_sz)
+                                                   MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
+                                                const void *am_hdr, MPI_Aint am_hdr_sz,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                 struct iovec *am_hdrs, size_t iov_len,
+                                                 struct iovec *am_hdrs, MPI_Aint iov_len,
                                                  const void *data, MPI_Count count,
                                                  MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                          int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+                                                         const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -83,7 +83,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
                                                       int src_rank, int handler_id,
-                                                      const void *am_hdr, size_t am_hdr_sz,
+                                                      const void *am_hdr, MPI_Aint am_hdr_sz,
                                                       const void *data, MPI_Count count,
                                                       MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_hdr_max_sz(void)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/src/shm_impl.c
+++ b/src/mpid/ch4/shm/src/shm_impl.c
@@ -358,7 +358,7 @@ int MPIDI_SHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Wi
     return ret;
 }
 
-int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     int ret;
 
@@ -371,7 +371,7 @@ int MPIDI_SHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char 
     return ret;
 }
 
-int MPIDI_SHM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_SHM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                               int **remote_lupids)
 {
     int ret;
@@ -398,7 +398,7 @@ int MPIDI_SHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, con
     return ret;
 }
 
-void *MPIDI_SHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_SHM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ret;
 

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking)
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr, size_t am_hdr_sz)
+                                                   const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, i
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
-                                                const void *am_hdr, size_t am_hdr_sz,
+                                                const void *am_hdr, MPI_Aint am_hdr_sz,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -65,7 +65,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
-                                                 struct iovec *am_hdrs, size_t iov_len,
+                                                 struct iovec *am_hdrs, MPI_Aint iov_len,
                                                  const void *data, MPI_Count count,
                                                  MPI_Datatype datatype, MPIR_Request * sreq)
 {
@@ -84,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
                                                          int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+                                                         const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     int ret;
 
@@ -100,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t conte
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                       int handler_id, const void *am_hdr,
-                                                      size_t am_hdr_sz, const void *data,
+                                                      MPI_Aint am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
                                                       MPIR_Request * sreq)
 {
@@ -117,7 +117,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
+MPL_STATIC_INLINE_PREFIX MPI_Aint MPIDI_SHM_am_hdr_max_sz(void)
 {
     int ret;
 

--- a/src/mpid/ch4/shm/src/shm_mem.c
+++ b/src/mpid/ch4/shm/src/shm_mem.c
@@ -9,7 +9,7 @@
 #include "shm_noinline.h"
 #include "../posix/posix_noinline.h"
 
-void *MPIDI_SHMI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_SHMI_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *ret;
 

--- a/src/mpid/ch4/shm/src/shm_misc.c
+++ b/src/mpid/ch4/shm/src/shm_misc.c
@@ -9,7 +9,7 @@
 #include "shm_noinline.h"
 #include "../posix/posix_noinline.h"
 
-int MPIDI_SHMI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_SHMI_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     int ret;
 
@@ -22,7 +22,7 @@ int MPIDI_SHMI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char
     return ret;
 }
 
-int MPIDI_SHMI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_SHMI_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                int **remote_lupids)
 {
     int ret;

--- a/src/mpid/ch4/shm/src/shm_noinline.h
+++ b/src/mpid/ch4/shm/src/shm_noinline.h
@@ -48,12 +48,12 @@ int MPIDI_SHMI_mpi_win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * info, 
                                 void *baseptr, MPIR_Win ** win);
 int MPIDI_SHMI_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win);
 
-int MPIDI_SHMI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_SHMI_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_SHMI_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids);
+int MPIDI_SHMI_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                int **remote_lupids);
 int MPIDI_SHMI_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 
-void *MPIDI_SHMI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_SHMI_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_SHMI_mpi_free_mem(void *ptr);
 
 #ifdef SHM_INLINE

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -452,12 +452,12 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k,
     MPL_shm_hnd_t fd;
     int num_ranks, rank;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
-    size_t shm_size;
+    MPI_Aint shm_size;
     int **bind_map = NULL;
     int *max_entries_per_level = NULL;
     int **ranks_per_package = NULL;
     int *package_ctr = NULL;
-    size_t topo_depth = 0;
+    MPI_Aint topo_depth = 0;
     int package_level = 0, i, max_ranks_per_package = 0;
     bool mapfail_flag = false;
 
@@ -509,7 +509,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k,
 
         /* STEP 3.1. Count the maximum entries at each level - used for breaking the tree into
          * intra/inter socket */
-        max_entries_per_level = (int *) MPL_calloc(topo_depth, sizeof(size_t), MPL_MEM_OTHER);
+        max_entries_per_level = (int *) MPL_calloc(topo_depth, sizeof(MPI_Aint), MPL_MEM_OTHER);
         MPIR_ERR_CHKANDJUMP(!max_entries_per_level, mpi_errno, MPI_ERR_OTHER, "**nomem");
         package_level =
             MPIDI_SHM_topotree_get_package_level(topo_depth, max_entries_per_level, num_ranks,

--- a/src/mpid/ch4/shm/stubshm/shm_noinline.h
+++ b/src/mpid/ch4/shm/stubshm/shm_noinline.h
@@ -49,12 +49,13 @@ int MPIDI_STUBSHM_mpi_win_allocate(MPI_Aint size, int disp_unit, MPIR_Info * inf
                                    void *baseptr, MPIR_Win ** win);
 int MPIDI_STUBSHM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win ** win);
 
-int MPIDI_STUBSHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids);
-int MPIDI_STUBSHM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_STUBSHM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size,
+                                  char **local_upids);
+int MPIDI_STUBSHM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                   int **remote_lupids);
 int MPIDI_STUBSHM_create_intercomm_from_lpids(MPIR_Comm * newcomm_ptr, int size, const int lpids[]);
 
-void *MPIDI_STUBSHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDI_STUBSHM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDI_STUBSHM_mpi_free_mem(void *ptr);
 
 #endif

--- a/src/mpid/ch4/shm/stubshm/stubshm_am.h
+++ b/src/mpid/ch4/shm/stubshm/stubshm_am.h
@@ -16,7 +16,7 @@ static inline int MPIDI_STUBSHM_am_isend(int rank,
                                          MPIR_Comm * comm,
                                          int handler_id,
                                          const void *am_hdr,
-                                         size_t am_hdr_sz,
+                                         MPI_Aint am_hdr_sz,
                                          const void *data,
                                          MPI_Count count,
                                          MPI_Datatype datatype, MPIR_Request * sreq)
@@ -34,7 +34,7 @@ static inline int MPIDI_STUBSHM_am_isendv(int rank,
                                           MPIR_Comm * comm,
                                           int handler_id,
                                           struct iovec *am_hdr,
-                                          size_t iov_len,
+                                          MPI_Aint iov_len,
                                           const void *data,
                                           MPI_Count count,
                                           MPI_Datatype datatype, MPIR_Request * sreq)
@@ -51,7 +51,7 @@ static inline int MPIDI_STUBSHM_am_isendv(int rank,
 static inline int MPIDI_STUBSHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz,
+                                               MPI_Aint am_hdr_sz,
                                                const void *data,
                                                MPI_Count count,
                                                MPI_Datatype datatype, MPIR_Request * sreq)
@@ -65,7 +65,7 @@ static inline int MPIDI_STUBSHM_am_isend_reply(MPIR_Context_id_t context_id, int
     return MPI_SUCCESS;
 }
 
-static inline size_t MPIDI_STUBSHM_am_hdr_max_sz(void)
+static inline MPI_Aint MPIDI_STUBSHM_am_hdr_max_sz(void)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_HDR_MAX_SZ);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_HDR_MAX_SZ);
@@ -78,7 +78,7 @@ static inline size_t MPIDI_STUBSHM_am_hdr_max_sz(void)
 
 static inline int MPIDI_STUBSHM_am_send_hdr(int rank,
                                             MPIR_Comm * comm,
-                                            int handler_id, const void *am_hdr, size_t am_hdr_sz)
+                                            int handler_id, const void *am_hdr, MPI_Aint am_hdr_sz)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR);
@@ -91,7 +91,7 @@ static inline int MPIDI_STUBSHM_am_send_hdr(int rank,
 
 static inline int MPIDI_STUBSHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
                                                   int handler_id, const void *am_hdr,
-                                                  size_t am_hdr_sz)
+                                                  MPI_Aint am_hdr_sz)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_AM_SEND_HDR_REPLY);

--- a/src/mpid/ch4/shm/stubshm/stubshm_init.c
+++ b/src/mpid/ch4/shm/stubshm/stubshm_init.c
@@ -46,7 +46,7 @@ int MPIDI_STUBSHM_mpi_finalize_hook(void)
     return MPI_SUCCESS;
 }
 
-void *MPIDI_STUBSHM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDI_STUBSHM_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_MPI_ALLOC_MEM);
@@ -90,7 +90,7 @@ int MPIDI_STUBSHM_get_max_node_id(MPIR_Comm * comm, int *max_id_p)
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBSHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)
+int MPIDI_STUBSHM_get_local_upids(MPIR_Comm * comm, MPI_Aint ** local_upid_size, char **local_upids)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_GET_LOCAL_UPIDS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_STUBSHM_GET_LOCAL_UPIDS);
@@ -101,7 +101,7 @@ int MPIDI_STUBSHM_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, c
     return MPI_SUCCESS;
 }
 
-int MPIDI_STUBSHM_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDI_STUBSHM_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                                   int **remote_lupids)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_STUBSHM_UPIDS_TO_LUPIDS);

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -296,7 +296,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
     int local_size = 0;
     int *local_node_ids = NULL, *remote_node_ids = NULL;
     int *local_lupids = NULL;
-    size_t *local_upid_size = NULL, *remote_upid_size = NULL;
+    MPI_Aint *local_upid_size = NULL, *remote_upid_size = NULL;
     int upid_send_size = 0, upid_recv_size = 0;
     char *local_upids = NULL, *remote_upids = NULL;
 
@@ -369,7 +369,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                         (MPL_DBG_FDEST, "Intercomm map exchange stage 1: leaders"));
         if (!pure_intracomm) {
             /* Stage 1.1 UPID exchange between leaders */
-            MPIR_CHKLMEM_MALLOC(remote_upid_size, size_t *, (*remote_size) * sizeof(size_t),
+            MPIR_CHKLMEM_MALLOC(remote_upid_size, MPI_Aint *, (*remote_size) * sizeof(MPI_Aint),
                                 mpi_errno, "remote_upid_size", MPL_MEM_ADDRESS);
 
             mpi_errno = MPIDI_NM_get_local_upids(local_comm, &local_upid_size, &local_upids);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -207,7 +207,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
             (dt_ptr_)        = NULL;                            \
             (dt_contig_out_) = TRUE;                            \
             (dt_true_lb_)    = 0;                               \
-            (data_sz_out_)   = (size_t)(count_) *               \
+            (data_sz_out_)   = (MPI_Aint)(count_) *               \
                 MPIR_Datatype_get_basic_size(datatype_);        \
         } else {                                                \
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
@@ -215,7 +215,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
             {                                                   \
                 (dt_contig_out_) = (dt_ptr_)->is_contig;        \
                 (dt_true_lb_)    = (dt_ptr_)->true_lb;          \
-                (data_sz_out_)   = (size_t)(count_) *           \
+                (data_sz_out_)   = (MPI_Aint)(count_) *           \
                     (dt_ptr_)->size;                            \
             }                                                   \
             else                                                \
@@ -232,11 +232,11 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     do {                                                        \
         if (IS_BUILTIN(datatype_)) {                            \
             (dt_ptr_)        = NULL;                            \
-            (data_sz_out_)   = (size_t)(count_) *               \
+            (data_sz_out_)   = (MPI_Aint)(count_) *               \
                 MPIR_Datatype_get_basic_size(datatype_);        \
         } else {                                                \
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
-            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *   \
+            (data_sz_out_)   = (dt_ptr_) ? (MPI_Aint)(count_) *   \
                 (dt_ptr_)->size : 0;                            \
         }                                                       \
     } while (0)
@@ -258,14 +258,14 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     do {                                                        \
         if (IS_BUILTIN(datatype_)) {                            \
             (dt_contig_out_) = TRUE;                            \
-            (data_sz_out_)   = (size_t)(count_) *               \
+            (data_sz_out_)   = (MPI_Aint)(count_) *               \
                 MPIR_Datatype_get_basic_size(datatype_);        \
         } else {                                                \
             MPIR_Datatype *dt_ptr_;                             \
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
             if (dt_ptr_) {                                      \
                 (dt_contig_out_) = (dt_ptr_)->is_contig;        \
-                (data_sz_out_)   = (size_t)(count_) *           \
+                (data_sz_out_)   = (MPI_Aint)(count_) *           \
                     (dt_ptr_)->size;                            \
             } else {                                            \
                 (dt_contig_out_) = 1;                           \
@@ -277,12 +277,12 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 #define MPIDI_Datatype_check_size(datatype_,count_,data_sz_out_)        \
     do {                                                                \
         if (IS_BUILTIN(datatype_)) {                                    \
-            (data_sz_out_)   = (size_t)(count_) *                       \
+            (data_sz_out_)   = (MPI_Aint)(count_) *                       \
                 MPIR_Datatype_get_basic_size(datatype_);                \
         } else {                                                        \
             MPIR_Datatype *dt_ptr_;                                     \
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));              \
-            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *           \
+            (data_sz_out_)   = (dt_ptr_) ? (MPI_Aint)(count_) *           \
                 (dt_ptr_)->size : 0;                                    \
         }                                                               \
     } while (0)
@@ -291,13 +291,13 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
                                      dt_true_lb_)                       \
     do {                                                                \
         if (IS_BUILTIN(datatype_)) {                                    \
-            (data_sz_out_)   = (size_t)(count_) *                       \
+            (data_sz_out_)   = (MPI_Aint)(count_) *                       \
                 MPIR_Datatype_get_basic_size(datatype_);                \
             (dt_true_lb_)    = 0;                                       \
         } else {                                                        \
             MPIR_Datatype *dt_ptr_;                                     \
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));              \
-            (data_sz_out_)   = (dt_ptr_) ? (size_t)(count_) *           \
+            (data_sz_out_)   = (dt_ptr_) ? (MPI_Aint)(count_) *           \
                 (dt_ptr_)->size : 0;                                    \
             (dt_true_lb_)    = (dt_ptr_) ? (dt_ptr_)->true_lb : 0;      \
         }                                                               \
@@ -310,7 +310,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     do {                                                        \
         if (IS_BUILTIN(datatype_)) {                            \
             (dt_contig_out_) = TRUE;                            \
-            (data_sz_out_)   = (size_t)(count_) *               \
+            (data_sz_out_)   = (MPI_Aint)(count_) *               \
                 MPIR_Datatype_get_basic_size(datatype_);        \
             (dt_true_lb_)    = 0;                               \
         } else {                                                \
@@ -318,7 +318,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
             MPIR_Datatype_get_ptr((datatype_), (dt_ptr_));      \
             if (dt_ptr_) {                                      \
                 (dt_contig_out_) = (dt_ptr_)->is_contig;        \
-                (data_sz_out_)   = (size_t)(count_) *           \
+                (data_sz_out_)   = (MPI_Aint)(count_) *           \
                     (dt_ptr_)->size;                            \
                 (dt_true_lb_)    = (dt_ptr_)->true_lb;          \
             } else {                                            \

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -656,7 +656,7 @@ int MPID_Get_processor_name(char *name, int namelen, int *resultlen)
     goto fn_exit;
 }
 
-void *MPID_Alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPID_Alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     void *p;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_ALLOC_MEM);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -130,7 +130,7 @@ typedef struct MPIDIG_hdr_t {
 
 typedef struct MPIDIG_send_long_req_mst_t {
     MPIDIG_hdr_t hdr;
-    size_t data_sz;             /* Message size in bytes */
+    MPI_Aint data_sz;           /* Message size in bytes */
     uint64_t sreq_ptr;          /* Pointer value of the request object at the sender side */
 } MPIDIG_send_long_req_mst_t;
 

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -14,7 +14,7 @@
 #include "ch4r_callbacks.h"
 
 static int handle_unexp_cmpl(MPIR_Request * rreq);
-static int do_send_target(void **data, size_t * p_data_sz, int *is_contig,
+static int do_send_target(void **data, MPI_Aint * p_data_sz, int *is_contig,
                           MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request * rreq);
 static int recv_target_cmpl_cb(MPIR_Request * rreq);
 
@@ -73,11 +73,11 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS, in_use;
     MPIR_Comm *root_comm;
     MPIR_Request *match_req = NULL;
-    size_t nbytes;
+    MPI_Aint nbytes;
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
-    size_t dt_sz;
+    MPI_Aint dt_sz;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIR_Request *anysource_partner = NULL;
@@ -248,13 +248,13 @@ static int handle_unexp_cmpl(MPIR_Request * rreq)
 }
 
 
-static int do_send_target(void **data, size_t * p_data_sz, int *is_contig,
+static int do_send_target(void **data, MPI_Aint * p_data_sz, int *is_contig,
                           MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request * rreq)
 {
     int dt_contig;
     MPI_Aint dt_true_lb, num_iov;
     MPIR_Datatype *dt_ptr;
-    size_t data_sz;
+    MPI_Aint data_sz;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_DO_SEND_TARGET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_DO_SEND_TARGET);
@@ -398,7 +398,7 @@ int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req)
 }
 
 
-int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                               int is_local, int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -507,7 +507,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t 
 }
 
 int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req)
 {
@@ -620,7 +620,7 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data
 }
 
 int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req)
 {
@@ -641,7 +641,7 @@ int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void **data
     return mpi_errno;
 }
 
-int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                int is_local, int *is_contig,
                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -667,7 +667,7 @@ int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     goto fn_exit;
 }
 
-int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                    int is_local, int *is_contig,
                                    MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -690,7 +690,7 @@ int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, si
 }
 
 int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req)
 {
@@ -750,7 +750,7 @@ int MPIDIG_comm_abort_origin_cb(MPIR_Request * sreq)
     return MPI_SUCCESS;
 }
 
-int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                     int is_local, int *is_contig,
                                     MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -23,29 +23,29 @@ void MPIDIG_progress_compl_list(void);
 int MPIDIG_send_origin_cb(MPIR_Request * sreq);
 int MPIDIG_send_long_lmt_origin_cb(MPIR_Request * sreq);
 int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req);
-int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                               int is_local, int *is_contig,
                               MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req);
 int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req);
-int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                int is_local, int *is_contig,
                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                   size_t * p_data_sz, int is_local, int *is_contig,
+                                   MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                    MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+                                       MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                        MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                        MPIR_Request ** req);
 int MPIDIG_comm_abort_origin_cb(MPIR_Request * sreq);
-int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                     int is_local, int *is_contig,
                                     MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 

--- a/src/mpid/ch4/src/ch4r_comm.c
+++ b/src/mpid/ch4/src/ch4r_comm.c
@@ -12,7 +12,7 @@
 #include "mpidimpl.h"
 #include "ch4r_comm.h"
 
-int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDIU_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                            int **remote_lupids, int *remote_node_ids)
 {
     int mpi_errno = MPI_SUCCESS, i;
@@ -61,7 +61,7 @@ int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upi
 
 int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, int *remote_size,
                                      int *is_low_group, int pure_intracomm,
-                                     size_t * remote_upid_size, char *remote_upids,
+                                     MPI_Aint * remote_upid_size, char *remote_upids,
                                      int **remote_lupids, int *remote_node_ids)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -69,7 +69,7 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
     int upid_recv_size = 0;
     int map_info[4];
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    size_t *_remote_upid_size = NULL;
+    MPI_Aint *_remote_upid_size = NULL;
     char *_remote_upids = NULL;
     int *_remote_node_ids = NULL;
 
@@ -123,7 +123,7 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         MPIR_CHKPMEM_MALLOC((*remote_lupids), int *, (*remote_size) * sizeof(int),
                             mpi_errno, "remote_lupids", MPL_MEM_COMM);
         if (!pure_intracomm) {
-            MPIR_CHKLMEM_MALLOC(_remote_upid_size, size_t *, (*remote_size) * sizeof(size_t),
+            MPIR_CHKLMEM_MALLOC(_remote_upid_size, MPI_Aint *, (*remote_size) * sizeof(MPI_Aint),
                                 mpi_errno, "_remote_upid_size", MPL_MEM_COMM);
             mpi_errno = MPIR_Bcast_intra_auto(_remote_upid_size, *remote_size, MPI_UNSIGNED_LONG,
                                               local_leader, local_comm, &errflag);

--- a/src/mpid/ch4/src/ch4r_comm.h
+++ b/src/mpid/ch4/src/ch4r_comm.h
@@ -12,11 +12,11 @@
 #ifndef CH4R_COMM_H_INCLUDED
 #define CH4R_COMM_H_INCLUDED
 
-int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upids,
+int MPIDIU_upids_to_lupids(int size, MPI_Aint * remote_upid_size, char *remote_upids,
                            int **remote_lupids, int *remote_node_ids);
 int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, int *remote_size,
                                      int *is_low_group, int pure_intracomm,
-                                     size_t * remote_upid_size, char *remote_upids,
+                                     MPI_Aint * remote_upid_size, char *remote_upids,
                                      int **remote_lupids, int *remote_node_ids);
 int MPIDIU_alloc_lut(MPIDI_rank_map_lut_t ** lut, int size);
 int MPIDIU_release_lut(MPIDI_rank_map_lut_t * lut);

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -92,7 +92,7 @@ int MPIDIG_destroy_comm(MPIR_Comm * comm)
     return mpi_errno;
 }
 
-void *MPIDIG_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
+void *MPIDIG_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);

--- a/src/mpid/ch4/src/ch4r_init.h
+++ b/src/mpid/ch4/src/ch4r_init.h
@@ -13,7 +13,7 @@
 
 int MPIDIG_init_comm(MPIR_Comm * comm);
 int MPIDIG_destroy_comm(MPIR_Comm * comm);
-void *MPIDIG_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
+void *MPIDIG_mpi_alloc_mem(MPI_Aint size, MPIR_Info * info_ptr);
 int MPIDIG_mpi_free_mem(void *ptr);
 
 #endif /* CH4R_INIT_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -51,11 +51,11 @@ static inline int MPIDIG_reply_ssend(MPIR_Request * rreq)
 static inline int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t message_sz;
+    MPI_Aint message_sz;
     int dt_contig;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
-    size_t data_sz ATTRIBUTE((unused)), dt_sz, nbytes;
+    MPI_Aint data_sz ATTRIBUTE((unused)), dt_sz, nbytes;
     void *buf;
     MPI_Aint count;
     MPI_Datatype datatype;

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -25,10 +25,10 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
     MPIR_Request *sreq = NULL;
     MPIDIG_put_msg_t am_hdr;
     uint64_t offset;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint num_iov;
     struct iovec *dt_iov, am_iov[2];
-    size_t am_hdr_max_size;
+    MPI_Aint am_hdr_max_size;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int is_local;
 #endif
@@ -182,10 +182,10 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
                                 MPIR_Request ** sreq_ptr)
 {
     int mpi_errno = MPI_SUCCESS, n_iov, c;
-    size_t offset;
+    MPI_Aint offset;
     MPIR_Request *sreq = NULL;
     MPIDIG_get_msg_t am_hdr;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPI_Aint num_iov;
     struct iovec *dt_iov;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -319,7 +319,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 {
     int mpi_errno = MPI_SUCCESS, c, n_iov;
     MPIR_Request *sreq = NULL;
-    size_t basic_type_size;
+    MPI_Aint basic_type_size;
     MPIDIG_acc_req_msg_t am_hdr;
     uint64_t data_sz, target_data_sz;
     MPI_Aint num_iov;
@@ -500,7 +500,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 {
     int mpi_errno = MPI_SUCCESS, c, n_iov;
     MPIR_Request *sreq = NULL;
-    size_t basic_type_size;
+    MPI_Aint basic_type_size;
     MPIDIG_get_acc_req_msg_t am_hdr;
     uint64_t data_sz, result_data_sz, target_data_sz;
     MPI_Aint num_iov;
@@ -916,7 +916,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = NULL;
     MPIDIG_cswap_req_msg_t am_hdr;
-    size_t data_sz;
+    MPI_Aint data_sz;
     void *p_data;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_COMPARE_AND_SWAP);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -26,7 +26,7 @@ static void win_post_proc(const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win);
 static void win_unlock_done(const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win);
 static int handle_acc_cmpl(MPIR_Request * rreq);
 static int handle_get_acc_cmpl(MPIR_Request * rreq);
-static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPIR_Request * rreq);
+static void handle_acc_data(void **data, MPI_Aint * p_data_sz, int *is_contig, MPIR_Request * rreq);
 static int get_target_cmpl_cb(MPIR_Request * req);
 static int put_target_cmpl_cb(MPIR_Request * rreq);
 static int put_iov_target_cmpl_cb(MPIR_Request * rreq);
@@ -265,7 +265,7 @@ static int ack_cswap(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS, c;
     MPIDIG_cswap_ack_msg_t ack_msg;
     void *result_addr;
-    size_t data_sz;
+    MPI_Aint data_sz;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ACK_CSWAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ACK_CSWAP);
@@ -575,7 +575,7 @@ static int handle_acc_cmpl(MPIR_Request * rreq)
     MPI_Aint basic_sz, count;
     struct iovec *iov;
     char *src_ptr;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int shm_locked ATTRIBUTE((unused)) = 0;
     MPIR_Win *win ATTRIBUTE((unused)) = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
 
@@ -668,7 +668,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
     MPI_Aint basic_sz, count, offset = 0;
     struct iovec *iov;
     char *src_ptr, *original = NULL;
-    size_t data_sz;
+    MPI_Aint data_sz;
     int shm_locked ATTRIBUTE((unused)) = 0;
     MPIR_Win *win ATTRIBUTE((unused)) = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
 
@@ -765,10 +765,10 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPIR_Request * rreq)
+static void handle_acc_data(void **data, MPI_Aint * p_data_sz, int *is_contig, MPIR_Request * rreq)
 {
     void *p_data = NULL;
-    size_t data_sz;
+    MPI_Aint data_sz;
     uintptr_t base;
     int i;
     struct iovec *iov;
@@ -811,7 +811,7 @@ static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPI
 static int get_target_cmpl_cb(MPIR_Request * req)
 {
     int mpi_errno = MPI_SUCCESS, i, c;
-    size_t data_sz, offset;
+    MPI_Aint data_sz, offset;
     MPIDIG_get_ack_msg_t get_ack;
     struct iovec *iov;
     char *p_data;
@@ -1042,7 +1042,7 @@ static int cswap_target_cmpl_cb(MPIR_Request * rreq)
     int mpi_errno = MPI_SUCCESS;
     void *compare_addr;
     void *origin_addr;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPIR_Win *win ATTRIBUTE((unused)) = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CSWAP_TARGET_CMPL_CB);
@@ -1202,7 +1202,7 @@ static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
     return mpi_errno;
 }
 
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1234,7 +1234,7 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     return mpi_errno;
 }
 
-int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1267,15 +1267,15 @@ int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_get_acc_ack_msg_t *msg_hdr = (MPIDIG_get_acc_ack_msg_t *) am_hdr;
     MPIR_Request *areq;
 
-    size_t data_sz;
+    MPI_Aint data_sz;
     int dt_contig, n_iov;
     MPI_Aint dt_true_lb, num_iov;
     MPIR_Datatype *dt_ptr;
@@ -1329,7 +1329,7 @@ int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     return mpi_errno;
 }
 
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                    int is_local, int *is_contig,
                                    MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1357,7 +1357,7 @@ int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, si
 }
 
 
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1418,16 +1418,16 @@ int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
     return mpi_errno;
 }
 
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
-    size_t data_sz;
+    MPI_Aint data_sz;
     struct iovec *iov, *dt_iov;
     uintptr_t base;             /* Base address of the window */
-    size_t offset;
+    MPI_Aint offset;
 
     int dt_contig, n_iov;
     MPI_Aint dt_true_lb, num_iov;
@@ -1515,7 +1515,7 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     goto fn_exit;
 }
 
-int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1523,7 +1523,7 @@ int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     MPIR_Request *rreq = NULL;
     struct iovec *dt_iov;
     uintptr_t base;
-    size_t offset;
+    MPI_Aint offset;
 
     MPIR_Win *win;
     MPIDIG_put_msg_t *msg_hdr = (MPIDIG_put_msg_t *) am_hdr;
@@ -1572,8 +1572,8 @@ int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     goto fn_exit;
 }
 
-int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1629,8 +1629,8 @@ int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     goto fn_exit;
 }
 
-int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1689,7 +1689,7 @@ int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
 }
 
 int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                         size_t * p_data_sz, int is_local, int *is_contig,
+                                         MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                          MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                          MPIR_Request ** req)
 {
@@ -1748,7 +1748,7 @@ int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **da
     goto fn_exit;
 }
 
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1783,7 +1783,7 @@ int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
     return mpi_errno;
 }
 
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1806,8 +1806,8 @@ int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                      int is_local, int *is_contig,
+int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                      MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                       MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                       MPIR_Request ** req)
 {
@@ -1830,16 +1830,16 @@ int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data,
     return mpi_errno;
 }
 
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                int is_local, int *is_contig,
                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
-    size_t data_sz;
+    MPI_Aint data_sz;
     MPIR_Win *win;
     uintptr_t base;
-    size_t offset;
+    MPI_Aint offset;
 
     int dt_contig;
     void *p_data;
@@ -1890,18 +1890,18 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     goto fn_exit;
 }
 
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
-    size_t data_sz;
+    MPI_Aint data_sz;
     void *p_data = NULL;
     struct iovec *iov, *dt_iov;
     MPIR_Win *win;
     uintptr_t base;
-    size_t offset;
+    MPI_Aint offset;
     int i;
 
     MPIDIG_acc_req_msg_t *msg_hdr = (MPIDIG_acc_req_msg_t *) am_hdr;
@@ -1974,7 +1974,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 }
 
 
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -1996,7 +1996,7 @@ int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     return mpi_errno;
 }
 
-int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -2005,7 +2005,7 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     struct iovec *dt_iov;
     MPIR_Win *win;
     uintptr_t base;
-    size_t offset;
+    MPI_Aint offset;
 
     MPIDIG_acc_req_msg_t *msg_hdr = (MPIDIG_acc_req_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ACC_IOV_TARGET_MSG_CB);
@@ -2058,8 +2058,8 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     goto fn_exit;
 }
 
-int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -2079,7 +2079,7 @@ int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     return mpi_errno;
 }
 
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
@@ -2089,7 +2089,7 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     struct iovec *iov;
     MPIR_Win *win;
     uintptr_t base;
-    size_t offset;
+    MPI_Aint offset;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_TARGET_MSG_CB);
@@ -2137,13 +2137,13 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     goto fn_exit;
 }
 
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *get_req;
-    size_t data_sz;
+    MPI_Aint data_sz;
 
     int dt_contig, n_iov;
     MPI_Aint dt_true_lb, num_iov;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -39,70 +39,70 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_data ATTRIBUTE((unused));
 extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unused));
 
 int MPIDIG_RMA_Init_targetcb_pvars(void);
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                 size_t * p_data_sz, int is_local, int *is_contig,
+                                 MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                      MPIR_Request ** req);
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                    int is_local, int *is_contig,
                                    MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                      MPIR_Request ** req);
-int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                      MPIR_Request ** req);
 int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                         size_t * p_data_sz, int is_local, int *is_contig,
+                                         MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                          MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                          MPIR_Request ** req);
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                   int is_local, int *is_contig,
                                   MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                      int is_local, int *is_contig,
+int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                      MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                       MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                       MPIR_Request ** req);
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                int is_local, int *is_contig,
                                MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig,
+int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data,
+                                     MPI_Aint * p_data_sz, int is_local, int *is_contig,
                                      MPIDIG_am_target_cmpl_cb * target_cmpl_cb,
                                      MPIR_Request ** req);
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                              int is_local, int *is_contig,
                              MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
+int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, MPI_Aint * p_data_sz,
                                  int is_local, int *is_contig,
                                  MPIDIG_am_target_cmpl_cb * target_cmpl_cb, MPIR_Request ** req);
 

--- a/src/mpid/ch4/src/ch4r_symheap.h
+++ b/src/mpid/ch4/src/ch4r_symheap.h
@@ -42,7 +42,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-size_t MPIDIU_get_mapsize(size_t size, size_t * psz);
+MPI_Aint MPIDIU_get_mapsize(MPI_Aint size, MPI_Aint * psz);
 int MPIDIU_get_shm_symheap(MPI_Aint shm_size, MPI_Aint * shm_offsets, MPIR_Comm * comm,
                            MPIR_Win * win, bool * fail_flag);
 

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -19,7 +19,7 @@ enum {
 };
 
 static void parse_info_accu_ops_str(const char *str, uint32_t * ops_ptr);
-static void get_info_accu_ops_str(uint32_t val, char *buf, size_t maxlen);
+static void get_info_accu_ops_str(uint32_t val, char *buf, MPI_Aint maxlen);
 static int win_set_info(MPIR_Win * win, MPIR_Info * info, bool is_init);
 static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_Info * info,
                     MPIR_Comm * comm_ptr, int create_flavor, int model);
@@ -94,7 +94,7 @@ static void parse_info_accu_ops_str(const char *str, uint32_t * ops_ptr)
         *ops_ptr = ops;
 }
 
-static void get_info_accu_ops_str(uint32_t val, char *buf, size_t maxlen)
+static void get_info_accu_ops_str(uint32_t val, char *buf, MPI_Aint maxlen)
 {
     int c = 0;
 
@@ -431,11 +431,11 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
     int i, mpi_errno = MPI_SUCCESS;
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
     MPIR_Win *win = NULL;
-    size_t total_shm_size = 0LL;
+    MPI_Aint total_shm_size = 0LL;
     MPIDIG_win_shared_info_t *shared_table = NULL;
     MPI_Aint *shm_offsets = NULL;
     MPIR_Comm *shm_comm_ptr = comm_ptr->node_comm;
-    size_t page_sz = 0, mapsize;
+    MPI_Aint page_sz = 0, mapsize;
     bool symheap_mapfail_flag = false, shm_mapfail_flag = false;
     bool symheap_flag = true, global_symheap_flag = false;
 

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -12,7 +12,7 @@
 
 static MPIDU_shm_seg_t memory;
 static MPIDU_shm_barrier_t *barrier;
-static size_t *indices;
+static MPI_Aint *indices;
 static int local_size;
 static char *segment;
 
@@ -37,7 +37,7 @@ int MPIDU_bc_table_destroy(void *bc_table)
 
 
 int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int same_len,
-                       void **bc_table, size_t ** bc_indices)
+                       void **bc_table, MPI_Aint ** bc_indices)
 {
     int mpi_errno = MPI_SUCCESS;
     int local_rank = -1, local_leader = -1;
@@ -54,7 +54,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &local_rank, &local_leader);
     if (rank != local_leader) {
-        size_t start = local_leader - nodemap[comm->rank] + (local_rank - 1);
+        MPI_Aint start = local_leader - nodemap[comm->rank] + (local_rank - 1);
 
         memcpy(&segment[start * bc_len], bc, bc_len);
     }
@@ -90,7 +90,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
 #define KEYLEN 64
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
-                          int roots_only, void **bc_table, size_t ** bc_indices)
+                          int roots_only, void **bc_table, MPI_Aint ** bc_indices)
 {
     int rc, mpi_errno = MPI_SUCCESS;
     int start, end, i;
@@ -100,7 +100,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     pmix_info_t *info;
     pmix_proc_t proc;
     int local_rank, local_leader;
-    size_t my_bc_len = bc_len;
+    MPI_Aint my_bc_len = bc_len;
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &local_rank, &local_leader);
 
@@ -186,7 +186,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 
   single:
     if (!same_len) {
-        indices = MPL_malloc(size * sizeof(size_t), MPL_MEM_ADDRESS);
+        indices = MPL_malloc(size * sizeof(MPI_Aint), MPL_MEM_ADDRESS);
         for (i = 0; i < size; i++)
             indices[i] = bc_len * i;
         *bc_indices = indices;
@@ -205,14 +205,14 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 #include <pmi2.h>
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
-                          int roots_only, void **bc_table, size_t ** bc_indices)
+                          int roots_only, void **bc_table, MPI_Aint ** bc_indices)
 {
     int rc, mpi_errno = MPI_SUCCESS;
     int start, end, i;
     int out_len, val_len, rem;
     char *key = NULL, *val = NULL, *val_p;
     int local_rank, local_leader;
-    size_t my_bc_len = bc_len;
+    MPI_Aint my_bc_len = bc_len;
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &local_rank, &local_leader);
 
@@ -286,7 +286,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 
   single:
     if (!same_len) {
-        indices = MPL_malloc(size * sizeof(size_t), MPL_MEM_ADDRESS);
+        indices = MPL_malloc(size * sizeof(MPI_Aint), MPL_MEM_ADDRESS);
         for (i = 0; i < size; i++)
             indices[i] = bc_len * i;
         *bc_indices = indices;
@@ -306,14 +306,14 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 #include <pmi.h>
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
-                          int roots_only, void **bc_table, size_t ** bc_indices)
+                          int roots_only, void **bc_table, MPI_Aint ** bc_indices)
 {
     int rc, mpi_errno = MPI_SUCCESS;
     int start, end, i;
     int key_max, val_max, name_max, out_len, rem;
     char *kvsname = NULL, *key = NULL, *val = NULL, *val_p;
     int local_rank = -1, local_leader = -1;
-    size_t my_bc_len = bc_len;
+    MPI_Aint my_bc_len = bc_len;
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &local_rank, &local_leader);
 
@@ -401,7 +401,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 
   single:
     if (!same_len) {
-        indices = MPL_malloc(size * sizeof(size_t), MPL_MEM_ADDRESS);
+        indices = MPL_malloc(size * sizeof(MPI_Aint), MPL_MEM_ADDRESS);
         MPIR_Assert(indices);
         for (i = 0; i < size; i++)
             indices[i] = bc_len * i;

--- a/src/mpid/common/bc/mpidu_bc.h
+++ b/src/mpid/common/bc/mpidu_bc.h
@@ -11,9 +11,9 @@
 #include "build_nodemap.h"
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
-                          int roots_only, void **bc_table, size_t ** bc_indices);
+                          int roots_only, void **bc_table, MPI_Aint ** bc_indices);
 int MPIDU_bc_table_destroy(void *bc_table);
 int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int same_len,
-                       void **bc_table, size_t ** bc_indices);
+                       void **bc_table, MPI_Aint ** bc_indices);
 
 #endif /* MPIDU_BC_H_INCLUDED */

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -70,7 +70,7 @@ static int get_mpi_type_contents(void *mpi_type, int max_integers, int max_addre
                                  void *array_of_addresses, void *array_of_datatypes);
 static int get_hcoll_type(void *mpi_type, dte_data_representation_t * hcoll_type);
 static int set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type);
-static int get_mpi_constants(size_t * mpi_datatype_size,
+static int get_mpi_constants(MPI_Aint * mpi_datatype_size,
                              int *mpi_order_c, int *mpi_order_fortran,
                              int *mpi_distribute_block,
                              int *mpi_distribute_cyclic,
@@ -120,7 +120,7 @@ static int recv_nb(struct dte_data_representation_t data,
     MPI_Datatype dtype;
     MPIR_Request *request;
     MPIR_Comm *comm;
-    size_t size;
+    MPI_Aint size;
     mpi_errno = MPI_SUCCESS;
     comm = (MPIR_Comm *) grp_h;
     if (!ec_h.handle) {
@@ -132,7 +132,7 @@ static int recv_nb(struct dte_data_representation_t data,
     if (!buffer && !HCOL_DTE_IS_ZERO(data)) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**null_buff_ptr");
     }
-    size = (size_t) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
+    size = (MPI_Aint) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
     dtype = MPI_CHAR;
     request = NULL;
     mpi_errno = MPIC_Irecv(buffer, size, dtype, ec_h.rank, tag, comm, &request);
@@ -155,7 +155,7 @@ static int send_nb(dte_data_representation_t data,
     MPI_Datatype dtype;
     MPIR_Request *request;
     MPIR_Comm *comm;
-    size_t size;
+    MPI_Aint size;
     mpi_errno = MPI_SUCCESS;
     comm = (MPIR_Comm *) grp_h;
     if (!ec_h.handle) {
@@ -167,7 +167,7 @@ static int send_nb(dte_data_representation_t data,
     if (!buffer && !HCOL_DTE_IS_ZERO(data)) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**null_buff_ptr");
     }
-    size = (size_t) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
+    size = (MPI_Aint) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
     dtype = MPI_CHAR;
     request = NULL;
     MPIR_Errflag_t err = MPIR_ERR_NONE;
@@ -396,7 +396,7 @@ static int set_hcoll_type(void *mpi_type, dte_data_representation_t hcoll_type)
     return HCOLL_SUCCESS;
 }
 
-static int get_mpi_constants(size_t * mpi_datatype_size,
+static int get_mpi_constants(MPI_Aint * mpi_datatype_size,
                              int *mpi_order_c, int *mpi_order_fortran,
                              int *mpi_distribute_block,
                              int *mpi_distribute_cyclic,

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -197,7 +197,7 @@ int MPIDU_Sched_next_tag(MPIR_Comm * comm_ptr, int *tag)
 /* initiates the schedule entry "e" in the NBC described by "s", where
  * "e" is at "idx" in "s".  This means posting nonblocking sends/recvs,
  * performing reductions, calling callbacks, etc. */
-static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPIDU_Sched_entry *e)
+static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, MPI_Aint idx, struct MPIDU_Sched_entry *e)
 {
     int mpi_errno = MPI_SUCCESS, ret_errno = MPI_SUCCESS;
     MPIR_Request *r = s->req;
@@ -357,7 +357,7 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
 static int MPIDU_Sched_continue(struct MPIDU_Sched *s)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t i;
+    MPI_Aint i;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SCHED_CONTINUE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SCHED_CONTINUE);
@@ -877,7 +877,7 @@ int MPIDU_Sched_cb2(MPIR_Sched_cb2_t * cb_p, void *cb_state, void *cb_state2, MP
 static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made_progress)
 {
     int mpi_errno = MPI_SUCCESS;
-    size_t i;
+    MPI_Aint i;
     struct MPIDU_Sched *s;
     struct MPIDU_Sched *tmp;
     if (made_progress)

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -107,8 +107,8 @@ struct MPIDU_Sched_entry {
 };
 
 struct MPIDU_Sched {
-    size_t size;                /* capacity (in entries) of the entries array */
-    size_t idx;                 /* index into entries array of first yet-outstanding entry */
+    MPI_Aint size;              /* capacity (in entries) of the entries array */
+    MPI_Aint idx;               /* index into entries array of first yet-outstanding entry */
     int num_entries;            /* number of populated entries, num_entries <= size */
     int tag;
     struct MPIR_Request *req;   /* really needed? could cause MT problems... */

--- a/src/mpid/common/shm/mpidu_shm.h
+++ b/src/mpid/common/shm/mpidu_shm.h
@@ -17,7 +17,7 @@ typedef struct MPIDU_shm_barrier {
 } MPIDU_shm_barrier_t;
 
 typedef struct MPIDU_shm_seg {
-    size_t segment_len;
+    MPI_Aint segment_len;
     /* Handle to shm seg */
     MPL_shm_hnd_t hnd;
     /* Pointers */
@@ -29,11 +29,11 @@ typedef struct MPIDU_shm_seg {
 } MPIDU_shm_seg_t;
 
 typedef struct MPIDU_shm_seg_info {
-    size_t size;
+    MPI_Aint size;
     char *addr;
 } MPIDU_shm_seg_info_t;
 
-int MPIDU_shm_seg_alloc(size_t len, void **ptr_p, MPL_memory_class class);
+int MPIDU_shm_seg_alloc(MPI_Aint len, void **ptr_p, MPL_memory_class class);
 int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrier,
                          int num_local, int local_rank, int local_procs_0, int rank,
                          MPL_memory_class class);

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -35,7 +35,7 @@ extern int mkstemp(char *t);
 typedef struct alloc_elem {
     struct alloc_elem *next;
     void **ptr_p;
-    size_t len;
+    MPI_Aint len;
 } alloc_elem_t;
 
 static struct {
@@ -51,7 +51,7 @@ static int check_alloc(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t * barrier,
 #define ALLOCQ_ENQUEUE(ep) GENERIC_Q_ENQUEUE(&allocq, ep, next)
 #define ALLOCQ_DEQUEUE(epp) GENERIC_Q_DEQUEUE(&allocq, epp, next)
 
-static size_t segment_len = 0;
+static MPI_Aint segment_len = 0;
 
 static int num_segments = 0;
 
@@ -74,7 +74,7 @@ static asym_check_region *asym_check_region_p = NULL;
    and the *ptr_p pointer will be valid only after
    MPIDU_SHM_Seg_commit() is called.
 */
-int MPIDU_shm_seg_alloc(size_t len, void **ptr_p, MPL_memory_class class)
+int MPIDU_shm_seg_alloc(MPI_Aint len, void **ptr_p, MPL_memory_class class)
 {
     int mpi_errno = MPI_SUCCESS;
     alloc_elem_t *ep;
@@ -85,7 +85,7 @@ int MPIDU_shm_seg_alloc(size_t len, void **ptr_p, MPL_memory_class class)
 
     /* round up to multiple of 8 to ensure the start of the next
      * region is 64-bit aligned. */
-    len = MPL_ROUND_UP_ALIGN(len, (size_t) 8);
+    len = MPL_ROUND_UP_ALIGN(len, (MPI_Aint) 8);
     MPIR_Assert(len);
     MPIR_Assert(ptr_p);
 
@@ -141,7 +141,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
     char *serialized_hnd = NULL;
     void *current_addr;
     void *start_addr ATTRIBUTE((unused));
-    size_t size_left;
+    MPI_Aint size_left;
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(2);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SHM_SEG_COMMIT);
@@ -328,7 +328,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
     } else {
         pmix_proc_t proc, *procs;
         char *nodename = NULL;
-        size_t nprocs;
+        MPI_Aint nprocs;
         pmix_value_t value, *pvalue = NULL;
         pmix_info_t *info;
         int flag = 1;


### PR DESCRIPTION
## Pull Request Description

Trying out the other side of idea in issue #3365: replace all internal use of size_t with MPI_Aint.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
* [ ] Passes tests (included warning check)
