### PR TITLE
mtest: Lower default max buffer size

### DIFF
--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -98,6 +98,11 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
 
     DTPI_ERR_ARG_CHECK(!dtpi, rc);
 
+    /* The code will enter deadloop if maxbufsize is too small or overflown to negative.
+     * Use 100000 as an arbitary sanity guard.
+     */
+    DTPI_ERR_ARG_CHECK(maxbufsize < 100000, rc);
+
     /* find number of nestings */
     if (getenv("DTP_MAX_TREE_DEPTH"))
         max_tree_depth = atoi(getenv("DTP_MAX_TREE_DEPTH"));

--- a/test/mpi/util/mtest_common.c
+++ b/test/mpi/util/mtest_common.c
@@ -18,7 +18,7 @@
 */
 MPI_Aint MTestDefaultMaxBufferSize()
 {
-    MPI_Aint max_size = 2147483648;
+    MPI_Aint max_size = 1073741824;
     char *envval = NULL;
     envval = getenv("MPITEST_MAXBUFFER");
     if (envval) {


### PR DESCRIPTION
## Pull Request Description

The previous value was negative when MPI_Aint is a 32-bit signed
integer. Decrement it by one to ensure a positive buffer size.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
