### PR TITLE
mpl: Fix configure check

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -797,7 +797,7 @@ fi
 # fdopen() converts from an fd to a FILE*
 AC_HAVE_FUNCS(fdopen)
 if test "$ac_cv_func_fdopen" = "yes" ; then
-    PAC_FUNC_NEEDS_DECL([#include <stdlib.h>],fdopen)
+    PAC_FUNC_NEEDS_DECL([#include <stdio.h>],fdopen)
 fi
 
 AC_CHECK_FUNCS(getpid)


### PR DESCRIPTION
## Pull Request Description

fdopen is declared in stdio.h. This check would always fail because it
was looking in the wrong header file.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
