### PR TITLE
test/mpi/fortran: Fix tests without mpi_finalize

### DIFF
--- a/test/mpi/f08/ext/c2f2cf90.f90
+++ b/test/mpi/f08/ext/c2f2cf90.f90
@@ -116,15 +116,7 @@
 !
 ! Summarize the errors
 !
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM, &
-      &     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+      call mtest_finalize( errs )
 
       end
 

--- a/test/mpi/f77/attr/commattr4f.f
+++ b/test/mpi/f77/attr/commattr4f.f
@@ -86,8 +86,6 @@ C
       call mpi_comm_free_keyval(key,
      $     ierr)
 
-      if (errs .eq. 0) then
-         print *, " No Errors"
-      end if
+      call mtest_finalize( errs )
 
       end

--- a/test/mpi/f77/ext/c2f2cf.f
+++ b/test/mpi/f77/ext/c2f2cf.f
@@ -106,15 +106,7 @@ C Test using a C routine to provide the Fortran handle
 C
 C Summarize the errors
 C
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,
-     $     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+      call mtest_finalize( errs )
 
       end
       

--- a/test/mpi/f77/io/c2f2ciof.f
+++ b/test/mpi/f77/io/c2f2ciof.f
@@ -45,15 +45,7 @@ C     name is temp, in comm world, no info provided
 C
 C Summarize the errors
 C
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,
-     $     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+      call mtest_finalize( errs )
 
       end
       

--- a/test/mpi/f77/rma/c2f2cwinf.f
+++ b/test/mpi/f77/rma/c2f2cwinf.f
@@ -38,15 +38,7 @@ C     displacement unit 1
 C
 C Summarize the errors
 C
-      call mpi_allreduce( errs, toterrs, 1, MPI_INTEGER, MPI_SUM,
-     $     MPI_COMM_WORLD, ierr )
-      if (wrank .eq. 0) then
-         if (toterrs .eq. 0) then
-            print *, ' No Errors'
-         else
-            print *, ' Found ', toterrs, ' errors'
-         endif
-      endif
+      call mtest_finalize( errs )
 
       end
       

--- a/test/mpi/f90/attr/fandcattrf90.f90
+++ b/test/mpi/f90/attr/fandcattrf90.f90
@@ -48,11 +48,7 @@
       call mpi_type_free_keyval( ctype2_keyval, ierr )
       call mpi_win_free_keyval( cwin2_keyval, ierr )
 
-      if (errs .eq. 0) then
-         print *, ' No Errors'
-      else
-         print *, ' Found ', errs, ' errors'
-      endif
+      call mtest_finalize( errs )
 
       end
 !

--- a/test/mpi/f90/misc/sizeof2.f90
+++ b/test/mpi/f90/misc/sizeof2.f90
@@ -52,10 +52,6 @@
              print *, "real array size is ", size2, " sizeof claims ", size1
           endif
 
-          if (errs .gt. 0) then
-             print *, ' Found ', errs, ' errors'
-          else
-             print *, ' No Errors'
-          endif
+          call mtest_finalize( errs )
           
         end program main

--- a/test/mpi/f90/timer/wtimef90.f90
+++ b/test/mpi/f90/timer/wtimef90.f90
@@ -24,8 +24,8 @@
 ! pass this test by mistake).
           if (time1 .lt. 0.0d0) then
              print *, ' Negative time result'
-          else
-                print *, ' No Errors'
+             err = 1
           endif
           
+          call mtest_finalize(err)
         end


### PR DESCRIPTION
## Pull Request Description

Several Fortran tests did not finalize MPI properly, leading to
occasional failures, particularly when testing PMIx client
integration. Fix tests to use either mtest_finalize or mpi_finalize
where appropriate.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
