### PR TITLE
datatypes: bugfix: update orig_block in segment_seek

### DIFF
--- a/src/mpi/datatype/typerep/dataloop/segment.c
+++ b/src/mpi/datatype/typerep/dataloop/segment.c
@@ -311,8 +311,10 @@ static void segment_seek(struct MPIR_Segment *segp, MPI_Aint position,
                     for (num_blocks = 0; num_blocks < cur_elmp->orig_count; num_blocks++) {
                         blocksize = STACKELM_INDEXED_BLOCKSIZE(cur_elmp, num_blocks);
 
-                        if (position - segp->stream_off < cur_elmp->loop_p->el_size * blocksize)
+                        if (position - segp->stream_off < cur_elmp->loop_p->el_size * blocksize) {
+                            cur_elmp->orig_block = blocksize;
                             break;
+                        }
 
                         segp->stream_off += cur_elmp->loop_p->el_size * blocksize;
                     }
@@ -367,8 +369,10 @@ static void segment_seek(struct MPIR_Segment *segp, MPI_Aint position,
                         blocksize = STACKELM_INDEXED_BLOCKSIZE(cur_elmp, num_blocks);
                         dloop = STACKELM_STRUCT_DATALOOP(cur_elmp, num_blocks);
 
-                        if (position - segp->stream_off < dloop->el_size * blocksize)
+                        if (position - segp->stream_off < dloop->el_size * blocksize) {
+                            cur_elmp->orig_block = blocksize;
                             break;
+                        }
 
                         segp->stream_off += cur_elmp->loop_p->el_size * blocksize;
                     }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -282,7 +282,7 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
     if (!rreq)
         goto fn_exit;
 
-    MPIDI_OFI_AMREQUEST(rreq, req_hdr) = NULL;
+    MPIDI_OFI_am_clear_request(rreq);
     mpi_errno = MPIDI_OFI_am_init_request(NULL, 0, rreq);
 
     if (mpi_errno != MPI_SUCCESS)

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -18,22 +18,40 @@ coll/bcast_comm_world_only::1 512 262144:timeLimit=360:10:16:1024
 cxx/attr/fkeyvaltypex::1::1:1024:
 cxx/datatype/packsizex::1::1:1024:
 pt2pt/pingping::1 512 262144::2:8:32
+pt2pt/pingping::17 1018 65530::2:8:32
 pt2pt/sendrecv1::1 512 262144::2:32:1024
+pt2pt/sendrecv1::17 1018 65530::2:32:1024
 pt2pt/sendself::1 512 262144::1:32:1024
+pt2pt/sendself::17 1018 65530::1:32:1024
 rma/accfence1::1 512 262144::4:16:1024
+rma/accfence1::17 1018 65530::4:16:1024
 rma/accpscw1::1 512 262144::4:16:1024
+rma/accpscw1::17 1018 65530::4:16:1024
 rma/epochtest::1 512 262144:timeLimit=300:4:16:1024
+rma/epochtest::17 1018 65530:timeLimit=300:4:16:1024
 rma/getfence1::1 512 262144::2:16:1024
+rma/getfence1::17 1018 65530::2:16:1024
 rma/getfence1::16000000:timeLimit=1800:2:4:
 rma/lock_contention_dt::1 512 262144:timeLimit=600:4:16:1024
+rma/lock_contention_dt::17 1018 65530:timeLimit=600:4:16:1024
 rma/lock_dt::1 512 262144::2:16:1024
+rma/lock_dt::17 1018 65530::2:16:1024
 rma/lock_dt_flush::1 512 262144::2:16:1024
+rma/lock_dt_flush::17 1018 65530::2:16:1024
 rma/lock_dt_flushlocal::1 512 262144::2:16:1024
+rma/lock_dt_flushlocal::17 1018 65530::2:16:1024
 rma/lockall_dt::1 512 262144::4:16:1024
+rma/lockall_dt::17 1018 65530::4:16:1024
 rma/lockall_dt_flush::1 512 262144::4:16:1024
+rma/lockall_dt_flush::17 1018 65530::4:16:1024
 rma/lockall_dt_flushall::1 512 262144::4:16:1024
+rma/lockall_dt_flushall::17 1018 65530::4:16:1024
 rma/lockall_dt_flushlocal::1 512 262144::4:16:1024
+rma/lockall_dt_flushlocal::17 1018 65530::4:16:1024
 rma/lockall_dt_flushlocalall::1 512 262144::4:16:1024
+rma/lockall_dt_flushlocalall::17 1018 65530::4:16:1024
 rma/putfence1::1 512 262144::2:16:1024
+rma/putfence1::17 1018 65530::2:16:1024
 rma/putfence1::16000000:timeLimit=1800:2:4:
 rma/putpscw1::1 512 262144::4:16:1024
+rma/putpscw1::17 1018 65530::4:16:1024

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -84,6 +84,7 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
 * * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 * * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
+* * am-only ch4:ofi * sed -i "s+\(^pingping .* arg=-sendcnt=65530 .*\)+\1 xfail=issue3886+g" test/mpi/pt2pt/testlist.dtp
 ################################################################################
 #ch3:ofi
 ofi * * ch3:ofi * sed -i  "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist


### PR DESCRIPTION
## Pull Request Description

With indexed datatype, each block have different size, so the stackelm's
seg_block need be updated as it advanced through the blocks.

This PR fixes issue #3830.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None.

## Known Issues

TODO: Add test to testsuite to cover this case.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Passes tests (included warning check)
