### PR TITLE
finalize: separate the ALLFUNC_MUTEX from all other mutexes

### DIFF
--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -46,7 +46,9 @@ int MPIR_Init_thread(int *, char ***, int, int *);
 void MPII_init_thread_and_enter_cs(int thread_required);
 void MPII_init_thread_and_exit_cs(int thread_provided);
 void MPII_init_thread_failed_exit_cs(void);
-void MPII_finalize_thread_cs(void);
+void MPII_finalize_thread_and_enter_cs(void);
+void MPII_finalize_thread_and_exit_cs(void);
+void MPII_finalize_thread_failed_exit_cs(void);
 void MPIR_Thread_CS_Init(void);
 void MPIR_Thread_CS_Finalize(void);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -123,7 +123,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 
 int MPIDI_UCX_mpi_finalize_hook(void)
 {
-    int mpi_errno = MPI_SUCCESS, pmi_errno;
+    int mpi_errno = MPI_SUCCESS;
     int i, p = 0, completed;
     MPIR_Comm *comm;
     ucs_status_ptr_t ucp_request;


### PR DESCRIPTION

## Pull Request Description

Current development is adding dynamically allocated mutexes so that de-allocation has to be before we call finalize_memory_tracing. So we need separate the `ALLFUNC` mutex from the rest of the run-time mutexes just like the way we do in `init`.

Apply the similar thread cs refactor to finalize as we did in init, so
that the critical section now protects the entire finalize function.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
