### PR TITLE
Assert on Null Request

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -287,8 +287,10 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
 
         MPID_Request_create_hook(req);
     } else {
-        /* FIXME: This fails to fail if debugging is turned off */
         MPL_DBG_MSG(MPIR_DBG_REQUEST, TYPICAL, "unable to allocate a request");
+        /* This assertion will always be false here. The alternative to this is to put checks after
+         * every request creation call. */
+        MPIR_Assert(req != NULL);
     }
 
     return req;


### PR DESCRIPTION
## Pull Request Description

There are two options for how to handle a request not being allocated.

1. Assert when the request is NULL

This isn't ideal as it's pretty bad error handling. On the other hand, the alternative is to...

2. Change every call to allocate a request to check for successful output and perform error handling.

This is obviously more correct, but has a performance impact. In the debug case, we already check to see if things were allocated correctly.

## Expected Performance Changes

None

## Known Issues

Error handling could be better here, but it's a much larger change.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
