### PR TITLE
datatype: Fix static checker issue

### DIFF
--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -251,7 +251,6 @@ char *MPIR_Datatype_combiner_to_string(int combiner)
     static char c_f90_complex[] = "f90_complex";
     static char c_f90_integer[] = "f90_integer";
     static char c_resized[] = "resized";
-    static char c_other[] = "not builtin";
 
     if (combiner == MPI_COMBINER_NAMED)
         return c_named;
@@ -292,7 +291,7 @@ char *MPIR_Datatype_combiner_to_string(int combiner)
     if (combiner == MPI_COMBINER_RESIZED)
         return c_resized;
 
-    return c_other;
+    return NULL;
 }
 
 /* --BEGIN DEBUG-- */
@@ -321,6 +320,7 @@ void MPIR_Datatype_debug(MPI_Datatype type, int array_ct)
     }
 #if (defined HAVE_ERROR_CHECKING) || (defined MPL_USE_DBG_LOGGING)
     string = MPIR_Datatype_builtin_to_string(type);
+    MPIR_Assert(string != NULL);
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                         "# MPIU_Datatype_debug: MPI_Datatype = 0x%0x (%s)", type,
                                         (is_builtin) ? string : "derived"));

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -319,11 +319,15 @@ void MPIR_Datatype_debug(MPI_Datatype type, int array_ct)
         return;
     }
 #if (defined HAVE_ERROR_CHECKING) || (defined MPL_USE_DBG_LOGGING)
-    string = MPIR_Datatype_builtin_to_string(type);
-    MPIR_Assert(string != NULL);
+    if (is_builtin) {
+        string = MPIR_Datatype_builtin_to_string(type);
+        MPIR_Assert(string != NULL);
+    } else {
+        string = "derived";
+    }
     MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST,
                                         "# MPIU_Datatype_debug: MPI_Datatype = 0x%0x (%s)", type,
-                                        (is_builtin) ? string : "derived"));
+                                        string));
 #endif
 
     if (is_builtin)


### PR DESCRIPTION
## Pull Request Description

Revert a commit that re-introduced a static checker issue. Fix it a different way in the second commit that safely converts a type to string.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
