### PR TITLE
ch4/rma: Checking ACC completion cntr in window synchronization

### DIFF
--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -728,7 +728,8 @@ static inline void MPIDIG_win_check_all_targets_remote_completed(MPIR_Win * win,
         target_ptr = MPIDIG_win_target_find(win, rank);
         if (!target_ptr)
             continue;
-        if (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0) {
+        if (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0 ||
+            MPIR_cc_get(target_ptr->remote_acc_cmpl_cnts) != 0) {
             *allcompleted = 0;
             break;
         }

--- a/src/mpid/ch4/src/ch4r_win.c
+++ b/src/mpid/ch4/src/ch4r_win.c
@@ -351,6 +351,7 @@ static int win_finalize(MPIR_Win ** win_ptr)
     /* All local outstanding OPs should have been completed. */
     MPIR_Assert(MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) == 0);
     MPIR_Assert(MPIR_cc_get(MPIDIG_WIN(win, remote_cmpl_cnts)) == 0);
+    MPIR_Assert(MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) == 0);
 
     /* Make progress till all OPs have been completed */
     do {
@@ -366,6 +367,7 @@ static int win_finalize(MPIR_Win ** win_ptr)
          * window. */
         all_completed = (MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) == 0) &&
             (MPIR_cc_get(MPIDIG_WIN(win, remote_cmpl_cnts)) == 0) &&
+            (MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) == 0) &&
             all_local_completed && all_remote_completed;
     } while (all_completed != 1);
 

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -398,7 +398,8 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
         MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
         MPIDIU_PROGRESS();
         MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
-    } while (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0);
+    } while (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0 ||
+             MPIR_cc_get(target_ptr->remote_acc_cmpl_cnts) != 0);
 
     if (target_ptr->sync.assert_mode & MPI_MODE_NOCHECK) {
         target_ptr->sync.lock.locked = 0;
@@ -467,7 +468,8 @@ static inline int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
         MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
         MPIDIU_PROGRESS();
         MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
-    } while (MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) != 0);
+    } while (MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) != 0 ||
+             MPIR_cc_get(MPIDIG_WIN(win, remote_acc_cmpl_cnts)) != 0);
     MPIDIG_EPOCH_FENCE_EVENT(win, massert);
 
     /*
@@ -574,7 +576,9 @@ static inline int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
         MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
         MPIDIU_PROGRESS();
         MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
-    } while (target_ptr && MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0);
+    } while (target_ptr &&
+             (MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0 ||
+              MPIR_cc_get(target_ptr->remote_acc_cmpl_cnts) != 0));
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_WIN_FLUSH);


### PR DESCRIPTION
ACC op is tracked by remote_acc_cmpl_cnts, which should be checked at
any window synchronization and finalization place, to make sure no
pending ACC ops are left.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
