### PR TITLE
ch4/ucx: do not pack user data for large messages

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -31,6 +31,7 @@ typedef union {
 typedef struct {
     int handler_id;
     char *pack_buffer;
+    ucp_dt_iov_t iov[2];
 } MPIDI_UCX_am_request_t;
 
 typedef struct MPIDI_UCX_am_header_t {


### PR DESCRIPTION
## Pull Request Description
Currently UCX AM send path copies user data into a pack buffer before sending it. This is not ideal for a number of reasons. Firstly, copying large messages into a pack buffer consumes CPU cycles, increasing latency; Secondly, allocating a pack buffer as big as the user buffer doubles memory consumption; Thirdly, when user buffers reside in GPU memory MPICH must be aware of it so to use the appropriate memory copy to pack data into the buffer (e.g., `cudaMemcpy` instead of `memcpy`).  

Running OSU latency for pt2pt operations shows that packing is beneficial for small messages while on the contrary is deleterious for large ones [see results below]. This PR avoids packing for large messages (i.e., messages that are larger than the EAGER threshold) and doing so achieves up to ~3x better bandwidth and ~30% latency reduction for large messages.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes
Higher bandwidth and lower latency for large messages

## Known Issues
None

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design

## TODOs
* [ ] Use a threshold to switch between packing and iovec on the sender side
* [ ] Modify AM rendezvous to eliminate the second AM after handshaking and replace this with ucx tagged send/recv if supported, thus receiving data directly into the receive buffer without unpacking.