### PR TITLE
adio: fix atomicity check

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrstr.c
@@ -18,7 +18,7 @@
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off,    \
                                  &status1, error_code);                 \
-                if (!(fd->atomicity))                                   \
+                if (fd->atomicity)                                   \
                     ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
@@ -35,7 +35,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (fd->atomicity)                                       \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -58,7 +58,7 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity))                                       \
+            if (fd->atomicity)                                       \
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
@@ -75,7 +75,7 @@
             writebuf_len = (unsigned) MPL_MIN(end_offset - writebuf_off + 1, \
                                               (writebuf_off / stripe_size + 1) * \
                                               stripe_size - writebuf_off); \
-            if (!(fd->atomicity))                                       \
+            if (fd->atomicity)                                       \
                 ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET,                       \
@@ -483,7 +483,7 @@ void ADIOI_LUSTRE_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (fd->atomicity)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 return;

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_read.c
@@ -85,11 +85,11 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, readbuf_off, SEEK_SET);                   \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_READ_LOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
+            if (fd->atomicity) ADIOI_READ_LOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
             MPE_Log_event(ADIOI_MPE_read_a, 0, NULL);                   \
             err = read(fd->fd_sys, readbuf, readbuf_len);               \
             MPE_Log_event(ADIOI_MPE_read_b, 0, NULL);                   \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
             if (err == -1) err_flag = 1;                                \
         }                                                               \
         while (req_len > readbuf_off + readbuf_len - req_off) {         \
@@ -106,11 +106,11 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, readbuf_off+partial_read, SEEK_SET);      \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_READ_LOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
+            if (fd->atomicity) ADIOI_READ_LOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
             MPE_Log_event(ADIOI_MPE_read_a, 0, NULL);                   \
             err = read(fd->fd_sys, readbuf+partial_read, readbuf_len-partial_read); \
             MPE_Log_event(ADIOI_MPE_read_b, 0, NULL);                   \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
             if (err == -1) err_flag = 1;                                \
         }                                                               \
         memcpy((char *)buf + userbuf_off, readbuf+req_off-readbuf_off, req_len); \
@@ -122,9 +122,9 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
             readbuf_off = req_off;                                      \
             readbuf_len = (int) (MPL_MIN(max_bufsize, end_offset-readbuf_off+1)); \
             lseek(fd->fd_sys, readbuf_off, SEEK_SET);                   \
-            if (!(fd->atomicity)) ADIOI_READ_LOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
+            if (fd->atomicity) ADIOI_READ_LOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
             err = read(fd->fd_sys, readbuf, readbuf_len);               \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, readbuf_off, SEEK_SET, readbuf_len); \
             if (err == -1) err_flag = 1;                                \
         }                                                               \
         while (req_len > readbuf_off + readbuf_len - req_off) {         \
@@ -139,9 +139,9 @@ void ADIOI_NFS_ReadContig(ADIO_File fd, void *buf, int count,
             readbuf_len = (int) (partial_read + MPL_MIN(max_bufsize,    \
                                                         end_offset-readbuf_off+1)); \
             lseek(fd->fd_sys, readbuf_off+partial_read, SEEK_SET);      \
-            if (!(fd->atomicity)) ADIOI_READ_LOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
+            if (fd->atomicity) ADIOI_READ_LOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
             err = read(fd->fd_sys, readbuf+partial_read, readbuf_len-partial_read); \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, readbuf_off+partial_read, SEEK_SET, readbuf_len-partial_read); \
             if (err == -1) err_flag = 1;                                \
         }                                                               \
         memcpy((char *)buf + userbuf_off, readbuf+req_off-readbuf_off, req_len); \
@@ -227,7 +227,7 @@ void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_READ_LOCK(fd, readbuf_off, SEEK_SET, readbuf_len);
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_read_a, 0, NULL);
@@ -236,7 +236,7 @@ void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_read_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_UNLOCK(fd, readbuf_off, SEEK_SET, readbuf_len);
         if (err == -1)
             err_flag = 1;
@@ -392,7 +392,7 @@ void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_READ_LOCK(fd, offset, SEEK_SET, readbuf_len);
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_read_a, 0, NULL);
@@ -401,7 +401,7 @@ void ADIOI_NFS_ReadStrided(ADIO_File fd, void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_read_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_UNLOCK(fd, offset, SEEK_SET, readbuf_len);
 
         if (err == -1)

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs_write.c
@@ -83,11 +83,11 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
             MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
             MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             writebuf_off = req_off;                                     \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
@@ -111,13 +111,13 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
             MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
             MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             req_len -= write_sz;                                        \
             userbuf_off += write_sz;                                    \
             writebuf_off += writebuf_len;                               \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
@@ -141,11 +141,11 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
         if (req_off >= writebuf_off + writebuf_len) {                   \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             writebuf_off = req_off;                                     \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             err = read(fd->fd_sys, writebuf, writebuf_len);             \
             if (err == -1) {                                            \
@@ -161,13 +161,13 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
         while (write_sz != req_len) {                                   \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             req_len -= write_sz;                                        \
             userbuf_off += write_sz;                                    \
             writebuf_off += writebuf_len;                               \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             err = read(fd->fd_sys, writebuf, writebuf_len);             \
             if (err == -1) {                                            \
@@ -192,11 +192,11 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
             MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             writebuf_off = req_off;                                     \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
@@ -207,11 +207,11 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
             MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);                  \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
             MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);                  \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
             MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);                  \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             req_len -= write_sz;                                        \
             userbuf_off += write_sz;                                    \
@@ -226,9 +226,9 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
     {                                                                   \
         if (req_off >= writebuf_off + writebuf_len) {                   \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             writebuf_off = req_off;                                     \
             writebuf_len = (int) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
@@ -237,9 +237,9 @@ void ADIOI_NFS_WriteContig(ADIO_File fd, const void *buf, int count,
         memcpy(writebuf+req_off-writebuf_off, (char *)buf +userbuf_off, write_sz); \
         while (write_sz != req_len) {                                   \
             lseek(fd->fd_sys, writebuf_off, SEEK_SET);                  \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             err = write(fd->fd_sys, writebuf, writebuf_len);            \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (err == -1) err_flag = 1;                                \
             req_len -= write_sz;                                        \
             userbuf_off += write_sz;                                    \
@@ -338,7 +338,7 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);
@@ -347,7 +347,7 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
         if (err == -1)
             err_flag = 1;
@@ -490,7 +490,7 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
         writebuf = (char *) ADIOI_Malloc(max_bufsize);
         memset(writebuf, -1, max_bufsize);
         writebuf_len = (int) (MPL_MIN(max_bufsize, end_offset - writebuf_off + 1));
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_lseek_a, 0, NULL);
@@ -630,7 +630,7 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_lseek_b, 0, NULL);
 #endif
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
 #ifdef ADIOI_MPE_LOGGING
         MPE_Log_event(ADIOI_MPE_write_a, 0, NULL);
@@ -640,7 +640,7 @@ void ADIOI_NFS_WriteStrided(ADIO_File fd, const void *buf, int count,
         MPE_Log_event(ADIOI_MPE_write_b, 0, NULL);
 #endif
 
-        if (!(fd->atomicity))
+        if (fd->atomicity)
             ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
         else
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);

--- a/src/mpi/romio/adio/common/ad_write_str.c
+++ b/src/mpi/romio/adio/common/ad_write_str.c
@@ -14,7 +14,7 @@
             if (writebuf_len) {                                         \
                 ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,  \
                                  ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-                if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+                if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
                 if (*error_code != MPI_SUCCESS) {                       \
                     *error_code = MPIO_Err_create_code(*error_code,     \
                                                        MPIR_ERR_RECOVERABLE, myname, \
@@ -25,7 +25,7 @@
             }                                                           \
             writebuf_off = req_off;                                     \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -42,7 +42,7 @@
         while (write_sz != req_len) {                                   \
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE,      \
                              ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
-            if (!(fd->atomicity)) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             if (*error_code != MPI_SUCCESS) {                           \
                 *error_code = MPIO_Err_create_code(*error_code,         \
                                                    MPIR_ERR_RECOVERABLE, myname, \
@@ -54,7 +54,7 @@
             userbuf_off += write_sz;                                    \
             writebuf_off += writebuf_len;                               \
             writebuf_len = (unsigned) (MPL_MIN(max_bufsize,end_offset-writebuf_off+1)); \
-            if (!(fd->atomicity)) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
+            if (fd->atomicity) ADIOI_WRITE_LOCK(fd, writebuf_off, SEEK_SET, writebuf_len); \
             ADIO_ReadContig(fd, writebuf, writebuf_len, MPI_BYTE,       \
                             ADIO_EXPLICIT_OFFSET, writebuf_off, &status1, error_code); \
             if (*error_code != MPI_SUCCESS) {                           \
@@ -448,7 +448,7 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         if (writebuf_len) {
             ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE, ADIO_EXPLICIT_OFFSET,
                              writebuf_off, &status1, error_code);
-            if (!(fd->atomicity))
+            if (fd->atomicity)
                 ADIOI_UNLOCK(fd, writebuf_off, SEEK_SET, writebuf_len);
             if (*error_code != MPI_SUCCESS)
                 goto fn_exit;


### PR DESCRIPTION
## Pull Request Description

When atomicity is enabled (==1) locks should be used, and not
the opposite.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

Common strided write implementation, nfs read and writes and lustre strided write implementation will now behave as expected, meaning that locks will be used iff atomicity is set for the file.

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
