### PR TITLE
ch4/ofi: Remove `is_reply` argument from AM functions

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -39,10 +39,9 @@ static inline int MPIDI_NM_am_isend(int rank,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_AM_ISEND);
     if (count)
         mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id,
-                                          am_hdr, am_hdr_sz, data, count, datatype, sreq, FALSE);
+                                          am_hdr, am_hdr_sz, data, count, datatype, sreq);
     else
-        mpi_errno = MPIDI_OFI_do_am_isend_header(rank, comm, handler_id,
-                                                 am_hdr, am_hdr_sz, sreq, FALSE);
+        mpi_errno = MPIDI_OFI_do_am_isend_header(rank, comm, handler_id, am_hdr, am_hdr_sz, sreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND);
     return mpi_errno;
@@ -110,10 +109,10 @@ static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
     if (count)
         mpi_errno = MPIDI_OFI_do_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id),
                                           handler_id, am_hdr, am_hdr_sz, data, count, datatype,
-                                          sreq, TRUE);
+                                          sreq);
     else
         mpi_errno = MPIDI_OFI_do_am_isend_header(src_rank, MPIDIG_context_id_to_comm(context_id),
-                                                 handler_id, am_hdr, am_hdr_sz, sreq, TRUE);
+                                                 handler_id, am_hdr, am_hdr_sz, sreq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND_REPLY);
     return mpi_errno;
 }
@@ -136,7 +135,7 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
-    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, FALSE);
+    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);
@@ -158,7 +157,7 @@ static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
 
     mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
-                                    am_hdr, am_hdr_sz, TRUE);
+                                    am_hdr, am_hdr_sz);
 
     if (mpi_errno != MPI_SUCCESS)
         MPIR_ERR_POP(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -199,7 +199,7 @@ static inline int MPIDI_OFI_do_am_isend_header(int rank,
                                                MPIR_Comm * comm,
                                                int handler_id,
                                                const void *am_hdr,
-                                               size_t am_hdr_sz, MPIR_Request * sreq, int is_reply)
+                                               size_t am_hdr_sz, MPIR_Request * sreq)
 {
     struct iovec *iov;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -388,8 +388,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
                                         const void *am_hdr,
                                         size_t am_hdr_sz,
                                         const void *buf,
-                                        size_t count,
-                                        MPI_Datatype datatype, MPIR_Request * sreq, int is_reply)
+                                        size_t count, MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int dt_contig, mpi_errno = MPI_SUCCESS;
     char *send_buf;
@@ -493,8 +492,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
 
 static inline int MPIDI_OFI_do_inject(int rank,
                                       MPIR_Comm * comm,
-                                      int handler_id,
-                                      const void *am_hdr, size_t am_hdr_sz, int is_reply)
+                                      int handler_id, const void *am_hdr, size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t msg_hdr;

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -31,7 +31,7 @@ static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
 
     mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
                                     MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                    (void *) control, sizeof(*control), FALSE);
+                                    (void *) control, sizeof(*control));
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
     return mpi_errno;


### PR DESCRIPTION
Now that `is_reply` is not used anywhere, this commit removes them.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
