### PR TITLE
threads: implement a scheduling point

### DIFF
--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -488,6 +488,8 @@ M*/
                 MPIDU_Thread_yield(&mutex, &err_);                          \
                 MPL_DBG_MSG(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_yield"); \
                 MPIR_Assert(err_ == 0);                                 \
+            } else {                                                    \
+                MPL_thread_schedule();                                  \
             }                                                           \
         }                                                               \
     } while (0)
@@ -561,8 +563,10 @@ M*/
         int saved_count_ = (mutex_ptr_)->count;                         \
         MPL_thread_id_t saved_owner_ = (mutex_ptr_)->owner;             \
         MPIR_Assert(saved_count_ > 0);                                  \
-        if (OPA_load_int(&(mutex_ptr_)->num_queued_threads) == 0)       \
+        if (OPA_load_int(&(mutex_ptr_)->num_queued_threads) == 0) {     \
+            MPL_thread_schedule();                                      \
             break;                                                      \
+        }                                                               \
         (mutex_ptr_)->count = 0;                                        \
         (mutex_ptr_)->owner = 0;                                        \
         MPIDU_Thread_mutex_unlock(mutex_ptr_, err_ptr_);                \

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -58,6 +58,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
  * ======================================================================*/
 
 #define MPL_thread_yield ABT_thread_yield
+#define MPL_thread_schedule ABT_thread_yield
 
 /* ======================================================================
  *    Mutexes

--- a/src/mpl/include/mpl_thread_posix.h
+++ b/src/mpl/include/mpl_thread_posix.h
@@ -54,6 +54,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
     } while (0)
 
 #define MPL_thread_yield MPL_sched_yield
+#define MPL_thread_schedule() do {} while (0)
 
 
 /*

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -48,6 +48,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
     } while (0)
 
 #define MPL_thread_yield thr_yield
+#define MPL_thread_schedule() do {} while (0)
 
 
 /*

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -43,6 +43,7 @@ void MPL_thread_exit(void);
 void MPL_thread_self(MPL_thread_id_t * id);
 void MPL_thread_same(MPL_thread_id_t * id1, MPL_thread_id_t * id2, int *same);
 void MPL_thread_yield();
+void MPL_thread_schedule(void);
 
 void MPL_thread_mutex_create(MPL_thread_mutex_t * mutex, int *err);
 void MPL_thread_mutex_destroy(MPL_thread_mutex_t * mutex, int *err);

--- a/src/mpl/src/thread/mpl_thread_win.c
+++ b/src/mpl/src/thread/mpl_thread_win.c
@@ -99,6 +99,8 @@ void MPL_thread_yield(void)
     Sleep(0);
 }
 
+void MPL_thread_schedule(void) { }
+
 /*
  *    Mutexes
  */


### PR DESCRIPTION
## Pull Request Description

Unlike OS-level threads, most user-level threads (ULTs, e.g., Argobots) are non-preemptive, so explicit yield is necessary to progress other threads. `MPIDU_Thread_yield` and `MPIDUI_THREAD_CS_YIELD_GLOBAL` contain `yield` int their names, but they do actually "yield" if mutexes are not contended. Even in that case, ULTs require explicit yield.

To address this, this PR adds a new function `MPL_thread_schedule`, which yields if a ULT library is used, and does nothing otherwise, and puts this function to these yield macros.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

This PR does not change the behavior if Argobots threads are not used. With Argobots, it is necessary for correctness.

## Known Issues

Nothing.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
