### PR TITLE
mpi/coll: Add generic vertex type in gentran scheduler

### DIFF
--- a/src/mpi/coll/transports/gentran/tsp_gentran.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.h
@@ -27,6 +27,8 @@
 #undef MPIR_TSP_sched_selective_sink
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
+#undef MPIR_TSP_sched_new_type
+#undef MPIR_TSP_sched_generic
 #undef MPIR_TSP_sched_malloc
 #undef MPIR_TSP_sched_start
 #undef MPIR_TSP_sched_free
@@ -49,6 +51,8 @@
 #define MPIR_TSP_sched_selective_sink      MPII_Genutil_sched_selective_sink
 #define MPIR_TSP_sched_sink                MPII_Genutil_sched_sink
 #define MPIR_TSP_sched_fence               MPII_Genutil_sched_fence
+#define MPIR_TSP_sched_new_type            MPII_Genutil_sched_new_type
+#define MPIR_TSP_sched_generic             MPII_Genutil_sched_generic
 #define MPIR_TSP_sched_malloc              MPII_Genutil_sched_malloc
 #define MPIR_TSP_sched_start               MPII_Genutil_sched_start
 
@@ -57,6 +61,14 @@ extern int MPII_Genutil_progress_hook_id;
 
 /* Transport function to initialize a new schedule */
 int MPII_Genutil_sched_create(MPII_Genutil_sched_t * sched);
+
+int MPII_Genutil_sched_new_type(MPII_Genutil_sched_t * sched, MPII_Genutil_sched_issue_fn issue_fn,
+                                MPII_Genutil_sched_complete_fn complete_fn,
+                                MPII_Genutil_sched_free_fn free_fn);
+
+int MPII_Genutil_sched_generic(int type_id, void *data,
+                               MPII_Genutil_sched_t * sched, int n_in_vtcs, int *in_vtcs,
+                               int *vtx_id);
 
 /* Transport function to schedule a isend vertex */
 int MPII_Genutil_sched_isend(const void *buf,

--- a/src/mpi/coll/transports/gentran/tsp_gentran_types.h
+++ b/src/mpi/coll/transports/gentran/tsp_gentran_types.h
@@ -23,6 +23,7 @@ typedef enum {
     MPII_GENUTIL_VTX_KIND__SELECTIVE_SINK,
     MPII_GENUTIL_VTX_KIND__SINK,
     MPII_GENUTIL_VTX_KIND__FENCE,
+    MPII_GENUTIL_VTX_KIND__LAST,        /* marks the last built-in kind */
 } MPII_Genutil_vtx_kind_e;
 
 typedef enum {
@@ -95,6 +96,9 @@ typedef struct MPII_Genutil_vtx_t {
             MPI_Aint recvcount;
             MPI_Datatype recvtype;
         } localcopy;
+        struct {
+            void *data;
+        } generic;
     } u;
 
     struct MPII_Genutil_vtx_t *next;
@@ -112,8 +116,22 @@ typedef struct {
     /* issued vertices linked list */
     struct MPII_Genutil_vtx_t *issued_head;
     struct MPII_Genutil_vtx_t *issued_tail;
+
+    /* list of new type */
+    UT_array generic_types;
 } MPII_Genutil_sched_t;
 
 typedef MPII_Genutil_vtx_t vtx_t;
+
+typedef int (*MPII_Genutil_sched_issue_fn) (MPII_Genutil_vtx_t * vtxp, int *done);
+typedef int (*MPII_Genutil_sched_complete_fn) (MPII_Genutil_vtx_t * vtxp, int *is_completed);
+typedef int (*MPII_Genutil_sched_free_fn) (MPII_Genutil_vtx_t * vtxp);
+
+typedef struct {
+    int id;
+    MPII_Genutil_sched_issue_fn issue_fn;
+    MPII_Genutil_sched_complete_fn complete_fn;
+    MPII_Genutil_sched_free_fn free_fn;
+} MPII_Genutil_vtx_type_t;
 
 #endif /* TSP_GENTRAN_TYPES_H_INCLUDED */

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran.h
@@ -24,6 +24,8 @@
 #undef MPIR_TSP_sched_selective_sink
 #undef MPIR_TSP_sched_sink
 #undef MPIR_TSP_sched_fence
+#undef MPIR_TSP_sched_new_type
+#undef MPIR_TSP_sched_generic
 #undef MPIR_TSP_sched_malloc
 #undef MPIR_TSP_sched_start
 #undef MPIR_TSP_sched_free
@@ -46,10 +48,21 @@
 #define MPIR_TSP_sched_selective_sink       MPII_Stubutil_sched_selective_sink
 #define MPIR_TSP_sched_sink                 MPII_Stubutil_sched_sink
 #define MPIR_TSP_sched_fence                MPII_Stubutil_sched_fence
+#define MPIR_TSP_sched_new_type             MPII_Stubutil_sched_new_type
+#define MPIR_TSP_sched_generic              MPII_Stubutil_sched_generic
 #define MPIR_TSP_sched_malloc               MPII_Stubutil_sched_malloc
 #define MPIR_TSP_sched_start                MPII_Stubutil_sched_start
 
 int MPII_Stubutil_sched_create(MPII_Stubutil_sched_t * sched);
+void MPII_Stubutil_sched_free(MPII_Stubutil_sched_t * sched);
+int MPII_Stubutil_sched_new_type(MPII_Stubutil_sched_t * sched,
+                                 MPII_Stubutil_sched_issue_fn issue_fn,
+                                 MPII_Stubutil_sched_complete_fn complete_fn,
+                                 MPII_Stubutil_sched_free_fn free_fn);
+
+int MPII_Stubutil_sched_generic(int type_id, void *data,
+                                MPII_Stubutil_sched_t * sched, int n_in_vtcs, int *in_vtcs,
+                                int *vtx_id);
 int MPII_Stubutil_sched_isend(const void *buf, int count, MPI_Datatype dt, int dest, int tag,
                               MPIR_Comm * comm_ptr, MPII_Stubutil_sched_t * sched,
                               int n_invtcs, int *invtcs);

--- a/src/mpi/coll/transports/stubtran/tsp_stubtran_types.h
+++ b/src/mpi/coll/transports/stubtran/tsp_stubtran_types.h
@@ -16,4 +16,8 @@ typedef struct MPII_Stubutil_sched_t {
     int dummy;
 } MPII_Stubutil_sched_t;
 
+typedef int (*MPII_Stubutil_sched_issue_fn) (void *vtxp, int *done);
+typedef int (*MPII_Stubutil_sched_complete_fn) (void *vtxp, int *is_completed);
+typedef int (*MPII_Stubutil_sched_free_fn) (void *vtxp);
+
 #endif /* TSP_STUBTRAN_TYPES_H_INCLUDED */

--- a/src/mpl/include/utarray.h
+++ b/src/mpl/include/utarray.h
@@ -258,6 +258,7 @@ static const UT_icd ut_ptr_icd _UNUSED_ = { sizeof(void *), NULL, NULL, NULL };
 #define ut_int_array(a) ((int*)(a)->d)
 #define ut_str_array(a) ((char**)(a)->d)
 #define ut_ptr_array(a) ((void**)(a)->d)
+#define ut_type_array(a, type) ((type)(a)->d)
 
 
 #endif /* UTARRAY_H_INCLUDED */


### PR DESCRIPTION
Add Gentran API to register a generic vertex type, which enables composite schedulers.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
