### PR TITLE
posix: lonely common symbol get lost during static linking

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/globals.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/globals.c
@@ -12,9 +12,10 @@
 #include "fbox_impl.h"
 #include "fbox_types.h"
 
-/* *INDENT-OFF* */
-MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global;
-/* *INDENT-ON* */
+/* Note: without the following initialiazation, the common symbol may get lost
+   during linking. This is manifested by static linking on mac osx.
+*/
+MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global = { 0 };
 
 #ifdef MPL_USE_DBG_LOGGING
 MPL_dbg_class MPIDI_CH4_SHM_POSIX_FBOX_GENERAL;


### PR DESCRIPTION
## Pull Request Description

src/mpid/ch4/shm/posix/eager/fbox/globals.c contains a single global variable definition (MPIDI_CH4_SHM_POSIX_FBOX_GENERAL). It compiles into a common symbol. Apparently, during static linking on mac, this lonely common symbol will get lost. By adding a zero initializer, turning it into an explicit bss symbol, seems to solve the issue.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)

Fixes #3908.

* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
