### PR TITLE
init: Workaround Intel compiler TLS bug on macOS

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -248,6 +248,20 @@ static int thread_cs_init(void)
 
     MPID_THREADPRIV_KEY_CREATE;
 
+    {
+        /*
+         * Hack to workaround an Intel compiler bug on macOS. Touching
+         * MPIR_Per_thread in this file forces the compiler to allocate it as TLS.
+         * See https://github.com/pmodels/mpich/issues/3437.
+         */
+        MPIR_Per_thread_t *per_thread = NULL;
+
+        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
+                                     MPIR_Per_thread, per_thread, &err);
+        MPIR_Assert(err == 0);
+        memset(per_thread, 0, sizeof(MPIR_Per_thread_t));
+    }
+
     MPL_DBG_MSG(MPIR_DBG_INIT, TYPICAL, "Created global mutex and private storage");
     return MPI_SUCCESS;
 }


### PR DESCRIPTION
## Pull Request Description

Work around a bug in the Intel compiler on macOS that does not treat
MPIR_Per_thread as thread-local storage when it is
instantiated. References to MPIR_Per_thread in other files would then
conflict with the non-TLS version. See pmodels/mpich#3437 for more
details.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
