### PR TITLE
mpl: default to use usleep on OSX for MPL_thread_yield

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -579,7 +579,9 @@ AC_ARG_ENABLE([yield],
      AS_CASE([$host],
         [*-*-darwin*],
             [# In Lion, sched_yield worked but none of the other options had any effect
-             AS_IF([test "x$ac_cv_func_sched_yield" = "xyes"], [enable_yield=sched_yield],
+             # In Mojave x86_64, sched_yield may yield to threads in thread_wait_barrier which is slow to yield back,
+             #    usleep(0) seems work well.
+             AS_IF([test "x$ac_cv_func_usleep" = "xyes"], [enable_yield=usleep],
                    [enable_yield=nothing])],
         [*-*-linux*],
             [# sched_yield() has been broken in linux since 2.6.23, and no good alternative exists.

--- a/test/mpi/threads/pt2pt/multisend4.c
+++ b/test/mpi/threads/pt2pt/multisend4.c
@@ -81,6 +81,13 @@ int main(int argc, char **argv)
     int i, pmode, nprocs, rank;
     int errs = 0, err;
 
+    ownerWaits = 0;
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-mode=1") == 0) {
+            ownerWaits = 1;
+        }
+    }
+
     MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &pmode);
     if (pmode != MPI_THREAD_MULTIPLE) {
         fprintf(stderr, "Thread Multiple not supported by the MPI implementation\n");

--- a/test/mpi/threads/pt2pt/testlist
+++ b/test/mpi/threads/pt2pt/testlist
@@ -6,6 +6,7 @@ multisend 2
 multisend2 5
 multisend3 5
 multisend4 5
+multisend4 5 arg=-mode=1
 greq_wait 1
 greq_test 1
 ibsend 2


### PR DESCRIPTION
## Pull Request Description

The test `multisend4 5` is timing out on osx due to `sched_yield()` is slow to return when the osx node is oversubscribed and other other thread does not yield back -- seems to be the case when other threads are inside `pthread_barrier_wait`.

`usleep(0)` seems work well (contrary to previous comment in `src/mpl/configure.ac` about Lion. 

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
        Fixes #3943
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
