### PR TITLE
test/mpi: Correct test name in xfail.conf

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -59,7 +59,7 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * * ch4:ofi * sed -i "s+\(^bcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
 * * * ch4:ofi * sed -i "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
-* * * ch4:ofi * sed -i "s+\(^large-acc-flush_local .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
 # xfail known failures of OFI build in fortran bindings
 * * * ch4:ofi * sed -i "s+\(^psendf .*\)+\1 xfail=issue3821+g" test/mpi/f77/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^prsendf .*\)+\1 xfail=issue3821+g" test/mpi/f77/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description

The test for large_acc_flush_local was mistakenly added with dashes
instead of underscores in the name, thus it was still run in Jenkins
tests.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
