### PR TITLE
init: MPI predefined pairtypes

### DIFF
--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -10,7 +10,7 @@
 #include "mpiimpl.h"
 
 /* Definitions private to the datatype code */
-extern int MPIR_Datatype_init(void);
+extern int MPII_create_pairtypes(void);
 extern int MPIR_Datatype_builtin_fillin(void);
 extern int MPIR_Datatype_init_names(void);
 extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -21,7 +21,7 @@ MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, MPIR_DATATYPE,
     MPIR_DATATYPE_PREALLOC
 };
 
-static int MPIR_Datatype_finalize(void *dummy);
+static int pairtypes_finalize_cb(void *dummy);
 static int datatype_attr_finalize_cb(void *dummy);
 
 /* Call this routine to associate a MPIR_Datatype with each predefined
@@ -113,9 +113,9 @@ static MPI_Datatype mpi_dtypes[] = {
 };
 
 /*
-  MPIR_Datatype_init()
+  MPII_create_pairtypes()
 
-  Main purpose of this function is to set up the following pair types:
+  The purpose of this function is to set up the following pair types:
   - MPI_FLOAT_INT
   - MPI_DOUBLE_INT
   - MPI_LONG_INT
@@ -138,7 +138,7 @@ static MPI_Datatype mpi_pairtypes[] = {
     (MPI_Datatype) - 1
 };
 
-int MPIR_Datatype_init(void)
+int MPII_create_pairtypes(void)
 {
     int i;
     int mpi_errno = MPI_SUCCESS;
@@ -176,13 +176,13 @@ int MPIR_Datatype_init(void)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    MPIR_Add_finalize(MPIR_Datatype_finalize, 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
+    MPIR_Add_finalize(pairtypes_finalize_cb, 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
 
   fn_fail:
     return mpi_errno;
 }
 
-static int MPIR_Datatype_finalize(void *dummy ATTRIBUTE((unused)))
+static int pairtypes_finalize_cb(void *dummy ATTRIBUTE((unused)))
 {
     int i;
     MPIR_Datatype *dptr;

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -112,9 +112,16 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
     MPII_pre_init_memory_tracing();
 
+    /* Call any and all MPIR_Init type functions */
+    MPIR_Err_init();
+    MPIR_Group_init();
+
     int thread_provided = 0;
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
+
+    /* init datatypes after MPID_Init because MPID_Type_commit_hook is used */
+    MPIR_Datatype_init();
 
     /* Initialize collectives infrastructure */
     mpi_errno = MPII_Coll_init();

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -121,8 +121,8 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* init datatypes after MPID_Init because MPID_Type_commit_hook is used */
-    mpi_errno = MPIR_Datatype_init();
+    /* create pairtypes after MPID_Init because MPID_Type_commit_hook is used */
+    mpi_errno = MPII_create_pairtypes();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize collectives infrastructure */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -114,14 +114,16 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
     /* Call any and all MPIR_Init type functions */
     MPIR_Err_init();
-    MPIR_Group_init();
+    mpi_errno = MPIR_Group_init();
+    MPIR_ERR_CHECK(mpi_errno);
 
     int thread_provided = 0;
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* init datatypes after MPID_Init because MPID_Type_commit_hook is used */
-    MPIR_Datatype_init();
+    mpi_errno = MPIR_Datatype_init();
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize collectives infrastructure */
     mpi_errno = MPII_Coll_init();

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -103,11 +103,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_INIT);
 
-    /* Call any and all MPID_Init type functions */
-    MPIR_Err_init();
-    MPIR_Datatype_init();
-    MPIR_Group_init();
-
     /* initialization routine for ch3u_comm.c */
     mpi_errno = MPIDI_CH3I_Comm_init();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -448,11 +448,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
         MPIR_Process.tag_bits = MPL_MIN(shm_tag_bits, nm_tag_bits);
     }
 
-    /* Call any and all MPID_Init type functions */
-    MPIR_Err_init();
-    MPIR_Datatype_init();
-    MPIR_Group_init();
-
     /* Override split_type */
     MPIDI_global.MPIR_Comm_fns_store.split_type = MPIDI_Comm_split_type;
     MPIR_Comm_fns = &MPIDI_global.MPIR_Comm_fns_store;


### PR DESCRIPTION
## Pull Request Description

Based on #3956. Cleans up some fragile dependencies related to creating/committing the MPI predefined pairtypes, which depend on active device hooks in ch4 configurations.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
