### PR TITLE
configure: fix 'confcross' placement.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1626,7 +1626,7 @@ if test "$with_cross" != "no" ; then
 	rm -f confcross
 	(set) 2>&1 | grep CROSS_ | \
 	      sed -e 's/^/export /g' -e 's/=.*//g' > confcross
-	. confcross
+	. ./confcross
 	rm -f confcross
     fi
 fi


### PR DESCRIPTION
During cross compile export variables are source via 'confcross' file
which is located in the mpich root source directory. It's need to set
full path to file to be sourced where bash works in posix mode.

If './' wasn't set an error occur:
```
# MPICHLIB_CFLAGS="-march=skylake-avx512" MPICHLIB_CXXFLAGS="-march=skylake-avx512" LDFLAGS="-Wl,--disable-new-dtags" ./configure --with-pic --enable-shared AR="ar" RANLIB="ranlib" --enable-f77 --enable-fc --enable-cxx --enable-fast=all,nompit --host=x86_64-pc-linux-gnu --with-cross=/root/fort.types
. . .
. . .
. . .
Reading values from cross-compilation file /root/fort.types
./configure: line 40426: .: confcross: file not found
```