### PR TITLE
datatype: Cleanup and refactor predefined init

### DIFF
--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -12,7 +12,6 @@
 /* Definitions private to the datatype code */
 extern int MPII_create_pairtypes(void);
 extern int MPIR_Datatype_builtin_fillin(void);
-extern int MPIR_Datatype_init_names(void);
 extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);
 
 /* LB/UB calculation helper macros */

--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -12,6 +12,7 @@
 /* Definitions private to the datatype code */
 extern int MPII_create_pairtypes(void);
 extern int MPIR_Datatype_builtin_fillin(void);
+extern int MPIR_Datatype_commit_pairtypes(void);
 extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);
 
 /* LB/UB calculation helper macros */

--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -10,8 +10,7 @@
 #include "mpiimpl.h"
 
 /* Definitions private to the datatype code */
-extern int MPII_create_pairtypes(void);
-extern int MPIR_Datatype_builtin_fillin(void);
+extern int MPIR_Datatype_init_predefined(void);
 extern int MPIR_Datatype_commit_pairtypes(void);
 extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);
 

--- a/src/mpi/datatype/type_create_pairtype.c
+++ b/src/mpi/datatype/type_create_pairtype.c
@@ -69,7 +69,7 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
 
     /* handle is filled in by MPIR_Handle_obj_alloc() */
     MPIR_Object_set_ref(new_dtp, 1);
-    new_dtp->is_committed = 1;  /* predefined types are pre-committed */
+    new_dtp->is_committed = 0;
     new_dtp->attributes = NULL;
     new_dtp->name[0] = 0;
     new_dtp->contents = NULL;
@@ -156,29 +156,6 @@ int MPIR_Type_create_pairtype(MPI_Datatype type, MPIR_Datatype * new_dtp)
 
     new_dtp->is_contig = (((MPI_Aint) type_size) == type_extent) ? 1 : 0;
     new_dtp->max_contig_blocks = (((MPI_Aint) type_size) == type_extent) ? 1 : 2;
-
-    /* fill in typereps -- only case where we precreate typereps
-     *
-     * this is necessary because these types aren't committed by the
-     * user, which is the other place where we create typereps. so
-     * if the user uses one of these w/out building some more complex
-     * type and then committing it, then the typerep will be missing.
-     */
-
-    MPIR_Typerep_create(type, &(new_dtp->typerep));
-
-    int err = MPID_Type_commit_hook(new_dtp);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (err) {
-        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
-                                         MPIR_ERR_RECOVERABLE,
-                                         "MPID_Type_commit_hook",
-                                         __LINE__, MPI_ERR_OTHER, "**nomem", 0);
-        return mpi_errno;
-
-    }
-    /* --END ERROR HANDLING-- */
 
     return mpi_errno;
 }

--- a/src/mpi/datatype/type_get_name.c
+++ b/src/mpi/datatype/type_get_name.c
@@ -153,15 +153,6 @@ int MPIR_Datatype_init_names(void)
 
     MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     if (needsInit) {
-        /* Make sure that the basics have datatype structures allocated
-         * and filled in for them.  They are just integers prior to this
-         * call.
-         */
-        mpi_errno = MPIR_Datatype_builtin_fillin();
-        if (mpi_errno != MPI_SUCCESS) {
-            MPIR_ERR_POPFATAL(mpi_errno);
-        }
-
         /* For each predefined type, ensure that there is a corresponding
          * object and that the object's name is set */
         for (i = 0; mpi_names[i].name != 0; i++) {

--- a/src/mpi/datatype/type_get_name.c
+++ b/src/mpi/datatype/type_get_name.c
@@ -29,181 +29,6 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
 
 #endif
 
-/* This routine initializes all of the name fields in the predefined
-   datatypes */
-#ifndef MPICH_MPI_FROM_PMPI
-/* Include these definitions only with the PMPI version */
-typedef struct mpi_names_t {
-    MPI_Datatype dtype;
-    const char *name;
-} mpi_names_t;
-/* The MPI standard specifies that the names must be the MPI names,
-   not the related language names (e.g., MPI_CHAR, not char) */
-#define type_name_entry(x_) { x_, #x_ }
-static mpi_names_t mpi_names[] = {
-    type_name_entry(MPI_CHAR),
-    type_name_entry(MPI_SIGNED_CHAR),
-    type_name_entry(MPI_UNSIGNED_CHAR),
-    type_name_entry(MPI_BYTE),
-    type_name_entry(MPI_WCHAR),
-    type_name_entry(MPI_SHORT),
-    type_name_entry(MPI_UNSIGNED_SHORT),
-    type_name_entry(MPI_INT),
-    type_name_entry(MPI_UNSIGNED),
-    type_name_entry(MPI_LONG),
-    type_name_entry(MPI_UNSIGNED_LONG),
-    type_name_entry(MPI_FLOAT),
-    type_name_entry(MPI_DOUBLE),
-    type_name_entry(MPI_LONG_DOUBLE),
-    /* LONG_LONG is a synonym of LONG_LONG_INT; we don't make it a separate
-     * type */
-/*    type_name_entry(MPI_LONG_LONG), */
-    type_name_entry(MPI_LONG_LONG_INT),
-    type_name_entry(MPI_UNSIGNED_LONG_LONG),
-    type_name_entry(MPI_PACKED),
-    type_name_entry(MPI_LB),
-    type_name_entry(MPI_UB),
-
-/* The maxloc/minloc types are not builtin because their size and
-   extent may not be the same. */
-/*
-    type_name_entry(MPI_FLOAT_INT),
-    type_name_entry(MPI_DOUBLE_INT),
-    type_name_entry(MPI_LONG_INT),
-    type_name_entry(MPI_SHORT_INT),
-*/
-    /* Fortran */
-    type_name_entry(MPI_COMPLEX),
-    type_name_entry(MPI_DOUBLE_COMPLEX),
-    type_name_entry(MPI_LOGICAL),
-    type_name_entry(MPI_REAL),
-    type_name_entry(MPI_DOUBLE_PRECISION),
-    type_name_entry(MPI_INTEGER),
-    type_name_entry(MPI_2INTEGER),
-#ifdef MPICH_DEFINE_2COMPLEX
-    type_name_entry(MPI_2COMPLEX),
-    type_name_entry(MPI_2DOUBLE_COMPLEX),
-#endif
-    type_name_entry(MPI_2REAL),
-    type_name_entry(MPI_2DOUBLE_PRECISION),
-    type_name_entry(MPI_CHARACTER),
-    /* Size-specific types (C, Fortran, and C++) */
-    type_name_entry(MPI_REAL4),
-    type_name_entry(MPI_REAL8),
-    type_name_entry(MPI_REAL16),
-    type_name_entry(MPI_COMPLEX8),
-    type_name_entry(MPI_COMPLEX16),
-    type_name_entry(MPI_COMPLEX32),
-    type_name_entry(MPI_INTEGER1),
-    type_name_entry(MPI_INTEGER2),
-    type_name_entry(MPI_INTEGER4),
-    type_name_entry(MPI_INTEGER8),
-    type_name_entry(MPI_INTEGER16),
-
-    /* C99 types */
-    type_name_entry(MPI_INT8_T),
-    type_name_entry(MPI_INT16_T),
-    type_name_entry(MPI_INT32_T),
-    type_name_entry(MPI_INT64_T),
-    type_name_entry(MPI_UINT8_T),
-    type_name_entry(MPI_UINT16_T),
-    type_name_entry(MPI_UINT32_T),
-    type_name_entry(MPI_UINT64_T),
-    type_name_entry(MPI_C_BOOL),
-    /* C_FLOAT_COMPLEX is a synonym of C_COMPLEX; we don't make it a separate
-     * type */
-/*    type_name_entry(MPI_C_FLOAT_COMPLEX), */
-    type_name_entry(MPI_C_COMPLEX),
-    type_name_entry(MPI_C_DOUBLE_COMPLEX),
-    type_name_entry(MPI_C_LONG_DOUBLE_COMPLEX),
-
-    /* C++ types */
-    type_name_entry(MPI_CXX_BOOL),
-    type_name_entry(MPI_CXX_FLOAT_COMPLEX),
-    type_name_entry(MPI_CXX_DOUBLE_COMPLEX),
-    type_name_entry(MPI_CXX_LONG_DOUBLE_COMPLEX),
-
-    /* address/offset types */
-    type_name_entry(MPI_AINT),
-    type_name_entry(MPI_OFFSET),
-    type_name_entry(MPI_COUNT),
-
-    {0, (char *) 0},    /* Sentinel used to indicate the last element */
-};
-
-static mpi_names_t mpi_maxloc_names[] = {
-    type_name_entry(MPI_FLOAT_INT),
-    type_name_entry(MPI_DOUBLE_INT),
-    type_name_entry(MPI_LONG_INT),
-    type_name_entry(MPI_SHORT_INT),
-    type_name_entry(MPI_2INT),
-    type_name_entry(MPI_LONG_DOUBLE_INT),
-    {0, (char *) 0},    /* Sentinel used to indicate the last element */
-};
-
-#undef type_name_entry
-/* This routine is also needed by type_set_name */
-
-int MPIR_Datatype_init_names(void)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int i;
-    MPIR_Datatype *datatype_ptr = NULL;
-    static volatile int needsInit = 1;
-
-    MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    if (needsInit) {
-        /* For each predefined type, ensure that there is a corresponding
-         * object and that the object's name is set */
-        for (i = 0; mpi_names[i].name != 0; i++) {
-            /* The size-specific types may be DATATYPE_NULL, as might be those
-             * based on 'long long' and 'long double' if those types were
-             * disabled at configure time. */
-            if (mpi_names[i].dtype == MPI_DATATYPE_NULL)
-                continue;
-
-            MPIR_Datatype_get_ptr(mpi_names[i].dtype, datatype_ptr);
-
-            if (datatype_ptr < MPIR_Datatype_builtin ||
-                datatype_ptr > MPIR_Datatype_builtin + MPIR_DATATYPE_N_BUILTIN) {
-                MPIR_ERR_SETFATALANDJUMP1(mpi_errno, MPI_ERR_INTERN,
-                                          "**typeinitbadmem", "**typeinitbadmem %d", i);
-            }
-            if (!datatype_ptr) {
-                MPIR_ERR_SETFATALANDJUMP1(mpi_errno, MPI_ERR_INTERN,
-                                          "**typeinitfail", "**typeinitfail %d", i - 1);
-            }
-
-            MPL_DBG_MSG_FMT(MPIR_DBG_DATATYPE, VERBOSE, (MPL_DBG_FDEST,
-                                                         "mpi_names[%d].name = %p", i,
-                                                         mpi_names[i].name));
-
-            MPL_strncpy(datatype_ptr->name, mpi_names[i].name, MPI_MAX_OBJECT_NAME);
-        }
-        /* Handle the minloc/maxloc types */
-        for (i = 0; mpi_maxloc_names[i].name != 0; i++) {
-            /* types based on 'long long' and 'long double' may be disabled at
-             * configure time, and their values set to MPI_DATATYPE_NULL.  skip
-             * those types. */
-            if (mpi_maxloc_names[i].dtype == MPI_DATATYPE_NULL)
-                continue;
-
-            MPIR_Datatype_get_ptr(mpi_maxloc_names[i].dtype, datatype_ptr);
-            if (!datatype_ptr) {
-                MPIR_ERR_SETFATALANDJUMP(mpi_errno, MPI_ERR_INTERN, "**typeinitminmaxloc");
-            }
-            MPL_strncpy(datatype_ptr->name, mpi_maxloc_names[i].name, MPI_MAX_OBJECT_NAME);
-        }
-        needsInit = 0;
-    }
-
-  fn_fail:
-    /* empty statement */ ;
-    MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    return mpi_errno;
-}
-#endif
-
 /*@
    MPI_Type_get_name - Get the print name for a datatype
 
@@ -230,7 +55,6 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *datatype_ptr = NULL;
-    static int setup = 0;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TYPE_GET_NAME);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -273,14 +97,6 @@ int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen)
 #endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
-
-    /* If this is the first call, initialize all of the predefined names */
-    if (!setup) {
-        mpi_errno = MPIR_Datatype_init_names();
-        if (mpi_errno != MPI_SUCCESS)
-            goto fn_fail;
-        setup = 1;
-    }
 
     /* Include the null in MPI_MAX_OBJECT_NAME */
     MPL_strncpy(type_name, datatype_ptr->name, MPI_MAX_OBJECT_NAME);

--- a/src/mpi/datatype/type_set_name.c
+++ b/src/mpi/datatype/type_set_name.c
@@ -49,7 +49,6 @@ int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *datatype_ptr = NULL;
-    static int setup = 0;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_TYPE_SET_NAME);
 
     MPIR_ERRTEST_INITIALIZED_ORDIE();
@@ -92,13 +91,6 @@ int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name)
 #endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
-
-    /* If this is the first call, initialize all of the predefined names.
-     * Note that type_get_name must also make the same call */
-    if (!setup) {
-        MPIR_Datatype_init_names();
-        setup = 1;
-    }
 
     /* Include the null in MPI_MAX_OBJECT_NAME */
     MPL_strncpy(datatype_ptr->name, type_name, MPI_MAX_OBJECT_NAME);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -108,9 +108,6 @@ static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_CXX_FLOAT_COMPLEX),
     type_name_entry(MPI_CXX_DOUBLE_COMPLEX),
     type_name_entry(MPI_CXX_LONG_DOUBLE_COMPLEX),
-
-    /* This entry is a guaranteed end-of-list item */
-    {(MPI_Datatype) - 1, ""}
 };
 
 static mpi_names_t mpi_pairtypes[] = {
@@ -119,7 +116,6 @@ static mpi_names_t mpi_pairtypes[] = {
     type_name_entry(MPI_LONG_INT),
     type_name_entry(MPI_SHORT_INT),
     type_name_entry(MPI_LONG_DOUBLE_INT),
-    {(MPI_Datatype) - 1, ""}
 };
 
 static int pairtypes_finalize_cb(void *dummy ATTRIBUTE((unused)))
@@ -127,7 +123,7 @@ static int pairtypes_finalize_cb(void *dummy ATTRIBUTE((unused)))
     int i;
     MPIR_Datatype *dptr;
 
-    for (i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; i++) {
+    for (i = 0; i < sizeof(mpi_pairtypes) / sizeof(mpi_pairtypes[0]); i++) {
         if (mpi_pairtypes[i].dtype != MPI_DATATYPE_NULL) {
             MPIR_Datatype_get_ptr(mpi_pairtypes[i].dtype, dptr);
             MPIR_Datatype_ptr_release(dptr);
@@ -146,8 +142,7 @@ int MPIR_Datatype_init_predefined(void)
     MPIR_Datatype *dptr;
     MPI_Datatype d = MPI_DATATYPE_NULL;
 
-    /* If the datatype is -1, we're at the end of mpi_dtypes */
-    for (i = 0; i < MPIR_DATATYPE_N_BUILTIN && mpi_dtypes[i].dtype != -1; i++) {
+    for (i = 0; i < sizeof(mpi_dtypes) / sizeof(mpi_dtypes[0]); i++) {
         /* Compute the index from the value of the handle */
         d = mpi_dtypes[i].dtype;
 
@@ -179,16 +174,6 @@ int MPIR_Datatype_init_predefined(void)
         dptr->contents = NULL;  /* should never get referenced? */
         MPL_strncpy(dptr->name, mpi_dtypes[i].name, MPI_MAX_OBJECT_NAME);
     }
-    /* --BEGIN ERROR HANDLING-- */
-    if (d != -1 && i < sizeof(mpi_dtypes) / sizeof(*mpi_dtypes) && mpi_dtypes[i].dtype != -1) {
-        /* We did not hit the end-of-list */
-        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
-                                         __func__, __LINE__,
-                                         MPI_ERR_INTERN, "**typeinitfail",
-                                         "**typeinitfail %d", i - 1);
-        return mpi_errno;
-    }
-    /* --END ERROR HANDLING-- */
 
     /* Setup pairtypes. The following assertions ensure that:
      * - this function is called before other types are allocated
@@ -199,7 +184,7 @@ int MPIR_Datatype_init_predefined(void)
     MPIR_Assert(MPIR_Datatype_mem.initialized == 0);
     MPIR_Assert(MPIR_DATATYPE_PREALLOC >= 5);
 
-    for (i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; ++i) {
+    for (i = 0; i < sizeof(mpi_pairtypes) / sizeof(mpi_pairtypes[0]); ++i) {
         /* types based on 'long long' and 'long double', may be disabled at
          * configure time, and their values set to MPI_DATATYPE_NULL.  skip any
          * such types. */
@@ -238,7 +223,7 @@ int MPIR_Datatype_init_predefined(void)
 int MPIR_Datatype_commit_pairtypes(void)
 {
     /* commit pairtypes */
-    for (int i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; i++) {
+    for (int i = 0; i < sizeof(mpi_pairtypes) / sizeof(mpi_pairtypes[0]); i++) {
         if (mpi_pairtypes[i].dtype != MPI_DATATYPE_NULL) {
             int err;
 

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -30,10 +30,6 @@ typedef struct mpi_names_t {
 } mpi_names_t;
 #define type_name_entry(x_) { x_, #x_ }
 
-/* FIXME does the order of this list need to correspond to anything in
-   particular?  There are several lists of predefined types sprinkled throughout
-   the codebase and it's unclear which (if any) of them must match exactly.
-   [goodell@ 2009-03-17] */
 static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_CHAR),
     type_name_entry(MPI_UNSIGNED_CHAR),

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -107,6 +107,12 @@ static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_INTEGER16),
 #endif
 
+    /* C++ types */
+    type_name_entry(MPI_CXX_BOOL),
+    type_name_entry(MPI_CXX_FLOAT_COMPLEX),
+    type_name_entry(MPI_CXX_DOUBLE_COMPLEX),
+    type_name_entry(MPI_CXX_LONG_DOUBLE_COMPLEX),
+
     /* This entry is a guaranteed end-of-list item */
     {(MPI_Datatype) - 1, ""}
 };

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -253,6 +253,29 @@ int MPIR_Datatype_builtin_fillin(void)
     return mpi_errno;
 }
 
+int MPIR_Datatype_commit_pairtypes(void)
+{
+    /* commit pairtypes */
+    for (int i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; i++) {
+        if (mpi_pairtypes[i].dtype != MPI_DATATYPE_NULL) {
+            int err;
+
+            err = MPIR_Type_commit(&mpi_pairtypes[i].dtype);
+
+            /* --BEGIN ERROR HANDLING-- */
+            if (err) {
+                return MPIR_Err_create_code(MPI_SUCCESS,
+                                            MPIR_ERR_RECOVERABLE,
+                                            "MPIR_Type_commit",
+                                            __LINE__, MPI_ERR_OTHER, "**nomem", 0);
+            }
+            /* --END ERROR HANDLING-- */
+        }
+    }
+
+    return MPI_SUCCESS;
+}
+
 /* This will eventually be removed once ROMIO knows more about MPICH */
 void MPIR_Datatype_iscontig(MPI_Datatype datatype, int *flag)
 {

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -24,84 +24,91 @@ MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, MPIR_DATATYPE,
 static int pairtypes_finalize_cb(void *dummy);
 static int datatype_attr_finalize_cb(void *dummy);
 
+typedef struct mpi_names_t {
+    MPI_Datatype dtype;
+    const char *name;
+} mpi_names_t;
+#define type_name_entry(x_) { x_, #x_ }
+
 /* FIXME does the order of this list need to correspond to anything in
    particular?  There are several lists of predefined types sprinkled throughout
    the codebase and it's unclear which (if any) of them must match exactly.
    [goodell@ 2009-03-17] */
-static MPI_Datatype mpi_dtypes[] = {
-    MPI_CHAR,
-    MPI_UNSIGNED_CHAR,
-    MPI_SIGNED_CHAR,
-    MPI_BYTE,
-    MPI_WCHAR,
-    MPI_SHORT,
-    MPI_UNSIGNED_SHORT,
-    MPI_INT,
-    MPI_UNSIGNED,
-    MPI_LONG,
-    MPI_UNSIGNED_LONG,
-    MPI_FLOAT,
-    MPI_DOUBLE,
-    MPI_LONG_DOUBLE,
-    MPI_LONG_LONG,
-    MPI_UNSIGNED_LONG_LONG,
-    MPI_PACKED,
-    MPI_LB,
-    MPI_UB,
-    MPI_2INT,
+static mpi_names_t mpi_dtypes[] = {
+    type_name_entry(MPI_CHAR),
+    type_name_entry(MPI_UNSIGNED_CHAR),
+    type_name_entry(MPI_SIGNED_CHAR),
+    type_name_entry(MPI_BYTE),
+    type_name_entry(MPI_WCHAR),
+    type_name_entry(MPI_SHORT),
+    type_name_entry(MPI_UNSIGNED_SHORT),
+    type_name_entry(MPI_INT),
+    type_name_entry(MPI_UNSIGNED),
+    type_name_entry(MPI_LONG),
+    type_name_entry(MPI_UNSIGNED_LONG),
+    type_name_entry(MPI_FLOAT),
+    type_name_entry(MPI_DOUBLE),
+    type_name_entry(MPI_LONG_DOUBLE),
+    type_name_entry(MPI_LONG_LONG_INT),
+    type_name_entry(MPI_UNSIGNED_LONG_LONG),
+    type_name_entry(MPI_PACKED),
+    type_name_entry(MPI_LB),
+    type_name_entry(MPI_UB),
+    type_name_entry(MPI_2INT),
 
     /* C99 types */
-    MPI_INT8_T,
-    MPI_INT16_T,
-    MPI_INT32_T,
-    MPI_INT64_T,
-    MPI_UINT8_T,
-    MPI_UINT16_T,
-    MPI_UINT32_T,
-    MPI_UINT64_T,
-    MPI_C_BOOL,
-    MPI_C_FLOAT_COMPLEX,
-    MPI_C_DOUBLE_COMPLEX,
-    MPI_C_LONG_DOUBLE_COMPLEX,
+    type_name_entry(MPI_INT8_T),
+    type_name_entry(MPI_INT16_T),
+    type_name_entry(MPI_INT32_T),
+    type_name_entry(MPI_INT64_T),
+    type_name_entry(MPI_UINT8_T),
+    type_name_entry(MPI_UINT16_T),
+    type_name_entry(MPI_UINT32_T),
+    type_name_entry(MPI_UINT64_T),
+    type_name_entry(MPI_C_BOOL),
+    type_name_entry(MPI_C_COMPLEX),
+    type_name_entry(MPI_C_DOUBLE_COMPLEX),
+    type_name_entry(MPI_C_LONG_DOUBLE_COMPLEX),
 
     /* address/offset/count types */
-    MPI_AINT,
-    MPI_OFFSET,
-    MPI_COUNT,
+    type_name_entry(MPI_AINT),
+    type_name_entry(MPI_OFFSET),
+    type_name_entry(MPI_COUNT),
 
     /* Fortran types */
-    MPI_COMPLEX,
-    MPI_DOUBLE_COMPLEX,
-    MPI_LOGICAL,
-    MPI_REAL,
-    MPI_DOUBLE_PRECISION,
-    MPI_INTEGER,
-    MPI_2INTEGER,
+    type_name_entry(MPI_COMPLEX),
+    type_name_entry(MPI_DOUBLE_COMPLEX),
+    type_name_entry(MPI_LOGICAL),
+    type_name_entry(MPI_REAL),
+    type_name_entry(MPI_DOUBLE_PRECISION),
+    type_name_entry(MPI_INTEGER),
+    type_name_entry(MPI_2INTEGER),
 #ifdef MPICH_DEFINE_2COMPLEX
-    MPI_2COMPLEX,
-    MPI_2DOUBLE_COMPLEX,
+    type_name_entry(MPI_2COMPLEX),
+    type_name_entry(MPI_2DOUBLE_COMPLEX),
 #endif
-    MPI_2REAL,
-    MPI_2DOUBLE_PRECISION,
-    MPI_CHARACTER,
+    type_name_entry(MPI_2REAL),
+    type_name_entry(MPI_2DOUBLE_PRECISION),
+    type_name_entry(MPI_CHARACTER),
 #ifdef HAVE_FORTRAN_BINDING
     /* Size-specific types; these are in section 10.2.4 (Extended Fortran
      * Support) as well as optional in MPI-1
      */
-    MPI_REAL4,
-    MPI_REAL8,
-    MPI_REAL16,
-    MPI_COMPLEX8,
-    MPI_COMPLEX16,
-    MPI_COMPLEX32,
-    MPI_INTEGER1,
-    MPI_INTEGER2,
-    MPI_INTEGER4,
-    MPI_INTEGER8,
-    MPI_INTEGER16,
+    type_name_entry(MPI_REAL4),
+    type_name_entry(MPI_REAL8),
+    type_name_entry(MPI_REAL16),
+    type_name_entry(MPI_COMPLEX8),
+    type_name_entry(MPI_COMPLEX16),
+    type_name_entry(MPI_COMPLEX32),
+    type_name_entry(MPI_INTEGER1),
+    type_name_entry(MPI_INTEGER2),
+    type_name_entry(MPI_INTEGER4),
+    type_name_entry(MPI_INTEGER8),
+    type_name_entry(MPI_INTEGER16),
 #endif
+
     /* This entry is a guaranteed end-of-list item */
-    (MPI_Datatype) - 1,
+    {(MPI_Datatype) - 1, ""}
 };
 
 /*
@@ -121,13 +128,13 @@ static MPI_Datatype mpi_dtypes[] = {
     these types could be terribly difficult to track down!)
 
  */
-static MPI_Datatype mpi_pairtypes[] = {
-    MPI_FLOAT_INT,
-    MPI_DOUBLE_INT,
-    MPI_LONG_INT,
-    MPI_SHORT_INT,
-    MPI_LONG_DOUBLE_INT,
-    (MPI_Datatype) - 1
+static mpi_names_t mpi_pairtypes[] = {
+    type_name_entry(MPI_FLOAT_INT),
+    type_name_entry(MPI_DOUBLE_INT),
+    type_name_entry(MPI_LONG_INT),
+    type_name_entry(MPI_SHORT_INT),
+    type_name_entry(MPI_LONG_DOUBLE_INT),
+    {(MPI_Datatype) - 1, ""}
 };
 
 int MPII_create_pairtypes(void)
@@ -139,11 +146,11 @@ int MPII_create_pairtypes(void)
     MPIR_Assert(MPIR_Datatype_mem.initialized == 0);
     MPIR_Assert(MPIR_DATATYPE_PREALLOC >= 5);
 
-    for (i = 0; mpi_pairtypes[i] != (MPI_Datatype) - 1; ++i) {
+    for (i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; ++i) {
         /* types based on 'long long' and 'long double', may be disabled at
          * configure time, and their values set to MPI_DATATYPE_NULL.  skip any
          * such types. */
-        if (mpi_pairtypes[i] == MPI_DATATYPE_NULL)
+        if (mpi_pairtypes[i].dtype == MPI_DATATYPE_NULL)
             continue;
         /* XXX: this allocation strategy isn't right if one or more of the
          * pairtypes is MPI_DATATYPE_NULL.  in fact, the assert below will
@@ -159,13 +166,14 @@ int MPII_create_pairtypes(void)
         ptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc_unsafe(&MPIR_Datatype_mem);
 
         MPIR_Assert(ptr);
-        MPIR_Assert(ptr->handle == mpi_pairtypes[i]);
+        MPIR_Assert(ptr->handle == mpi_pairtypes[i].dtype);
         /* this is a redundant alternative to the previous statement */
         MPIR_Assert((void *) ptr ==
-                    (void *) (MPIR_Datatype_direct + HANDLE_INDEX(mpi_pairtypes[i])));
+                    (void *) (MPIR_Datatype_direct + HANDLE_INDEX(mpi_pairtypes[i].dtype)));
 
-        mpi_errno = MPIR_Type_create_pairtype(mpi_pairtypes[i], (MPIR_Datatype *) ptr);
+        mpi_errno = MPIR_Type_create_pairtype(mpi_pairtypes[i].dtype, (MPIR_Datatype *) ptr);
         MPIR_ERR_CHECK(mpi_errno);
+        MPL_strncpy(ptr->name, mpi_pairtypes[i].name, MPI_MAX_OBJECT_NAME);
     }
 
     MPIR_Add_finalize(pairtypes_finalize_cb, 0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
@@ -179,11 +187,11 @@ static int pairtypes_finalize_cb(void *dummy ATTRIBUTE((unused)))
     int i;
     MPIR_Datatype *dptr;
 
-    for (i = 0; mpi_pairtypes[i] != (MPI_Datatype) - 1; i++) {
-        if (mpi_pairtypes[i] != MPI_DATATYPE_NULL) {
-            MPIR_Datatype_get_ptr(mpi_pairtypes[i], dptr);
+    for (i = 0; mpi_pairtypes[i].dtype != (MPI_Datatype) - 1; i++) {
+        if (mpi_pairtypes[i].dtype != MPI_DATATYPE_NULL) {
+            MPIR_Datatype_get_ptr(mpi_pairtypes[i].dtype, dptr);
             MPIR_Datatype_ptr_release(dptr);
-            mpi_pairtypes[i] = MPI_DATATYPE_NULL;
+            mpi_pairtypes[i].dtype = MPI_DATATYPE_NULL;
         }
     }
     return 0;
@@ -199,9 +207,9 @@ int MPIR_Datatype_builtin_fillin(void)
     MPI_Datatype d = MPI_DATATYPE_NULL;
 
     /* If the datatype is -1, we're at the end of mpi_dtypes */
-    for (i = 0; i < MPIR_DATATYPE_N_BUILTIN && mpi_dtypes[i] != -1; i++) {
+    for (i = 0; i < MPIR_DATATYPE_N_BUILTIN && mpi_dtypes[i].dtype != -1; i++) {
         /* Compute the index from the value of the handle */
-        d = mpi_dtypes[i];
+        d = mpi_dtypes[i].dtype;
 
         /* Some of the size-specific types may be null, as might be types
          * based on 'long long' and 'long double' if those types were
@@ -224,14 +232,15 @@ int MPIR_Datatype_builtin_fillin(void)
         dptr->handle = d;
         dptr->is_contig = 1;
         MPIR_Object_set_ref(dptr, 1);
-        MPIR_Datatype_get_size_macro(mpi_dtypes[i], dptr->size);
+        MPIR_Datatype_get_size_macro(mpi_dtypes[i].dtype, dptr->size);
         dptr->extent = dptr->size;
         dptr->ub = dptr->size;
         dptr->true_ub = dptr->size;
         dptr->contents = NULL;  /* should never get referenced? */
+        MPL_strncpy(dptr->name, mpi_dtypes[i].name, MPI_MAX_OBJECT_NAME);
     }
     /* --BEGIN ERROR HANDLING-- */
-    if (d != -1 && i < sizeof(mpi_dtypes) / sizeof(*mpi_dtypes) && mpi_dtypes[i] != -1) {
+    if (d != -1 && i < sizeof(mpi_dtypes) / sizeof(*mpi_dtypes) && mpi_dtypes[i].dtype != -1) {
         /* We did not hit the end-of-list */
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
                                          __func__, __LINE__,

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -86,7 +86,6 @@ static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_2REAL),
     type_name_entry(MPI_2DOUBLE_PRECISION),
     type_name_entry(MPI_CHARACTER),
-#ifdef HAVE_FORTRAN_BINDING
     /* Size-specific types; these are in section 10.2.4 (Extended Fortran
      * Support) as well as optional in MPI-1
      */
@@ -101,7 +100,6 @@ static mpi_names_t mpi_dtypes[] = {
     type_name_entry(MPI_INTEGER4),
     type_name_entry(MPI_INTEGER8),
     type_name_entry(MPI_INTEGER16),
-#endif
 
     /* C++ types */
     type_name_entry(MPI_CXX_BOOL),

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -167,7 +167,7 @@ int MPIR_Datatype_init_predefined(void)
         dptr->handle = d;
         dptr->is_contig = 1;
         MPIR_Object_set_ref(dptr, 1);
-        MPIR_Datatype_get_size_macro(mpi_dtypes[i].dtype, dptr->size);
+        dptr->size = MPIR_Datatype_get_basic_size(d);
         dptr->extent = dptr->size;
         dptr->ub = dptr->size;
         dptr->true_ub = dptr->size;

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -206,8 +206,7 @@ int MPIR_Datatype_init_predefined(void)
         MPIR_Assert(dptr);
         MPIR_Assert(dptr->handle == mpi_pairtypes[i].dtype);
         /* this is a redundant alternative to the previous statement */
-        MPIR_Assert((void *) dptr ==
-                    (void *) (MPIR_Datatype_direct + HANDLE_INDEX(mpi_pairtypes[i].dtype)));
+        MPIR_Assert(HANDLE_INDEX(mpi_pairtypes[i].dtype) == i);
 
         mpi_errno = MPIR_Type_create_pairtype(mpi_pairtypes[i].dtype, (MPIR_Datatype *) dptr);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -117,16 +117,18 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPIR_Group_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Initialize builtin datatype structures */
+    /* Initialize predefined datatype structures */
     mpi_errno = MPIR_Datatype_builtin_fillin();
+    MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPII_create_pairtypes();
     MPIR_ERR_CHECK(mpi_errno);
 
     int thread_provided = 0;
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* create pairtypes after MPID_Init because MPID_Type_commit_hook is used */
-    mpi_errno = MPII_create_pairtypes();
+    /* Commit pairtypes after device hooks are activated */
+    mpi_errno = MPIR_Datatype_commit_pairtypes();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize collectives infrastructure */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -117,6 +117,10 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPIR_Group_init();
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* Initialize builtin datatype structures */
+    mpi_errno = MPIR_Datatype_builtin_fillin();
+    MPIR_ERR_CHECK(mpi_errno);
+
     int thread_provided = 0;
     mpi_errno = MPID_Init(argc, argv, required, &thread_provided);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -118,9 +118,7 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Initialize predefined datatype structures */
-    mpi_errno = MPIR_Datatype_builtin_fillin();
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPII_create_pairtypes();
+    mpi_errno = MPIR_Datatype_init_predefined();
     MPIR_ERR_CHECK(mpi_errno);
 
     int thread_provided = 0;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -978,6 +978,9 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     mpi_errno = MPIR_Comm_register_hint("eagain", set_eagain, NULL);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* index datatypes for RMA atomics */
+    MPIDI_OFI_index_datatypes();
+
   fn_exit:
 
     /* -------------------------------- */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -554,7 +554,6 @@ extern MPIDI_OFI_huge_recv_t *MPIDI_unexp_huge_recv_tail;
 extern MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_head;
 extern MPIDI_OFI_huge_recv_list_t *MPIDI_posted_huge_recv_tail;
 
-extern int MPIR_Datatype_init_names(void);
 extern MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS];
 
 #endif /* OFI_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -526,7 +526,6 @@ static int win_init(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_INIT);
 
-    MPIR_Datatype_init_names();
     MPIDI_OFI_index_datatypes();
 
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devwin_t) >= sizeof(MPIDI_OFI_win_t));

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -526,8 +526,6 @@ static int win_init(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_WIN_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_WIN_INIT);
 
-    MPIDI_OFI_index_datatypes();
-
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devwin_t) >= sizeof(MPIDI_OFI_win_t));
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devdt_t) >= sizeof(MPIDI_OFI_datatype_t));
 

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -513,11 +513,7 @@ static inline void add_index(MPI_Datatype datatype, int *idx)
 
 void MPIDI_OFI_index_datatypes()
 {
-    static bool needs_init = true;
     int idx = 0;
-
-    if (!needs_init)
-        return;
 
     add_index(MPI_CHAR, &idx);
     add_index(MPI_UNSIGNED_CHAR, &idx);
@@ -600,7 +596,4 @@ void MPIDI_OFI_index_datatypes()
     /* do not generate map when atomics are not enabled */
     if (MPIDI_OFI_ENABLE_ATOMICS)
         create_dt_map();
-
-    /* only need to do this once */
-    needs_init = false;
 }

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -274,7 +274,7 @@ MPL_STATIC_INLINE_PREFIX bool check_mpi_acc_valid(MPI_Datatype dtype, MPI_Op op)
     return valid_flag;
 }
 
-static inline int mpi_to_ofi(MPI_Datatype dt, enum fi_datatype *fi_dt, MPI_Op op, enum fi_op *fi_op)
+static int mpi_to_ofi(MPI_Datatype dt, enum fi_datatype *fi_dt, MPI_Op op, enum fi_op *fi_op)
 {
     *fi_dt = FI_DATATYPE_LAST;
     *fi_op = FI_ATOMIC_OP_LAST;
@@ -449,7 +449,7 @@ static MPI_Op mpi_ops[] = {
   _TBL.field2 = atomic_count;                  \
     }
 
-static inline void create_dt_map()
+static void create_dt_map()
 {
     int i, j;
     size_t dtsize[FI_DATATYPE_LAST];
@@ -499,7 +499,7 @@ static inline void create_dt_map()
         }
 }
 
-static inline void add_index(MPI_Datatype datatype, int *idx)
+static void add_index(MPI_Datatype datatype, int *idx)
 {
     /* MPICH sets predefined datatype handles to MPI_DATATYPE_NULL if they are not supported
      * on the target platform */

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -108,6 +108,13 @@ static mpi_names_t mpi_names[] = {
      * this ifdef allows the test to be built and run. */
     {MPI_INTEGER16, "MPI_INTEGER16"},
 #endif
+
+    /* C++ types */
+    {MPI_CXX_BOOL, "MPI_CXX_BOOL"},
+    {MPI_CXX_FLOAT_COMPLEX, "MPI_CXX_FLOAT_COMPLEX"},
+    {MPI_CXX_DOUBLE_COMPLEX, "MPI_CXX_DOUBLE_COMPLEX"},
+    {MPI_CXX_LONG_DOUBLE_COMPLEX, "MPI_CXX_LONG_DOUBLE_COMPLEX"},
+
     /* Semi-optional types - if the compiler doesn't support long double
      * or long long, these might be MPI_DATATYPE_NULL */
     {MPI_LONG_DOUBLE, "MPI_LONG_DOUBLE"},


### PR DESCRIPTION
## Pull Request Description

Cleanup some builtin datatype utilities and make usage more explicit in ch4/ofi.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
