### PR TITLE
ch4: Cancel both NM/SHM when ANY_SOURCE recv

### DIFF
--- a/test/mpi/Makefile_f08.mtest
+++ b/test/mpi/Makefile_f08.mtest
@@ -21,6 +21,6 @@ $(top_builddir)/f08/util/mtestf08.o: $(top_srcdir)/f08/util/mtestf08.f90
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \
-		-mpiexec=${MPIEXEC} -xmlfile=summary.xml
+		-mpiexec=${MPIEXEC} -xmlfile=summary.xml -tapfile=summary.tap -junitfile=summary.junit.xml
 
-CLEANFILES = summary.xml summary.tap
+CLEANFILES = summary.xml summary.tap summary.junit.xml

--- a/test/mpi/Makefile_f77.mtest
+++ b/test/mpi/Makefile_f77.mtest
@@ -31,6 +31,6 @@ $(top_builddir)/f77/util/mtestf.o: $(top_srcdir)/f77/util/mtestf.f
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \
-		-mpiexec=${MPIEXEC} -xmlfile=summary.xml
+		-mpiexec=${MPIEXEC} -xmlfile=summary.xml -tapfile=summary.tap -junitfile=summary.junit.xml
 
-CLEANFILES = summary.xml summary.tap
+CLEANFILES = summary.xml summary.tap summary.junit.xml

--- a/test/mpi/Makefile_f90.mtest
+++ b/test/mpi/Makefile_f90.mtest
@@ -21,6 +21,6 @@ $(top_builddir)/f90/util/mtestf90.o: $(top_srcdir)/f90/util/mtestf90.f90
 
 testing:
 	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist \
-		-mpiexec=${MPIEXEC} -xmlfile=summary.xml
+		-mpiexec=${MPIEXEC} -xmlfile=summary.xml -tapfile=summary.tap -junitfile=summary.junit.xml
 
-CLEANFILES = summary.xml summary.tap
+CLEANFILES = summary.xml summary.tap summary.junit.xml

--- a/test/mpi/f77/ext/c2f2c.c
+++ b/test/mpi/f77/ext/c2f2c.c
@@ -173,13 +173,14 @@ MPI_Fint c2frequest_(MPI_Fint * request)
     MPI_Status status;
     int flag;
     MPI_Test(&req, &flag, &status);
-    MPI_Test_cancelled(&status, &flag);
-    if (!flag) {
-        fprintf(stderr, "Request: Wrong value for flag\n");
-        return 1;
-    } else {
-        *request = MPI_Request_c2f(req);
+    if (flag) {
+        MPI_Test_cancelled(&status, &flag);
+        if (!flag) {
+            fprintf(stderr, "Request: Wrong value for flag\n");
+            return 1;
+        }
     }
+    *request = MPI_Request_c2f(req);
     return 0;
 }
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -59,10 +59,6 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
 # the below tests timeout with the ofi/sockets provider
 * * * ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-# debug
-* * debug ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-* * debug ch4:ofi * sed -i "s+\(^c2f2cf .*\)+\1 xfail=ticket0+g" test/mpi/f77/ext/testlist
-* * debug ch4:ofi * sed -i "s+\(^c2f2cf90 .*\)+\1 xfail=ticket0+g" test/mpi/f90/ext/testlist
 # am-only failures
 * * am-only ch4:ofi * sed -i "s+\(^ssendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
 * * am-only ch4:ofi * sed -i "s+\(^ssendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description

When canceling a receive that was issued to MPI_ANY_SOURCE, both netmod and shmmod cancel have to be called, because receive calls in both modules have been invoked.

Fixes #3859 

## Expected Performance Changes

Virtually none (a few extra instructions on receve-cancel path)

## Known Issues

None

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design