### PR TITLE
test/mpi: Remove unneeded xfail

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -114,7 +114,6 @@ ofi * * ch3:ofi * sed -i  "s+\(^manyrma2_shm .*\)+\1 xfail=ticket0+g" test/mpi/r
 * intel * * * sed -i "s+\(^iwriteshf90 .*\)+\1 xfail=ticket0+g" test/mpi/f08/io/testlist
 * intel * * * sed -i "s+\(^writeshf90 .*\)+\1 xfail=ticket0+g" test/mpi/f08/io/testlist
 * intel * * * sed -i "s+\(^ring .*\)+\1 xfail=ticket0+g" test/mpi/f08/misc/testlist
-* intel * * * sed -i "s+\(^profile1f90 .*\)+\1 xfail=ticket0+g" test/mpi/f08/profile/testlist
 ################################################################################
 * * * * osx sed -i "s+\(^throwtest .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/errhan/testlist
 * * * * osx sed -i "s+\(^commerrx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/errhan/testlist


### PR DESCRIPTION
## Pull Request Description

This test was fixed in [b2728897c8d9], but I neglected to remove the
xfail for it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
