### PR TITLE
ch4/shm: free local rank cache in fastbox allocation if error occurs

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
@@ -48,14 +48,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     MPIDI_CH4_SHM_POSIX_FBOX_GENERAL = MPL_dbg_class_alloc("SHM_POSIX_FBOX", "shm_posix_fbox");
 #endif /* MPL_USE_DBG_LOGGING */
 
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL(4);
 
     MPIDI_POSIX_eager_fbox_control_global.num_seg = 1;
-    MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks =
-        MPL_malloc(sizeof(*MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks) *
-                   MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE + 1, MPL_MEM_SHM);
-    if (NULL == MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**nomem");
+    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks,
+                        int16_t *,
+                        sizeof(*MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks) *
+                        MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE + 1, mpi_errno,
+                        "fist_poll_local_ranks", MPL_MEM_SHM);
 
     /* -1 means we aren't looking for anything in particular. */
     for (i = 0; i < MPIR_CVAR_CH4_POSIX_EAGER_FBOX_POLL_CACHE_SIZE; i++) {


### PR DESCRIPTION
## Pull Request Description

The fastbox `first_poll_local_ranks` cache should be freed if an error
happens. This patch changes the allocation from using `MPL_malloc` to
`MPIR_CHKPMEM_MALLOC` which manages errors and redirects to appropriate
error handling, i.e., `MPIR_CHKPMEM_REAP`.
Fixes https://github.com/pmodels/mpich/issues/3891

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes
None

## Known Issues
None

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
