### PR TITLE
pmi/simple: Remove unused header

### DIFF
--- a/src/pmi/simple/simple_pmiutil.c
+++ b/src/pmi/simple/simple_pmiutil.c
@@ -32,9 +32,6 @@
 #include "pmi.h"
 #include "simple_pmiutil.h"
 
-/* Use the memory definitions from mpich/src/include */
-#include "mpir_mem.h"
-
 #define MAXVALLEN 1024
 #define MAXKEYLEN   32
 


### PR DESCRIPTION
## Pull Request Description

Simple PMI now uses MPL for memory allocation. Remove the old
mpir_mem.h header that used to provide this functionality.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
