### PR TITLE
ofi: remove MPIDI_OFI_MPI_CALL_POP macro

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -373,9 +373,10 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
             recv_elem->wc.len = recv_elem->cur_offset;
             recv_elem->done_fn(&recv_elem->wc, recv_elem->localreq, recv_elem->event_id);
             ctrl.type = MPIDI_OFI_CTRL_HUGEACK;
-            MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_do_control_send
-                                   (&ctrl, NULL, 0, recv_elem->remote_info.origin_rank,
-                                    recv_elem->comm_ptr, recv_elem->remote_info.ackreq));
+            mpi_errno =
+                MPIDI_OFI_do_control_send(&ctrl, NULL, 0, recv_elem->remote_info.origin_rank,
+                                          recv_elem->comm_ptr, recv_elem->remote_info.ackreq);
+            MPIR_ERR_CHECK(mpi_errno);
 
             MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters, key_to_erase);
             MPL_free(recv_elem);
@@ -773,7 +774,8 @@ int MPIDI_OFI_handle_cq_entries(struct fi_cq_tagged_entry *wc, ssize_t num)
 
     for (i = 0; i < num; i++) {
         req = MPIDI_OFI_context_to_request(wc[i].op_context);
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_dispatch_function(&wc[i], req));
+        mpi_errno = MPIDI_OFI_dispatch_function(&wc[i], req);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -112,13 +112,6 @@ int MPIDI_OFI_progress(int vci, int blocking);
             (_ret) = FUNC;                                              \
         } while (0)
 
-#define MPIDI_OFI_MPI_CALL_POP(FUNC)                               \
-  do                                                                 \
-    {                                                                \
-      mpi_errno = FUNC;                                              \
-      MPIR_ERR_CHECK(mpi_errno); \
-    } while (0)
-
 #define MPIDI_OFI_STR_CALL(FUNC,STR)                                   \
   do                                                            \
     {                                                           \

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -453,16 +453,12 @@ static inline int MPIDI_OFI_do_put(const void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_put_get(win,
-                                                                  origin_count,
-                                                                  target_count,
-                                                                  target_rank,
-                                                                  origin_datatype,
-                                                                  target_datatype,
-                                                                  origin_bytes,
-                                                                  target_bytes,
-                                                                  MPIDI_OFI_global.max_msg_size,
-                                                                  &req, &flags, &ep, sigreq));
+    mpi_errno =
+        MPIDI_OFI_allocate_win_request_put_get(win, origin_count, target_count, target_rank,
+                                               origin_datatype, target_datatype, origin_bytes,
+                                               target_bytes, MPIDI_OFI_global.max_msg_size, &req,
+                                               &flags, &ep, sigreq);
+    MPIR_ERR_CHECK(mpi_errno);
 
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
 
@@ -631,12 +627,12 @@ static inline int MPIDI_OFI_do_get(void *origin_addr,
         goto fn_exit;
     }
 
-    MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_put_get(win, origin_count, target_count,
-                                                                  target_rank,
-                                                                  origin_datatype, target_datatype,
-                                                                  origin_bytes, target_bytes,
-                                                                  MPIDI_OFI_global.max_msg_size,
-                                                                  &req, &flags, &ep, sigreq));
+    mpi_errno =
+        MPIDI_OFI_allocate_win_request_put_get(win, origin_count, target_count, target_rank,
+                                               origin_datatype, target_datatype, origin_bytes,
+                                               target_bytes, MPIDI_OFI_global.max_msg_size, &req,
+                                               &flags, &ep, sigreq);
+    MPIR_ERR_CHECK(mpi_errno);
 
     offset = target_disp * MPIDI_OFI_winfo_disp_unit(win, target_rank);
     req->event_id = MPIDI_OFI_EVENT_ABORT;
@@ -925,10 +921,12 @@ static inline int MPIDI_OFI_do_accumulate(const void *origin_addr,
         goto am_fallback;
     /* Accumulate is WRITE. */
     MPIDIG_wait_am_acc(win, target_rank, (MPIDIG_ACCU_ORDER_WAW | MPIDIG_ACCU_ORDER_WAR));
-    MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_accumulate
-                           (win, origin_count, target_count, target_rank, origin_datatype,
-                            target_datatype, origin_bytes, target_bytes, max_size, &req, &flags,
-                            &ep, sigreq));
+    mpi_errno =
+        MPIDI_OFI_allocate_win_request_accumulate(win, origin_count, target_count, target_rank,
+                                                  origin_datatype, target_datatype, origin_bytes,
+                                                  target_bytes, max_size, &req, &flags, &ep,
+                                                  sigreq);
+    MPIR_ERR_CHECK(mpi_errno);
 
     req->event_id = MPIDI_OFI_EVENT_ABORT;
     req->next = MPIDI_OFI_WIN(win).syncQ;
@@ -1076,10 +1074,13 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
         MPIDIG_wait_am_acc(win, target_rank,
                            (MPIDIG_ACCU_ORDER_RAW | MPIDIG_ACCU_ORDER_WAR | MPIDIG_ACCU_ORDER_WAW));
     }
-    MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_allocate_win_request_get_accumulate
-                           (win, origin_count, target_count, result_count, target_rank, op,
-                            origin_datatype, target_datatype, result_datatype, origin_bytes,
-                            target_bytes, result_bytes, max_size, &req, &flags, &ep, sigreq));
+    mpi_errno =
+        MPIDI_OFI_allocate_win_request_get_accumulate(win, origin_count, target_count, result_count,
+                                                      target_rank, op, origin_datatype,
+                                                      target_datatype, result_datatype,
+                                                      origin_bytes, target_bytes, result_bytes,
+                                                      max_size, &req, &flags, &ep, sigreq);
+    MPIR_ERR_CHECK(mpi_errno);
 
     req->event_id = MPIDI_OFI_EVENT_RMA_DONE;
     req->next = MPIDI_OFI_WIN(win).syncQ;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -368,8 +368,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ctrl.tag = tag;
 
         /* Send information about the memory region here to get the lmt going. */
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_do_control_send
-                               (&ctrl, send_buf, data_sz, dst_rank, comm, sreq));
+        mpi_errno = MPIDI_OFI_do_control_send(&ctrl, send_buf, data_sz, dst_rank, comm, sreq);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -300,7 +300,8 @@ static inline int MPIDI_NM_mpi_win_flush_all(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_ALL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_ALL);
 
-    MPIDI_OFI_MPI_CALL_POP(MPIDIG_mpi_win_flush_all(win));
+    mpi_errno = MPIDIG_mpi_win_flush_all(win);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_WIN_FLUSH_ALL);
@@ -329,7 +330,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_win_progress_fence(win));
+        mpi_errno = MPIDI_OFI_win_progress_fence(win);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -346,7 +348,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_WIN_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_win_progress_fence(win));
+        mpi_errno = MPIDI_OFI_win_progress_fence(win);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -364,7 +367,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_win_progress_fence(win));
+        mpi_errno = MPIDI_OFI_win_progress_fence(win);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
@@ -382,7 +386,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_RMA_TARGET_LOCAL_CMPL_HOOK);
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        MPIDI_OFI_MPI_CALL_POP(MPIDI_OFI_win_progress_fence(win));
+        mpi_errno = MPIDI_OFI_win_progress_fence(win);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
use MPIR_ERR_CHECK to keep the code consistent with the rest of the code
base.

Instead of 
```
#define MPIDI_OFI_MPI_CALL_POP(FUNC)                               \
  do                                                                 \
    {                                                                \
      mpi_errno = FUNC;                                              \
      MPIR_ERR_CHECK(mpi_errno); \
    } while (0)
```
do 
```
mpi_errno = FUNC;
MPIR_ERR_CHECK(mpi_errno); 
```
directly. We have decided to prefer the latter style, now let's keep the code consistent.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
