### PR TITLE
pmi/bgq: add dummy implementation for PMI_Spawn_multiple.

### DIFF
--- a/src/pmi/Makefile.mk
+++ b/src/pmi/Makefile.mk
@@ -7,5 +7,6 @@
 
 include $(top_srcdir)/src/pmi/pmi2/Makefile.mk
 include $(top_srcdir)/src/pmi/simple/Makefile.mk
+include $(top_srcdir)/src/pmi/bgq/Makefile.mk
 
 errnames_txt_files += src/pmi/errnames.txt

--- a/src/pmi/bgq/Makefile.mk
+++ b/src/pmi/bgq/Makefile.mk
@@ -1,0 +1,17 @@
+## -*- Mode: Makefile; -*-
+## vim: set ft=automake :
+##
+## (C) 2011 by Argonne National Laboratory.
+##     See COPYRIGHT in top-level directory.
+##
+
+if BUILD_PMI_BGQ
+
+mpi_core_sources +=       \
+    src/pmi/bgq/bgq_pmi.c
+
+noinst_HEADERS +=
+
+AM_CPPFLAGS += -I$(top_srcdir)/src/pmi/bgq
+
+endif BUILD_PMI_BGQ

--- a/src/pmi/bgq/bgq_pmi.c
+++ b/src/pmi/bgq/bgq_pmi.c
@@ -1,0 +1,29 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpichconf.h"
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#include "pmi.h"
+
+int PMI_Spawn_multiple(int count,
+                       const char *cmds[],
+                       const char **argvs[],
+                       const int maxprocs[],
+                       const int info_keyval_sizes[],
+                       const PMI_keyval_t * info_keyval_vectors[],
+                       int preput_keyval_size,
+                       const PMI_keyval_t preput_keyval_vector[], int errors[])
+{
+    PMI_Abort(-1, NULL);
+    return PMI_SUCCESS;
+}


### PR DESCRIPTION
Spawn is not supported on BGQ. Redirect the call to PMI_Abort.

The BGQ PMI is implemented in the BGQ provider of libfabric which misses the PMI_Spawn_multiple function.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
