### PR TITLE
Move OpenPA codes to mpl/atomic [mpl/atomic part 1]

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -1703,3 +1703,17 @@ AC_DEFUN([PAC_CHECK_PTR_ALIGN]), [
         AC_MSG_RESULT([int or better])
     fi
 ])
+
+dnl PAC_ARG_ATOMIC_PRIMITIVES
+dnl  - Provide configure option to select atomic primitives. Defaults to auto.
+AC_DEFUN([PAC_ARG_ATOMIC_PRIMITIVES], [
+     AC_ARG_WITH([mpl-atomic-primitives],
+     [  --with-mpl-atomic-primitives=package  Atomic primitives to use. The following is include:
+        auto - Automatically choose the best one (default)
+        c11 - C11 atomics
+        gcc_atomic - GCC atomic builtins
+        gcc_sync - GCC sync builtins
+        win - Windows builtins
+        lock - Mutex-based synchronization
+        no|none - atomic operations are performed without synchronization
+     ],,with_mpl_atomic_primitives=auto)])

--- a/src/mpl/Makefile.am
+++ b/src/mpl/Makefile.am
@@ -21,6 +21,7 @@ strsep_LDADD = lib@MPLLIBNAME@.la
 
 mpl_headers =               \
     include/mpl.h           \
+    include/mpl_atomic.h    \
     include/mpl_base.h      \
     include/mpl_math.h      \
     include/mplconfig.h     \

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -786,6 +786,102 @@ fi
 #######################################################################
 
 #######################################################################
+## START OF ATOMIC CODE
+#######################################################################
+
+PAC_ARG_ATOMIC_PRIMITIVES
+
+AC_DEFUN([MPL_ATOMIC_TEST_PROGRAM], [AC_LANG_PROGRAM([[
+        #include "$1"
+    ]],[[
+        MPL_atomic_int_t a, b;
+        int c;
+
+        MPL_atomic_relaxed_store_int(&a, 0);
+        MPL_atomic_relaxed_store_int(&b, 1);
+        c = MPL_atomic_relaxed_load_int(&a);
+
+        MPL_atomic_release_store_int(&a, 0);
+        MPL_atomic_release_store_int(&b, 1);
+        c = MPL_atomic_acquire_load_int(&a);
+
+        MPL_atomic_fetch_add_int(&a, 10);
+        MPL_atomic_fetch_sub_int(&a, 10);
+
+        c = MPL_atomic_cas_int(&a, 10, 11);
+        c = MPL_atomic_swap_int(&a, 10);
+
+        MPL_atomic_write_barrier();
+        MPL_atomic_read_barrier();
+        MPL_atomic_read_write_barrier();
+    ]])]
+)
+
+dnl MPL_TRY_ATOMIC_HEADER([header file from src/ dir],
+dnl                       [HAVE_ macro suffix],[feature description])
+dnl Does an AC_LINK_IFELSE() to see if the header file works.
+AC_DEFUN([MPL_TRY_ATOMIC_HEADER],[
+    checked_specified_primitive=yes
+    AC_MSG_CHECKING([for support for $3])
+
+    PAC_PUSH_FLAG([CFLAGS])
+    CFLAGS="$CFLAGS -I${srcdir}/include"
+    AC_LINK_IFELSE([MPL_ATOMIC_TEST_PROGRAM([$1])],
+        [AC_DEFINE([HAVE_$2], [1], [Define to 1 if we have support for $3])]
+        [AC_MSG_RESULT([yes])]
+        [mpl_atomic_primitives_set=true]
+    ,
+        [AC_MSG_RESULT([no])]
+    )
+    PAC_POP_FLAG([CFLAGS])
+])
+
+AC_CHECK_SIZEOF([void *])
+
+mpl_atomic_primitives_set=false
+if test "$with_mpl_atomic_primitives" = "auto" \
+        -o "$with_mpl_atomic_primitives" = "gcc_sync"; then
+    MPL_TRY_ATOMIC_HEADER([mpl_atomic_gcc_sync.h], [GCC_INTRINSIC_SYNC],
+                          [gcc __sync intrinsics])
+fi
+if test "$with_mpl_atomic_primitives" = "auto" \
+        -o "$with_mpl_atomic_primitives" = "gcc_atomic"; then
+    MPL_TRY_ATOMIC_HEADER([mpl_atomic_gcc_atomic.h], [GCC_INTRINSIC_ATOMIC],
+                          [gcc __atomic intrinsics])
+fi
+if test "$with_mpl_atomic_primitives" = "auto" \
+        -o "$with_mpl_atomic_primitives" = "c11"; then
+    MPL_TRY_ATOMIC_HEADER([mpl_atomic_c11.h], [C11_ATOMICS],
+                          [C11 atomic intrinsics])
+fi
+if test "$with_mpl_atomic_primitives" = "auto" \
+        -o "$with_mpl_atomic_primitives" = "windows"; then
+    MPL_TRY_ATOMIC_HEADER([mpl_atomic_nt_intrinsics.h], [NT_INTRINSICS],
+                          [Windows NT atomic intrinsics])
+fi
+
+if test "$with_mpl_atomic_primitives" = "auto" \
+        -o "$with_mpl_atomic_primitives" = "lock" ; then
+    AC_DEFINE(USE_LOCK_BASED_PRIMITIVES, 1,
+             [Define to 1 if mutex-based synchronization is used])
+    mpl_atomic_primitives_set=true
+elif test "$with_mpl_atomic_primitives" = "no" \
+          -o "$with_mpl_atomic_primitives" = "none" ; then
+    AC_DEFINE(USE_NO_ATOMIC_PRIMITIVES, 1,
+             [Define to 1 if no atomic primitives are used])
+    mpl_atomic_primitives_set=true
+fi
+
+if test "$mpl_atomic_primitives_set" = "false"; then
+    AC_MSG_ERROR([cannot support atomic primitives (argument: \
+`--with-mpl-atomic-primitives=$with_mpl_atomic_primitives`)])
+fi
+
+#######################################################################
+## END OF ATOMIC CODE
+#######################################################################
+
+#######################################################################
 ## START OF DBG CODE
 #######################################################################
 

--- a/src/mpl/include/mpl.h
+++ b/src/mpl/include/mpl.h
@@ -12,6 +12,7 @@
 #include "mpl_valgrind.h"
 #include "mpl_argstr.h"
 #include "mpl_arg_serial.h"
+#include "mpl_atomic.h"
 #include "mpl_str.h"
 #include "mpl_trmem.h"
 #include "mpl_env.h"

--- a/src/mpl/include/mpl_atomic.h
+++ b/src/mpl/include/mpl_atomic.h
@@ -1,0 +1,105 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_H_INCLUDED
+#define MPL_ATOMIC_H_INCLUDED
+
+#include "mplconfig.h"
+#include <stdint.h>
+
+typedef struct MPL_atomic_int_t MPL_atomic_int_t;
+typedef struct MPL_atomic_int32_t MPL_atomic_int32_t;
+typedef struct MPL_atomic_uint32_t MPL_atomic_uint32_t;
+typedef struct MPL_atomic_int64_t MPL_atomic_int64_t;
+typedef struct MPL_atomic_uint64_t MPL_atomic_uint64_t;
+typedef struct MPL_atomic_ptr_t MPL_atomic_ptr_t;
+
+/* Forward declarations of atomic functions */
+/* MPL_atomic_relaxed_load */
+static int MPL_atomic_relaxed_load_int(const MPL_atomic_int_t * ptr);
+static int32_t MPL_atomic_relaxed_load_int32(const MPL_atomic_int32_t * ptr);
+static uint32_t MPL_atomic_relaxed_load_uint32(const MPL_atomic_uint32_t * ptr);
+static int64_t MPL_atomic_relaxed_load_int64(const MPL_atomic_int64_t * ptr);
+static uint64_t MPL_atomic_relaxed_load_uint64(const MPL_atomic_uint64_t * ptr);
+static void *MPL_atomic_relaxed_load_ptr(const MPL_atomic_ptr_t * ptr);
+/* MPL_atomic_acquire_load */
+static int MPL_atomic_acquire_load_int(const MPL_atomic_int_t * ptr);
+static int32_t MPL_atomic_acquire_load_int32(const MPL_atomic_int32_t * ptr);
+static uint32_t MPL_atomic_acquire_load_uint32(const MPL_atomic_uint32_t * ptr);
+static int64_t MPL_atomic_acquire_load_int64(const MPL_atomic_int64_t * ptr);
+static uint64_t MPL_atomic_acquire_load_uint64(const MPL_atomic_uint64_t * ptr);
+static void *MPL_atomic_acquire_load_ptr(const MPL_atomic_ptr_t * ptr);
+/* MPL_atomic_relaxed_store */
+static void MPL_atomic_relaxed_store_int(MPL_atomic_int_t * ptr, int val);
+static void MPL_atomic_relaxed_store_int32(MPL_atomic_int32_t * ptr, int32_t val);
+static void MPL_atomic_relaxed_store_uint32(MPL_atomic_uint32_t * ptr, uint32_t val);
+static void MPL_atomic_relaxed_store_int64(MPL_atomic_int64_t * ptr, int64_t val);
+static void MPL_atomic_relaxed_store_uint64(MPL_atomic_uint64_t * ptr, uint64_t val);
+static void MPL_atomic_relaxed_store_ptr(MPL_atomic_ptr_t * ptr, void *val);
+/* MPL_atomic_release_store */
+static void MPL_atomic_release_store_int(MPL_atomic_int_t * ptr, int val);
+
+static void MPL_atomic_release_store_int32(MPL_atomic_int32_t * ptr, int32_t val);
+static void MPL_atomic_release_store_uint32(MPL_atomic_uint32_t * ptr, uint32_t val);
+static void MPL_atomic_release_store_int64(MPL_atomic_int64_t * ptr, int64_t val);
+static void MPL_atomic_release_store_uint64(MPL_atomic_uint64_t * ptr, uint64_t val);
+static void MPL_atomic_release_store_ptr(MPL_atomic_ptr_t * ptr, void *val);
+/* MPL_atomic_swap */
+static int MPL_atomic_swap_int(MPL_atomic_int_t * ptr, int val);
+static int32_t MPL_atomic_swap_int32(MPL_atomic_int32_t * ptr, int32_t val);
+static uint32_t MPL_atomic_swap_uint32(MPL_atomic_uint32_t * ptr, uint32_t val);
+static int64_t MPL_atomic_swap_int64(MPL_atomic_int64_t * ptr, int64_t val);
+static uint64_t MPL_atomic_swap_uint64(MPL_atomic_uint64_t * ptr, uint64_t val);
+static void *MPL_atomic_swap_ptr(MPL_atomic_ptr_t * ptr, void *val);
+/* MPL_atomic_cas (compare-and-swap) */
+static int MPL_atomic_cas_int(MPL_atomic_int_t * ptr, int oldv, int newv);
+static int32_t MPL_atomic_cas_int32(MPL_atomic_int32_t * ptr, int32_t oldv, int32_t newv);
+static uint32_t MPL_atomic_cas_uint32(MPL_atomic_uint32_t * ptr, uint32_t oldv, uint32_t newv);
+static int64_t MPL_atomic_cas_int64(MPL_atomic_int64_t * ptr, int64_t oldv, int64_t newv);
+static uint64_t MPL_atomic_cas_uint64(MPL_atomic_uint64_t * ptr, uint64_t oldv, uint64_t newv);
+static void *MPL_atomic_cas_ptr(MPL_atomic_ptr_t * ptr, void *oldv, void *newv);
+/* MPL_atomic_fetch_add */
+static int MPL_atomic_fetch_add_int(MPL_atomic_int_t * ptr, int val);
+static int32_t MPL_atomic_fetch_add_int32(MPL_atomic_int32_t * ptr, int32_t val);
+static uint32_t MPL_atomic_fetch_add_uint32(MPL_atomic_uint32_t * ptr, uint32_t val);
+static int64_t MPL_atomic_fetch_add_int64(MPL_atomic_int64_t * ptr, int64_t val);
+static uint64_t MPL_atomic_fetch_add_uint64(MPL_atomic_uint64_t * ptr, uint64_t val);
+/* MPL_atomic_fetch_sub */
+static int MPL_atomic_fetch_sub_int(MPL_atomic_int_t * ptr, int val);
+static int32_t MPL_atomic_fetch_sub_int32(MPL_atomic_int32_t * ptr, int32_t val);
+static uint32_t MPL_atomic_fetch_sub_uint32(MPL_atomic_uint32_t * ptr, uint32_t val);
+static int64_t MPL_atomic_fetch_sub_int64(MPL_atomic_int64_t * ptr, int64_t val);
+static uint64_t MPL_atomic_fetch_sub_uint64(MPL_atomic_uint64_t * ptr, uint64_t val);
+
+/* MPL_atomic_barrier */
+static void MPL_atomic_write_barrier(void);
+static void MPL_atomic_read_barrier(void);
+static void MPL_atomic_read_write_barrier(void);
+static void MPL_atomic_compiler_barrier(void);
+
+#ifdef MPL_HAVE_PTHREAD_H
+#include <pthread.h>
+typedef pthread_mutex_t MPL_atomic_emulation_ipl_t;
+int MPL_atomic_interprocess_lock_init(MPL_atomic_emulation_ipl_t * shm_lock, int isLeader);
+#endif /* HAVE_PTHREAD_H */
+
+#if defined(MPL_USE_NO_ATOMIC_PRIMITIVES)
+#include "mpl_atomic_none.h"
+#elif defined(MPL_HAVE_C11_ATOMICS)
+#include "mpl_atomic_c11.h"
+#elif defined(MPL_HAVE_GCC_INTRINSIC_ATOMIC)
+#include "mpl_atomic_gcc_atomic.h"
+#elif defined(MPL_HAVE_GCC_INTRINSIC_SYNC)
+#include "mpl_atomic_gcc_sync.h"
+#elif defined(MPL_HAVE_NT_INTRINSICS)
+#include "mpl_atomic_nt_intrinsics.h"
+#elif defined(MPL_USE_LOCK_BASED_PRIMITIVES)
+#include "mpl_atomic_by_lock.h"
+#else
+#error no primitives implementation specified
+#endif
+
+#endif /* MPL_ATOMIC_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -1,0 +1,160 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_BY_LOCK_H_INCLUDED
+#define MPL_ATOMIC_BY_LOCK_H_INCLUDED
+
+#include <stdint.h>
+#include <assert.h>
+#include <pthread.h>
+
+/* defined in mpl_atomic.c */
+extern pthread_mutex_t *MPL_emulation_lock;
+
+#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()        \
+    do {                                        \
+        assert(MPL_emulation_lock);             \
+        pthread_mutex_lock(MPL_emulation_lock); \
+    } while (0)
+
+#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()             \
+    do {                                            \
+        assert(MPL_emulation_lock);                 \
+        pthread_mutex_unlock(MPL_emulation_lock);   \
+    } while (0)
+
+
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+    volatile TYPE v;                                                           \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    TYPE val;                                                                  \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    val = (TYPE)ptr->v;                                                        \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return val;                                                                \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    TYPE val;                                                                  \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    val = (TYPE)ptr->v;                                                        \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return val;                                                                \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    ptr->v = val;                                                              \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    ptr->v = val;                                                              \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+                                           TYPE oldv, TYPE newv)               \
+{                                                                              \
+    TYPE prev;                                                                 \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    prev = (TYPE)ptr->v;                                                       \
+    if (prev == oldv)                                                          \
+        ptr->v = newv;                                                         \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return prev;                                                               \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+                                            TYPE val)                          \
+{                                                                              \
+    TYPE prev;                                                                 \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    prev = (TYPE)ptr->v;                                                       \
+    ptr->v = val;                                                              \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return prev;                                                               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    TYPE prev;                                                                 \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    prev = (TYPE)ptr->v;                                                       \
+    ptr->v += val;                                                             \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return prev;                                                               \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    TYPE prev;                                                                 \
+    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    prev = (TYPE)ptr->v;                                                       \
+    ptr->v -= val;                                                             \
+    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    return prev;                                                               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+
+/* int */
+MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+/* int32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+/* uint32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+/* int64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+/* uint64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+/* void * */
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+
+/* lock/unlock provides barrier */
+static inline void MPL_atomic_write_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    ;
+}
+
+#endif /* MPL_ATOMIC_BY_LOCK_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -1,0 +1,118 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_C11_H_INCLUDED
+#define MPL_ATOMIC_C11_H_INCLUDED
+
+#include <stdint.h>
+#include <stdatomic.h>
+
+#if __STDC_VERSION__ >= 201710L
+// C17 obsoletes ATOMIC_VAR_INIT.
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#else
+#define MPL_ATOMIC_INITIALIZER(val_) { ATOMIC_VAR_INIT(val_) }
+#endif
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
+        MPL_ATOMIC_INITIALIZER((intptr_t)(val_))
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)        \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+    ATOMIC_TYPE v;                                                             \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return (TYPE)atomic_load_explicit(&ptr->v, memory_order_relaxed);          \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return (TYPE)atomic_load_explicit(&ptr->v, memory_order_acquire);          \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_relaxed);      \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_release);      \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+                                           TYPE oldv, TYPE newv)               \
+{                                                                              \
+    CAST_TYPE oldv_tmp = (CAST_TYPE)oldv;                                      \
+    atomic_compare_exchange_strong_explicit(&ptr->v, &oldv_tmp,                \
+                                            (CAST_TYPE)newv,                   \
+                                            memory_order_acq_rel,              \
+                                            memory_order_acquire);             \
+    return (TYPE)oldv_tmp;                                                     \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+                                            TYPE val)                          \
+{                                                                              \
+    return (TYPE)atomic_exchange_explicit(&ptr->v, (CAST_TYPE)val,             \
+                                          memory_order_acq_rel);               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)           \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return (TYPE)atomic_fetch_add_explicit(&ptr->v, (CAST_TYPE)val,            \
+                                           memory_order_acq_rel);              \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return (TYPE)atomic_fetch_sub_explicit(&ptr->v, (CAST_TYPE)val,            \
+                                           memory_order_acq_rel);              \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
+
+MPL_ATOMIC_DECL_FUNC_VAL(int, int, atomic_int, int)
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32, atomic_int_fast32_t, int_fast32_t)
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, atomic_uint_fast32_t, uint_fast32_t)
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64, atomic_int_fast64_t, int_fast64_t)
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, atomic_uint_fast64_t, uint_fast64_t)
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, atomic_intptr_t, intptr_t)
+
+static inline void MPL_atomic_write_barrier(void)
+{
+    atomic_thread_fence(memory_order_release);
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    atomic_thread_fence(memory_order_acquire);
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    atomic_thread_fence(memory_order_acq_rel);
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    /* atomic_signal_fence performs a compiler barrier without any overhead */
+    atomic_signal_fence(memory_order_acq_rel);
+}
+
+#endif /* MPL_ATOMIC_C11_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -1,0 +1,111 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_GCC_ATOMIC_H_INCLUDED
+#define MPL_ATOMIC_GCC_ATOMIC_H_INCLUDED
+
+#include <stdint.h>
+
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+     TYPE volatile v;                                                          \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);                         \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);                         \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);                          \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);                          \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+                                           TYPE oldv, TYPE newv)               \
+{                                                                              \
+    __atomic_compare_exchange_n(&ptr->v, &oldv, newv, 0, __ATOMIC_ACQ_REL,     \
+                                __ATOMIC_ACQUIRE);                             \
+    return oldv;                                                               \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+                                            TYPE val)                          \
+{                                                                              \
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_ACQ_REL);                \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return __atomic_fetch_add(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return __atomic_fetch_sub(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+
+/* int */
+MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+/* int32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+/* uint32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+/* int64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+/* uint64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+/* void * */
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+
+static inline void MPL_atomic_write_barrier(void)
+{
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    __atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    __atomic_thread_fence(__ATOMIC_ACQ_REL);
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    /* atomic_signal_fence performs a compiler barrier without any overhead */
+    __atomic_signal_fence(__ATOMIC_ACQ_REL);
+}
+
+#endif /* MPL_ATOMIC_GCC_ATOMIC_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -1,0 +1,125 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_GCC_SYNC_H_INCLUDED
+#define MPL_ATOMIC_GCC_SYNC_H_INCLUDED
+
+#include <stdint.h>
+
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+
+/* The following implementation assumes that loads/stores are atomic on the
+ * current platform, even though this may not be true at all. */
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+    TYPE volatile v;                                                           \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return ptr->v;                                                             \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    volatile int i = 0;                                                        \
+    TYPE val = ptr->v;                                                         \
+    __sync_lock_test_and_set(&i, 1); /* guarantees acquire semantics */        \
+    return val;                                                                \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    ptr->v = val;                                                              \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    volatile int i = 1;                                                        \
+    __sync_lock_release(&i); /* guarantees release semantics */                \
+    ptr->v = val;                                                              \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+                                           TYPE oldv, TYPE newv)               \
+{                                                                              \
+    return __sync_val_compare_and_swap(&ptr->v, oldv, newv,                    \
+                                       /* protected variables: */ &ptr->v);    \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+                                            TYPE val)                          \
+{                                                                              \
+    TYPE cmp;                                                                  \
+    TYPE prev = MPL_atomic_acquire_load_ ## NAME(ptr);                         \
+    do {                                                                       \
+        cmp = prev;                                                            \
+        prev = MPL_atomic_cas_ ## NAME(ptr, cmp, val);                         \
+    } while (cmp != prev);                                                     \
+    return prev;                                                               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return __sync_fetch_and_add(&ptr->v, val,                                  \
+                                /* protected variables: */ &ptr->v);           \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return __sync_fetch_and_sub(&ptr->v, val,                                  \
+                                /* protected variables: */ &ptr->v);           \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+
+/* int */
+MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+/* int32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+/* uint32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+/* int64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+/* uint64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+/* void * */
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+
+static inline void MPL_atomic_write_barrier(void)
+{
+    __sync_synchronize();
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    __sync_synchronize();
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    __sync_synchronize();
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    __asm__ __volatile__("":::"memory");
+}
+
+#endif /* MPL_ATOMIC_GCC_SYNC_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_none.h
+++ b/src/mpl/include/mpl_atomic_none.h
@@ -1,0 +1,121 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_NONE_H_INCLUDED
+#define MPL_ATOMIC_NONE_H_INCLUDED
+
+#include <stdint.h>
+
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+
+/* The following implementation assumes that loads/stores are atomic on the
+ * current platform, even though this may not be true at all. */
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+    TYPE v;                                                                    \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return ptr->v;                                                             \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return ptr->v;                                                             \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    ptr->v = val;                                                              \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    ptr->v = val;                                                              \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                       (MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
+{                                                                              \
+    TYPE prev = ptr->v;                                                        \
+    if (prev == oldv)                                                          \
+        ptr->v = newv;                                                         \
+    return prev;                                                               \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    TYPE prev = ptr->v;                                                        \
+    ptr->v = val;                                                              \
+    return prev;                                                               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    TYPE prev = ptr->v;                                                        \
+    ptr->v += val;                                                             \
+    return prev;                                                               \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    TYPE prev = ptr->v;                                                        \
+    ptr->v -= val;                                                             \
+    return prev;                                                               \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+
+/* int */
+MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+/* int32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+/* uint32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+/* int64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+/* uint64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+/* void * */
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+
+/* Null barriers */
+static inline void MPL_atomic_write_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    ;
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    ;
+}
+
+#endif /* MPL_ATOMIC_NONE_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_nt_intrinsics.h
+++ b/src/mpl/include/mpl_atomic_nt_intrinsics.h
@@ -1,0 +1,162 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPL_ATOMIC_NT_INTRINSICS_H_INCLUDED
+#define MPL_ATOMIC_NT_INTRINSICS_H_INCLUDED
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <intrin.h>
+
+#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#if MPL_SIZEOF_VOID_P == 4
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
+        MPL_ATOMIC_INITIALIZER((long)(val_))
+#elif MPL_SIZEOF_VOID_P == 8
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
+        MPL_ATOMIC_INITIALIZER((__int64)(val_))
+#else
+#error "MPL_SIZEOF_VOID_P not valid"
+#endif
+
+/*
+ * NOTE: the current implementations assumes the following:
+ * - _Interlocked builtins do not support int, uint32_t, uint64_t, and a void
+ *   pointer, so they are internally converted to long, long, __int64, and
+ *   long/__int64, respectively.
+ * - Any normal read and write satisfy the relaxed memory ordering.
+ * - Full memory barriers are used for acquire/release loads in a naive way.
+ * TODO: read-write barriers guarantees nothing about interthread memory
+ *       synchronization (see MSDN + _ReadWriteBarrier).  Use std::atomic.
+ * Someone with more Windows expertise should feel free to improve these.
+ */
+
+#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC, \
+                                    CAST_TO_ATOMIC, SUFFIX)                    \
+typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+    ATOMIC_TYPE volatile v;                                                    \
+} MPL_atomic_ ## NAME ## _t;                                                   \
+static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    return CAST_FROM_ATOMIC(ptr->v);                                           \
+}                                                                              \
+static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
+                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+{                                                                              \
+    TYPE val = CAST_FROM_ATOMIC(ptr->v);                                       \
+    _ReadWriteBarrier();                                                       \
+    return val;                                                                \
+}                                                                              \
+static inline void MPL_atomic_relaxed_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    ptr->v = CAST_TO_ATOMIC(val);                                              \
+}                                                                              \
+static inline void MPL_atomic_release_store_ ## NAME                           \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    _ReadWriteBarrier();                                                       \
+    ptr->v = CAST_TO_ATOMIC(val);                                              \
+}                                                                              \
+static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+                                           TYPE oldv, TYPE newv)               \
+{                                                                              \
+    return CAST_FROM_ATOMIC(_InterlockedCompareExchange ## SUFFIX              \
+                            ((ATOMIC_TYPE volatile *)&ptr->v,                  \
+                             CAST_TO_ATOMIC(newv), CAST_TO_ATOMIC(oldv)));     \
+}                                                                              \
+static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+                                            TYPE val)                          \
+{                                                                              \
+    return CAST_FROM_ATOMIC(_InterlockedExchange ## SUFFIX                     \
+                            ((ATOMIC_TYPE volatile *)&ptr->v,                  \
+                             CAST_TO_ATOMIC(val)));                            \
+}
+
+#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,    \
+                                 CAST_TO_ATOMIC, SUFFIX)                       \
+static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
+                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+{                                                                              \
+    return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
+                             (&ptr->v, CAST_TO_ATOMIC(val)));                  \
+}                                                                              \
+static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
+                                    (MPL_atomic_ ## NAME ## _t *ptr, TYPE val) \
+{                                                                              \
+    return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
+                             (&ptr->v, -CAST_TO_ATOMIC(val)));                 \
+}
+
+#define MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE)      (TYPE)
+#define MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE) (ATOMIC_TYPE)
+#define MPL_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE)      (TYPE)(LONG_PTR)
+#define MPL_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE) (ATOMIC_TYPE)(LONG_PTR)
+
+#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
+                                    MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
+                                    MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE),\
+                                    SUFFIX) \
+        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, \
+                                 MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
+                                 MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE), \
+                                 SUFFIX) \
+
+#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
+        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
+                                    MPL_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE), \
+                                    MPL_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE),\
+                                    SUFFIX)
+
+/* int */
+MPL_ATOMIC_DECL_FUNC_VAL(int, int, long, /*empty */)
+/* int32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32, long, /*empty */)
+/* uint32_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, long, /*empty */)
+/* int64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64, __int64, 64)
+/* uint64_t */
+MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, __int64, 64)
+/* void * */
+#if MPL_SIZEOF_VOID_P == 4
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, long, /* empty */)
+#elif MPL_SIZEOF_VOID_P == 8
+MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, __int64, 64)
+#else
+#error "MPL_SIZEOF_VOID_P not valid"
+#endif
+/* Barriers */
+static inline void MPL_atomic_write_barrier(void)
+{
+    _WriteBarrier();
+}
+
+static inline void MPL_atomic_read_barrier(void)
+{
+    _ReadBarrier();
+}
+
+static inline void MPL_atomic_read_write_barrier(void)
+{
+    _ReadWriteBarrier();
+}
+
+static inline void MPL_atomic_compiler_barrier(void)
+{
+    /* FIXME: there must be a more efficient way to implement this. */
+    _ReadWriteBarrier();
+}
+
+#endif /* MPL_ATOMIC_NT_INTRINSICS_H_INCLUDED */

--- a/src/mpl/src/Makefile.mk
+++ b/src/mpl/src/Makefile.mk
@@ -4,6 +4,7 @@
 #     See COPYRIGHT in top-level directory.
 #
 
+include src/atomic/Makefile.mk
 include src/bt/Makefile.mk
 include src/dbg/Makefile.mk
 include src/env/Makefile.mk

--- a/src/mpl/src/atomic/Makefile.mk
+++ b/src/mpl/src/atomic/Makefile.mk
@@ -1,0 +1,7 @@
+# -*- Mode: Makefile; -*-
+#
+# (C) 2019 by Argonne National Laboratory.
+#     See COPYRIGHT in top-level directory.
+#
+
+lib@MPLLIBNAME@_la_SOURCES += src/atomic/mpl_atomic.c

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -1,0 +1,36 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+/* FIXME For now we rely on pthreads for our IPC locks.  This is fairly
+ * portable, although it is obviously not 100% portable.  We need to figure out
+ * how to support other threading packages and lock implementations, such as the
+ * BG/P lockbox. */
+
+#ifdef MPL_HAVE_PTHREAD_H
+#include <pthread.h>
+#include "mpl_atomic.h"
+
+pthread_mutex_t *MPL_emulation_lock = NULL;
+
+int MPL_atomic_interprocess_lock_init(MPL_atomic_emulation_ipl_t * shm_lock, int isLeader)
+{
+    int mpi_errno = 0;          /*MPI_SUCCESS */
+    pthread_mutexattr_t attr;
+    MPL_emulation_lock = shm_lock;
+
+    if (isLeader) {
+        /* Set the mutex attributes to work correctly on inter-process
+         * shared memory as well. This is required for some compilers
+         * (such as SUN Studio) that don't enable it by default. */
+        if (pthread_mutexattr_init(&attr) ||
+            pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) ||
+            pthread_mutex_init(MPL_emulation_lock, &attr))
+            mpi_errno = 16;     /* MPI_ERR_INTERN */
+    }
+
+    return mpi_errno;
+}
+#endif /* MPL_HAVE_PTHREAD_H */


### PR DESCRIPTION
This PR is related to #3761.
This commit attempts to move the OpenPA's atomic codes to mpl/mpl_atomic.h.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
