### PR TITLE
pmi: add mpir_pmi and refactor ch4_init

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -61,6 +61,7 @@ noinst_HEADERS +=                   \
     src/include/mpir_thread.h       \
     src/include/mpir_nbc.h          \
     src/include/mpir_op.h           \
+    src/include/mpir_pmi.h          \
     src/include/mpir_process.h      \
     src/include/mpir_misc.h         \
     src/include/mpir_tags.h         \

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -102,17 +102,11 @@ int vsnprintf(char *str, size_t size, const char *format, va_list ap);
 #define __func__ "__func__"
 #endif
 
-#ifdef USE_PMIX_API
 /* pmix.h contains inline functions that calls malloc, calloc, and free,
    and it will break with MPL's memory tracing when enabled.
    Make sure it is included *before* mpl.h.
 */
-#include <pmix.h>
-#elif defined(USE_PMI2_API)
-#include <pmi2.h>
-#else
-#include <pmi.h>
-#endif
+#include "mpir_pmi.h"
 
 /*****************************************************************************
  * We use the following ordering of information in this file:

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -1,0 +1,87 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#ifndef MPIR_PMI_H_INCLUDED
+#define MPIR_PMI_H_INCLUDED
+
+#include "mpichconf.h"
+
+#if !defined USE_PMI1_API && !defined USE_PMI2_API && !defined USE_PMIX_API
+#define USE_PMI1_API
+#endif
+
+#ifdef USE_PMI1_API
+#include <pmi.h>
+#elif defined(USE_PMI2_API)
+#include <pmi2.h>
+#elif defined(USE_PMIX_API)
+#include <pmix.h>
+#endif
+
+/* Domain options for init-time collectives */
+typedef enum {
+    MPIR_PMI_DOMAIN_ALL = 0,
+    MPIR_PMI_DOMAIN_LOCAL = 1,
+    MPIR_PMI_DOMAIN_NODE_ROOTS = 2
+} MPIR_PMI_DOMAIN;
+
+/* key/val pair struct to abstract PMI key/val pair */
+typedef struct MPIR_PMI_KEYVAL {
+    const char *key;
+    char *val;
+} MPIR_PMI_KEYVAL_t;
+
+/* PMI init / finalize */
+int MPIR_pmi_init(void);
+void MPIR_pmi_finalize(void);
+void MPIR_pmi_abort(int exit_code, const char *error_msg);
+
+/* PMI getters for private fields */
+int MPIR_pmi_max_val_size(void);
+const char *MPIR_pmi_job_id(void);
+
+/* PMI wrapper utilities */
+
+/* * barrier or kvs fence. "domain" is a hint for efficiency (eg PMIx) */
+int MPIR_pmi_barrier(MPIR_PMI_DOMAIN domain);
+/* * put, to global domain */
+int MPIR_pmi_kvs_put(char *key, char *val);
+/* * get. src in [0..size-1] or -1 for anysrc. val_size <= MPIR_pmi_max_val_size(). */
+int MPIR_pmi_kvs_get(int src, char *key, char *val, int val_size);
+
+/* * bcast from rank 0 to ALL or NODE_ROOTS processes. Both are collective over ALL */
+int MPIR_pmi_bcast(void *buf, int size, MPIR_PMI_DOMAIN domain);
+
+/* * allgather over either ALL or NODE_ROOTS processes. Both are collective over ALL.
+ *   recvsize <= MPIR_pmi_max_val_size().
+ *   recvbuf of size either "size x recvsize" or "num_nodes x recvsize".
+ */
+int MPIR_pmi_allgather(const void *sendbuf, int sendsize, void *recvbuf, int recvsize,
+                       MPIR_PMI_DOMAIN domain);
+
+/* * allgather utilizing shared memory. shm_buf is assumed to be a shared-memory.
+ *   all processes in ALL or NODE_ROOTS will first publish using put. Then
+ *   all processes will cooperatively gather using get.
+ */
+int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int recvsize,
+                           MPIR_PMI_DOMAIN domain);
+
+/* * bcast_local: all processes will participate.
+ *   Each local leader bcast to each local proc (within a node).
+ */
+int MPIR_pmi_bcast_local(char *val, int val_size);
+
+/* Other misc functions */
+int MPIR_pmi_get_universe_size(int *universe_size);
+char *MPIR_pmi_get_failed_procs(void);
+
+struct MPIR_Info;               /* forward declare (mpir_info.h) */
+int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
+                            const int maxprocs[], struct MPIR_Info *info_ptrs[],
+                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
+                            int *pmi_errcodes);
+
+#endif /* MPIR_PMI_H_INCLUDED */

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -30,6 +30,20 @@ typedef struct PreDefined_attrs {
 typedef struct MPIR_Process_t {
     OPA_int_t mpich_state;      /* State of MPICH. Use OPA_int_t to make MPI_Initialized() etc.
                                  * thread-safe per MPI-3.1.  See MPI-Forum ticket 357 */
+
+    /* Fields to be initialized by MPIR_pmi_init() */
+    int has_parent;
+    int appnum;
+    int rank;
+    int size;
+    int local_rank;
+    int local_size;
+    int num_nodes;
+    int *node_map;              /* int[size], maps rank to node_id */
+    int *node_local_map;        /* int[local_size], maps local_id to rank of local proc */
+    int *node_root_map;         /* int[num_nodes], maps node_id to the rank of node root */
+
+    /* -------------- */
     int do_error_checks;        /* runtime error check control */
     struct MPIR_Comm *comm_world;       /* Easy access to comm_world for
                                          * error handler */

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -88,21 +88,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_get_source(uint64_t match_bits)
                              ucs_status_string(STATUS));                \
     } while (0)
 
-
-#define MPIDI_UCX_PMI_ERROR(_errno)                             \
-    do                                                          \
-    {                                                           \
-        MPIR_ERR_CHKANDJUMP4(_errno!=PMI_SUCCESS,               \
-                             mpi_errno,                         \
-                             MPI_ERR_OTHER,                     \
-                             "**ucx_nm_pmi_error",              \
-                             "**ucx_nm_pmi_error %s %d %s %s",  \
-                             __SHORT_FILE__,                    \
-                             __LINE__,                          \
-                             __func__,                            \
-                             "pmi_error");                      \
-    } while (0)
-
 #define MPIDI_UCX_MPI_ERROR(_errno)                                     \
     do                                                                  \
     {                                                                   \

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -157,29 +157,8 @@ int MPIDI_UCX_mpi_finalize_hook(void)
         ucp_request_release(pending[i]);
     }
 
-#ifdef USE_PMIX_API
-    pmix_value_t value;
-    pmix_info_t *info;
-    int flag = 1;
-
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-    pmi_errno = PMIx_Fence(&MPIR_Process.pmix_wcproc, 1, info, 1);
-    if (pmi_errno != PMIX_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(pmi_errno, MPI_ERR_OTHER, "**pmix_fence", "**pmix_fence %d",
-                             pmi_errno);
-    }
-    PMIX_INFO_FREE(info, 1);
-#elif defined(USE_PMI2_API)
-    pmi_errno = PMI2_KVS_Fence();
-    if (pmi_errno != PMI2_SUCCESS) {
-        MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**pmi_kvsfence");
-    }
-#else
-    pmi_errno = PMI_Barrier();
-    MPIDI_UCX_PMI_ERROR(pmi_errno);
-#endif
-
+    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDI_UCX_global.worker != NULL)
         ucp_worker_destroy(MPIDI_UCX_global.worker);

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -135,7 +135,7 @@ int MPIDI_check_for_failed_procs(void)
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
     int len;
-    char *kvsname = MPIDI_global.jobid;
+    const char *kvsname = MPIR_pmi_job_id();
     char *failed_procs_string = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CHECK_FOR_FAILED_PROCS);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -376,6 +376,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_ERR_CHECK(mpi_errno);
 
     if (has_parent) {
+#ifdef USE_PMI1_API
         const char *kvs_name = MPIR_pmi_job_id();
         int pmi_errno;
         pmi_errno = PMI_KVS_Get(kvs_name, MPIDI_PARENT_PORT_KVSKEY,
@@ -388,6 +389,9 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
                           &MPIR_Process.comm_parent);
         MPIR_Assert(MPIR_Process.comm_parent != NULL);
         MPL_strncpy(MPIR_Process.comm_parent->name, "MPI_COMM_PARENT", MPI_MAX_OBJECT_NAME);
+#else
+        MPIR_Assert(0);
+#endif
     }
     /* -------------------------------- */
     /* Return MPICH Parameters          */

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -284,7 +284,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIDI_av_table[0]->size = size;
     MPIR_Object_set_ref(MPIDI_av_table[0], 1);
 
-    MPIDIU_alloc_globals_for_avtid(avtid);
+    MPIDI_global.node_map[0] = MPIR_Process.node_map;
 
     MPIDI_av_table0 = MPIDI_av_table[0];
 
@@ -320,10 +320,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
         MPIDI_av_table0->table[i].is_local = 0;
     }
-    mpi_errno = MPIDIU_build_nodemap(MPIR_Process.comm_world->rank, MPIR_Process.comm_world,
-                                     MPIR_Process.comm_world->local_size,
-                                     MPIDI_global.node_map[0], &MPIDI_global.max_node_id);
-    MPIR_ERR_CHECK(mpi_errno);
+    MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;
 
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "MPIDI_global.max_node_id = %d", MPIDI_global.max_node_id));

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -82,13 +82,6 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-#ifdef USE_PMI2_API
-/* PMI does not specify a max size for jobid_size in PMI2_Job_GetId.
-   CH3 uses jobid_size=MAX_JOBID_LEN=1024 when calling
-   PMI2_Job_GetId. */
-#define MPIDI_MAX_JOBID_LEN PMI2_MAX_VALLEN
-#endif
-
 static int choose_netmod(void);
 static const char *get_mt_model_name(int mt);
 static void print_runtime_configurations(void);
@@ -209,14 +202,11 @@ static int set_runtime_configurations(void)
 
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
-    int pmi_errno, mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
+    int mpi_errno = MPI_SUCCESS, rank, has_parent, size, appnum, thr_err;
     int avtid;
     int n_nm_vcis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int n_shm_vcis_provided;
-#endif
-#ifndef USE_PMI2_API
-    int max_pmi_name_length;
 #endif
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_INIT);
@@ -245,87 +235,14 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 #endif
 
     choose_netmod();
-#ifdef USE_PMI2_API
-    pmi_errno = PMI2_Init(&has_parent, &size, &rank, &appnum);
 
-    if (pmi_errno != PMI2_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_init", "**pmi_init %d", pmi_errno);
-    }
+    mpi_errno = MPIR_pmi_init();
+    MPIR_ERR_CHECK(mpi_errno);
 
-    MPIDI_global.jobid = (char *) MPL_malloc(MPIDI_MAX_JOBID_LEN, MPL_MEM_OTHER);
-    pmi_errno = PMI2_Job_GetId(MPIDI_global.jobid, MPIDI_MAX_JOBID_LEN);
-    if (pmi_errno != PMI2_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_job_getid",
-                             "**pmi_job_getid %d", pmi_errno);
-    }
-#elif defined(USE_PMIX_API)
-    {
-        pmix_value_t *pvalue = NULL;
-
-        pmi_errno = PMIx_Init(&MPIR_Process.pmix_proc, NULL, 0);
-        if (pmi_errno != PMIX_SUCCESS) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmix_init", "**pmix_init %d",
-                                 pmi_errno);
-        }
-        rank = MPIR_Process.pmix_proc.rank;
-
-        PMIX_PROC_CONSTRUCT(&MPIR_Process.pmix_wcproc);
-        MPL_strncpy(MPIR_Process.pmix_wcproc.nspace, MPIR_Process.pmix_proc.nspace, PMIX_MAX_NSLEN);
-        MPIR_Process.pmix_wcproc.rank = PMIX_RANK_WILDCARD;
-
-        pmi_errno = PMIx_Get(&MPIR_Process.pmix_wcproc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
-        if (pmi_errno != PMIX_SUCCESS) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmix_get", "**pmix_get %d",
-                                 pmi_errno);
-        }
-        size = pvalue->data.uint32;
-        PMIX_VALUE_RELEASE(pvalue);
-
-        /* appnum, has_parent is not set for now */
-        appnum = 0;
-        has_parent = 0;
-    }
-#else
-    pmi_errno = PMI_Init(&has_parent);
-
-    if (pmi_errno != PMI_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_init", "**pmi_init %d", pmi_errno);
-    }
-
-    pmi_errno = PMI_Get_rank(&rank);
-
-    if (pmi_errno != PMI_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_get_rank",
-                             "**pmi_get_rank %d", pmi_errno);
-    }
-
-    pmi_errno = PMI_Get_size(&size);
-
-    if (pmi_errno != 0) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_get_size",
-                             "**pmi_get_size %d", pmi_errno);
-    }
-
-    pmi_errno = PMI_Get_appnum(&appnum);
-
-    if (pmi_errno != PMI_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_get_appnum",
-                             "**pmi_get_appnum %d", pmi_errno);
-    }
-
-    pmi_errno = PMI_KVS_Get_name_length_max(&max_pmi_name_length);
-    if (pmi_errno != PMI_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get_name_length_max",
-                             "**pmi_kvs_get_name_length_max %d", pmi_errno);
-    }
-
-    MPIDI_global.jobid = (char *) MPL_malloc(max_pmi_name_length, MPL_MEM_OTHER);
-    pmi_errno = PMI_KVS_Get_my_name(MPIDI_global.jobid, max_pmi_name_length);
-    if (pmi_errno != PMI_SUCCESS) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get_my_name",
-                             "**pmi_kvs_get_my_name %d", pmi_errno);
-    }
-#endif
+    rank = MPIR_Process.rank;
+    size = MPIR_Process.size;
+    has_parent = MPIR_Process.has_parent;
+    appnum = MPIR_Process.appnum;
 
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_MUTEX, &thr_err);
     MPID_Thread_mutex_create(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX, &thr_err);
@@ -462,7 +379,9 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_ERR_CHECK(mpi_errno);
 
     if (has_parent) {
-        pmi_errno = PMI_KVS_Get(MPIDI_global.jobid, MPIDI_PARENT_PORT_KVSKEY,
+        const char *kvs_name = MPIR_pmi_job_id();
+        int pmi_errno;
+        pmi_errno = PMI_KVS_Get(kvs_name, MPIDI_PARENT_PORT_KVSKEY,
                                 MPIDI_global.parent_port, MPIDI_MAX_KVS_VALUE_LEN);
         if (pmi_errno != PMI_SUCCESS) {
             MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_get_parent_port",
@@ -532,15 +451,8 @@ int MPID_Finalize(void)
     }
 
     MPIDIU_avt_destroy();
-    MPL_free(MPIDI_global.jobid);
 
-#ifdef USE_PMIX_API
-    PMIx_Finalize(NULL, 0);
-#elif defined(USE_PMI2_API)
-    PMI2_Finalize();
-#else
-    PMI_Finalize();
-#endif
+    MPIR_pmi_finalize();
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_FINALIZE);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -294,7 +294,6 @@ typedef struct MPIDI_CH4_Global_t {
     progress_hook_slot_t progress_hooks[MAX_PROGRESS_HOOKS];
     MPID_Thread_mutex_t m[3];
     MPIDIU_map_t *win_map;
-    char *jobid;
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE
     MPIDIG_rreq_t *posted_list;
     MPIDIG_rreq_t *unexp_list;

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -115,7 +115,9 @@ int MPIDIU_free_globals_for_avtid(int avtid)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
-    MPL_free(MPIDI_global.node_map[avtid]);
+    if (avtid > 0) {
+        MPL_free(MPIDI_global.node_map[avtid]);
+    }
     MPIDI_global.node_map[avtid] = NULL;
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_FREE_GLOBALS_FOR_AVTID);
     return MPI_SUCCESS;
@@ -237,7 +239,6 @@ int MPIDIU_avt_release_ref(int avtid)
     MPIR_Object_release_ref(MPIDIU_get_av_table(avtid), &in_use);
     if (!in_use) {
         MPIDIU_free_avt(avtid);
-        MPIDIU_free_globals_for_avtid(avtid);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_AVT_RELEASE_REF);

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -88,9 +88,8 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     int rc, mpi_errno = MPI_SUCCESS;
     int start, end, i;
     char *val = NULL, *val_p;
-    int out_len, val_len, rem, flag;
+    int out_len, val_len, rem;
     pmix_value_t value, *pvalue;
-    pmix_info_t *info;
     pmix_proc_t proc;
     int local_rank, local_leader;
     size_t my_bc_len = bc_len;
@@ -131,11 +130,8 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_commit");
     }
 
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-    rc = PMIx_Fence(&MPIR_Process.pmix_wcproc, 1, info, 1);
-    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_fence");
-    PMIX_INFO_FREE(info, 1);
+    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {
         start = local_rank * (size / local_size);
@@ -237,8 +233,9 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         rc = PMI2_KVS_Put(key, val);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_kvsput");
     }
-    rc = PMI2_KVS_Fence();
-    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_kvsfence");
+
+    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {
         start = local_rank * (size / local_size);
@@ -349,8 +346,9 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         rc = PMI_KVS_Commit(kvsname);
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_commit");
     }
-    rc = PMI_Barrier();
-    MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_barrier");
+
+    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {
         start = local_rank * (size / local_size);

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -207,7 +207,8 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         MPIR_CHKLMEM_MALLOC(key, char *, PMI2_MAX_KEYLEN, mpi_errno, "key", MPL_MEM_SHM);
-        MPL_snprintf(key, PMI2_MAX_KEYLEN, "sharedFilename-%d", num_segments);
+        int node_id = MPIR_Process.node_map[MPIR_Process.rank];
+        MPL_snprintf(key, PMI2_MAX_KEYLEN, "sharedFilename[%d]-%d", node_id, num_segments);
 
         if (local_rank == 0) {
             mpl_err =

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -68,9 +68,9 @@
 **pmi_jobdisconnect: PMI2 Job_Disconnect failed
 **pmi_jobdisconnect %s: PMI2 Job_Disconnect failed: %s
 **pmi_kvsput: PMI2 KVS_Put failed
-**pmi_kvsput %s: PMI2 KVS_Put failed: %s
+**pmi_kvsput %d: PMI2 KVS_Put failed: %d
 **pmi_kvsfence: PMI2 KVS_Fence failed
-**pmi_kvsfence %s: PMI2 KVS_Fence failed: %s
+**pmi_kvsfence %d: PMI2 KVS_Fence failed: %d
 **pmi_kvsget: PMI2 KVS_Get failed
 **pmi_kvsget %s: PMI2 KVS_Get failed: %s
 **pmi_kvsget %d: PMI2 KVS_Get failed: %d
@@ -81,13 +81,15 @@
 **pmi_putnodeattr: PMI2 PutNodeAttr failed
 **pmi_putnodeattr %s: PMI2 PutNodeAttr failed: %s
 **pmi_getjobattr: PMI2 GetJobAttr failed
-**pmi_getjobattr %s: PMI2 GetJobAttr failed: %s
+**pmi_getjobattr %d: PMI2 GetJobAttr failed: %d
 **pmi_nameservpublish: PMI2 Nameserv_publish failed
 **pmi_nameservpublish %s: PMI2 Nameserv_publish failed: %s
 **connect_to_pm: Unable to connect process manager
 **connect_to_pm %s %d: Unable to connect process manager at host %s port %d
 **pmi_port: Unable to decide hostport from PMI_PORT
 **pmi_port %s: Unable to decide hostport from \"%s\"
+**pmi2_info_getjobattr: PMI2_Info_GetJobAttr failed
+**pmi2_info_getjobattr %d: PMI2_Info_GetJobAttr returned %d
 #
 # PMIx
 #

--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -10,6 +10,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/util
 mpi_core_sources +=   \
     src/util/mpir_assert.c     \
     src/util/mpir_cvars.c      \
+    src/util/mpir_pmi.c        \
     src/util/mpir_handlemem.c  \
     src/util/mpir_strerror.c   \
     src/util/mpir_localproc.c

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -1,0 +1,8 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include <mpir_pmi.h>
+#include <mpiimpl.h>

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -144,6 +144,10 @@ void MPIR_pmi_finalize(void)
     PMIx_Finalize(NULL, 0);
     /* pmix_proc does not need free */
 #endif
+
+    MPL_free(MPIR_Process.node_map);
+    MPL_free(MPIR_Process.node_root_map);
+    MPL_free(MPIR_Process.node_local_map);
 }
 
 /* getters for internal constants */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -6,3 +6,139 @@
 
 #include <mpir_pmi.h>
 #include <mpiimpl.h>
+
+static int pmi_max_key_size;
+static int pmi_max_val_size;
+
+#ifdef USE_PMI1_API
+static int pmi_max_kvs_name_length;
+static char *pmi_kvs_name;
+#elif defined USE_PMI2_API
+static char *pmi_jobid;
+#elif defined USE_PMIX_API
+static pmix_proc_t pmix_proc;
+static pmix_proc_t pmix_wcproc;
+#endif
+
+int MPIR_pmi_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    int has_parent, rank, size, appnum;
+
+#ifdef USE_PMI1_API
+    pmi_errno = PMI_Init(&has_parent);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_init", "**pmi_init %d", pmi_errno);
+    pmi_errno = PMI_Get_rank(&rank);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_rank", "**pmi_get_rank %d", pmi_errno);
+    pmi_errno = PMI_Get_size(&size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_size", "**pmi_get_size %d", pmi_errno);
+    pmi_errno = PMI_Get_appnum(&appnum);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_appnum", "**pmi_get_appnum %d", pmi_errno);
+
+    pmi_errno = PMI_KVS_Get_name_length_max(&pmi_max_kvs_name_length);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_name_length_max",
+                         "**pmi_kvs_get_name_length_max %d", pmi_errno);
+    pmi_kvs_name = (char *) MPL_malloc(pmi_max_kvs_name_length, MPL_MEM_OTHER);
+    pmi_errno = PMI_KVS_Get_my_name(pmi_kvs_name, pmi_max_kvs_name_length);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_my_name", "**pmi_kvs_get_my_name %d", pmi_errno);
+
+    pmi_errno = PMI_KVS_Get_key_length_max(&pmi_max_key_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_key_length_max",
+                         "**pmi_kvs_get_key_length_max %d", pmi_errno);
+    pmi_errno = PMI_KVS_Get_value_length_max(&pmi_max_val_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_value_length_max",
+                         "**pmi_kvs_get_value_length_max %d", pmi_errno);
+
+#elif defined USE_PMI2_API
+    pmi_max_key_size = PMI2_MAX_KEYLEN;
+    pmi_max_val_size = PMI2_MAX_VALLEN;
+
+    pmi_errno = PMI2_Init(&has_parent, &size, &rank, &appnum);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_init", "**pmi_init %d", pmi_errno);
+
+    pmi_jobid = (char *) MPL_malloc(PMI2_MAX_VALLEN, MPL_MEM_OTHER);
+    pmi_errno = PMI2_Job_GetId(pmi_jobid, PMI2_MAX_VALLEN);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_job_getid", "**pmi_job_getid %d", pmi_errno);
+
+#elif defined USE_PMIX_API
+    pmi_max_key_size = PMIX_MAX_KEYLEN;
+    pmi_max_val_size = 1024;    /* this is what PMI2_MAX_VALLEN currently set to */
+
+    pmix_value_t *pvalue = NULL;
+
+    pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_init", "**pmix_init %d", pmi_errno);
+
+    rank = pmix_proc.rank;
+    PMIX_PROC_CONSTRUCT(&pmix_wcproc);
+    MPL_strncpy(pmix_wcproc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
+    pmix_wcproc.rank = PMIX_RANK_WILDCARD;
+
+    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    size = pvalue->data.uint32;
+    PMIX_VALUE_RELEASE(pvalue);
+
+    /* appnum, has_parent is not set for now */
+    appnum = 0;
+    has_parent = 0;
+
+    MPIR_Process.pmix_proc = pmix_proc;
+    MPIR_Process.pmix_wcproc = pmix_wcproc;
+
+#endif
+    MPIR_Process.has_parent = has_parent;
+    MPIR_Process.rank = rank;
+    MPIR_Process.size = size;
+    MPIR_Process.appnum = appnum;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+void MPIR_pmi_finalize(void)
+{
+#ifdef USE_PMI1_API
+    PMI_Finalize();
+    MPL_free(pmi_kvs_name);
+#elif defined(USE_PMI2_API)
+    PMI2_Finalize();
+    MPL_free(pmi_jobid);
+#elif defined(USE_PMIX_API)
+    PMIx_Finalize(NULL, 0);
+    /* pmix_proc does not need free */
+#endif
+}
+
+/* getters for internal constants */
+int MPIR_pmi_max_val_size(void)
+{
+    return pmi_max_val_size;
+}
+
+const char *MPIR_pmi_job_id(void)
+{
+#ifdef USE_PMI1_API
+    return (const char *) pmi_kvs_name;
+#elif defined USE_PMI2_API
+    return (const char *) pmi_jobid;
+#elif defined USE_PMIX_API
+    return (const char *) pmix_proc.nspace;
+#endif
+}


### PR DESCRIPTION
## Pull Request Description

Add `MPIR_pmi_init` to abstract PMI environment initialization and building `node_map` in the `MPIR` layer (`src/util/mpir_pmi.c` and `src/include/mpir_pmi.h`).

Eventually we will abstract all PMI functions in `mpir_pmi.c`. This PR only replaces the building of `node_map` in `CH4`.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
