### PR TITLE
cvar: check error returns for MPIR_T_env_init

### DIFF
--- a/maint/extractcvars.in
+++ b/maint/extractcvars.in
@@ -419,14 +419,10 @@ EOT
             print OUTPUT_C $sp, "    $var_name = $var_name\_$a;\n";
             $c = "else if";
         }
-        # FIXME: There is no failure mode designed for the entire MPIR_T_..._init currently
-        #        MPIR_T_cvar_env_init and MPIR_T_env_init et el returns void
-        #        I don't see why not, but the change is another PR.
-        #        Once we checks the error code, uncomment the following.
-        # print OUTPUT_C $sp, "else {\n";
-        # print OUTPUT_C $sp, "    mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,__func__,__LINE__,MPI_ERR_ARG, \"**cvar_val\", \"**cvar_val %s %s\", \"$var_name\", tmp_str);\n";
-        # print OUTPUT_C $sp, "    goto fn_fail;\n";
-        # print OUTPUT_C $sp, "}\n";
+        print OUTPUT_C $sp, "else {\n";
+        print OUTPUT_C $sp, "    mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,MPI_ERR_OTHER, \"**cvar_val\", \"**cvar_val %s %s\", \"$var_name\", tmp_str);\n";
+        print OUTPUT_C $sp, "    goto fn_fail;\n";
+        print OUTPUT_C $sp, "}\n";
         print OUTPUT_C "    }\n";
     }
     print OUTPUT_C "\n";

--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -1229,7 +1229,7 @@ extern MPID_Thread_mutex_t mpi_t_mutex;
 #endif
 
 /* Init and finalize routines */
-extern void MPIR_T_env_init(void);
+extern int MPIR_T_env_init(void);
 extern void MPIR_T_env_finalize(void);
 
 #endif /* MPITIMPL_H_INCLUDED */

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -153,7 +153,9 @@ int MPI_Init(int *argc, char ***argv)
     MPIR_ThreadInfo.isThreaded = 0;
 #endif /* MPICH_IS_THREADED */
 
-    MPIR_T_env_init();
+    mpi_errno = MPIR_T_env_init();
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
 
     if (!strcasecmp(MPIR_CVAR_DEFAULT_THREAD_LEVEL, "MPI_THREAD_MULTIPLE"))
         threadLevel = MPI_THREAD_MULTIPLE;

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -764,7 +764,9 @@ int MPI_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_ThreadInfo.isThreaded = 0;
 #endif /* MPICH_IS_THREADED */
 
-    MPIR_T_env_init();
+    mpi_errno = MPIR_T_env_init();
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
 
     /* If the user requested for asynchronous progress, request for
      * THREAD_MULTIPLE. */

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -128,7 +128,7 @@ int MPI_T_init_thread(int required, int *provided)
     ++MPIR_T_init_balance;
     if (MPIR_T_init_balance == 1) {
         MPIR_T_THREAD_CS_INIT();
-        MPIR_T_env_init();
+        mpi_errno = MPIR_T_env_init();
     }
 
     /* ... end of body of routine ... */

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -42,13 +42,13 @@ static inline void MPIR_T_cat_env_init(void)
     cat_stamp = 0;
 }
 
-static inline void MPIR_T_cvar_env_init(void)
+static inline int MPIR_T_cvar_env_init(void)
 {
     static const UT_icd cvar_table_entry_icd = { sizeof(cvar_table_entry_t), NULL, NULL, NULL };
 
     utarray_new(cvar_table, &cvar_table_entry_icd, MPL_MEM_MPIT);
     cvar_hash = NULL;
-    MPIR_T_cvar_init();
+    return MPIR_T_cvar_init();
 }
 
 static inline void MPIR_T_pvar_env_init(void)
@@ -62,17 +62,19 @@ static inline void MPIR_T_pvar_env_init(void)
     }
 }
 
-void MPIR_T_env_init(void)
+int MPIR_T_env_init(void)
 {
+    int mpi_errno = MPI_SUCCESS;
     static int initialized = FALSE;
 
     if (!initialized) {
         initialized = TRUE;
         MPIR_T_enum_env_init();
         MPIR_T_cat_env_init();
-        MPIR_T_cvar_env_init();
+        mpi_errno = MPIR_T_cvar_env_init();
         MPIR_T_pvar_env_init();
     }
+    return mpi_errno;
 }
 
 #endif /* MPICH_MPI_FROM_PMPI */

--- a/test/mpi/maint/test_coll_algos.sh
+++ b/test/mpi/maint/test_coll_algos.sh
@@ -94,7 +94,7 @@ testing_env="env=MPIR_CVAR_ALLREDUCE_DEVICE_COLLECTIVE=0"
 #test nb algorithms
 testing_env="${testing_env} env=MPIR_CVAR_ALLREDUCE_INTRA_ALGORITHM=nb"
 testing_env="${testing_env} env=MPIR_CVAR_IALLREDUCE_DEVICE_COLLECTIVE=0"
-algo_names="gentran_recexch_single_buffer gentran_recexch_multiple_buffer gentran_tree gentran_ring recexch_reduce_scatter_recexch_allgatherv"
+algo_names="gentran_recexch_single_buffer gentran_recexch_multiple_buffer gentran_tree gentran_ring gentran_recexch_reduce_scatter_recexch_allgatherv"
 tree_types="kary knomial_1 knomial_2"
 kvalues="2 3 4"
 


### PR DESCRIPTION
## Pull Request Description

We control a large portion of features using CVAR. It is a common mistake to supply the wrong CVAR values resulting in the desired feature option being silently dropped.

This PR enables the checking of invalid CVAR enum values and raise errors in the init routines.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
