### PR TITLE
testsuite: only print the actual testlist file that is being run

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -428,7 +428,6 @@ sub RunList {
     # eg: runtests -tests='testlist,testlist.dtp'
     my @all_listfiles = split /,\s*/, $listfile;
     foreach my $_f (@all_listfiles){
-        print "Looking in $curdir/$_f\n" if $debug;
         my $listfileSource = $_f;
         if (! -s "$_f" && -s "$srcdir/$curdir/$_f" ) {
             $listfileSource = "$srcdir/$curdir/$_f";
@@ -437,6 +436,7 @@ sub RunList {
             # just skip, do not complain missing unless it is "testlist"
             next;
         }
+        print "Looking in $curdir/$_f\n" if $debug;
         # FIXME: keeping the indentation to facilitate review, indent back on merge
     open( $LIST, "<$listfileSource" ) || 
 	die "Could not open $listfileSource\n";


### PR DESCRIPTION
## Pull Request Description

This PR is split from PR #3876 and it is based on top of that PR. Advise to review and merge that PR first.

*Currently it prints:
```
Looking at pt2pt/testlist
Looking at pt2pt/testlist.cvar
```
even when pt2pt/testlist.cvar does not exist.
This patch fixes that.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
