### PR TITLE
adio: enable filesystem owned lock functions

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos.c
@@ -44,4 +44,9 @@ struct ADIOI_Fns_struct ADIO_DAOS_operations = {
     "DAOS: ROMIO driver for DAOS",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
     ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs.c
@@ -59,5 +59,10 @@ struct ADIOI_Fns_struct ADIO_GPFS_operations = {
     "GPFS: IBM GPFS",
 #endif
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_ime/ad_ime.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime.c
@@ -37,4 +37,9 @@ struct ADIOI_Fns_struct ADIO_IME_operations = {
     ADIOI_IME_Delete,   /* Delete */
     ADIOI_IME_Feature,
     ADIOI_IME_PREFIX,
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre.c
@@ -42,5 +42,10 @@ struct ADIOI_Fns_struct ADIO_LUSTRE_operations = {
     ADIOI_GEN_Feature,  /* Features */
     "LUSTRE:",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_nfs/ad_nfs.c
+++ b/src/mpi/romio/adio/ad_nfs/ad_nfs.c
@@ -39,5 +39,10 @@ struct ADIOI_Fns_struct ADIO_NFS_operations = {
     ADIOI_NFS_Feature,  /* Features */
     "NFS:",     /* fsname: just a string */
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_panfs/ad_panfs.c
+++ b/src/mpi/romio/adio/ad_panfs/ad_panfs.c
@@ -53,5 +53,10 @@ struct ADIOI_Fns_struct ADIO_PANFS_operations = {
     ADIOI_GEN_Feature,
     "PANFS: Panasas PanFS",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2.c
@@ -41,7 +41,12 @@ struct ADIOI_Fns_struct ADIO_PVFS2_operations = {
     ADIOI_PVFS2_Feature,
     "PVFS2: the PVFS v2 or OrangeFS file systems",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };
 
 /*

--- a/src/mpi/romio/adio/ad_testfs/ad_testfs.c
+++ b/src/mpi/romio/adio/ad_testfs/ad_testfs.c
@@ -37,5 +37,10 @@ struct ADIOI_Fns_struct ADIO_TESTFS_operations = {
     ADIOI_GEN_Feature,  /* Features */
     "TESTFS: the logging-only file system",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_ufs/ad_ufs.c
+++ b/src/mpi/romio/adio/ad_ufs/ad_ufs.c
@@ -42,5 +42,10 @@ struct ADIOI_Fns_struct ADIO_UFS_operations = {
     ADIOI_GEN_Feature,  /* Features */
     "UFS: Generic ROMIO driver for all UNIX-like file systems",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/ad_xfs/ad_xfs.c
+++ b/src/mpi/romio/adio/ad_xfs/ad_xfs.c
@@ -42,5 +42,10 @@ struct ADIOI_Fns_struct ADIO_XFS_operations = {
     ADIOI_GEN_Feature,  /* Features */
     "XFS: SGI XFS",
     ADIOI_GEN_IreadStridedColl, /* IreadStridedColl */
-    ADIOI_GEN_IwriteStridedColl /* IwriteStridedColl */
+    ADIOI_GEN_IwriteStridedColl,        /* IwriteStridedColl */
+#if defined(F_SETLKW64)
+    ADIOI_GEN_SetLock   /* SetLock */
+#else
+    ADIOI_GEN_SetLock64 /* SetLock */
+#endif
 };

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -225,6 +225,8 @@ struct ADIOI_Fns_struct {
                                          MPI_Datatype datatype, int file_ptr_type,
                                          ADIO_Offset offset, ADIO_Request * request,
                                          int *error_code);
+    int (*ADIOI_xxx_SetLock) (ADIO_File fd, int cmd, int type, ADIO_Offset offset, int whence,
+                              ADIO_Offset len);
 };
 
 /* optypes for ADIO_RequestD */
@@ -814,43 +816,51 @@ int MPIOI_File_iread_all(MPI_File fh,
 
 #if defined(F_SETLKW64)
 
-#define ADIOI_WRITE_LOCK(fd, offset, whence, len) \
-     ADIOI_Set_lock64((fd)->fd_sys, F_SETLKW64, F_WRLCK, offset, whence, len)
-#define ADIOI_READ_LOCK(fd, offset, whence, len) \
-     ADIOI_Set_lock64((fd)->fd_sys, F_SETLKW64, F_RDLCK, offset, whence, len)
-#define ADIOI_UNLOCK(fd, offset, whence, len) \
-     ADIOI_Set_lock64((fd)->fd_sys, F_SETLK64, F_UNLCK, offset, whence, len)
+#define ADIOI_WRITE_LOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLKW64, F_WRLCK, offset, whence, len)
+#define ADIOI_READ_LOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLKW64, F_RDLCK, offset, whence, len)
+#define ADIOI_UNLOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLK64, F_UNLCK, offset, whence, len)
 
 #else
+
+#define ADIOI_WRITE_LOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLKW, F_WRLCK, offset, whence, len)
+#define ADIOI_READ_LOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLKW, F_RDLCK, offset, whence, len)
+#define ADIOI_UNLOCK_FUNC(fd, offset, whence, len) \
+        (*(fd->fns->ADIOI_xxx_SetLock))(fd, F_SETLK, F_UNLCK, offset, whence, len)
+
+#endif
+
 
 #ifdef ADIOI_MPE_LOGGING
 #define ADIOI_WRITE_LOCK(fd, offset, whence, len) do { \
         MPE_Log_event(ADIOI_MPE_writelock_a, 0, NULL); \
-        ADIOI_Set_lock((fd)->fd_sys, F_SETLKW, F_WRLCK, offset, whence, len); \
+        ADIOI_WRITE_LOCK_FUNC(fd, offset, whence, len); \
         MPE_Log_event(ADIOI_MPE_writelock_b, 0, NULL); } while (0)
 #define ADIOI_READ_LOCK(fd, offset, whence, len) \
         MPE_Log_event(ADIOI_MPE_readlock_a, 0, NULL); do { \
-        ADIOI_Set_lock((fd)->fd_sys, F_SETLKW, F_RDLCK, offset, whence, len); \
+        ADIOI_READ_LOCK_FUNC(fd, offset, whence, len); \
         MPE_Log_event(ADIOI_MPE_readlock_b, 0, NULL); } while (0)
 #define ADIOI_UNLOCK(fd, offset, whence, len) do { \
         MPE_Log_event(ADIOI_MPE_unlock_a, 0, NULL); \
-        ADIOI_Set_lock((fd)->fd_sys, F_SETLK, F_UNLCK, offset, whence, len); \
+        ADIOI_UNLOCK_FUNC(fd, offset, whence, len); \
         MPE_Log_event(ADIOI_MPE_unlock_b, 0, NULL); } while (0)
 #else
 #define ADIOI_WRITE_LOCK(fd, offset, whence, len) \
-          ADIOI_Set_lock((fd)->fd_sys, F_SETLKW, F_WRLCK, offset, whence, len)
+        ADIOI_WRITE_LOCK_FUNC(fd, offset, whence, len)
 #define ADIOI_READ_LOCK(fd, offset, whence, len) \
-          ADIOI_Set_lock((fd)->fd_sys, F_SETLKW, F_RDLCK, offset, whence, len)
+        ADIOI_READ_LOCK_FUNC(fd, offset, whence, len)
 #define ADIOI_UNLOCK(fd, offset, whence, len) \
-          ADIOI_Set_lock((fd)->fd_sys, F_SETLK, F_UNLCK, offset, whence, len)
+        ADIOI_UNLOCK_FUNC(fd, offset, whence, len)
 #endif
 
-#endif
-
-int ADIOI_Set_lock(FDTYPE fd_sys, int cmd, int type, ADIO_Offset offset, int whence,
-                   ADIO_Offset len);
-int ADIOI_Set_lock64(FDTYPE fd_sys, int cmd, int type, ADIO_Offset offset, int whence,
-                     ADIO_Offset len);
+int ADIOI_GEN_SetLock(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int whence,
+                      ADIO_Offset len);
+int ADIOI_GEN_SetLock64(ADIO_File fd, int cmd, int type, ADIO_Offset offset, int whence,
+                        ADIO_Offset len);
 
 #define ADIOI_Malloc(a) ADIOI_Malloc_fn(a,__LINE__,__FILE__)
 #define ADIOI_Calloc(a,b) ADIOI_Calloc_fn(a,b,__LINE__,__FILE__)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -724,7 +724,7 @@ AC_TRY_COMPILE([#include <fcntl.h>],
 ],pac_cv_struct_flock_and_mpi_offset=yes,pac_cv_struct_flock_and_mpi_offset=no)
 AC_MSG_RESULT($pac_cv_struct_flock_and_mpi_offset)
 # FIXME: We should look for struct flock64 and the F_SETLK64/F_GETLK64
-# ADIOI_Set_lock could use these instead.
+# ADIOI_GEN_SetLock. could use these instead.
 if test "$pac_cv_struct_flock_and_mpi_offset" = no ; then
     AC_MSG_CHECKING([whether struct flock compatible with int])
     AC_TRY_COMPILE([#include <fcntl.h>],


### PR DESCRIPTION
##  Pull Request Description

Currently unix fcntl is called for any implementation. Some filesystem should be able to use their own lock implementation.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [X] Passes tests (included warning check)
* [X] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [X] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [X] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [X] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
