### PR TITLE
ch4: Release builtin comms at device layer

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1005,7 +1005,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     int i = 0;
     int barrier[2] = { 0 };
     MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-    MPIR_Comm *comm;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_FINALIZE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_FINALIZE);
@@ -1058,15 +1057,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.fabric->fid), fabricclose);
 
     fi_freeinfo(MPIDI_OFI_global.prov_use);
-
-    /* --------------------------------------- */
-    /* Free comm world addr table              */
-    /* --------------------------------------- */
-    comm = MPIR_Process.comm_world;
-    MPIR_Comm_release_always(comm);
-
-    comm = MPIR_Process.comm_self;
-    MPIR_Comm_release_always(comm);
 
     MPIDIG_finalize();
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -166,11 +166,6 @@ int MPIDI_UCX_mpi_finalize_hook(void)
     if (MPIDI_UCX_global.context != NULL)
         ucp_cleanup(MPIDI_UCX_global.context);
 
-    MPIR_Comm_release_always(comm);
-
-    comm = MPIR_Process.comm_self;
-    MPIR_Comm_release_always(comm);
-
     MPIDIG_finalize();
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -442,6 +442,10 @@ int MPID_Finalize(void)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    /* Release builtin comms */
+    MPIR_Comm_release_always(MPIR_Process.comm_world);
+    MPIR_Comm_release_always(MPIR_Process.comm_self);
+
     int i;
     int max_n_avts;
     max_n_avts = MPIDIU_get_max_n_avts();


### PR DESCRIPTION
## Pull Request Description

Release these communicators in the common device layer, as the netmods
are not holding any additional reference. This is consistent with how
ch3 handles the builtin comms during finalize.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
