### PR TITLE
adio: avoid calling write with zero length

### DIFF
--- a/src/mpi/romio/adio/common/ad_write_str.c
+++ b/src/mpi/romio/adio/common/ad_write_str.c
@@ -201,8 +201,10 @@ void ADIOI_GEN_WriteStrided(ADIO_File fd, const void *buf, int count,
         }
 
         /* write the buffer out finally */
-        ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE, ADIO_EXPLICIT_OFFSET,
-                         writebuf_off, &status1, error_code);
+        if (writebuf_len) {
+            ADIO_WriteContig(fd, writebuf, writebuf_len, MPI_BYTE, ADIO_EXPLICIT_OFFSET,
+                             writebuf_off, &status1, error_code);
+        }
 
         if (fd->atomicity)
             ADIOI_UNLOCK(fd, start_off, SEEK_SET, end_offset - start_off + 1);


### PR DESCRIPTION
## Pull Request Description

In strided write for noncontiguous in memory and contiguous in file the 
last contiguous write is being called with writebuf_len equals to zero.
Some filesystems do not accept zero write length.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [X] Passes tests (included warning check)
* [X] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [X] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [X] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [X] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
