### PR TITLE
datatype: Remove manpages for internal functions

### DIFF
--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -25,17 +25,6 @@ int MPI_Type_commit(MPI_Datatype * datatype) __attribute__ ((weak, alias("PMPI_T
 #undef MPI_Type_commit
 #define MPI_Type_commit PMPI_Type_commit
 
-/*@
-  MPIR_Type_commit
-
-Input Parameters:
-. datatype_p - pointer to MPI datatype
-
-Output Parameters:
-
-  Return Value:
-  0 on success, -1 on failure.
-@*/
 int MPIR_Type_commit(MPI_Datatype * datatype_p)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -27,19 +27,6 @@ int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype)
 #undef MPI_Type_contiguous
 #define MPI_Type_contiguous PMPI_Type_contiguous
 
-/*@
-  MPIR_Type_contiguous - create a contiguous datatype
-
-Input Parameters:
-+ count - number of elements in the contiguous block
-- oldtype - type (using handle) of datatype on which vector is based
-
-Output Parameters:
-. newtype - handle of new contiguous datatype
-
-  Return Value:
-  MPI_SUCCESS on success, MPI error code on failure.
-@*/
 int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -28,18 +28,6 @@ int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
 
 #endif
 
-/*@
-  MPIR_Type_dup - create a copy of a datatype
-
-Input Parameters:
-- oldtype - handle of original datatype
-
-Output Parameters:
-. newtype - handle of newly created copy of datatype
-
-  Return Value:
-  0 on success, MPI error code on failure.
-@*/
 int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpi/datatype/type_get_contents.c
+++ b/src/mpi/datatype/type_get_contents.c
@@ -31,21 +31,6 @@ int MPI_Type_get_contents(MPI_Datatype datatype, int max_integers, int max_addre
 #undef MPI_Type_get_contents
 #define MPI_Type_get_contents PMPI_Type_get_contents
 
-/*@
-  MPIR_Type_get_contents - get content information from datatype
-
-Input Parameters:
-+ datatype - MPI datatype
-. max_integers - size of array_of_integers
-. max_addresses - size of array_of_addresses
-- max_datatypes - size of array_of_datatypes
-
-Output Parameters:
-+ array_of_integers - integers used in creating type
-. array_of_addresses - MPI_Aints used in creating type
-- array_of_datatypes - MPI_Datatypes used in creating type
-
-@*/
 int MPIR_Type_get_contents(MPI_Datatype datatype,
                            int max_integers,
                            int max_addresses,

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -28,26 +28,6 @@ int MPI_Type_indexed(int count, const int *array_of_blocklengths,
 #undef MPI_Type_indexed
 #define MPI_Type_indexed PMPI_Type_indexed
 
-/*@
-  MPIR_Type_indexed - create an indexed datatype
-
-Input Parameters:
-+ count - number of blocks in type
-. blocklength_array - number of elements in each block
-. displacement_array - offsets of blocks from start of type (see next
-  parameter for units)
-. dispinbytes - if nonzero, then displacements are in bytes (the
-  displacement_array is an array of ints), otherwise they in terms of
-  extent of oldtype (the displacement_array is an array of MPI_Aints)
-- oldtype - type (using handle) of datatype on which new type is based
-
-Output Parameters:
-. newtype - handle of new indexed datatype
-
-  Return Value:
-  0 on success, -1 on failure.
-@*/
-
 int MPIR_Type_indexed(int count,
                       const int *blocklength_array,
                       const void *displacement_array,

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -134,22 +134,6 @@ static MPI_Aint MPII_Type_struct_alignsize(int count,
     return max_alignsize;
 }
 
-
-/*@
-  MPIR_Type_struct - create a struct datatype
-
-Input Parameters:
-+ count - number of blocks in vector
-. blocklength_array - number of elements in each block
-. displacement_array - offsets of blocks from start of type in bytes
-- oldtype_array - types (using handle) of datatypes on which vector is based
-
-Output Parameters:
-. newtype - handle of new struct datatype
-
-  Return Value:
-  MPI_SUCCESS on success, MPI errno on failure.
-@*/
 int MPIR_Type_struct(int count,
                      const int *blocklength_array,
                      const MPI_Aint * displacement_array,

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -27,24 +27,6 @@ int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype
 #undef MPI_Type_vector
 #define MPI_Type_vector PMPI_Type_vector
 
-/*@
-  MPIR_Type_vector - create a vector datatype
-
-Input Parameters:
-+ count - number of blocks in vector
-. blocklength - number of elements in each block
-. stride - distance from beginning of one block to the next (see next
-  parameter for units)
-. strideinbytes - if nonzero, then stride is in bytes, otherwise stride
-  is in terms of extent of oldtype
-- oldtype - type (using handle) of datatype on which vector is based
-
-Output Parameters:
-. newtype - handle of new vector datatype
-
-  Return Value:
-  0 on success, MPI error code on failure.
-@*/
 int MPIR_Type_vector(int count,
                      int blocklength,
                      MPI_Aint stride,


### PR DESCRIPTION
## Pull Request Description

These datatype functions were mistakenly given comment headers which
generate manpages in [f9d01d70f6ce].

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
