### PR TITLE
ch4/ofi: Remove dubious macro

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -406,7 +406,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
         uint64_t mr_key = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr));
         MPIDI_OFI_mr_key_free(mr_key);
     }
-    MPIDI_OFI_CALL_NOLOCK(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
+    MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr)->fid), mr_unreg);
     OPA_decr_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
 
     MPL_free(MPIDI_OFI_AMREQUEST_HDR(sreq, pack_buffer));

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -304,14 +304,13 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
                                  lmt_info->rma_key,
                                  0ULL, &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
     else
-        MPIDI_OFI_CALL_NOLOCK(fi_mr_reg(MPIDI_OFI_global.domain,
-                                        data,
-                                        data_sz,
-                                        FI_REMOTE_READ,
-                                        0ULL,
-                                        lmt_info->rma_key,
-                                        0ULL,
-                                        &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
+        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.domain,
+                                 data,
+                                 data_sz,
+                                 FI_REMOTE_READ,
+                                 0ULL,
+                                 lmt_info->rma_key,
+                                 0ULL, &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
     OPA_incr_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
 
     if (!MPIDI_OFI_ENABLE_MR_SCALABLE) {

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -304,7 +304,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_huge_event(struct fi_cq_tagged_entry
             uint64_t key = fi_mr_key(huge_send_mr);
             MPIDI_OFI_mr_key_free(key);
         }
-        MPIDI_OFI_CALL_NOLOCK(fi_close(&huge_send_mr->fid), mr_unreg);
+        MPIDI_OFI_CALL(fi_close(&huge_send_mr->fid), mr_unreg);
 
         if (MPIDI_OFI_REQUEST(sreq, noncontig.pack)) {
             MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack));

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -143,8 +143,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(struct fi_cq_tagged_entry *wc,
         mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, NULL, 0, NULL,
                                            MPIDI_OFI_REQUEST(rreq, util_comm->rank),
                                            MPIDI_OFI_comm_to_phys(c, r),
-                                           ss_bits, NULL, MPIDI_OFI_DO_INJECT,
-                                           MPIDI_OFI_CALL_NO_LOCK, FALSE);
+                                           ss_bits, NULL, MPIDI_OFI_DO_INJECT, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     }
@@ -395,7 +394,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry 
                                      MPIDI_OFI_recv_rbase(recv_elem) + recv_elem->cur_offset,   /* remote maddr */
                                      remote_key,        /* Key          */
                                      (void *) &recv_elem->context), rdma_readfrom,      /* Context */
-                             MPIDI_OFI_CALL_NO_LOCK, FALSE);
+                             FALSE);
         recv_elem->cur_offset += bytesToGet;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -88,9 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
                               fi_strerror(-_ret));          \
     } while (0)
 
-#define MPIDI_OFI_CALL_LOCK 1
-#define MPIDI_OFI_CALL_NO_LOCK 0
-#define MPIDI_OFI_CALL_RETRY(FUNC,STR,LOCK,EAGAIN)          \
+#define MPIDI_OFI_CALL_RETRY(FUNC,STR,EAGAIN)               \
     do {                                                    \
     ssize_t _ret;                                           \
     int _retry = MPIR_CVAR_CH4_OFI_MAX_EAGAIN_RETRY;        \
@@ -433,16 +431,16 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_OFI_context_to_request(void *contex
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_handler(struct fid_ep *ep, const void *buf, size_t len,
                                                     void *desc, uint32_t src, fi_addr_t dest_addr,
                                                     uint64_t tag, void *context, int is_inject,
-                                                    int do_lock, int do_eagain)
+                                                    int do_eagain)
 {
     int mpi_errno = MPI_SUCCESS;
 
     if (is_inject) {
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(ep, buf, len, src, dest_addr, tag), tinjectdata,
-                             do_lock, do_eagain);
+                             do_eagain);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(ep, buf, len, desc, src, dest_addr, tag, context),
-                             tsenddata, do_lock, do_eagain);
+                             tsenddata, do_eagain);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -121,31 +121,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
     } while (_ret == -FI_EAGAIN);                           \
     } while (0)
 
-#define MPIDI_OFI_CALL_RETRY2(FUNC1,FUNC2,STR)                       \
-    do {                                                    \
-    ssize_t _ret;                                           \
-    FUNC1;                                                  \
-    do {                                                    \
-        _ret = FUNC2;                                       \
-        if (likely(_ret==0)) break;                          \
-        MPIDI_OFI_ERR(_ret!=-FI_EAGAIN,             \
-                              mpi_errno,                    \
-                              MPI_ERR_OTHER,                \
-                              "**ofid_"#STR,                \
-                              "**ofid_"#STR" %s %d %s %s",  \
-                              __SHORT_FILE__,               \
-                              __LINE__,                     \
-                              __func__,                       \
-                              fi_strerror(-_ret));          \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
-        mpi_errno = MPIDI_OFI_retry_progress();                      \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);        \
-        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);\
-        if (mpi_errno != MPI_SUCCESS)                                \
-            MPIR_ERR_POP(mpi_errno);                                 \
-    } while (_ret == -FI_EAGAIN);                           \
-    } while (0)
-
 #define MPIDI_OFI_CALL_RETURN(FUNC, _ret)                               \
         do {                                                            \
             (_ret) = FUNC;                                              \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -74,20 +74,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
                               fi_strerror(-_ret));          \
     } while (0)
 
-#define MPIDI_OFI_CALL_NOLOCK(FUNC,STR)                              \
-    do {                                                    \
-        ssize_t _ret = FUNC;                                \
-        MPIDI_OFI_ERR(_ret<0,                       \
-                              mpi_errno,                    \
-                              MPI_ERR_OTHER,                \
-                              "**ofid_"#STR,                \
-                              "**ofid_"#STR" %s %d %s %s",  \
-                              __SHORT_FILE__,               \
-                              __LINE__,                     \
-                              __func__,                       \
-                              fi_strerror(-_ret));          \
-    } while (0)
-
 #define MPIDI_OFI_CALL_RETRY(FUNC,STR,EAGAIN)               \
     do {                                                    \
     ssize_t _ret;                                           \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -389,8 +389,7 @@ static int conn_manager_destroy()
                                                   NULL,
                                                   conn[j],
                                                   match_bits,
-                                                  mask_bits, &req[j].context),
-                                         trecv, MPIDI_OFI_CALL_LOCK, FALSE);
+                                                  mask_bits, &req[j].context), trecv, FALSE);
                     j++;
                     break;
                 default:
@@ -455,7 +454,7 @@ static int dynproc_send_disconnect(int conn_id)
         msg.data = 0;
         MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg,
                                          FI_COMPLETION | FI_TRANSMIT_COMPLETE | FI_REMOTE_CQ_DATA),
-                             tsendmsg, MPIDI_OFI_CALL_LOCK, FALSE);
+                             tsendmsg, FALSE);
         MPIDI_OFI_PROGRESS_WHILE(!req.done);
     }
 
@@ -961,8 +960,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
             MPIDI_OFI_global.am_msg[i].iov_count = 1;
             MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[0].rx,
                                             &MPIDI_OFI_global.am_msg[i],
-                                            FI_MULTI_RECV | FI_COMPLETION), prepost,
-                                 MPIDI_OFI_CALL_LOCK, FALSE);
+                                            FI_MULTI_RECV | FI_COMPLETION), prepost, FALSE);
         }
 
         /* Grow the header handlers down */

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -155,8 +155,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.data = 0;
     msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr);
 
-    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv,
-                         MPIDI_OFI_CALL_LOCK, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_RECV_IOV);
@@ -263,8 +262,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                       (MPI_ANY_SOURCE ==
                                        rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr),
                                       match_bits, mask_bits,
-                                      (void *) &(MPIDI_OFI_REQUEST(rreq, context))), trecv,
-                             MPIDI_OFI_CALL_LOCK, FALSE);
+                                      (void *) &(MPIDI_OFI_REQUEST(rreq, context))), trecv, FALSE);
     else {
         MPIDI_OFI_request_util_iov(rreq)->iov_base = recv_buf;
         MPIDI_OFI_request_util_iov(rreq)->iov_len = data_sz;
@@ -279,8 +277,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.data = 0;
         msg.addr = FI_ADDR_UNSPEC;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv,
-                             MPIDI_OFI_CALL_LOCK, FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[0].rx, &msg, flags), trecv, FALSE);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -423,16 +423,16 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
     }
 
     if (origin_contig && target_contig && (origin_bytes <= MPIDI_OFI_global.max_buffered_write)) {
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_win_cntr_incr(win),
-                              fi_inject_write(MPIDI_OFI_WIN(win).ep,
-                                              (char *) origin_addr + origin_true_lb, target_bytes,
-                                              MPIDI_OFI_av_to_phys(addr),
-                                              (uint64_t) MPIDI_OFI_winfo_base(win, target_rank)
-                                              + target_disp * MPIDI_OFI_winfo_disp_unit(win,
-                                                                                        target_rank)
-                                              + target_true_lb, MPIDI_OFI_winfo_mr_key(win,
-                                                                                       target_rank)),
-                              rdma_inject_write);
+        MPIDI_OFI_win_cntr_incr(win);
+        MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
+                                             (char *) origin_addr + origin_true_lb, target_bytes,
+                                             MPIDI_OFI_av_to_phys(addr),
+                                             (uint64_t) MPIDI_OFI_winfo_base(win, target_rank)
+                                             + target_disp * MPIDI_OFI_winfo_disp_unit(win,
+                                                                                       target_rank)
+                                             + target_true_lb, MPIDI_OFI_winfo_mr_key(win,
+                                                                                      target_rank)),
+                             rdma_inject_write, FALSE);
         goto null_op_exit;
     } else if (origin_contig && target_contig) {
         MPIDI_OFI_INIT_SIGNAL_REQUEST(win, sigreq, &flags);
@@ -450,8 +450,8 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         riov.addr = (uint64_t) (MPIDI_OFI_winfo_base(win, target_rank) + offset + target_true_lb);
         riov.len = target_bytes;
         riov.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), rdma_write);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), rdma_write, FALSE);
         goto fn_exit;
     }
 
@@ -506,8 +506,8 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         msg.iov_count = oout;
         msg.rma_iov = targetv;
         msg.rma_iov_count = tout;
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_writemsg(ep, &msg, flags), rdma_write);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_writemsg(ep, &msg, flags), rdma_write, FALSE);
 
         /* By default, progress is called only during fence, which significantly
          * slows down the RMA operations for large non-contiguous data. Adding manual
@@ -630,8 +630,8 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         riov.addr = (uint64_t) (MPIDI_OFI_winfo_base(win, target_rank) + offset + target_true_lb);
         riov.len = target_bytes;
         riov.key = MPIDI_OFI_winfo_mr_key(win, target_rank);
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), rdma_write);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), rdma_write, FALSE);
         goto fn_exit;
     }
 
@@ -684,8 +684,8 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         msg.iov_count = oout;
         msg.rma_iov = targetv;
         msg.rma_iov_count = tout;
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_readmsg(ep, &msg, flags), rdma_write);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_readmsg(ep, &msg, flags), rdma_write, FALSE);
 
         /* By default, progress is called only during fence, which significantly
          * slows down the RMA operations for large non-contiguous data. Adding manual
@@ -857,9 +857,10 @@ static inline int MPIDI_NM_mpi_compare_and_swap(const void *origin_addr,
     msg.data = 0;
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(&comparev);
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(&resultv);
-    MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_win_cntr_incr(win),
-                          fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
-                                               &comparev, NULL, 1, &resultv, NULL, 1, 0), atomicto);
+    MPIDI_OFI_win_cntr_incr(win);
+    MPIDI_OFI_CALL_RETRY(fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
+                                              &comparev, NULL, 1, &resultv, NULL, 1, 0), atomicto,
+                         FALSE);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_COMPARE_AND_SWAP);
     return mpi_errno;
@@ -986,8 +987,8 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.iov_count = oout;
         msg.rma_iov = targetv;
         msg.rma_iov_count = tout;
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_atomicmsg(ep, &msg, flags), rdma_atomicto);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_atomicmsg(ep, &msg, flags), rdma_atomicto, FALSE);
 
         /* By default, progress is called only during fence, which significantly
          * slows down the RMA operations for large non-contiguous data. Adding manual
@@ -1168,9 +1169,9 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         msg.rma_iov = targetv;
         msg.rma_iov_count = tout;
         MPIDI_OFI_ASSERT_IOVEC_ALIGN(resultv);
-        MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq),
-                              fi_fetch_atomicmsg(ep, &msg, resultv,
-                                                 NULL, rout, flags), rdma_readfrom);
+        MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
+        MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(ep, &msg, resultv,
+                                                NULL, rout, flags), rdma_readfrom, FALSE);
         /* By default, progress is called only during fence, which significantly
          * slows down the RMA operations for large non-contiguous data. Adding manual
          * progress helps improve the performance. */
@@ -1390,9 +1391,9 @@ static inline int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.context = NULL;
     msg.data = 0;
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(&resultv);
-    MPIDI_OFI_CALL_RETRY2(MPIDI_OFI_win_cntr_incr(win),
-                          fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
-                                             NULL, 1, 0), rdma_readfrom);
+    MPIDI_OFI_win_cntr_incr(win);
+    MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
+                                            NULL, 1, 0), rdma_readfrom, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_FETCH_AND_OP);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -29,8 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     mpi_errno =
         MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, src_rank,
                                MPIDI_OFI_av_to_phys(addr), match_bits,
-                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
-                               MPIDI_OFI_COMM(comm).eagain);
+                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_COMM(comm).eagain);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
   fn_exit:
@@ -58,8 +57,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
     mpi_errno =
         MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, src_rank,
                                MPIDI_OFI_av_to_phys(addr), match_bits,
-                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
-                               MPIDI_OFI_COMM(comm).eagain);
+                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_COMM(comm).eagain);
     /* If we set CC>0 in case of injection, we need to decrement the CC
      * to tell the main thread we completed the injection. */
     MPIDI_OFI_SEND_REQUEST_COMPLETE_LW_CONDITIONAL(*request);
@@ -207,8 +205,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.data = comm->rank;
     msg.addr = MPIDI_OFI_av_to_phys(addr);
 
-    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg, flags), tsendv,
-                         MPIDI_OFI_CALL_LOCK, FALSE);
+    MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[0].tx, &msg, flags), tsendv, FALSE);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_IOV);
@@ -264,8 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                       MPIDI_OFI_av_to_phys(addr),       /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
-                                      (void *) &(ackreq->context)), trecvsync, MPIDI_OFI_CALL_LOCK,
-                             FALSE);
+                                      (void *) &(ackreq->context)), trecvsync, FALSE);
     }
 
     send_buf = (char *) buf + dt_true_lb;
@@ -307,8 +303,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         mpi_errno =
             MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
                                    MPIDI_OFI_av_to_phys(addr),
-                                   match_bits, NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_CALL_LOCK,
-                                   FALSE);
+                                   match_bits, NULL, MPIDI_OFI_DO_INJECT, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
@@ -317,7 +312,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
                                    MPIDI_OFI_av_to_phys(addr),
                                    match_bits, (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
-                                   MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+                                   MPIDI_OFI_DO_SEND, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
     } else if (unlikely(1)) {
@@ -368,7 +363,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                            MPIDI_OFI_av_to_phys(addr),
                                            match_bits,
                                            (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
-                                           MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_NO_LOCK, FALSE);
+                                           MPIDI_OFI_DO_SEND, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
         ctrl.type = MPIDI_OFI_CTRL_HUGE;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -331,15 +331,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             rma_key = ctrl.rma_key;
         }
 
-        MPIDI_OFI_CALL_NOLOCK(fi_mr_reg(MPIDI_OFI_global.domain,        /* In:  Domain Object       */
-                                        send_buf,       /* In:  Lower memory address */
-                                        data_sz,        /* In:  Length              */
-                                        FI_REMOTE_READ, /* In:  Expose MR for read  */
-                                        0ULL,   /* In:  offset(not used)    */
-                                        rma_key,        /* In:  requested key       */
-                                        0ULL,   /* In:  flags               */
-                                        &huge_send_mr,  /* Out: memregion object    */
-                                        NULL), mr_reg); /* In:  context             */
+        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.domain,       /* In:  Domain Object       */
+                                 send_buf,      /* In:  Lower memory address */
+                                 data_sz,       /* In:  Length              */
+                                 FI_REMOTE_READ,        /* In:  Expose MR for read  */
+                                 0ULL,  /* In:  offset(not used)    */
+                                 rma_key,       /* In:  requested key       */
+                                 0ULL,  /* In:  flags               */
+                                 &huge_send_mr, /* Out: memregion object    */
+                                 NULL), mr_reg);        /* In:  context             */
 
         /* Create map to the memory region */
         MPIDIU_map_set(MPIDI_OFI_COMM(comm).huge_send_counters, sreq->handle, huge_send_mr,

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -285,9 +285,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
                                       &buf,
                                       sizeof(int),
                                       NULL,
-                                      *conn,
-                                      match_bits,
-                                      mask_bits, &req.context), trecv, MPIDI_OFI_CALL_LOCK, FALSE);
+                                      *conn, match_bits, mask_bits, &req.context), trecv, FALSE);
         time_gap = 0.0;
         MPID_Wtime(&time_sta);
         do {
@@ -324,8 +322,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
                                            comm_ptr->rank,
                                            *conn,
                                            match_bits,
-                                           (void *) &req.context,
-                                           MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+                                           (void *) &req.context, MPIDI_OFI_DO_SEND, FALSE);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -406,9 +403,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                       (*remote_size) * sizeof(size_t),
                                       NULL,
                                       FI_ADDR_UNSPEC,
-                                      match_bits,
-                                      mask_bits, &req[0].context), trecv, MPIDI_OFI_CALL_LOCK,
-                             FALSE);
+                                      match_bits, mask_bits, &req[0].context), trecv, FALSE);
         MPIDI_OFI_PROGRESS_WHILE(!req[0].done);
 
         for (i = 0; i < (*remote_size); i++)
@@ -421,18 +416,14 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                       remote_upid_recvsize,
                                       NULL,
                                       FI_ADDR_UNSPEC,
-                                      match_bits,
-                                      mask_bits, &req[1].context), trecv, MPIDI_OFI_CALL_LOCK,
-                             FALSE);
+                                      match_bits, mask_bits, &req[1].context), trecv, FALSE);
 
         MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[0].rx,
                                       *remote_node_ids,
                                       (*remote_size) * sizeof(int),
                                       NULL,
                                       FI_ADDR_UNSPEC,
-                                      match_bits,
-                                      mask_bits, &req[2].context), trecv, MPIDI_OFI_CALL_LOCK,
-                             FALSE);
+                                      match_bits, mask_bits, &req[2].context), trecv, FALSE);
 
         MPIDI_OFI_PROGRESS_WHILE(!req[1].done || !req[2].done);
         size_t disp = 0;
@@ -477,8 +468,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                            comm_ptr->rank,
                                            *conn,
                                            match_bits,
-                                           (void *) &req[0].context,
-                                           MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+                                           (void *) &req[0].context, MPIDI_OFI_DO_SEND, FALSE);
         if (mpi_errno) {
             MPL_free(local_upid_size);
             MPL_free(local_upids);
@@ -492,12 +482,10 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                NULL,
                                comm_ptr->rank,
                                *conn,
-                               match_bits,
-                               (void *) &req[1].context, MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK,
-                               FALSE);
+                               match_bits, (void *) &req[1].context, MPIDI_OFI_DO_SEND, FALSE);
         MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, local_node_ids, local_size * sizeof(int),
                                NULL, comm_ptr->rank, *conn, match_bits, (void *) &req[2].context,
-                               MPIDI_OFI_DO_SEND, MPIDI_OFI_CALL_LOCK, FALSE);
+                               MPIDI_OFI_DO_SEND, FALSE);
 
         MPIDI_OFI_PROGRESS_WHILE(!req[0].done || !req[1].done || !req[2].done);
 


### PR DESCRIPTION
## Pull Request Description

Cleaning up some dubious macro functions in ch4/ofi. RETRY and RETRY2 macros shared a lot of functionality, so I removed RETRY2.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
