### PR TITLE
mpi/attr: Remove problematic error check

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -1677,3 +1677,29 @@ AC_DEFUN([PAC_CC_CHECK_TLS], [
         AC_DEFINE_UNQUOTED([TLS], [$pac_cv_tls], [Defined the keyword for thread-local storage.])
     fi
 ])
+
+dnl Test whether pointers can be aligned on a int boundary or require
+dnl a pointer boundary.
+AC_DEFUN([PAC_CHECK_PTR_ALIGN]), [
+    AC_MSG_CHECKING([for alignment restrictions on pointers])
+    AC_TRY_RUN(
+    changequote(<<,>>)
+    struct foo { int a; void *b; };
+    int main() {
+        int buf[10];
+        struct foo *p1;
+        p1=(struct foo*)&buf[0];
+        p1->b = (void *)0;
+        p1=(struct foo*)&buf[1];
+        p1->b = (void *)0;
+        return 0;
+    changequote([,])
+    },pac_cv_pointers_have_int_alignment=yes,pac_cv_pointers_have_int_alignment=no,pac_cv_pointers_have_int_alignment=unknown)
+
+    if test "$pac_cv_pointers_have_int_alignment" != "yes" ; then
+        AC_DEFINE(NEEDS_POINTER_ALIGNMENT_ADJUST,1,[define if pointers must be aligned on pointer boundaries])
+        AC_MSG_RESULT([pointer])
+    else
+        AC_MSG_RESULT([int or better])
+    fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -3032,30 +3032,6 @@ if test "$pac_cv_c_double_alignment_exception" = "four" ; then
    AC_DEFINE_UNQUOTED(HAVE_DOUBLE_ALIGNMENT_EXCEPTION,4,[Controls how alignment of doubles is performed, separate from other FP values])
 fi
 
-# Test whether pointers can be aligned on a int boundary or require
-# a pointer boundary.
-AC_MSG_CHECKING([for alignment restrictions on pointers])
-AC_TRY_RUN(
-changequote(<<,>>)
-struct foo { int a; void *b; };
-int main() {
-    int buf[10];
-    struct foo *p1;
-    p1=(struct foo*)&buf[0];
-    p1->b = (void *)0;
-    p1=(struct foo*)&buf[1];
-    p1->b = (void *)0;
-    return 0;
-changequote([,])
-},pac_cv_pointers_have_int_alignment=yes,pac_cv_pointers_have_int_alignment=no,pac_cv_pointers_have_int_alignment=unknown)
-
-if test "$pac_cv_pointers_have_int_alignment" != "yes" ; then
-   AC_DEFINE(NEEDS_POINTER_ALIGNMENT_ADJUST,1,[define if pointers must be aligned on pointer boundaries])
-   AC_MSG_RESULT([pointer])
-else
-   AC_MSG_RESULT([int or better])
-fi
-
 # Require strict alignment memory access for alignment-sensitive platform (e.g., SPARC)
 if test "$host_cpu" = "sparc" ; then
     AC_DEFINE(NEEDS_STRICT_ALIGNMENT,1,[Define if strict alignment memory access is required])

--- a/src/mpi/attr/attr_get.c
+++ b/src/mpi/attr/attr_get.c
@@ -86,15 +86,6 @@ int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag)
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_ERRTEST_COMM(comm, mpi_errno);
-#ifdef NEEDS_POINTER_ALIGNMENT_ADJUST
-            /* A common user error is to pass the address of a 4-byte
-             * int when the address of a pointer (or an address-sized int)
-             * should have been used.  We can test for this specific
-             * case.  Note that this code assumes sizeof(intptr_t) is
-             * a power of 2. */
-            MPIR_ERR_CHKANDJUMP((intptr_t) attribute_val & (sizeof(intptr_t) - 1),
-                                mpi_errno, MPI_ERR_ARG, "**attrnotptr");
-#endif
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/attr/comm_get_attr.c
+++ b/src/mpi/attr/comm_get_attr.c
@@ -54,16 +54,6 @@ int MPII_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val,
         {
             MPIR_ERRTEST_COMM(comm, mpi_errno);
             MPIR_ERRTEST_KEYVAL(comm_keyval, MPIR_COMM, "communicator", mpi_errno);
-#ifdef NEEDS_POINTER_ALIGNMENT_ADJUST
-            /* A common user error is to pass the address of a 4-byte
-             * int when the address of a pointer (or an address-sized int)
-             * should have been used.  We can test for this specific
-             * case.  Note that this code assumes sizeof(intptr_t) is
-             * a power of 2. */
-            if ((intptr_t) attribute_val & (sizeof(intptr_t) - 1)) {
-                MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**attrnotptr");
-            }
-#endif
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/attr/type_get_attr.c
+++ b/src/mpi/attr/type_get_attr.c
@@ -47,16 +47,6 @@ int MPII_Type_get_attr(MPI_Datatype datatype, int type_keyval, void *attribute_v
         {
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_KEYVAL(type_keyval, MPIR_DATATYPE, "datatype", mpi_errno);
-#ifdef NEEDS_POINTER_ALIGNMENT_ADJUST
-            /* A common user error is to pass the address of a 4-byte
-             * int when the address of a pointer (or an address-sized int)
-             * should have been used.  We can test for this specific
-             * case.  Note that this code assumes sizeof(intptr_t) is
-             * a power of 2. */
-            if ((intptr_t) attribute_val & (sizeof(intptr_t) - 1)) {
-                MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**attrnotptr");
-            }
-#endif
         }
         MPID_END_ERROR_CHECKS;
     }

--- a/src/mpi/attr/win_get_attr.c
+++ b/src/mpi/attr/win_get_attr.c
@@ -45,16 +45,6 @@ int MPII_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val,
         {
             MPIR_ERRTEST_WIN(win, mpi_errno);
             MPIR_ERRTEST_KEYVAL(win_keyval, MPIR_WIN, "window", mpi_errno);
-#ifdef NEEDS_POINTER_ALIGNMENT_ADJUST
-            /* A common user error is to pass the address of a 4-byte
-             * int when the address of a pointer (or an address-sized int)
-             * should have been used.  We can test for this specific
-             * case.  Note that this code assumes sizeof(intptr_t) is
-             * a power of 2. */
-            if ((intptr_t) attribute_val & (sizeof(intptr_t) - 1)) {
-                MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**attrnotptr");
-            }
-#endif
         }
         MPID_END_ERROR_CHECKS;
     }


### PR DESCRIPTION
## Pull Request Description

An attempt was made to catch users providing the wrong pointer type
when retrieving an attribute value. However, the check could cause
working codes to crash on platforms without strict alignment
requirements (e.g. x86_64). Remove this check, as it is not required.

Reported-by: Nick Radcliffe <nradclif@cray.com>

[EDIT] A second commit was added to remove the configure check for pointer alignment that is no longer in use.

[EDIT2] Updated description to describe the check as problematic rather than ineffective. The check does work if we assume users are writing safe/portable code.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
