### PR TITLE
adio: add error handling for strided read

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -379,6 +379,7 @@ be in the range 0 to %d
 **ioRMWrdwr:Must open file with MPI_MODE_RDWR for read-modify-write
 **iowsrc:Unable to read from the file as part of a strided write operation
 **iowswc:Unable to write to the file as part of a strided write operation
+**iorsrc:Unable to read from the file as part of a strided read operation
 **ioagnomatch:No aggregators match
 **iobadsize:Invalid size argument
 **unsupporteddatarep:Only native data representation currently supported

--- a/src/mpi/romio/adio/common/ad_read_str.c
+++ b/src/mpi/romio/adio/common/ad_read_str.c
@@ -15,7 +15,13 @@
             readbuf_len = (unsigned) (MPL_MIN(max_bufsize, end_offset-readbuf_off+1)); \
             ADIO_ReadContig(fd, readbuf, readbuf_len, MPI_BYTE,         \
                             ADIO_EXPLICIT_OFFSET, readbuf_off, &status1, error_code); \
-            if (*error_code != MPI_SUCCESS) return;                     \
+            if (*error_code != MPI_SUCCESS) {                           \
+                *error_code = MPIO_Err_create_code(*error_code,         \
+                                          MPIR_ERR_RECOVERABLE, myname, \
+                                                  __LINE__, MPI_ERR_IO, \
+                                                   "**iorsrc", 0);      \
+                return;                                                 \
+            }                                                           \
         }                                                               \
         while (req_len > readbuf_off + readbuf_len - req_off) {         \
             ADIOI_Assert((readbuf_off + readbuf_len - req_off) == (int) (readbuf_off + readbuf_len - req_off)); \
@@ -32,7 +38,13 @@
             ADIO_ReadContig(fd, readbuf+partial_read, readbuf_len-partial_read, \
                             MPI_BYTE, ADIO_EXPLICIT_OFFSET, readbuf_off+partial_read, \
                             &status1, error_code);                      \
-            if (*error_code != MPI_SUCCESS) return;                     \
+            if (*error_code != MPI_SUCCESS) {                           \
+                *error_code = MPIO_Err_create_code(*error_code,         \
+                                          MPIR_ERR_RECOVERABLE, myname, \
+                                                  __LINE__, MPI_ERR_IO, \
+                                                   "**iorsrc", 0);      \
+                return;                                                 \
+            }                                                           \
         }                                                               \
         ADIOI_Assert(req_len == (size_t)req_len);                       \
         memcpy((char *)buf + userbuf_off, readbuf+req_off-readbuf_off, req_len); \
@@ -64,6 +76,7 @@ void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, int count,
     int info_flag;
     unsigned max_bufsize, readbuf_len;
     ADIO_Status status1;
+    static char myname[] = "ADIOI_GEN_ReadStrided";
 
     if (fd->hints->ds_read == ADIOI_HINT_DISABLE) {
         /* if user has disabled data sieving on reads, use naive
@@ -389,5 +402,4 @@ void ADIOI_GEN_ReadStrided(ADIO_File fd, void *buf, int count,
    keep track of how much data was actually read and placed in buf
    by ADIOI_BUFFERED_READ. */
 #endif
-
 }


### PR DESCRIPTION
## Pull Request Description

Current version aborts when a strided read has failed without any
explanation. It is hard to debug while running I/O tests without proper error messages.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None.

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [X] Passes tests (included warning check)
* [X] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [X] Commits are self-contained and do not do two things at once
* [X] Remove xfail from the test suite when fixing a test
* [X] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [X] Add comments such that someone without knowledge of the code could understand
* [X] Add Devel Docs in the `doc/` directory for any new code design
