### PR TITLE
test/mpi: Fix MPI_Accumulate usage

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -59,7 +59,6 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * * ch4:ofi * sed -i "s+\(^bcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
 * * * ch4:ofi * sed -i "s+\(^ibcastlength .*\)+\1 xfail=ticket0+g" test/mpi/errors/coll/testlist
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
-* * * ch4:ofi * sed -i "s+\(^large-acc-flush_local .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 # xfail known failures of OFI build in fortran bindings
 * * * ch4:ofi * sed -i "s+\(^psendf .*\)+\1 xfail=issue3821+g" test/mpi/f77/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^prsendf .*\)+\1 xfail=issue3821+g" test/mpi/f77/pt2pt/testlist

--- a/test/mpi/rma/large_acc_flush_local.c
+++ b/test/mpi/rma/large_acc_flush_local.c
@@ -42,15 +42,15 @@ int main(int argc, char *argv[])
 
     for (j = 0; j < LOOP; j++) {
 
-        MPI_Win_create(tar_buf, MAX_DATA_SIZE, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win);
+        MPI_Win_create(tar_buf, MAX_DATA_SIZE, sizeof(int), MPI_INFO_NULL, MPI_COMM_WORLD, &win);
 
         MPI_Win_lock_all(0, win);
 
         if (rank != 0) {
             for (data_size = MIN_DATA_SIZE; data_size <= MAX_DATA_SIZE; data_size *= 2) {
                 for (i = 0; i < OPS_NUM; i++) {
-                    MPI_Accumulate(orig_buf, data_size, MPI_BYTE,
-                                   0, 0, data_size, MPI_BYTE, MPI_SUM, win);
+                    MPI_Accumulate(orig_buf, data_size / sizeof(int), MPI_INT,
+                                   0, 0, data_size / sizeof(int), MPI_INT, MPI_SUM, win);
                     MPI_Win_flush_local(0, win);
                 }
                 MPI_Win_flush(0, win);


### PR DESCRIPTION
## Pull Request Description

It is not allowed to use MPI_BYTE with arithmetic operations like
MPI_SUM. Change this test to use MPI_INT instead for correctness.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

This test is slow for ch4/ofi direct-nm builds. It may timeout in Jenkins until the related performance issue #3251 has been fixed.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
