### PR TITLE
dtpools: Use private copy of confdb

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -636,6 +636,7 @@ confdb_dirs="${confdb_dirs} src/pm/hydra2/confdb"
 confdb_dirs="${confdb_dirs} src/pm/hydra/mpl/confdb"
 confdb_dirs="${confdb_dirs} src/pm/hydra2/mpl/confdb"
 confdb_dirs="${confdb_dirs} test/mpi/confdb"
+confdb_dirs="${confdb_dirs} test/mpi/dtpools/confdb"
 
 # hydra's copies of mpl and hwloc
 sync_external src/mpl src/pm/hydra/mpl

--- a/test/mpi/dtpools/configure.ac
+++ b/test/mpi/dtpools/configure.ac
@@ -23,8 +23,8 @@ AH_BOTTOM([
 #endif /* !defined(DTPOOLSCONF_H_INCLUDED) */
 ])
 
-AC_CONFIG_AUX_DIR([../confdb])
-AC_CONFIG_MACRO_DIR([../confdb])
+AC_CONFIG_AUX_DIR([confdb])
+AC_CONFIG_MACRO_DIR([confdb])
 
 # Ensure we have an MPI compiler wrapper
 if test -n "$MPICC" ; then


### PR DESCRIPTION
## Pull Request Description

Avoid using confdb from the testsuite, which could cause issues when
building from tarball. Fixes pmodels/mpich#3939.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
