### PR TITLE
coll: Bcast-based neighbor allgather for cartesian communicators

### DIFF
--- a/src/include/mpir_topo.h
+++ b/src/include/mpir_topo.h
@@ -56,6 +56,8 @@ struct MPIR_Topology {
         MPII_Cart_topology cart;
         MPII_Dist_graph_topology dist_graph;
     } topo;
+    MPIR_Comm **subcomms;
+    int num_subcomms;
 };
 
 int MPIR_Dims_create(int, int, int *);

--- a/src/mpi/coll/ineighbor_allgather/Makefile.mk
+++ b/src/mpi/coll/ineighbor_allgather/Makefile.mk
@@ -18,4 +18,5 @@ mpi_sources += \
 mpi_core_sources += \
     src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_linear.c			\
     src/mpi/coll/ineighbor_allgather/ineighbor_allgather_gentran_algos.c			\
-    src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_gentran_linear.c
+    src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_gentran_linear.c               \
+    src/mpi/coll/ineighbor_allgather/ineighbor_allgather_cart_bcast.c

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -22,6 +22,7 @@ cvars:
         auto            - Internal algorithm selection
         linear          - Force linear algorithm
         gentran_linear  - Force generic transport based linear algorithm
+        cart_bcast      - Force bcast-based algorithm for cartesian comms
 
     - name        : MPIR_CVAR_INEIGHBOR_ALLGATHER_INTER_ALGORITHM
       category    : COLLECTIVE
@@ -127,6 +128,12 @@ int MPIR_Ineighbor_allgather_sched_impl(const void *sendbuf, int sendcount, MPI_
                     MPIR_Ineighbor_allgather_sched_allcomm_linear(sendbuf, sendcount, sendtype,
                                                                   recvbuf, recvcount, recvtype,
                                                                   comm_ptr, s);
+                break;
+            case MPIR_CVAR_INEIGHBOR_ALLGATHER_INTRA_ALGORITHM_cart_bcast:
+                mpi_errno =
+                    MPIR_Ineighbor_allgather_sched_cart_bcast(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm_ptr, s);
                 break;
             case MPIR_CVAR_INEIGHBOR_ALLGATHER_INTRA_ALGORITHM_auto:
                 MPL_FALLTHROUGH;

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_cart_bcast.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_cart_bcast.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpiimpl.h"
+
+/*
+ * Broadcast-based neighbor allgather for cartesian communicators
+ *
+ */
+
+int MPIR_Ineighbor_allgather_sched_cart_bcast(const void *sendbuf, int sendcount,
+                                              MPI_Datatype sendtype, void *recvbuf,
+                                              int recvcount, MPI_Datatype recvtype,
+                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int indegree, outdegree, weighted;
+    int k, l;
+    int *srcs, *dsts;
+    MPI_Aint recvtype_extent;
+    MPIR_CHKLMEM_DECL(2);
+
+    MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
+
+    mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
+                                    indegree, srcs, MPI_UNWEIGHTED,
+                                    outdegree, dsts, MPI_UNWEIGHTED);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    MPIR_Topology *topo_ptr = MPIR_Topology_get(comm_ptr);
+    MPIR_Assert(topo_ptr->kind == MPI_CART);
+
+    for (k = 0; k < MPIR_Comm_size(comm_ptr); k++) {
+        if (topo_ptr->subcomms[k] && MPIR_Comm_rank(topo_ptr->subcomms[k]) == 0) {
+            MPIR_Ibcast_sched((void *) sendbuf, sendcount, sendtype, 0, topo_ptr->subcomms[k], s);
+        }
+    }
+    for (k = 0; k < indegree; k++) {
+        if (srcs[k] != MPI_PROC_NULL) {
+            char *rb = ((char *) recvbuf) + k * recvcount * recvtype_extent;
+            MPIR_Ibcast_sched(rb, recvcount, recvtype, 0, topo_ptr->subcomms[srcs[k]], s);
+        }
+    }
+
+    MPIR_SCHED_BARRIER(s);
+
+  fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -201,6 +201,13 @@ static int MPIR_Topology_delete_fn(MPI_Comm comm ATTRIBUTE((unused)),
     MPL_UNREFERENCED_ARG(extra_data);
 
     /* FIXME - free the attribute data structure */
+    if (topology->subcomms) {
+        for (int i = 0; i < topology->num_subcomms; i++) {
+            if (topology->subcomms[i])
+                MPIR_Comm_free_impl(topology->subcomms[i]);
+        }
+        MPL_free(topology->subcomms);
+    }
 
     if (topology->kind == MPI_CART) {
         MPL_free(topology->topo.cart.dims);


### PR DESCRIPTION
## Pull Request Description

Implement neighbor_allgather using broadcasts on subcommunicators created as MPI_Cart_create time. We intend to measure the performance of this strategy vs. the default linear send/recv implementation. The expectation is that for high-degree allgathers, the collective calls will be more efficient.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

TBD. None in default configuration.

## Known Issues

Only works for cartesian topologies at the moment.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
