### PR TITLE
testsuite: longer time limit for some rma lockall tests

### DIFF
--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -41,15 +41,15 @@ rma/lock_dt_flush::17 1018 65530::2:16:1024
 rma/lock_dt_flushlocal::1 512 262144::2:16:1024
 rma/lock_dt_flushlocal::17 1018 65530::2:16:1024
 rma/lockall_dt::1 512 262144::4:16:1024
-rma/lockall_dt::17 1018 65530::4:16:1024
+rma/lockall_dt::17 1018 65530:timeLimit=600:4:16:1024
 rma/lockall_dt_flush::1 512 262144::4:16:1024
-rma/lockall_dt_flush::17 1018 65530::4:16:1024
+rma/lockall_dt_flush::17 1018 65530:timeLimit=600:4:16:1024
 rma/lockall_dt_flushall::1 512 262144::4:16:1024
-rma/lockall_dt_flushall::17 1018 65530::4:16:1024
+rma/lockall_dt_flushall::17 1018 65530:timeLimit=600:4:16:1024
 rma/lockall_dt_flushlocal::1 512 262144::4:16:1024
-rma/lockall_dt_flushlocal::17 1018 65530::4:16:1024
+rma/lockall_dt_flushlocal::17 1018 65530:timeLimit=600:4:16:1024
 rma/lockall_dt_flushlocalall::1 512 262144::4:16:1024
-rma/lockall_dt_flushlocalall::17 1018 65530::4:16:1024
+rma/lockall_dt_flushlocalall::17 1018 65530:timeLimit=600:4:16:1024
 rma/putfence1::1 512 262144::2:16:1024
 rma/putfence1::17 1018 65530::2:16:1024
 rma/putfence1::16000000:timeLimit=1800:2:4:


### PR DESCRIPTION
## Pull Request Description

Currently rma/lockall_dt_ tests with non-contiguous datatype are very
slow for ofi direct-nm configuration, potentially will be improved after
the a datatype refactor. Since these tests are running on the
border-line of the default 3 min. timeLimit, this patch increase the
limit to 10 minutes. It should prevent triggering test failures while we
monitor the situations.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)

Refer to issue #3886.

Also close PR #3961 if this PR gets merged.

* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
