### PR TITLE
MPL/atomic: enhance configure to check warnings

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -827,7 +827,7 @@ AC_DEFUN([MPL_TRY_ATOMIC_HEADER],[
     AC_MSG_CHECKING([for support for $3])
 
     PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$CFLAGS -I${srcdir}/include"
+    CFLAGS="$CFLAGS -I${srcdir}/include -Werror"
     AC_LINK_IFELSE([MPL_ATOMIC_TEST_PROGRAM([$1])],
         [AC_DEFINE([HAVE_$2], [1], [Define to 1 if we have support for $3])]
         [AC_MSG_RESULT([yes])]


### PR DESCRIPTION
As reported by #3997, some compilers do not fully support some atomic operations and cause warnings (e.g., ICC 19.0.3 + `mpl_atomic_c11.h`), but they are overlooked by the previous configure.  This patch makes configure check not only errors but also warnings by adding `-Werror` in `configure.ac`.

This patch will fix #3997 by using GCC's `__atomic` as a fallback when ICC-19.0.3 is used, which will suppress warnings about C11 atomics.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
