### PR TITLE
Fix intra-node topology aware trees

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -155,24 +155,6 @@ int MPI_Finalize(void)
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
 
-#ifdef HAVE_HWLOC
-    hwloc_topology_destroy(MPIR_Process.hwloc_topology);
-    hwloc_bitmap_free(MPIR_Process.bindset);
-#endif
-
-#ifdef HAVE_NETLOC
-    switch (MPIR_Process.network_attr.type) {
-        case MPIR_NETLOC_NETWORK_TYPE__TORUS:
-            MPL_free(MPIR_Process.network_attr.u.torus.geometry);
-            break;
-        case MPIR_NETLOC_NETWORK_TYPE__FAT_TREE:
-        case MPIR_NETLOC_NETWORK_TYPE__CLOS_NETWORK:
-        default:
-            MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
-            break;
-    }
-#endif
-
     /* Note: Only one thread may ever call MPI_Finalize (MPI_Finalize may
      * be called at most once in any program) */
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
@@ -333,6 +315,24 @@ int MPI_Finalize(void)
         int thread_err;
         MPL_thread_finalize(&thread_err);
         MPIR_Assert(thread_err == 0);
+    }
+#endif
+
+#ifdef HAVE_HWLOC
+    hwloc_topology_destroy(MPIR_Process.hwloc_topology);
+    hwloc_bitmap_free(MPIR_Process.bindset);
+#endif
+
+#ifdef HAVE_NETLOC
+    switch (MPIR_Process.network_attr.type) {
+        case MPIR_NETLOC_NETWORK_TYPE__TORUS:
+            MPL_free(MPIR_Process.network_attr.u.torus.geometry);
+            break;
+        case MPIR_NETLOC_NETWORK_TYPE__FAT_TREE:
+        case MPIR_NETLOC_NETWORK_TYPE__CLOS_NETWORK:
+        default:
+            MPL_free(MPIR_Process.network_attr.u.tree.node_levels);
+            break;
     }
 #endif
 

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -314,7 +314,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
         if (MPIR_CVAR_ENABLE_INTRANODE_TOPOLOGY_AWARE_TREES &&
             getenv("HYDRA_USER_PROVIDED_BINDING")) {
             /* Topology aware trees are created only when the user has specified process binding */
-            if (hwloc_topology_load(MPIR_Process.hwloc_topology) == 0) {
+            if (MPIR_Process.bindset_is_valid) {
                 mpi_errno =
                     MPIDI_SHM_topology_tree_init(comm_ptr, 0, MPIR_CVAR_BCAST_INTRANODE_TREE_KVAL,
                                                  &release_gather_info_ptr->bcast_tree,

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -136,6 +136,7 @@ void MPIDI_SHM_copy_tree(int *shared_region, int num_ranks, int rank,
     int num_children = child_ctr[rank + 1] - child_ctr[rank];
     int *my_children = &children[child_ctr[rank]];
 
+    *topotree_fail = 0;
     my_tree->parent = parent;
     my_tree->num_children = 0;
     my_tree->rank = rank;


### PR DESCRIPTION
## Pull Request Description

Intra-node topology aware trees were not getting build due to some reasons related to hwloc_topology. This PR fixes it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
