### PR TITLE
ch4/ofi: Remove send_handler wrapper

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -136,7 +136,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
-    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE, TRUE);
+    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -158,7 +158,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR_REPLY);
 
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
-                                    am_hdr, am_hdr_sz, TRUE, TRUE);
+                                    am_hdr, am_hdr_sz, TRUE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -136,7 +136,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
-    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE, TRUE, TRUE);
+    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE, TRUE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -158,7 +158,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR_REPLY);
 
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
-                                    am_hdr, am_hdr_sz, TRUE, TRUE, FALSE);
+                                    am_hdr, am_hdr_sz, TRUE, TRUE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -35,8 +35,8 @@ static inline int MPIDI_NM_am_isend(int rank,
                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_SEND_AM);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_SEND_AM);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_AM_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_AM_ISEND);
     if (count)
         mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id,
                                           am_hdr, am_hdr_sz, data, count, datatype, sreq, FALSE);
@@ -44,7 +44,7 @@ static inline int MPIDI_NM_am_isend(int rank,
         mpi_errno = MPIDI_OFI_do_am_isend_header(rank, comm, handler_id,
                                                  am_hdr, am_hdr_sz, sreq, FALSE);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_SEND_AM);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND);
     return mpi_errno;
 }
 
@@ -60,8 +60,8 @@ static inline int MPIDI_NM_am_isendv(int rank,
     size_t am_hdr_sz = 0, i;
     char *am_hdr_buf;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_SEND_AMV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_SEND_AMV);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_ISENDV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_ISENDV);
 
     for (i = 0; i < iov_len; i++) {
         am_hdr_sz += am_hdr[i].iov_len;
@@ -91,7 +91,7 @@ static inline int MPIDI_NM_am_isendv(int rank,
     else
         MPIDIU_release_buf(am_hdr_buf);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_SEND_AMV);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_ISENDV);
     return mpi_errno;
 }
 
@@ -105,8 +105,8 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
                                           MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_SEND_AM_REPLY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_SEND_AM_REPLY);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_AM_ISEND_REPLY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_AM_ISEND_REPLY);
     if (count)
         mpi_errno = MPIDI_OFI_do_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id),
                                           handler_id, am_hdr, am_hdr_sz, data, count, datatype,
@@ -114,7 +114,7 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
     else
         mpi_errno = MPIDI_OFI_do_am_isend_header(src_rank, MPIDIG_context_id_to_comm(context_id),
                                                  handler_id, am_hdr, am_hdr_sz, sreq, TRUE);
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_SEND_AM_REPLY);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND_REPLY);
     return mpi_errno;
 }
 
@@ -134,15 +134,15 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
                                        int handler_id, const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
     mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -154,8 +154,8 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR_REPLY);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR_REPLY);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
 
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
                                     am_hdr, am_hdr_sz, TRUE);
@@ -164,7 +164,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_INJECT_AM_HDR);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -175,8 +175,8 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_send_long_ack_msg_t msg;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_MATCHED);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_MATCHED);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_RECV);
 
     msg.sreq_ptr = (MPIDIG_REQUEST(req, req->rreq.peer_req_ptr));
     msg.rreq_ptr = (uint64_t) req;
@@ -189,7 +189,7 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
         MPIR_ERR_POP(mpi_errno);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_MATCHED);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_OFI_AM_RECV);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -247,8 +247,7 @@ static inline int MPIDI_OFI_do_rdma_read(void *dst,
             .data = 0
         };
 
-        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[0].tx,
-                                           &msg, FI_COMPLETION), FALSE /* no lock */ , read);
+        MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[0].tx, &msg, FI_COMPLETION), read);
 
         done += curr_len;
         rem -= curr_len;
@@ -444,8 +443,7 @@ static inline int MPIDI_OFI_dispatch_ack(int rank, int context_id, uint64_t sreq
         = MPIDI_OFI_comm_to_phys(MPIR_Process.comm_world, MPIR_Process.comm_world->rank);
     msg.pyld.sreq_ptr = sreq_ptr;
     MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, &msg, sizeof(msg),
-                                      MPIDI_OFI_comm_to_phys(comm, rank)),
-                            FALSE /* no lock */ , inject);
+                                      MPIDI_OFI_comm_to_phys(comm, rank)), inject);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DISPATCH_ACK);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -494,8 +494,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
 static inline int MPIDI_OFI_do_inject(int rank,
                                       MPIR_Comm * comm,
                                       int handler_id,
-                                      const void *am_hdr,
-                                      size_t am_hdr_sz, int is_reply, int use_comm_table)
+                                      const void *am_hdr, size_t am_hdr_sz, int is_reply)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t msg_hdr;
@@ -520,7 +519,7 @@ static inline int MPIDI_OFI_do_inject(int rank,
 
     MPIR_Assert((uint64_t) comm->rank < (1ULL << MPIDI_OFI_AM_RANK_BITS));
 
-    addr = use_comm_table ? MPIDI_OFI_comm_to_phys(comm, rank) : MPIDI_OFI_to_phys(rank);
+    addr = MPIDI_OFI_comm_to_phys(comm, rank);
 
     if (unlikely(am_hdr_sz + sizeof(msg_hdr) > MPIDI_OFI_global.max_buffered_send)) {
         mpi_errno = MPIDI_OFI_do_emulated_inject(addr, &msg_hdr, am_hdr, am_hdr_sz);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -54,7 +54,7 @@ MPL_STATIC_INLINE_PREFIX uint16_t MPIDI_OFI_am_fetch_incr_send_seqno(MPIR_Comm *
     not grab the lock because the progress engine is already holding the lock.
     This is the case for reply functions such as am_isend_reply.
 */
-#define MPIDI_OFI_CALL_RETRY_AM(FUNC,LOCK,STR)                  \
+#define MPIDI_OFI_CALL_RETRY_AM(FUNC,STR)                               \
     do {                                                                \
         ssize_t _ret;                                                   \
         do {                                                            \
@@ -142,7 +142,7 @@ static inline int MPIDI_OFI_repost_buffer(void *buf, MPIR_Request * req)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_REPOST_BUFFER);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[0].rx,
                                        &MPIDI_OFI_global.am_msg[am->index],
-                                       FI_MULTI_RECV | FI_COMPLETION), FALSE /* lock */ , repost);
+                                       FI_MULTI_RECV | FI_COMPLETION), repost);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_REPOST_BUFFER);
     return mpi_errno;
@@ -242,7 +242,7 @@ static inline int MPIDI_OFI_do_am_isend_header(int rank,
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 2,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
-                                     &MPIDI_OFI_AMREQUEST(sreq, context)), !is_reply, sendv);
+                                     &MPIDI_OFI_AMREQUEST(sreq, context)), sendv);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_AM_ISEND_HEADER);
     return mpi_errno;
@@ -255,8 +255,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
                                           int handler_id,
                                           const void *am_hdr,
                                           size_t am_hdr_sz,
-                                          const void *data,
-                                          size_t data_sz, MPIR_Request * sreq, int need_lock)
+                                          const void *data, size_t data_sz, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -295,22 +294,13 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
     MPIR_cc_incr(sreq->cc_ptr, &c);     /* lmt ack handler */
     MPIR_Assert((sizeof(*msg_hdr) + sizeof(*lmt_info) + am_hdr_sz) <=
                 MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);
-    if (need_lock)
-        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.domain,
-                                 data,
-                                 data_sz,
-                                 FI_REMOTE_READ,
-                                 0ULL,
-                                 lmt_info->rma_key,
-                                 0ULL, &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
-    else
-        MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.domain,
-                                 data,
-                                 data_sz,
-                                 FI_REMOTE_READ,
-                                 0ULL,
-                                 lmt_info->rma_key,
-                                 0ULL, &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
+    MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.domain,
+                             data,
+                             data_sz,
+                             FI_REMOTE_READ,
+                             0ULL,
+                             lmt_info->rma_key,
+                             0ULL, &MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr), NULL), mr_reg);
     OPA_incr_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs);
 
     if (!MPIDI_OFI_ENABLE_MR_SCALABLE) {
@@ -332,7 +322,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 3,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
-                                     &MPIDI_OFI_AMREQUEST(sreq, context)), need_lock, sendv);
+                                     &MPIDI_OFI_AMREQUEST(sreq, context)), sendv);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_AM_ISEND_LONG);
     return mpi_errno;
@@ -345,8 +335,7 @@ static inline int MPIDI_OFI_am_isend_short(int rank,
                                            int handler_id,
                                            const void *am_hdr,
                                            size_t am_hdr_sz,
-                                           const void *data,
-                                           MPI_Count count, MPIR_Request * sreq, int need_lock)
+                                           const void *data, MPI_Count count, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -385,7 +374,7 @@ static inline int MPIDI_OFI_am_isend_short(int rank,
     MPIDI_OFI_ASSERT_IOVEC_ALIGN(iov);
     MPIDI_OFI_CALL_RETRY_AM(fi_sendv(MPIDI_OFI_global.ctx[0].tx, iov, NULL, 3,
                                      MPIDI_OFI_comm_to_phys(comm, rank),
-                                     &MPIDI_OFI_AMREQUEST(sreq, context)), need_lock, sendv);
+                                     &MPIDI_OFI_AMREQUEST(sreq, context)), sendv);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_AM_ISEND_SHORT);
     return mpi_errno;
@@ -407,7 +396,6 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
     size_t data_sz;
     MPI_Aint dt_true_lb, last;
     MPIR_Datatype *dt_ptr;
-    int need_lock = !is_reply;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_AM_ISEND);
@@ -457,11 +445,11 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
     if (am_hdr_sz + data_sz + sizeof(MPIDI_OFI_am_header_t) <= MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE) {
         mpi_errno =
             MPIDI_OFI_am_isend_short(rank, comm, handler_id, MPIDI_OFI_AMREQUEST_HDR(sreq, am_hdr),
-                                     am_hdr_sz, send_buf, data_sz, sreq, need_lock);
+                                     am_hdr_sz, send_buf, data_sz, sreq);
     } else {
         mpi_errno =
             MPIDI_OFI_am_isend_long(rank, comm, handler_id, MPIDI_OFI_AMREQUEST_HDR(sreq, am_hdr),
-                                    am_hdr_sz, send_buf, data_sz, sreq, need_lock);
+                                    am_hdr_sz, send_buf, data_sz, sreq);
     }
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
@@ -475,8 +463,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
                                                           const MPIDI_OFI_am_header_t * msg_hdrp,
-                                                          const void *am_hdr,
-                                                          size_t am_hdr_sz, int need_lock)
+                                                          const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
@@ -497,7 +484,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
 
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[0].tx, ibuf, len,
                                     NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),
-                            need_lock, send);
+                            send);
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -508,8 +495,7 @@ static inline int MPIDI_OFI_do_inject(int rank,
                                       MPIR_Comm * comm,
                                       int handler_id,
                                       const void *am_hdr,
-                                      size_t am_hdr_sz,
-                                      int is_reply, int use_comm_table, int need_lock)
+                                      size_t am_hdr_sz, int is_reply, int use_comm_table)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t msg_hdr;
@@ -537,7 +523,7 @@ static inline int MPIDI_OFI_do_inject(int rank,
     addr = use_comm_table ? MPIDI_OFI_comm_to_phys(comm, rank) : MPIDI_OFI_to_phys(rank);
 
     if (unlikely(am_hdr_sz + sizeof(msg_hdr) > MPIDI_OFI_global.max_buffered_send)) {
-        mpi_errno = MPIDI_OFI_do_emulated_inject(addr, &msg_hdr, am_hdr, am_hdr_sz, need_lock);
+        mpi_errno = MPIDI_OFI_do_emulated_inject(addr, &msg_hdr, am_hdr, am_hdr_sz);
         goto fn_exit;
     }
 
@@ -546,8 +532,7 @@ static inline int MPIDI_OFI_do_inject(int rank,
     memcpy(buff, &msg_hdr, sizeof(msg_hdr));
     memcpy(buff + sizeof(msg_hdr), am_hdr, am_hdr_sz);
 
-    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, buff, buff_len, addr),
-                            need_lock, inject);
+    MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[0].tx, buff, buff_len, addr), inject);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -16,9 +16,7 @@
 static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
                                             char *send_buf,
                                             size_t msgsize,
-                                            int rank,
-                                            MPIR_Comm * comm_ptr,
-                                            MPIR_Request * ackreq, int need_lock)
+                                            int rank, MPIR_Comm * comm_ptr, MPIR_Request * ackreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
@@ -33,7 +31,7 @@ static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
 
     mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                    (void *) control, sizeof(*control), FALSE, TRUE, need_lock);
+                                    (void *) control, sizeof(*control), FALSE, TRUE);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -31,7 +31,7 @@ static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
 
     mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                    (void *) control, sizeof(*control), FALSE, TRUE);
+                                    (void *) control, sizeof(*control), FALSE);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -375,7 +375,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
             ctrl.type = MPIDI_OFI_CTRL_HUGEACK;
             MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_do_control_send
                                    (&ctrl, NULL, 0, recv_elem->remote_info.origin_rank,
-                                    recv_elem->comm_ptr, recv_elem->remote_info.ackreq, FALSE));
+                                    recv_elem->comm_ptr, recv_elem->remote_info.ackreq));
 
             MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters, key_to_erase);
             MPL_free(recv_elem);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -146,12 +146,11 @@ static int recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq, int ev
                                                   MPIDI_OFI_SYNC_SEND_ACK);
         MPIR_Comm *c = MPIDI_OFI_REQUEST(rreq, util_comm);
         int r = rreq->status.MPI_SOURCE;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, NULL, 0, NULL,
-                                           MPIDI_OFI_REQUEST(rreq, util_comm->rank),
-                                           MPIDI_OFI_comm_to_phys(c, r),
-                                           ss_bits, NULL, MPIDI_OFI_DO_INJECT, FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx, NULL /* buf */ ,
+                                            0 /* len */ ,
+                                            MPIDI_OFI_REQUEST(rreq, util_comm->rank),
+                                            MPIDI_OFI_comm_to_phys(c, r),
+                                            ss_bits), tinjectdata, FALSE /* eagain */);
     }
 
     MPIDIU_request_complete(rreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -390,27 +390,6 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDI_OFI_context_to_request(void *contex
     return (MPIR_Request *) MPL_container_of(base, MPIR_Request, dev.ch4.netmod);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_handler(struct fid_ep *ep, const void *buf, size_t len,
-                                                    void *desc, uint32_t src, fi_addr_t dest_addr,
-                                                    uint64_t tag, void *context, int is_inject,
-                                                    int do_eagain)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    if (is_inject) {
-        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(ep, buf, len, src, dest_addr, tag), tinjectdata,
-                             do_eagain);
-    } else {
-        MPIDI_OFI_CALL_RETRY(fi_tsenddata(ep, buf, len, desc, src, dest_addr, tag, context),
-                             tsenddata, do_eagain);
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 struct MPIDI_OFI_contig_blocks_params {
     size_t max_pipe;
     MPI_Aint count;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -26,12 +26,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
-    mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, src_rank,
-                               MPIDI_OFI_av_to_phys(addr), match_bits,
-                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_COMM(comm).eagain);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
+    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx,
+                                        buf,
+                                        data_sz,
+                                        src_rank,
+                                        MPIDI_OFI_av_to_phys(addr),
+                                        match_bits), tinjectdata, MPIDI_OFI_COMM(comm).eagain);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT);
     return mpi_errno;
@@ -54,15 +54,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight_request(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT_REQUEST);
     MPIDI_OFI_SEND_REQUEST_CREATE_LW_CONDITIONAL(*request);
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, tag, 0);
-    mpi_errno =
-        MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, buf, data_sz, NULL, src_rank,
-                               MPIDI_OFI_av_to_phys(addr), match_bits,
-                               NULL, MPIDI_OFI_DO_INJECT, MPIDI_OFI_COMM(comm).eagain);
+    MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx,
+                                        buf,
+                                        data_sz,
+                                        src_rank,
+                                        MPIDI_OFI_av_to_phys(addr),
+                                        match_bits), tinjectdata, MPIDI_OFI_COMM(comm).eagain);
     /* If we set CC>0 in case of injection, we need to decrement the CC
      * to tell the main thread we completed the injection. */
     MPIDI_OFI_SEND_REQUEST_COMPLETE_LW_CONDITIONAL(*request);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_SEND_LIGHTWEIGHT_REQUEST);
     return mpi_errno;
@@ -300,21 +300,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     }
 
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
-        mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_av_to_phys(addr),
-                                   match_bits, NULL, MPIDI_OFI_DO_INJECT, FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx,
+                                            send_buf,
+                                            data_sz,
+                                            comm->rank,
+                                            MPIDI_OFI_av_to_phys(addr),
+                                            match_bits), tinjectdata, FALSE /* eagain */);
         MPIDI_OFI_send_event(NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (data_sz <= MPIDI_OFI_global.max_msg_size) {
-        mpi_errno =
-            MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf, data_sz, NULL, comm->rank,
-                                   MPIDI_OFI_av_to_phys(addr),
-                                   match_bits, (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
-                                   MPIDI_OFI_DO_SEND, FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
+                                          send_buf, data_sz, NULL /* desc */ ,
+                                          comm->rank,
+                                          MPIDI_OFI_av_to_phys(addr),
+                                          match_bits,
+                                          (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
+                             tsenddata, FALSE /* eagain */);
     } else if (unlikely(1)) {
         MPIDI_OFI_send_control_t ctrl;
         int c;
@@ -356,16 +356,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
          * MPIDI_OFI_global.max_msg_size */
         MPIDI_OFI_REQUEST(sreq, util_comm) = comm;
         MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
-        mpi_errno = MPIDI_OFI_send_handler(MPIDI_OFI_global.ctx[0].tx, send_buf,
-                                           MPIDI_OFI_global.max_msg_size,
-                                           NULL,
-                                           comm->rank,
-                                           MPIDI_OFI_av_to_phys(addr),
-                                           match_bits,
-                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context)),
-                                           MPIDI_OFI_DO_SEND, FALSE);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
+                                          send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,
+                                          comm->rank,
+                                          MPIDI_OFI_av_to_phys(addr),
+                                          match_bits,
+                                          (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
+                             tsenddata, FALSE /* eagain */);
         ctrl.type = MPIDI_OFI_CTRL_HUGE;
         ctrl.seqno = 0;
         ctrl.tag = tag;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -369,7 +369,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 
         /* Send information about the memory region here to get the lmt going. */
         MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_do_control_send
-                               (&ctrl, send_buf, data_sz, dst_rank, comm, sreq, FALSE));
+                               (&ctrl, send_buf, data_sz, dst_rank, comm, sreq));
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -167,8 +167,6 @@ static inline int MPIDI_OFI_comm_to_ep(MPIR_Comm * comm_ptr, int rank)
 #endif
 }
 
-#define MPIDI_OFI_DO_SEND        0
-#define MPIDI_OFI_DO_INJECT      1
 #define MPIDI_OFI_NUM_CQ_ENTRIES 8
 
 /* Typedefs */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -173,18 +173,6 @@ static inline int MPIDI_OFI_comm_to_ep(MPIR_Comm * comm_ptr, int rank)
 
 /* Typedefs */
 enum {
-    MPIDI_OFI_CTRL_ASSERT,    /**< Lock acknowledge      */
-    MPIDI_OFI_CTRL_LOCKACK,   /**< Lock acknowledge      */
-    MPIDI_OFI_CTRL_LOCKALLACK,/**< Lock all acknowledge  */
-    MPIDI_OFI_CTRL_LOCKREQ,   /**< Lock window           */
-    MPIDI_OFI_CTRL_LOCKALLREQ,/**< Lock all window       */
-    MPIDI_OFI_CTRL_UNLOCK,    /**< Unlock window         */
-    MPIDI_OFI_CTRL_UNLOCKACK, /**< Unlock window         */
-    MPIDI_OFI_CTRL_UNLOCKALL, /**< Unlock window         */
-    MPIDI_OFI_CTRL_UNLOCKALLACK,
-    /**< Unlock window         */
-    MPIDI_OFI_CTRL_COMPLETE,  /**< End a START epoch     */
-    MPIDI_OFI_CTRL_POST,      /**< Begin POST epoch      */
     MPIDI_OFI_CTRL_HUGE,      /**< Huge message          */
     MPIDI_OFI_CTRL_HUGEACK    /**< Huge message ack      */
     /**< Huge message cleanup  */
@@ -211,11 +199,6 @@ enum {
     MPIDI_OFI_EVENT_INJECT_EMU,
     MPIDI_OFI_EVENT_DYNPROC_DONE,
     MPIDI_OFI_EVENT_ACCEPT_PROBE
-};
-
-enum {
-    MPIDI_OFI_REQUEST_LOCK,
-    MPIDI_OFI_REQUEST_LOCKALL
 };
 
 enum {


### PR DESCRIPTION
## Pull Request Description

`MPIDI_OFI_send_handler` was introduced to abstract CQ data availability, but given that now we always assume CQ data support, we no longer need this wrapper. This PR removes the function and its usage.

## Expected Performance Changes

None

## Known Issues

None

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design