### PR TITLE
MPL/atomic: bug fix

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -796,7 +796,7 @@ PAC_ARG_ATOMIC_PRIMITIVES
 AC_DEFUN([MPL_ATOMIC_TEST_PROGRAM], [AC_LANG_PROGRAM([[
         #include "$1"
     ]],[[
-        MPL_atomic_int_t a, b;
+        struct MPL_atomic_int_t a, b;
         int c;
 
         MPL_atomic_relaxed_store_int(&a, 0);

--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -41,7 +41,7 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     volatile TYPE v;                                                           \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -50,7 +50,7 @@ static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -59,20 +59,20 @@ static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
     ptr->v = val;                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
     ptr->v = val;                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
                                            TYPE oldv, TYPE newv)               \
 {                                                                              \
     TYPE prev;                                                                 \
@@ -83,7 +83,7 @@ static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
     return prev;                                                               \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
                                             TYPE val)                          \
 {                                                                              \
     TYPE prev;                                                                 \
@@ -96,7 +96,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -106,7 +106,7 @@ static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \

--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -41,7 +41,7 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     volatile TYPE v;                                                           \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -50,7 +50,7 @@ static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -59,21 +59,21 @@ static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
     ptr->v = val;                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
     ptr->v = val;                                                              \
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
-                                           TYPE oldv, TYPE newv)               \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -83,8 +83,8 @@ static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * pt
     MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
     return prev;                                                               \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
-                                            TYPE val)                          \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -96,7 +96,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * p
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
@@ -106,7 +106,7 @@ static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
     MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \

--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -30,26 +30,26 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE v;                                                             \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return (TYPE)atomic_load_explicit(&ptr->v, memory_order_relaxed);          \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return (TYPE)atomic_load_explicit(&ptr->v, memory_order_acquire);          \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_relaxed);      \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_release);      \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
                                            TYPE oldv, TYPE newv)               \
 {                                                                              \
     CAST_TYPE oldv_tmp = (CAST_TYPE)oldv;                                      \
@@ -59,7 +59,7 @@ static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
                                             memory_order_acquire);             \
     return (TYPE)oldv_tmp;                                                     \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
                                             TYPE val)                          \
 {                                                                              \
     return (TYPE)atomic_exchange_explicit(&ptr->v, (CAST_TYPE)val,             \
@@ -68,13 +68,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)           \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return (TYPE)atomic_fetch_add_explicit(&ptr->v, (CAST_TYPE)val,            \
                                            memory_order_acq_rel);              \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return (TYPE)atomic_fetch_sub_explicit(&ptr->v, (CAST_TYPE)val,            \
                                            memory_order_acq_rel);              \

--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -30,27 +30,27 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE v;                                                             \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return (TYPE)atomic_load_explicit(&ptr->v, memory_order_relaxed);          \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return (TYPE)atomic_load_explicit(&ptr->v, memory_order_acquire);          \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_relaxed);      \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     atomic_store_explicit(&ptr->v, (CAST_TYPE)val, memory_order_release);      \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
-                                           TYPE oldv, TYPE newv)               \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     CAST_TYPE oldv_tmp = (CAST_TYPE)oldv;                                      \
     atomic_compare_exchange_strong_explicit(&ptr->v, &oldv_tmp,                \
@@ -59,8 +59,8 @@ static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * pt
                                             memory_order_acquire);             \
     return (TYPE)oldv_tmp;                                                     \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
-                                            TYPE val)                          \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return (TYPE)atomic_exchange_explicit(&ptr->v, (CAST_TYPE)val,             \
                                           memory_order_acq_rel);               \
@@ -68,13 +68,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * p
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)           \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return (TYPE)atomic_fetch_add_explicit(&ptr->v, (CAST_TYPE)val,            \
                                            memory_order_acq_rel);              \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return (TYPE)atomic_fetch_sub_explicit(&ptr->v, (CAST_TYPE)val,            \
                                            memory_order_acq_rel);              \

--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -23,46 +23,46 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
      TYPE volatile v;                                                          \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);                         \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);                         \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);                          \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);                          \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
-                                           TYPE oldv, TYPE newv)               \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     __atomic_compare_exchange_n(&ptr->v, &oldv, newv, 0, __ATOMIC_ACQ_REL,     \
                                 __ATOMIC_ACQUIRE);                             \
     return oldv;                                                               \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
-                                            TYPE val)                          \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __atomic_exchange_n(&ptr->v, val, __ATOMIC_ACQ_REL);                \
 }
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __atomic_fetch_add(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __atomic_fetch_sub(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
 }

--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -23,33 +23,33 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
      TYPE volatile v;                                                          \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);                         \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);                         \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);                          \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);                          \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
                                            TYPE oldv, TYPE newv)               \
 {                                                                              \
     __atomic_compare_exchange_n(&ptr->v, &oldv, newv, 0, __ATOMIC_ACQ_REL,     \
                                 __ATOMIC_ACQUIRE);                             \
     return oldv;                                                               \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
                                             TYPE val)                          \
 {                                                                              \
     return __atomic_exchange_n(&ptr->v, val, __ATOMIC_ACQ_REL);                \
@@ -57,12 +57,12 @@ static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __atomic_fetch_add(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __atomic_fetch_sub(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
 }

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -26,12 +26,12 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE volatile v;                                                           \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     volatile int i = 0;                                                        \
     TYPE val = ptr->v;                                                         \
@@ -39,25 +39,25 @@ static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     volatile int i = 1;                                                        \
     __sync_lock_release(&i); /* guarantees release semantics */                \
     ptr->v = val;                                                              \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
-                                           TYPE oldv, TYPE newv)               \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv,                    \
                                        /* protected variables: */ &ptr->v);    \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
-                                            TYPE val)                          \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE cmp;                                                                  \
     TYPE prev = MPL_atomic_acquire_load_ ## NAME(ptr);                         \
@@ -70,13 +70,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * p
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __sync_fetch_and_add(&ptr->v, val,                                  \
                                 /* protected variables: */ &ptr->v);           \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __sync_fetch_and_sub(&ptr->v, val,                                  \
                                 /* protected variables: */ &ptr->v);           \

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -26,12 +26,12 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE volatile v;                                                           \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     volatile int i = 0;                                                        \
     TYPE val = ptr->v;                                                         \
@@ -39,24 +39,24 @@ static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     volatile int i = 1;                                                        \
     __sync_lock_release(&i); /* guarantees release semantics */                \
     ptr->v = val;                                                              \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
                                            TYPE oldv, TYPE newv)               \
 {                                                                              \
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv,                    \
                                        /* protected variables: */ &ptr->v);    \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
                                             TYPE val)                          \
 {                                                                              \
     TYPE cmp;                                                                  \
@@ -70,13 +70,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __sync_fetch_and_add(&ptr->v, val,                                  \
                                 /* protected variables: */ &ptr->v);           \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return __sync_fetch_and_sub(&ptr->v, val,                                  \
                                 /* protected variables: */ &ptr->v);           \

--- a/src/mpl/include/mpl_atomic_none.h
+++ b/src/mpl/include/mpl_atomic_none.h
@@ -26,27 +26,27 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE v;                                                                    \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline TYPE MPL_atomic_cas_ ## NAME                                     \
-                       (MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
+                       (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     if (prev == oldv)                                                          \
@@ -54,7 +54,7 @@ static inline TYPE MPL_atomic_cas_ ## NAME                                     \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_swap_ ## NAME                                    \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v = val;                                                              \
@@ -63,14 +63,14 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v += val;                                                             \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v -= val;                                                             \

--- a/src/mpl/include/mpl_atomic_none.h
+++ b/src/mpl/include/mpl_atomic_none.h
@@ -26,27 +26,27 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE v;                                                                    \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return ptr->v;                                                             \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline TYPE MPL_atomic_cas_ ## NAME                                     \
-                       (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     if (prev == oldv)                                                          \
@@ -54,7 +54,7 @@ static inline TYPE MPL_atomic_cas_ ## NAME                                     \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_swap_ ## NAME                                    \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v = val;                                                              \
@@ -63,14 +63,14 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
 
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v += val;                                                             \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev = ptr->v;                                                        \
     ptr->v -= val;                                                             \

--- a/src/mpl/include/mpl_atomic_nt_intrinsics.h
+++ b/src/mpl/include/mpl_atomic_nt_intrinsics.h
@@ -46,36 +46,36 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE volatile v;                                                    \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return CAST_FROM_ATOMIC(ptr->v);                                           \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const MPL_atomic_ ## NAME ## _t * ptr) \
+                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val = CAST_FROM_ATOMIC(ptr->v);                                       \
     _ReadWriteBarrier();                                                       \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = CAST_TO_ATOMIC(val);                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     _ReadWriteBarrier();                                                       \
     ptr->v = CAST_TO_ATOMIC(val);                                              \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,    \
+static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
                                            TYPE oldv, TYPE newv)               \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedCompareExchange ## SUFFIX              \
                             ((ATOMIC_TYPE volatile *)&ptr->v,                  \
                              CAST_TO_ATOMIC(newv), CAST_TO_ATOMIC(oldv)));     \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
+static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
                                             TYPE val)                          \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchange ## SUFFIX                     \
@@ -86,13 +86,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(MPL_atomic_ ## NAME ## _t * ptr,   \
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,    \
                                  CAST_TO_ATOMIC, SUFFIX)                       \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
                              (&ptr->v, CAST_TO_ATOMIC(val)));                  \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                    (MPL_atomic_ ## NAME ## _t *ptr, TYPE val) \
+                                    (struct MPL_atomic_ ## NAME ## _t *ptr, TYPE val) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
                              (&ptr->v, -CAST_TO_ATOMIC(val)));                 \

--- a/src/mpl/include/mpl_atomic_nt_intrinsics.h
+++ b/src/mpl/include/mpl_atomic_nt_intrinsics.h
@@ -46,37 +46,37 @@ struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE volatile v;                                                    \
 };                                                                             \
 static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     return CAST_FROM_ATOMIC(ptr->v);                                           \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
-                                       (const struct MPL_atomic_ ## NAME ## _t * ptr) \
+                                (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val = CAST_FROM_ATOMIC(ptr->v);                                       \
     _ReadWriteBarrier();                                                       \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     ptr->v = CAST_TO_ATOMIC(val);                                              \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     _ReadWriteBarrier();                                                       \
     ptr->v = CAST_TO_ATOMIC(val);                                              \
 }                                                                              \
-static inline TYPE MPL_atomic_cas_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,    \
-                                           TYPE oldv, TYPE newv)               \
+static inline TYPE MPL_atomic_cas_ ## NAME                                     \
+                (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedCompareExchange ## SUFFIX              \
                             ((ATOMIC_TYPE volatile *)&ptr->v,                  \
                              CAST_TO_ATOMIC(newv), CAST_TO_ATOMIC(oldv)));     \
 }                                                                              \
-static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * ptr,   \
-                                            TYPE val)                          \
+static inline TYPE MPL_atomic_swap_ ## NAME                                    \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchange ## SUFFIX                     \
                             ((ATOMIC_TYPE volatile *)&ptr->v,                  \
@@ -86,13 +86,13 @@ static inline TYPE MPL_atomic_swap_ ## NAME(struct MPL_atomic_ ## NAME ## _t * p
 #define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,    \
                                  CAST_TO_ATOMIC, SUFFIX)                       \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
-                                   (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
                              (&ptr->v, CAST_TO_ATOMIC(val)));                  \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
-                                    (struct MPL_atomic_ ## NAME ## _t *ptr, TYPE val) \
+                            (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     return CAST_FROM_ATOMIC(_InterlockedExchangeAdd ## SUFFIX                  \
                              (&ptr->v, -CAST_TO_ATOMIC(val)));                 \


### PR DESCRIPTION
## Pull Request Description

The commit 91e4bfa6eeffb86bb39547d4c151d385ddf21792 removed `typedef` of `MPL_atomic_xxx` in `mpl_atomic_xxx.h`.  However, `configure` directly includes `mpl_atomic_xxx.h`, not `mpl_atomic.h` (since `mpl_atomic.h` includes `mplconfig.h` that is not created at configuration time), which causes an undefined error at configuration time (i.e., by defining a function using `MPL_atomic_xxx`). As a result, the backup method (i.e., Pthreads-based atomics) is always chosen.

This patch fixes this issue by using `"struct" MPL_atomic_xxx` (not `MPL_atomic_xxx`) in `mpl_atomic_xxx.h` and `configure.ac`.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None. This is a bug fix.

## Known Issues

None

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
