### PR TITLE
test/mpi/threads: fix multithreaded tests with Argobots

### DIFF
--- a/test/mpi/threads/pt2pt/greq_test.c
+++ b/test/mpi/threads/pt2pt/greq_test.c
@@ -92,6 +92,7 @@ int main(int argc, char *argv[])
     flag = 0;
     while (!flag) {
         MPI_Test(&request, &flag, &status);
+        MTest_thread_yield();
     }
     MTest_Join_threads();
 
@@ -102,6 +103,7 @@ int main(int argc, char *argv[])
     outcount = 0;
     while (!outcount) {
         MPI_Testsome(1, &request, &outcount, indices, &status);
+        MTest_thread_yield();
     }
     MTest_Join_threads();
 
@@ -112,6 +114,7 @@ int main(int argc, char *argv[])
     flag = 0;
     while (!flag) {
         MPI_Testall(1, &request, &flag, &status);
+        MTest_thread_yield();
     }
     MTest_Join_threads();
 

--- a/test/mpi/threads/pt2pt/threaded_sr.c
+++ b/test/mpi/threads/pt2pt/threaded_sr.c
@@ -118,7 +118,8 @@ int main(int argc, char *argv[])
     }
 
     /* Loop until the send flag is set */
-    while (sendok == -1);
+    while (sendok == -1)
+        MTest_thread_yield();
     if (!sendok) {
         errs++;
     }


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

This PR solves an issue in /test/mpi/threads with Argobots.

This PR is related to #3861, but for the multithreaded testing. Non-preemptive threads (e.g., Argobots) need an explicit scheduling point to schedule other threads. Currently, some multithreading tests rely on busy-waits so they hang with Argobots. This patch fixes it by adding a scheduling point to the while loops.
Note that if preemptive threads (e.g., Pthreads) is used, a scheduling point is ignored so it does not affect the behavior of tests.

[EDIT] (2020/05/14) #4421 has fixed some part and this PR fixes the remaining tests (which may hang with certain numbers of execution streams).

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

No performance difference if non-Argobots threads are used. This change is necessary for Argobots.

## Known Issues

None.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
