### PR TITLE
mpid: Remove unused tBsend interface

### DIFF
--- a/src/mpi/pt2pt/bsend.c
+++ b/src/mpi/pt2pt/bsend.c
@@ -149,16 +149,6 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
 
     /* ... body of routine ...  */
 
-#ifdef MPID_HAS_TBSEND
-    {
-        mpi_errno = MPID_tBsend(buf, count, datatype, dest, tag, comm_ptr, 0);
-        if (mpi_errno == MPI_SUCCESS) {
-            goto fn_exit;
-        }
-        /* FIXME: Check for MPID_WOULD_BLOCK? */
-    }
-#endif
-
     mpi_errno = MPIR_Bsend_isend(buf, count, datatype, dest, tag, comm_ptr, BSEND, &request_ptr);
     /* Note that we can ignore the request_ptr because it is handled internally
      * by the bsend util routines */

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -215,10 +215,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
     MPI_Aint packsize;
     int pass;
 
-    /* Find a free segment and copy the data into it.  If we could
-     * have, we would already have used tBsend to send the message with
-     * no copying.
-     *
+    /*
      * We may want to decide here whether we need to pack at all
      * or if we can just use (a MPIR_Memcpy) of the buffer.
      */

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -96,9 +96,6 @@ int MPIR_Ibsend_impl(const void *buf, int count, MPI_Datatype datatype, int dest
     MPIR_Request *request_ptr, *new_request_ptr;
     ibsend_req_info *ibinfo = 0;
 
-    /* We don't try tbsend in for MPI_Ibsend because we must create a
-     * request even if we can send the message */
-
     mpi_errno = MPIR_Bsend_isend(buf, count, datatype, dest, tag, comm_ptr, IBSEND, &request_ptr);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -582,9 +582,6 @@ int MPID_Ssend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int context_offset,
 		MPIR_Request **request );
 
-int MPID_tBsend( const void *buf, int count, MPI_Datatype datatype,
-		 int dest, int tag, MPIR_Comm *comm, int context_offset );
-
 int MPID_Isend( const void *buf, MPI_Aint count, MPI_Datatype datatype,
 		int dest, int tag, MPIR_Comm *comm, int context_offset,
 		MPIR_Request **request );


### PR DESCRIPTION
## Pull Request Description

According to an old comment, "this interface had the semantics of
MPI_Bsend, except that it returns the internal error code
MPID_WOULD_BLOCK if the message can''t be sent immediately (t is for
'try')." I cannot find an instance of this interface (or
MPID_WOULD_BLOCK) in pamid, ch3 or ch4, so just remove it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
