### PR TITLE
mpi/test: remove dtpools static library dependency

### DIFF
--- a/test/mpi/Makefile.mtest
+++ b/test/mpi/Makefile.mtest
@@ -20,7 +20,7 @@ LDADD = $(top_builddir)/util/mtest.$(OBJEXT) $(top_builddir)/util/mtest_common.$
 
 # Add libdtpools support
 AM_CPPFLAGS += -I$(top_srcdir)/dtpools/include
-LDADD += $(top_builddir)/dtpools/src/.libs/libdtpools.a
+LDADD += $(top_builddir)/dtpools/src/libdtpools.la
 
 $(top_builddir)/util/mtest.$(OBJEXT): $(top_srcdir)/util/mtest.c
 	(cd $(top_builddir)/util && $(MAKE) mtest.$(OBJEXT))
@@ -28,7 +28,7 @@ $(top_builddir)/util/mtest.$(OBJEXT): $(top_srcdir)/util/mtest.c
 $(top_builddir)/util/mtest_common.$(OBJEXT): $(top_srcdir)/util/mtest_common.c
 	(cd $(top_builddir)/util && $(MAKE) mtest_common.$(OBJEXT))
 
-$(top_builddir)/dtpools/src/.libs/libdtpools.a: $(top_srcdir)/dtpools/src/*.c
+$(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
 SUMMARY_BASENAME ?= summary

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1378,6 +1378,9 @@ if test "$enable_cxx" = yes ; then
 fi
 
 AC_LANG_C
+
+LT_INIT()
+
 # IO
 iodir="#"
 if test "$enable_romio" != no ; then

--- a/test/mpi/dtpools/src/Makefile.am
+++ b/test/mpi/dtpools/src/Makefile.am
@@ -6,7 +6,6 @@
 AM_CPPFLAGS = $(MPI_H_INCLUDE)
 AM_CPPFLAGS += -DDTP_MPI_DATATYPE=@DTP_DATATYPES@   # Coma separated list of MPI datatypes
 
-pkglib_LTLIBRARIES = libdtpools.la
+noinst_LTLIBRARIES = libdtpools.la
 libdtpools_la_SOURCES = dtpools.c dtpools_misc.c dtpools_init_verify.c dtpools_desc.c dtpools_attr.c
-libdtpools_la_LDFLAGS = -version-info 0:0:0
 libdtpools_la_CPPFLAGS = -I$(top_srcdir)/include -I../include $(AM_CPPFLAGS)


### PR DESCRIPTION
## Pull Request Description

Currently `make testing` fails if the library is configured with `--disable-static` as the test suite relies on `libdtpools.a` to compile the tests, see https://github.com/pmodels/mpich/issues/3844. The reason for using `libdtpools.a` explicitly instead of `-ldtpools` is that the test suite does not employee `libtool`, instead it compiles all the objects files and then places them into every single test. This PR fixes the issue by adding `libtool` support in the test suite, turning `dtpools` into a convenience library and linking it to tests using `libtool`.

## Expected Performance Changes
None

## Known Issues
None

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
