### PR TITLE
test/mpi: Use mtest_finalize

### DIFF
--- a/test/mpi/f08/profile/profile1f90.f90
+++ b/test/mpi/f08/profile/profile1f90.f90
@@ -50,15 +50,7 @@
           endif
        endif
 
-       call mpi_allreduce( MPI_IN_PLACE, toterrs, 1, MPI_INT, MPI_SUM, &
-      &      MPI_COMM_WORLD, ierr )
-       if (wrank .eq. 0) then
-          if (toterrs .eq. 0) then
-             print *, " No Errors"
-          else
-             print *, " Found ", toterrs, " errors"
-          endif
-       endif
+       call mtest_finalize( toterrs )
 !
        end
 !

--- a/test/mpi/f77/profile/profile1f.f
+++ b/test/mpi/f77/profile/profile1f.f
@@ -50,15 +50,7 @@ C     check that we used the profiling versions of the routines
           endif
        endif
 
-       call mpi_allreduce( MPI_IN_PLACE, toterrs, 1, MPI_INT, MPI_SUM,
-     $      MPI_COMM_WORLD, ierr )
-       if (wrank .eq. 0) then
-          if (toterrs .eq. 0) then
-             print *, " No Errors"
-          else
-             print *, " Found ", toterrs, " errors"
-          endif
-       endif
+       call mtest_finalize( toterrs )
 C
        end
 C


### PR DESCRIPTION
## Pull Request Description

Use mtest_finalize utility in Fortran profiling interface tests and
reduce duplicated/error-prone code. In this case, the test program
neglected to call MPI_Finalize, which could lead to errors in our
Jenkins tests.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
