### PR TITLE
ch4/ofi: Process completion events only after ensuring progress

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -47,6 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_mpi_acc_op_index(int op)
 }
 
 int MPIDI_OFI_progress(int vci, int blocking);
+int MPIDI_OFI_progress_test(int vci, int *ofi_ret_ptr);
 /*
  * Helper routines and macros for request completion
  */

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -15,15 +15,32 @@
 
 int MPIDI_OFI_progress(int vci, int blocking)
 {
-    int mpi_errno;
-    struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];
-    ssize_t ret;
+    int mpi_errno, ofi_ret;
+
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS);
 
-    if (unlikely(MPIDI_OFI_get_buffered(wc, 1)))
+    mpi_errno = MPIDI_OFI_progress_test(vci, &ofi_ret);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_PROGRESS);
+    return mpi_errno;
+}
+
+int MPIDI_OFI_progress_test(int vci, int *ofi_ret_ptr)
+{
+    int mpi_errno;
+    struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];
+    ssize_t ret;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PROGRESS_TEST);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PROGRESS_TEST);
+
+    if (unlikely(MPIDI_OFI_get_buffered(wc, 1))) {
         mpi_errno = MPIDI_OFI_handle_cq_entries(wc, 1);
-    else if (likely(1)) {
+        if (mpi_errno != MPI_SUCCESS)
+            ret = 0;
+        else
+            ret = 1;
+    } else if (likely(1)) {
         ret = fi_cq_read(MPIDI_OFI_global.ctx[vci].cq, (void *) wc, MPIDI_OFI_NUM_CQ_ENTRIES);
 
         if (likely(ret > 0))
@@ -34,7 +51,8 @@ int MPIDI_OFI_progress(int vci, int blocking)
             mpi_errno = MPIDI_OFI_handle_cq_error(vci, ret);
     }
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_PROGRESS);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_PROGRESS_TEST);
 
+    *(ofi_ret_ptr) = (int) ret;
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -24,23 +24,20 @@ static inline int MPIDI_OFI_win_progress_fence_impl(MPIR_Win * win, bool do_free
 {
     int mpi_errno = MPI_SUCCESS;
     int itercount = 0;
-    int ret;
-    uint64_t tcount, donecount;
+    int ret, max_ofi_progress;
+    uint64_t tcount, firstcount, donecount;
     MPIDI_OFI_win_request_t *r;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE_IMPL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_PROGRESS_FENCE_IMPL);
 
     tcount = *MPIDI_OFI_WIN(win).issued_cntr;
-    donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
+    firstcount = donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
 
     MPIR_Assert(donecount <= tcount);
 
     while (tcount > donecount) {
         MPIR_Assert(donecount <= tcount);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
-        MPIDI_OFI_PROGRESS();
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
         donecount = fi_cntr_read(MPIDI_OFI_WIN(win).cmpl_cntr);
         itercount++;
 
@@ -55,6 +52,23 @@ static inline int MPIDI_OFI_win_progress_fence_impl(MPIR_Win * win, bool do_free
             itercount = 0;
         }
     }
+
+    /* We need to poll the CQ to process any completion events corresponding
+     * to the progress made by reading the counter.
+     * Since we don't know what the value of the fi_cntr was before reading
+     * it, we might have made progress by reading it. Hence, we need to poll
+     * the CQ at least and then for `max_ofi_progress` times, if needed */
+    itercount = 0;
+    max_ofi_progress =
+        (tcount - firstcount + MPIDI_OFI_NUM_CQ_ENTRIES - 1) / MPIDI_OFI_NUM_CQ_ENTRIES;
+    do {
+        mpi_errno = MPIDI_OFI_progress_test(0, &ret);
+        if (mpi_errno != MPI_SUCCESS)
+            MPIR_ERR_POP(mpi_errno);
+        if (ret == -FI_EAGAIN)
+            break;
+        itercount++;
+    } while (itercount < max_ofi_progress);
 
     r = MPIDI_OFI_WIN(win).syncQ;
 


### PR DESCRIPTION
## Pull Request Description

Currently, the RMA progress engine performs both `fi_cntr_read` and `fi_cq_read` in each iteration. However, calling `fi_cq_read` before the `fi_cntr` has reached the desired value is wasteful since both the calls ensure progress of operations (although the OFI provider might implement network progress inside each function at different frequencies). Additionally, operations such as Put and Get do not have any completion events associated with them. Hence, calling `fi_cq_read` is wasteful for such operations too.

Additionally, there exists a potential bug: if the code path gets to `fi_cntr_wait`, `fi_cq_read` is not called to process any potential completion events.

This PR does the following:

1) Removes wasteful calls to `fi_cq_read` until the `fi_cntr` has reached the target value. Once the counter has reached the target value, the CQ is polled to process any completion events.

2) Introduces a new interface to read the output of `fi_cq_read`. If there are no completion events to be processed, we don't need to poll the CQ for the maximum possible number of times

3) Fixes the bug mentioned above.

## Expected Performance Changes
None.

## Known Issues
None.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
