### PR TITLE
mpl/thread: Fix missing error value setting

### DIFF
--- a/src/mpl/include/mpl_thread_priv.h
+++ b/src/mpl/include/mpl_thread_priv.h
@@ -60,6 +60,7 @@ void MPLI_cleanup_tls(void *a);
         }                                                               \
         else {                                                          \
             addr = &(var);                                              \
+            *((int *) err_ptr_) = MPL_THREAD_SUCCESS;                   \
         }                                                               \
     } while (0)
 


### PR DESCRIPTION
## Pull Request Description

Add a missing error value setting in MPL_THREADPRIV_KEY_GET_ADDR when
using the fallback tls support in MPL. Fixes runtime errors with
recent PGI compilers in Jenkins tests.

EDIT: To be pedantic, it is not really a fallback tls support, it is when compiled under non-threaded option, a no-op fallback.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
