### PR TITLE
Heterogeneous Memory Integration for CH4 Fastboxes

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.h
@@ -28,18 +28,43 @@ cvars:
       description : >-
         The size of the array to store expected receives to speed up fastbox polling.
 
+    - name        : MPIR_CVAR_CH4_FBOX_MEM_BIND_TYPE
+      category    : CH4
+      type        : enum
+      default     : default
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : |-
+        Select target memory type for binding
+        default   - Default memory (DDR in most systems)
+        ddr       - Double data rate memory
+        hbm       - High-bandwidth memory
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-#define MPIDI_POSIX_MAILBOX_INDEX(sender, receiver) ((MPIDI_POSIX_global.num_local) * (sender) + (receiver))
-
 extern MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global;
+
+static void get_mem_type(MPIR_hwtopo_type_e * mem_type);
+static void get_proc_gids(MPIR_hwtopo_gid_t * proc_gids, bool * bind_is_valid);
+static int get_unique_gids(MPIR_hwtopo_gid_t * gids, int *num_unique_gids,
+                           MPIR_hwtopo_gid_t ** unique_gids);
+static void get_seg_len(MPIR_hwtopo_gid_t seg_gid, MPIR_hwtopo_gid_t * proc_gids, size_t * len);
+static void map_procs_to_seg(MPIR_hwtopo_gid_t seg_gid, MPIR_hwtopo_gid_t * proc_gids,
+                             MPIDI_POSIX_fastbox_t * seg_ptr, MPIDI_POSIX_fastbox_t ** ptr_table);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPIDI_POSIX_fastbox_t *fastboxes_p = NULL;
+    int num_seg;
+    bool bind_is_valid;
+    size_t len;
+    MPIR_hwtopo_gid_t *proc_gids;
+    MPIR_hwtopo_type_e mem_type;
+    MPIR_hwtopo_gid_t *seg_gids = NULL;
+    MPIDI_POSIX_fastbox_t **ptr_table = NULL;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_INIT);
@@ -48,7 +73,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     MPIDI_CH4_SHM_POSIX_FBOX_GENERAL = MPL_dbg_class_alloc("SHM_POSIX_FBOX", "shm_posix_fbox");
 #endif /* MPL_USE_DBG_LOGGING */
 
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL(4);
+    MPIR_CHKLMEM_DECL(3);
 
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks,
                         int16_t *,
@@ -65,15 +91,54 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
      * messages if all other entries in the cache are empty. */
     MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks[i] = 0;
 
-    /* Create region with one fastbox for every pair of local processes. */
-    size_t len =
-        MPIDI_POSIX_global.num_local * MPIDI_POSIX_global.num_local * sizeof(MPIDI_POSIX_fastbox_t);
+    /* Pointer table of processes region into segment(s) */
+    MPIR_CHKLMEM_MALLOC(ptr_table, MPIDI_POSIX_fastbox_t **,
+                        sizeof(*ptr_table) * MPIDI_POSIX_global.num_local, mpi_errno, "ptr_table",
+                        MPL_MEM_SHM);
 
-    /* Actually allocate the segment and assign regions to the pointers */
-    mpi_errno = MPIDU_Init_shm_alloc(len, &MPIDI_POSIX_eager_fbox_control_global.shm_ptr);
+    MPIR_CHKLMEM_MALLOC(proc_gids, MPIR_hwtopo_gid_t *,
+                        sizeof(MPIR_hwtopo_gid_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "proc_gids", MPL_MEM_OTHER);
+
+    get_mem_type(&mem_type);
+    proc_gids[MPIDI_POSIX_global.my_local_rank] = MPIR_hwtopo_get_obj_by_type(mem_type);
+
+    /* get memory type global ids for all processes in the node */
+    get_proc_gids(proc_gids, &bind_is_valid);
+
+    /* get unique proc_gids and assign separate shared memory
+     * segments to them */
+    mpi_errno = get_unique_gids(proc_gids, &num_seg, &seg_gids);
     MPIR_ERR_CHECK(mpi_errno);
 
-    fastboxes_p = (MPIDI_POSIX_fastbox_t *) MPIDI_POSIX_eager_fbox_control_global.shm_ptr;
+    MPIDI_POSIX_eager_fbox_control_global.num_seg = num_seg;
+
+    MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.shm_ptr, void **,
+                        sizeof(void *) * num_seg, mpi_errno, "shm_ptr", MPL_MEM_SHM);
+
+    /* We need to split the shared memory segment by the number of
+     * memory domains (num_seg) detected. The reason is that in Linux
+     * shared memory policies, unlike VMA policies, apply to the
+     * shared object instead of the VMA range. All processes that map
+     * shared memory into their address space inherit the policy from
+     * the shared object. Moreover, all the pages allocated to the
+     * shared object obey the shared policy. [Reference Linux Kernel
+     * documentation: `Documents/admin-guide/mm/numa_memory_policy.rst`] */
+    for (i = 0; i < num_seg; i++) {
+        get_seg_len(seg_gids[i], proc_gids, &len);
+
+        /* Allocate shared memory */
+        mpi_errno = MPIDU_Init_shm_alloc(len, &MPIDI_POSIX_eager_fbox_control_global.shm_ptr[i]);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        map_procs_to_seg(seg_gids[i], proc_gids,
+                         MPIDI_POSIX_eager_fbox_control_global.shm_ptr[i], ptr_table);
+
+        /* Bind shm to memory device */
+        if (MPIDI_POSIX_global.my_local_rank == 0 && bind_is_valid)
+            MPIR_hwtopo_mem_bind(MPIDI_POSIX_eager_fbox_control_global.shm_ptr[i],
+                                 len, seg_gids[i]);
+    }
 
     /* Allocate table of pointers to fastboxes */
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.mailboxes.in,
@@ -88,9 +153,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     /* Fill in fbox tables */
     for (i = 0; i < MPIDI_POSIX_global.num_local; i++) {
         MPIDI_POSIX_eager_fbox_control_global.mailboxes.in[i] =
-            &fastboxes_p[MPIDI_POSIX_MAILBOX_INDEX(i, MPIDI_POSIX_global.my_local_rank)];
+            ptr_table[MPIDI_POSIX_global.my_local_rank] + i;
         MPIDI_POSIX_eager_fbox_control_global.mailboxes.out[i] =
-            &fastboxes_p[MPIDI_POSIX_MAILBOX_INDEX(MPIDI_POSIX_global.my_local_rank, i)];
+            ptr_table[i] + MPIDI_POSIX_global.my_local_rank;
 
         memset(MPIDI_POSIX_eager_fbox_control_global.mailboxes.in[i], 0,
                sizeof(MPIDI_POSIX_fastbox_t));
@@ -102,6 +167,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_init(int rank, int size)
     MPIR_CHKPMEM_COMMIT();
 
   fn_exit:
+    MPL_free(seg_gids);
+    MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_EAGER_INIT);
     return mpi_errno;
   fn_fail:
@@ -122,7 +189,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_finalize()
     MPL_free(MPIDI_POSIX_eager_fbox_control_global.mailboxes.out);
     MPL_free(MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks);
 
-    mpi_errno = MPIDU_Init_shm_free(MPIDI_POSIX_eager_fbox_control_global.shm_ptr);
+    for (int i = 0; i < MPIDI_POSIX_eager_fbox_control_global.num_seg; i++)
+        mpi_errno = MPIDU_Init_shm_free(MPIDI_POSIX_eager_fbox_control_global.shm_ptr[i]);
+
+    MPL_free(MPIDI_POSIX_eager_fbox_control_global.shm_ptr);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_EAGER_FINALIZE);
@@ -130,5 +200,105 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_finalize()
   fn_fail:
     goto fn_exit;
 }
+
+static void get_mem_type(MPIR_hwtopo_type_e * mem_type)
+{
+    switch (MPIR_CVAR_CH4_FBOX_MEM_BIND_TYPE) {
+        case MPIR_CVAR_CH4_FBOX_MEM_BIND_TYPE_ddr:
+            *mem_type = MPIR_HWTOPO_TYPE__DDR;
+            break;
+        case MPIR_CVAR_CH4_FBOX_MEM_BIND_TYPE_hbm:
+            *mem_type = MPIR_HWTOPO_TYPE__HBM;
+            break;
+        default:       /* MPIR_CVAR_CH4_FBOX_MEM_BIND_TYPE_default */
+            *mem_type = MPIR_HWTOPO_TYPE__DDR;
+    }
+}
+
+static void get_proc_gids(MPIR_hwtopo_gid_t * proc_gids, bool * bind_is_valid)
+{
+    *bind_is_valid = true;
+    MPIDU_Init_shm_put(&proc_gids[MPIDI_POSIX_global.my_local_rank], sizeof(MPIR_hwtopo_gid_t));
+    MPIDU_Init_shm_barrier();
+    for (int i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        MPIDU_Init_shm_get(i, sizeof(MPIR_hwtopo_gid_t), &proc_gids[i]);
+        if (proc_gids[i] == MPIR_HWTOPO_GID_ROOT && *bind_is_valid) {
+            *bind_is_valid = false;
+        }
+    }
+    MPIDU_Init_shm_barrier();
+}
+
+static int compare_gid(const void *a, const void *b)
+{
+    return *(int *) a - *(int *) b;
+}
+
+static int get_unique_gids(MPIR_hwtopo_gid_t * gids, int *num_unique_gids,
+                           MPIR_hwtopo_gid_t ** unique_gids)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int count = 0;
+    int i, j;
+    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKPMEM_DECL(1);
+
+    /* Sort node global ids */
+    MPIR_hwtopo_gid_t *sorted_gids;
+    MPIR_CHKLMEM_MALLOC(sorted_gids, MPIR_hwtopo_gid_t *,
+                        sizeof(MPIR_hwtopo_gid_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "sorted_gids", MPL_MEM_OTHER);
+    memcpy(sorted_gids, gids, sizeof(MPIR_hwtopo_gid_t) * MPIDI_POSIX_global.num_local);
+
+    qsort(sorted_gids, MPIDI_POSIX_global.num_local, sizeof(MPIR_hwtopo_gid_t), compare_gid);
+
+    /* Count global ids */
+    MPIR_hwtopo_gid_t curr_gid = -1;
+    for (i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        if (curr_gid != sorted_gids[i]) {
+            count++;
+            curr_gid = sorted_gids[i];
+        }
+    }
+
+    /* Remove duplicates from sorted_gids */
+    MPIR_CHKPMEM_MALLOC(*unique_gids, MPIR_hwtopo_gid_t *,
+                        sizeof(MPIR_hwtopo_gid_t) * count, mpi_errno, "unique_gids", MPL_MEM_OTHER);
+    curr_gid = -1;
+    for (i = 0, j = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        if (curr_gid != sorted_gids[i]) {
+            curr_gid = sorted_gids[i];
+            (*unique_gids)[j++] = curr_gid;
+        }
+    }
+
+    MPIR_CHKPMEM_COMMIT();
+
+  fn_exit:
+    *num_unique_gids = count;
+    MPIR_CHKLMEM_FREEALL();
+    return mpi_errno;
+  fn_fail:
+    MPIR_CHKPMEM_REAP();
+    *unique_gids = NULL;
+    goto fn_exit;
+}
+
+static void get_seg_len(MPIR_hwtopo_gid_t seg_gid, MPIR_hwtopo_gid_t * proc_gids, size_t * len)
+{
+    *len = 0;
+    for (int i = 0; i < MPIDI_POSIX_global.num_local; i++)
+        if (seg_gid == proc_gids[i])
+            *len += (MPIDI_POSIX_global.num_local * sizeof(MPIDI_POSIX_fastbox_t));
+}
+
+static void map_procs_to_seg(MPIR_hwtopo_gid_t seg_gid, MPIR_hwtopo_gid_t * proc_gids,
+                             MPIDI_POSIX_fastbox_t * seg_ptr, MPIDI_POSIX_fastbox_t ** ptr_table)
+{
+    for (int i = 0, j = 0; i < MPIDI_POSIX_global.num_local; i++)
+        if (seg_gid == proc_gids[i])
+            ptr_table[i] = seg_ptr + MPIDI_POSIX_global.num_local * j++;
+}
+
 
 #endif /* POSIX_EAGER_FBOX_INIT_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
@@ -35,7 +35,8 @@ typedef struct MPIDI_POSIX_fbox_arrays {
 
 typedef struct MPIDI_POSIX_eager_fbox_control {
 
-    void *shm_ptr;
+    void **shm_ptr;
+    int num_seg;
 
     MPIDI_POSIX_fbox_arrays_t mailboxes;        /* The array of buffers that make up the total collection
                                                  * of mailboxes */

--- a/src/mpid/common/shm/mpidu_init_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_init_shm_alloc.c
@@ -32,14 +32,7 @@ typedef struct memory_list {
 static memory_list_t *memory_head = NULL;
 static memory_list_t *memory_tail = NULL;
 
-static int check_alloc(MPIDU_shm_seg_t * memory, int local_rank);
-
-typedef struct asym_check_region {
-    void *base_ptr;
-    OPA_int_t is_asym;
-} asym_check_region;
-
-static asym_check_region *asym_check_region_p = NULL;
+static int check_alloc(MPIDU_shm_seg_t * memory);
 
 /* MPIDU_Init_shm_alloc(len, ptr_p)
 
@@ -62,9 +55,6 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_ALLOC);
 
     MPIR_Assert(segment_len > 0);
-
-    /* allocate an area to check if the segment was allocated symmetrically */
-    segment_len += sizeof(asym_check_region);
 
     MPIR_CHKPMEM_MALLOC(memory, MPIDU_shm_seg_t *, sizeof(*memory), mpi_errno, "memory_handle",
                         MPL_MEM_OTHER);
@@ -131,9 +121,8 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
     /* assign sections of the shared memory segment to their pointers */
 
     *ptr = current_addr;
-    asym_check_region_p = (asym_check_region *) ((char *) current_addr + len);
 
-    mpi_errno = check_alloc(memory, local_rank);
+    mpi_errno = check_alloc(memory);
     MPIR_ERR_CHECK(mpi_errno);
 
     memory_node->ptr = *ptr;
@@ -209,31 +198,43 @@ int MPIDU_Init_shm_is_symm(void *ptr)
 /* check_alloc() checks to see whether the shared memory segment is
    allocated at the same virtual memory address at each process.
 */
-static int check_alloc(MPIDU_shm_seg_t * memory, int local_rank)
+static int check_alloc(MPIDU_shm_seg_t * memory)
 {
     int mpi_errno = MPI_SUCCESS;
+    int is_sym;
+    void *baseaddr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_SHM_CHECK_ALLOC);
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_SHM_CHECK_ALLOC);
 
     if (MPIR_Process.local_rank == 0) {
-        asym_check_region_p->base_ptr = memory->base_addr;
-        OPA_store_int(&asym_check_region_p->is_asym, 0);
+        MPIDU_Init_shm_put(memory->base_addr, sizeof(void *));
     }
 
     MPIDU_Init_shm_barrier();
 
-    if (asym_check_region_p->base_ptr != memory->base_addr)
-        OPA_store_int(&asym_check_region_p->is_asym, 1);
+    MPIDU_Init_shm_get(0, sizeof(void *), &baseaddr);
 
-    OPA_read_write_barrier();
+    if (baseaddr == memory->base_addr) {
+        is_sym = 1;
+        MPIDU_Init_shm_put(&is_sym, sizeof(int));
+    } else {
+        is_sym = 0;
+        MPIDU_Init_shm_put(&is_sym, sizeof(int));
+    }
 
     MPIDU_Init_shm_barrier();
 
-    if (OPA_load_int(&asym_check_region_p->is_asym)) {
-        memory->symmetrical = 0;
-    } else {
+    for (int i = 0; i < MPIR_Process.local_size; i++) {
+        MPIDU_Init_shm_get(i, sizeof(int), &is_sym);
+        if (is_sym == 0)
+            break;
+    }
+
+    if (is_sym) {
         memory->symmetrical = 1;
+    } else {
+        memory->symmetrical = 0;
     }
 
   fn_exit:

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -504,6 +504,7 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
         flags |= HWLOC_MEMBIND_BYNODESET;
     } else {
         fprintf(stderr, "%s: object type not valid, skipping memory binding\n", __func__);
+        hwloc_bitmap_free(bitmap);
         return MPI_ERR_OTHER;
     }
 


### PR DESCRIPTION
## Pull Request Description

This PR adds heterogeneous memory support and Numa-awareness for intranode pt2pt operations. This PR is based on the revamped hardware topology interface introduced by #4127. References issue https://github.com/pmodels/mpich/issues/3511. Replaces https://github.com/pmodels/mpich/pull/3200.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes
Improved bandwidth and message rate

## Known Issues
Currently only ch4/fastboxes are supported. Support for RMA (and collectives?) needs to be integrated next.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
