### PR TITLE
mpidu/shm: change get API to return actual value and introduce query API

### DIFF
--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -90,17 +90,32 @@ int MPIDU_Init_shm_put(void *orig, size_t len)
     return mpi_errno;
 }
 
-int MPIDU_Init_shm_get(int local_rank, void **target)
+int MPIDU_Init_shm_get(int local_rank, size_t len, void *target)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_GET);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_GET);
 
-    MPIR_Assert(local_rank < local_size);
-    *target = (char *) baseaddr + local_rank * sizeof(MPIDU_Init_shm_block_t);
+    MPIR_Assert(local_rank < local_size && len <= sizeof(MPIDU_Init_shm_block_t));
+    MPIR_Memcpy(target, (char *) baseaddr + local_rank * sizeof(MPIDU_Init_shm_block_t), len);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_GET);
+
+    return mpi_errno;
+}
+
+int MPIDU_Init_shm_query(int local_rank, void **target_addr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_QUERY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_QUERY);
+
+    MPIR_Assert(local_rank < local_size);
+    *target_addr = (char *) baseaddr + local_rank * sizeof(MPIDU_Init_shm_block_t);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_QUERY);
 
     return mpi_errno;
 }

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -18,8 +18,8 @@ int MPIDU_Init_shm_init(int rank, int size, int *nodemap)
     int mpi_errno = MPI_SUCCESS;
     int local_leader;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_SEG_INIT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_INIT);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_INIT);
 
     MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &my_local_rank, &local_leader);
 
@@ -36,7 +36,7 @@ int MPIDU_Init_shm_init(int rank, int size, int *nodemap)
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_SEG_INIT);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_INIT);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -46,8 +46,8 @@ int MPIDU_Init_shm_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_SEG_FINALIZE);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_FINALIZE);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_FINALIZE);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
     MPIR_ERR_CHECK(mpi_errno);
@@ -55,7 +55,7 @@ int MPIDU_Init_shm_finalize(void)
     mpi_errno = MPIDU_shm_seg_destroy(&memory, local_size);
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_SEG_FINALIZE);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_FINALIZE);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -65,12 +65,12 @@ int MPIDU_Init_shm_barrier(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_SEG_BARRIER);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_BARRIER);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_BARRIER);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_BARRIER);
 
     mpi_errno = MPIDU_shm_barrier(barrier, local_size);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_SEG_BARRIER);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_BARRIER);
 
     return mpi_errno;
 }
@@ -79,13 +79,13 @@ int MPIDU_Init_shm_put(void *orig, size_t len)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_SEG_PUT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_PUT);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_PUT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_PUT);
 
     MPIR_Assert(len <= sizeof(MPIDU_Init_shm_block_t));
     MPIR_Memcpy((char *) baseaddr + my_local_rank * sizeof(MPIDU_Init_shm_block_t), orig, len);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_SEG_PUT);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_PUT);
 
     return mpi_errno;
 }
@@ -94,13 +94,13 @@ int MPIDU_Init_shm_get(int local_rank, void **target)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_SEG_GET);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_SEG_GET);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_GET);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_GET);
 
     MPIR_Assert(local_rank < local_size);
     *target = (char *) baseaddr + local_rank * sizeof(MPIDU_Init_shm_block_t);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_SEG_GET);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDU_INIT_SHM_GET);
 
     return mpi_errno;
 }

--- a/src/mpid/common/shm/mpidu_init_shm.h
+++ b/src/mpid/common/shm/mpidu_init_shm.h
@@ -18,6 +18,7 @@ int MPIDU_Init_shm_init(int rank, int size, int *nodemap);
 int MPIDU_Init_shm_finalize(void);
 int MPIDU_Init_shm_barrier(void);
 int MPIDU_Init_shm_put(void *orig, size_t len);
-int MPIDU_Init_shm_get(int local_rank, void **target);
+int MPIDU_Init_shm_get(int local_rank, size_t len, void *target);
+int MPIDU_Init_shm_query(int local_rank, void **target_addr);
 
 #endif /* MPIDU_INIT_SHM_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description
The original get API only returns target item address. Thus, the calling routine has to first get the address and then copy the value (two steps). This patch renames the get API to "query", and changes the get routine to return the actual target value.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes
The calling routine can get target value in one step.

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
