### PR TITLE
maint: Unset libtool version string

### DIFF
--- a/maint/version.m4
+++ b/maint/version.m4
@@ -35,6 +35,6 @@ m4_define([MPICH_RELEASE_DATE_m4],[unreleased development copy])dnl
 # libmpi so version only includes functionality defined in the MPI
 # standard, and does not include MPIX_ functions and C++ bindings.
 
-m4_define([libmpi_so_version_m4],[13:6:1])dnl
+m4_define([libmpi_so_version_m4],[0:0:0])dnl
 
 [#] end of __file__


### PR DESCRIPTION
## Pull Request Description

Since we have branched the 3.3.x series, unset the ABI string on
master until we are preparing a 3.4 release.

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
