### PR TITLE
Fix src/mpl/test/strsep.c to pass "make check"

### DIFF
--- a/src/mpl/test/strsep.c
+++ b/src/mpl/test/strsep.c
@@ -21,14 +21,14 @@ int main(void)
     assert(next == NULL);
     assert(str == NULL);
 
-    orig = strdup("");
+    orig = MPL_strdup("");
     str = orig;
     next = MPL_strsep(&str, "|");
     assert(str == NULL);
     assert(next == orig);
-    free(orig);
+    MPL_free(orig);
 
-    orig = strdup("a|b|c");
+    orig = MPL_strdup("a|b|c");
     str = orig;
     next = MPL_strsep(&str, "|");
     assert(next == orig);
@@ -40,9 +40,9 @@ int main(void)
     next = MPL_strsep(&str, "|");
     assert(next == NULL);
     assert(str == NULL);
-    free(orig);
+    MPL_free(orig);
 
-    orig = strdup("a|b:c");
+    orig = MPL_strdup("a|b:c");
     str = orig;
     next = MPL_strsep(&str, ":|");
     assert(next == orig);
@@ -54,9 +54,9 @@ int main(void)
     next = MPL_strsep(&str, ":|");
     assert(next == NULL);
     assert(str == NULL);
-    free(orig);
+    MPL_free(orig);
 
-    orig = strdup("a|:b:c");
+    orig = MPL_strdup("a|:b:c");
     str = orig;
     next = MPL_strsep(&str, ":|");
     assert(next == orig);
@@ -70,7 +70,7 @@ int main(void)
     next = MPL_strsep(&str, ":|");
     assert(next == NULL);
     assert(str == NULL);
-    free(orig);
+    MPL_free(orig);
 
     return 0;
 }


### PR DESCRIPTION
Replace strdup with MPL_strdup
Replace free with MPL_free

Got the following errors when running "make check"

mpich/src/pm/hydra/mpl/test/strsep.c:24:21:
warning: character constant too long for its type
warning: assignment makes pointer from integer without a cast
error: expected ';' before ':' token
mpich/src/pm/hydra/mpl/test/strsep.c:29:14:
warning: character constant too long for its type
error: expected ';' before ':' token

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
