### PR TITLE
ch4: refactor av_table and node_map

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -547,10 +547,9 @@ typedef struct {
     MPIDI_av_entry_t table[0];
 } MPIDI_av_table_t;
 
+#define MPIDIU_get_node_map(avtid) (MPIDI_global.node_map_list[(avtid)])
 #define MPIDIU_get_av_table(avtid) (MPIDI_global.av_table_list[(avtid)])
 #define MPIDIU_get_av(avtid, lpid) (MPIDI_global.av_table_list[(avtid)]->table[(lpid)])
-
-#define MPIDIU_get_node_map(avtid)   (MPIDI_global.node_map[(avtid)])
 
 #define MPID_Progress_register_hook(fn_, id_) MPID_Progress_register(fn_, id_)
 #define MPID_Progress_deregister_hook(id_) MPID_Progress_deregister(id_)

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -547,11 +547,8 @@ typedef struct {
     MPIDI_av_entry_t table[0];
 } MPIDI_av_table_t;
 
-extern MPIDI_av_table_t **MPIDI_av_table;
-extern MPIDI_av_table_t *MPIDI_av_table0;
-
-#define MPIDIU_get_av_table(avtid) (MPIDI_av_table[(avtid)])
-#define MPIDIU_get_av(avtid, lpid) (MPIDI_av_table[(avtid)]->table[(lpid)])
+#define MPIDIU_get_av_table(avtid) (MPIDI_global.av_table_list[(avtid)])
+#define MPIDIU_get_av(avtid, lpid) (MPIDI_global.av_table_list[(avtid)]->table[(lpid)])
 
 #define MPIDIU_get_node_map(avtid)   (MPIDI_global.node_map[(avtid)])
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -865,7 +865,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         MPIR_Assert(MPIDI_OFI_global.addrnamelen <= FI_NAME_MAX);
 
         int ret_bc_len;
-        mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
+        mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map,
                                           &MPIDI_OFI_global.addrname, MPIDI_OFI_global.addrnamelen,
                                           TRUE, MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &ret_bc_len);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -72,7 +72,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 
     void *table;
     int recv_bc_len;
-    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map[0],
+    mpi_errno = MPIDU_bc_table_create(rank, size, MPIDI_global.node_map,
                                       MPIDI_UCX_global.if_address,
                                       (int) MPIDI_UCX_global.addrname_len, FALSE,
                                       MPIR_CVAR_CH4_ROOTS_ONLY_PMI, &table, &recv_bc_len);

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -16,8 +16,6 @@
 #include "ch4_impl.h"
 
 MPIDI_CH4_Global_t MPIDI_global;
-MPIDI_av_table_t **MPIDI_av_table;
-MPIDI_av_table_t *MPIDI_av_table0;
 
 MPIDI_NM_funcs_t *MPIDI_NM_func;
 MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -517,16 +517,8 @@ static void finalize_builtin_comms(void)
 
 static void finalize_av_table(void)
 {
-    int i;
-    int max_n_avts;
-    max_n_avts = MPIDIU_get_max_n_avts();
-    for (i = 0; i < max_n_avts; i++) {
-        if (MPIDI_global.av_table_list[i] != NULL) {
-            MPIDIU_avt_release_ref(i);
-        }
-    }
-
     MPIDIU_avt_destroy();
+    MPL_free(MPIDI_global.av_table);
 }
 
 int MPID_Finalize(void)

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -327,7 +327,8 @@ static int init_av_table(void)
     MPIDI_global.av_table_list[0] = MPIDI_global.av_table;
     MPIR_Object_set_ref(MPIDI_global.av_table_list[0], 1);
 
-    MPIDI_global.node_map[0] = MPIR_Process.node_map;
+    MPIDI_global.node_map = MPIR_Process.node_map;
+    MPIDI_global.node_map_list[0] = MPIR_Process.node_map;
 
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;
@@ -337,13 +338,13 @@ static int init_av_table(void)
 
     for (i = 0; i < size; i++) {
         MPIDI_global.av_table->table[i].is_local =
-            (MPIDI_global.node_map[0][i] == MPIDI_global.node_map[0][rank]) ? 1 : 0;
+            (MPIDI_global.node_map[i] == MPIDI_global.node_map[rank]) ? 1 : 0;
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "WORLD RANK %d %s local", i,
                          MPIDI_global.av_table->table[i].is_local ? "is" : "is not"));
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "Node id (i) (me) %d %d", MPIDI_global.node_map[0][i],
-                         MPIDI_global.node_map[0][rank]));
+                        (MPL_DBG_FDEST, "Node id (i) (me) %d %d", MPIDI_global.node_map[i],
+                         MPIDI_global.node_map[rank]));
     }
 #endif
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -320,15 +320,10 @@ static int init_av_table(void)
                    + sizeof(MPIDI_av_table_t), MPL_MEM_ADDRESS);
     MPIDI_global.av_table->size = size;
 
+    MPIDI_global.node_map = MPIR_Process.node_map;
+
     /* av_table management */
     MPIDIU_avt_init();
-    MPIDIU_get_next_avtid(&avtid);
-    MPIR_Assert(avtid == 0);
-    MPIDI_global.av_table_list[0] = MPIDI_global.av_table;
-    MPIR_Object_set_ref(MPIDI_global.av_table_list[0], 1);
-
-    MPIDI_global.node_map = MPIR_Process.node_map;
-    MPIDI_global.node_map_list[0] = MPIR_Process.node_map;
 
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -287,7 +287,11 @@ typedef struct MPIDI_CH4_Global_t {
     int is_initialized;
     MPIDIU_avt_manager avt_mgr;
     int is_ch4u_initialized;
-    int **node_map, max_node_id;
+    int max_node_id;
+    int *node_map;
+    MPIDI_av_table_t *av_table;
+    int **node_map_list;
+    MPIDI_av_table_t **av_table_list;
     MPIDIG_comm_req_list_t *comm_req_lists;
     int registered_progress_hooks;
     MPIR_Commops MPIR_Comm_fns_store;

--- a/src/mpid/ch4/src/ch4r_comm.c
+++ b/src/mpid/ch4/src/ch4r_comm.c
@@ -35,7 +35,7 @@ int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upi
                  * new process groups are always assumed to be remote,
                  * so CH4 don't care what node they are on
                  */
-                MPIDI_global.node_map[_avtid][_lpid] = remote_node_ids[i];
+                MPIDI_global.node_map_list[_avtid][_lpid] = remote_node_ids[i];
                 if (remote_node_ids[i] > MPIDI_global.max_node_id) {
                     MPIDI_global.max_node_id = remote_node_ids[i];
                 }

--- a/src/mpid/ch4/src/ch4r_comm.c
+++ b/src/mpid/ch4/src/ch4r_comm.c
@@ -40,7 +40,7 @@ int MPIDIU_upids_to_lupids(int size, size_t * remote_upid_size, char *remote_upi
                     MPIDI_global.max_node_id = remote_node_ids[i];
                 }
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
-                MPIDI_av_table[_avtid]->table[_lpid].is_local = 0;
+                MPIDI_global.av_table_list[_avtid]->table[_lpid].is_local = 0;
 #endif
             }
         }

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -22,7 +22,7 @@ int MPIDIU_get_node_id(MPIR_Comm * comm, int rank, int *id_p)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_GET_NODE_ID);
 
     MPIDIU_comm_rank_to_pid(comm, rank, &lpid, &avtid);
-    *id_p = MPIDI_global.node_map[avtid][lpid];
+    *id_p = MPIDI_global.node_map_list[avtid][lpid];
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_GET_NODE_ID);
     return mpi_errno;
@@ -104,7 +104,7 @@ int MPIDIU_alloc_globals_for_avtid(int avtid)
     new_node_map = (int *) MPL_malloc(MPIDI_global.av_table_list[avtid]->size * sizeof(int),
                                       MPL_MEM_ADDRESS);
     MPIR_ERR_CHKANDJUMP(new_node_map == NULL, mpi_errno, MPI_ERR_NO_MEM, "**nomem");
-    MPIDI_global.node_map[avtid] = new_node_map;
+    MPIDI_global.node_map_list[avtid] = new_node_map;
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_ALLOC_GLOBALS_FOR_AVTID);
@@ -118,9 +118,9 @@ int MPIDIU_free_globals_for_avtid(int avtid)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
     if (avtid > 0) {
-        MPL_free(MPIDI_global.node_map[avtid]);
+        MPL_free(MPIDI_global.node_map_list[avtid]);
     }
-    MPIDI_global.node_map[avtid] = NULL;
+    MPIDI_global.node_map_list[avtid] = NULL;
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
     return MPI_SUCCESS;
 }
@@ -265,10 +265,10 @@ int MPIDIU_avt_init(void)
     MPIR_ERR_CHKANDSTMT(MPIDI_global.av_table_list == MAP_FAILED, mpi_errno, MPI_ERR_NO_MEM,
                         goto fn_fail, "**nomem");
 
-    MPIDI_global.node_map = (int **)
+    MPIDI_global.node_map_list = (int **)
         MPL_mmap(NULL, MPIDI_global.avt_mgr.mmapped_size,
                  PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON, -1, 0, MPL_MEM_ADDRESS);
-    MPIR_ERR_CHKANDSTMT(MPIDI_global.node_map == MAP_FAILED, mpi_errno,
+    MPIR_ERR_CHKANDSTMT(MPIDI_global.node_map_list == MAP_FAILED, mpi_errno,
                         MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
     MPIDI_global.avt_mgr.free_avtid =
@@ -309,7 +309,7 @@ int MPIDIU_build_nodemap_avtid(int myrank, MPIR_Comm * comm, int sz, int avtid)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_BUILD_NODEMAP_AVTID);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_BUILD_NODEMAP_AVTID);
-    ret = MPIDIU_build_nodemap(myrank, comm, sz, MPIDI_global.node_map[avtid],
+    ret = MPIDIU_build_nodemap(myrank, comm, sz, MPIDI_global.node_map_list[avtid],
                                &MPIDI_global.max_node_id);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_BUILD_NODEMAP_AVTID);

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -281,6 +281,14 @@ int MPIDIU_avt_init(void)
     }
     MPIDI_global.avt_mgr.free_avtid[MPIDI_global.avt_mgr.max_n_avts - 1] = -1;
 
+    int tmp_id;
+    MPIDIU_get_next_avtid(&tmp_id);
+    MPIR_Assert(tmp_id == 0);
+    MPIDI_global.av_table_list[0] = MPIDI_global.av_table;
+    MPIDI_global.node_map_list[0] = MPIDI_global.node_map;
+    /* Why set_ref to 1? -1 seems more sensible as it really doesn't need the ref_count */
+    MPIR_Object_set_ref(MPIDI_global.av_table_list[0], 1);
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_AVT_INIT);
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -101,58 +101,56 @@ MPL_STATIC_INLINE_PREFIX MPIDI_av_entry_t *MPIDIU_comm_rank_to_av(MPIR_Comm * co
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_COMM_RANK_TO_AV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_COMM_RANK_TO_AV);
 
+    int idx;                    /* intermediate variable for av_table index (for better code format) */
     switch (MPIDI_COMM(comm, map).mode) {
         case MPIDI_RANK_MAP_DIRECT:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).avtid]->table[rank];
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).avtid]->table[rank];
             break;
         case MPIDI_RANK_MAP_DIRECT_INTRA:
-            ret = &MPIDI_av_table0->table[rank];
+            ret = &MPIDI_global.av_table->table[rank];
             break;
         case MPIDI_RANK_MAP_OFFSET:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).avtid]
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).avtid]
                 ->table[rank + MPIDI_COMM(comm, map).reg.offset];
             break;
         case MPIDI_RANK_MAP_OFFSET_INTRA:
-            ret = &MPIDI_av_table0->table[rank + MPIDI_COMM(comm, map).reg.offset];
+            ret = &MPIDI_global.av_table->table[rank + MPIDI_COMM(comm, map).reg.offset];
             break;
         case MPIDI_RANK_MAP_STRIDE:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).avtid]
-                ->table[MPIDI_CALC_STRIDE_SIMPLE(rank,
-                                                 MPIDI_COMM(comm, map).reg.stride.stride,
-                                                 MPIDI_COMM(comm, map).reg.stride.offset)];
+            idx = MPIDI_CALC_STRIDE_SIMPLE(rank,
+                                           MPIDI_COMM(comm, map).reg.stride.stride,
+                                           MPIDI_COMM(comm, map).reg.stride.offset);
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).avtid]->table[idx];
             break;
         case MPIDI_RANK_MAP_STRIDE_INTRA:
-            ret = &MPIDI_av_table0->table[MPIDI_CALC_STRIDE_SIMPLE(rank,
-                                                                   MPIDI_COMM(comm,
-                                                                              map).reg.
-                                                                   stride.stride, MPIDI_COMM(comm,
-                                                                                             map).
-                                                                   reg.stride.offset)];
+            idx = MPIDI_CALC_STRIDE_SIMPLE(rank,
+                                           MPIDI_COMM(comm, map).reg.stride.stride,
+                                           MPIDI_COMM(comm, map).reg.stride.offset);
+            ret = &MPIDI_global.av_table->table[idx];
             break;
         case MPIDI_RANK_MAP_STRIDE_BLOCK:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).avtid]
-                ->table[MPIDI_CALC_STRIDE(rank,
-                                          MPIDI_COMM(comm, map).reg.stride.stride,
-                                          MPIDI_COMM(comm, map).reg.stride.blocksize,
-                                          MPIDI_COMM(comm, map).reg.stride.offset)];
+            idx = MPIDI_CALC_STRIDE(rank,
+                                    MPIDI_COMM(comm, map).reg.stride.stride,
+                                    MPIDI_COMM(comm, map).reg.stride.blocksize,
+                                    MPIDI_COMM(comm, map).reg.stride.offset);
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).avtid]->table[idx];
             break;
         case MPIDI_RANK_MAP_STRIDE_BLOCK_INTRA:
-            ret = &MPIDI_av_table0->table[MPIDI_CALC_STRIDE(rank,
-                                                            MPIDI_COMM(comm, map).reg.stride.stride,
-                                                            MPIDI_COMM(comm,
-                                                                       map).reg.stride.blocksize,
-                                                            MPIDI_COMM(comm,
-                                                                       map).reg.stride.offset)];
+            idx = MPIDI_CALC_STRIDE(rank,
+                                    MPIDI_COMM(comm, map).reg.stride.stride,
+                                    MPIDI_COMM(comm, map).reg.stride.blocksize,
+                                    MPIDI_COMM(comm, map).reg.stride.offset);
+            ret = &MPIDI_global.av_table->table[idx];
             break;
         case MPIDI_RANK_MAP_LUT:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).avtid]
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).avtid]
                 ->table[MPIDI_COMM(comm, map).irreg.lut.lpid[rank]];
             break;
         case MPIDI_RANK_MAP_LUT_INTRA:
-            ret = &MPIDI_av_table0->table[MPIDI_COMM(comm, map).irreg.lut.lpid[rank]];
+            ret = &MPIDI_global.av_table->table[MPIDI_COMM(comm, map).irreg.lut.lpid[rank]];
             break;
         case MPIDI_RANK_MAP_MLUT:
-            ret = &MPIDI_av_table[MPIDI_COMM(comm, map).irreg.mlut.gpid[rank].avtid]
+            ret = &MPIDI_global.av_table_list[MPIDI_COMM(comm, map).irreg.mlut.gpid[rank].avtid]
                 ->table[MPIDI_COMM(comm, map).irreg.mlut.gpid[rank].lpid];
             break;
         case MPIDI_RANK_MAP_NONE:

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -16,8 +16,6 @@
 int MPIDIU_get_n_avts(void);
 int MPIDIU_get_max_n_avts(void);
 int MPIDIU_get_avt_size(int avtid);
-int MPIDIU_alloc_globals_for_avtid(int avtid);
-int MPIDIU_free_globals_for_avtid(int avtid);
 int MPIDIU_get_next_avtid(int *avtid);
 int MPIDIU_free_avtid(int avtid);
 int MPIDIU_new_avt(int size, int *avtid);


### PR DESCRIPTION
## Pull Request Description

If we don't need to support dynamic process, we will only need a single `node_map` and a single `av_table`, which will get initialized at init time. The dynamic process support requires a list of `node_map`s and `av_table`s, as well as `avt_mgr` interface. 

We note that there is a clear separation of init-time and run-time. While the first `node_map/av_table` is essential at init-time, the dynamic process and list management are entirely run-time entities.

The current code put a dependency on the av_table manager for init, which makes the code inflexible to restructure. The PR removes the dependency, therefore simplifies the init process, and brings a degree of abstraction to the dynamic process support.

This is a prerequisite PR for further init refactor.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

None.

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
This refactor untangles the dynamic process support, making it a run-time add-on component, therefore, fixes #3983 (makes the proposal unnecessary).
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
