### PR TITLE
mpir: Assert indirect sizes are positive

### DIFF
--- a/src/include/mpir_handlemem.h
+++ b/src/include/mpir_handlemem.h
@@ -128,6 +128,9 @@ static inline void *MPIR_Handle_indirect_init(void *(**indirect)[],
     char *ptr;
     int i;
 
+    MPIR_Assert(indirect_num_blocks > 0);
+    MPIR_Assert(indirect_num_indices > 0);
+
     /* Must create new storage for dynamically allocated objects */
     /* Create the table */
     if (!*indirect) {


### PR DESCRIPTION
## Pull Request Description

This patch adds assertions in MPIR_Handle_indirect_init to ensure
given sizes are positive. This will help not only static code
analyzer but also humans understanding requirements and behavior
of the function.

Fixes Klocwork 18172

## Expected Performance Changes

None

## Known Issues

None

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design