### PR TITLE
bug: fix enable memory tracing and pmix together

### DIFF
--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -102,6 +102,18 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #define __func__ "__func__"
 #endif
 
+#ifdef USE_PMIX_API
+/* pmix.h contains inline functions that calls malloc, calloc, and free,
+   and it will break with MPL's memory tracing when enabled.
+   Make sure it is included *before* mpl.h.
+*/
+#include <pmix.h>
+#elif defined(USE_PMI2_API)
+#include <pmi2.h>
+#else
+#include <pmi.h>
+#endif
+
 /*****************************************************************************
  * We use the following ordering of information in this file:
  *

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -12,10 +12,6 @@
 #include "hwloc.h"
 #endif
 
-#ifdef USE_PMIX_API
-#include "pmix.h"
-#endif
-
 #ifdef HAVE_NETLOC
 #include "netloc_util.h"
 #endif

--- a/src/mpid/ch4/include/mpidimpl.h
+++ b/src/mpid/ch4/include/mpidimpl.h
@@ -18,14 +18,6 @@
 #include <assert.h>
 #endif
 
-#ifdef USE_PMIX_API
-#include <pmix.h>
-#elif defined(USE_PMI2_API)
-#include <pmi2.h>
-#else
-#include <pmi.h>
-#endif
-
 #define MPICH_SKIP_MPICXX
 #include "mpiimpl.h"
 

--- a/src/mpid/ch4/shm/src/shm_impl.c
+++ b/src/mpid/ch4/shm/src/shm_impl.c
@@ -4,11 +4,8 @@
  *      See COPYRIGHT in top-level directory.
  */
 
-#include "mpl.h"
-
-MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
-
 #include "posix_impl.h"
+MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 #ifndef SHM_INLINE
 #ifndef SHM_DISABLE_INLINES

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -7,7 +7,6 @@
 
 #include "mpidimpl.h"
 #include "mpidu_shm.h"
-#include "mpl.h"
 #include "mpidu_bc.h"
 
 static MPIDU_shm_seg_t memory;

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -83,7 +83,6 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
 }
 
 #ifdef USE_PMIX_API
-#include <pmix.h>
 
 #define VALLEN 1024
 #define KEYLEN 64
@@ -201,7 +200,6 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
 }
 
 #elif defined(USE_PMI2_API)
-#include <pmi2.h>
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
                           int roots_only, void **bc_table, size_t ** bc_indices)

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -6,14 +6,6 @@
 #include <mpidimpl.h>
 #include "mpl_shm.h"
 
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#elif defined(USE_PMIX_API)
-#include "pmix.h"
-#else
-#include "pmi.h"
-#endif
-
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -7,6 +7,14 @@
 #ifndef MPL_TRMEM_H_INCLUDED
 #define MPL_TRMEM_H_INCLUDED
 
+/* Sometime we have memory allocated from external library but requires
+ * us to free. Use MPL_external_free for these cases.
+*/
+MPL_STATIC_INLINE_PREFIX void MPL_external_free(void *buf)
+{
+    free(buf);
+}
+
 #if defined MPL_NEEDS_STRDUP_DECL && !defined strdup
 extern char *strdup(const char *);
 #endif /* MPL_NEEDS_STRDUP_DECL */

--- a/src/nameserv/pmi/pmi_nameserv.c
+++ b/src/nameserv/pmi/pmi_nameserv.c
@@ -10,13 +10,6 @@
 
 #include "mpiimpl.h"
 #include "namepub.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#elif defined(USE_PMIX_API)
-#include "pmix.h"
-#else
-#include "pmi.h"
-#endif
 
 /* style: allow:fprintf:1 sig:0 */
 /* For writing the name/service pair */

--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -435,7 +435,8 @@ static inline int MPIR_NODEMAP_build_nodemap(int sz,
             node = strtok(NULL, ",");
         }
         *out_max_node_id = node_id - 1;
-        MPL_free(nodelist);
+        /* PMIx latest adds pmix_free. We should switch to that at some point */
+        MPL_external_free(nodelist);
         PMIX_PROC_FREE(procs, nprocs);
     }
 #else /* USE_PMI2_API */

--- a/src/util/nodemap/build_nodemap.h
+++ b/src/util/nodemap/build_nodemap.h
@@ -8,13 +8,6 @@
 #define BUILD_NODEMAP_H_INCLUDED
 
 #include "mpl.h"
-#ifdef USE_PMIX_API
-#include "pmix.h"
-#elif defined(USE_PMI2_API)
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===


### PR DESCRIPTION
## Pull Request Description

This PR fixes issue #3832: build failure with `--enable-g=all --with-pmix=path/to/pmix --with-device=ch4:ofi`.

The problem was `pmix` header files, in particular `pmix_common.h` contains naked calls to memory functions such as `malloc`, `free`. Some of them are in inline functions; many of them are in macros. When memory tracing requires all memory functions be called through `MPL_xxx` wrappers. With `--enable-g=all` or `--enable-g=mem`, we raise errors for any naked call to memory functions.

This PR makes sure the `pmix` headers are included before `mpl.h`. This works with memory function inside inline functions as they are parsed in the order of occurrence. However, the macros are expanded at usage, therefore, will still raise error. Upstream (https://github.com/pmix/pmix/issues/1312) is fixing this by wrapping all memroy functions inside inline functions. The combination of this PR that upstream fix will fix the issue.

## Expected Performance Changes

Minimal.

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)

Fixes #3832 

* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
* [x] Passes tests (included warning check)
