### PR TITLE
ROMIO: bug fix: preserve user's hints in the info object

### DIFF
--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -32,8 +32,13 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
     }
     ad_get_env_vars();
 
-    if (fd->info == MPI_INFO_NULL)
-        MPI_Info_create(&(fd->info));
+    if (fd->info == MPI_INFO_NULL) {
+        if (users_info == MPI_INFO_NULL)
+            MPI_Info_create(&(fd->info));
+        else
+            /* duplicate users_info to preserve hints not used in ROMIO */
+            MPI_Info_dup(users_info, &(fd->info));
+    }
     info = fd->info;
 
     MPI_Comm_size(fd->comm, &nprocs);


### PR DESCRIPTION
Duplicate user's info object for ADIO internal use, instead of creating a
new (empty) one. So the hints that are not used by ROMIO can be
preserved and future calls to MPI_Info_get() can still see them.

Here is a short test program. A user-defined hint "dummy" is added to
an MPI_Info object and passed to MPI_File_open. Later, a call to
MPI_File_get_info to retrieve the info object and checks whether it
can see hint "dummy". Note when compiled with OpenMPI, this short
program passes the test.

```
#include <stdio.h>
#include <stdlib.h>

int main(int argc, char **argv) {
    char value[MPI_MAX_INFO_VAL+1];
    int flag;
    MPI_File fh;
    MPI_Info info, info_used;

    MPI_Init(&argc, &argv);

    MPI_Info_create(&info);
    MPI_Info_set(info, "dummy", "abc");

    MPI_File_open(MPI_COMM_WORLD, "testfile", MPI_MODE_CREATE|MPI_MODE_RDWR, info, &fh);
    MPI_Info_free(&info);

    MPI_File_get_info(fh, &info_used);
    MPI_File_close(&fh);

    MPI_Info_get(info_used, "dummy", MPI_MAX_INFO_VAL, value, &flag);
    if (flag)
        printf("info_used dummy is defined to %s\n",value);
    else
        printf("Error: info_used dummy is not defined flag=%d\n",flag);
    MPI_Info_free(&info_used);

    MPI_Finalize();
    return 0;
}
```