### PR TITLE
Fix MPL/atomic issues

### DIFF
--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -37,9 +37,9 @@ extern pthread_mutex_t *MPL_emulation_lock;
 #define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
     volatile TYPE v;                                                           \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -26,9 +26,9 @@
         MPL_ATOMIC_INITIALIZER((intptr_t)(val_))
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)        \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE v;                                                             \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -19,9 +19,9 @@
 #define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
      TYPE volatile v;                                                          \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -22,9 +22,9 @@
  * current platform, even though this may not be true at all. */
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE volatile v;                                                           \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/include/mpl_atomic_none.h
+++ b/src/mpl/include/mpl_atomic_none.h
@@ -22,9 +22,9 @@
  * current platform, even though this may not be true at all. */
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE v;                                                                    \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/include/mpl_atomic_nt_intrinsics.h
+++ b/src/mpl/include/mpl_atomic_nt_intrinsics.h
@@ -42,9 +42,9 @@
 
 #define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC, \
                                     CAST_TO_ATOMIC, SUFFIX)                    \
-typedef struct MPL_atomic_ ## NAME ## _t {                                     \
+struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE volatile v;                                                    \
-} MPL_atomic_ ## NAME ## _t;                                                   \
+};                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                        (const MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -9,9 +9,10 @@
  * how to support other threading packages and lock implementations, such as the
  * BG/P lockbox. */
 
+#include "mpl_atomic.h"
+
 #ifdef MPL_HAVE_PTHREAD_H
 #include <pthread.h>
-#include "mpl_atomic.h"
 
 pthread_mutex_t *MPL_emulation_lock = NULL;
 


### PR DESCRIPTION
## Pull Request Description

This PR fixes some issues in MPL/atomic which is introduced by #3906.

The first commit is to remove warnings with `--enable-strict` (e.g., `-Wpedantic` in GCC). Previously typedef is defined in both `mpl_atomic.h` and `mpl_atomic_xxx.h`, so this PR removes the second typedef.

The second commit is moving `#include "mpl_atomic.h"` outside the ifdef block in order to make `MPL_HAVE_PTHREAD_H` visible.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None.

## Known Issues

None.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
