### PR TITLE
xfail: Add cmplit_type for gcc builds on FreeBSD

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -175,3 +175,6 @@ valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 * * * * * sed -i "s+\(^ialltoalllength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
 * * * * * sed -i "s+\(^scatterlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
 * * * * * sed -i "s+\(^iscatterlength .*\)+\1 xfail=ticket3655+g" test/mpi/errors/coll/testlist
+# hwloc is unable to detect topology info on FreeBSD in strict mode with GCC
+* gnu strict * freebsd64 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist
+* gnu strict * freebsd32 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist


### PR DESCRIPTION
## Pull Request Description

New jenkins nodes fail to build all hwloc functionality in strict mode
with gcc. See pmodels/mpich#3972.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

n/a

## Known Issues

n/a

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
