### PR TITLE
runtests: refactor and add lockfile option

### DIFF
--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -74,7 +74,7 @@ exscan 10
 exscan2 5
 gather 4
 gather2 4
-@largetest@gather_big 8
+@largetest@gather_big 8 mem=20.1
 scattern 4
 scatter2 4
 scatter3 4
@@ -124,7 +124,7 @@ opmax 5
 opmaxloc 5
 uoplong 4
 uoplong 11
-uoplong 16
+uoplong 16 mem=1.4
 nonblocking 4 mpiversion=3.0
 nonblocking 5 mpiversion=3.0
 nonblocking 10 mpiversion=3.0

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -59,7 +59,7 @@ dataalign 2
 @largetest@large_count 1 mpiversion=3.0
 cxx_types 1 mpiversion=3.0
 @largetest@large_type 1 mpiversion=3.0
-@largetest@large_type_sendrec 2 arg=31 mpiversion=3.0
-@largetest@large_type_sendrec 2 arg=32 mpiversion=3.0 timeLimit=360
-@largetest@large_type_sendrec 2 arg=33 mpiversion=3.0 timeLimit=360
-@largetest@large_vec 3 mpiversion=3.0
+@largetest@large_type_sendrec 2 arg=31 mpiversion=3.0 mem=4.3
+@largetest@large_type_sendrec 2 arg=32 mpiversion=3.0 timeLimit=360 mem=8.6
+@largetest@large_type_sendrec 2 arg=33 mpiversion=3.0 timeLimit=360 mem=17.2
+@largetest@large_vec 3 mpiversion=3.0 mem=9.8

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -9,12 +9,12 @@ async_any 4
 userioerr 1
 resized 1
 resized2 1
-bigtype 1
+bigtype 1 mem=6.5
 hindexed_io 1
 tst_fileview 1
 simple_collective 1 arg=simple_collective.testfile
 external32_derived_dtype 1
-i_bigtype 1 mpiversion=3.1
+i_bigtype 1 mpiversion=3.1 mem=6.5
 i_hindexed_io 1 mpiversion=3.1
 i_rdwrord 4 mpiversion=3.1
 i_setviewcur 4 mpiversion=3.1

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -13,45 +13,40 @@
 # NOTE: the second (ssv args), fourth (timeLimit) and seventh (maxtestsize) fields are optional.
 
 attr/fkeyvaltype::1::1:1024:
-coll/bcast::1 512 262144:timeLimit=420:4:16:1024
-coll/bcast_comm_world_only::1 512 262144:timeLimit=360:10:16:1024
+coll/bcast::1 512::4:16:1024
+coll/bcast::262144:timeLimit=420 mem=1.2:4:16:
+coll/bcast_comm_world_only::1 512::10:16:1024
+coll/bcast_comm_world_only::262144:timeLimit=360 mem=1.9:10:16:
 cxx/attr/fkeyvaltypex::1::1:1024:
 cxx/datatype/packsizex::1::1:1024:
-pt2pt/pingping::1 512 262144::2:8:32
-pt2pt/pingping::17 1018 65530::2:8:32
-pt2pt/sendrecv1::1 512 262144::2:32:1024
-pt2pt/sendrecv1::17 1018 65530::2:32:1024
-pt2pt/sendself::1 512 262144::1:32:1024
-pt2pt/sendself::17 1018 65530::1:32:1024
-rma/accfence1::1 512 262144::4:16:1024
-rma/accfence1::17 1018 65530::4:16:1024
-rma/accpscw1::1 512 262144::4:16:1024
-rma/accpscw1::17 1018 65530::4:16:1024
-rma/epochtest::1 512 262144:timeLimit=300:4:16:1024
-rma/epochtest::17 1018 65530:timeLimit=300:4:16:1024
-rma/getfence1::1 512 262144::2:16:1024
-rma/getfence1::17 1018 65530::2:16:1024
-rma/getfence1::16000000:timeLimit=1800:2:4:
-rma/lock_contention_dt::1 512 262144:timeLimit=600:4:16:1024
-rma/lock_contention_dt::17 1018 65530:timeLimit=600:4:16:1024
-rma/lock_dt::1 512 262144::2:16:1024
-rma/lock_dt::17 1018 65530::2:16:1024
-rma/lock_dt_flush::1 512 262144::2:16:1024
-rma/lock_dt_flush::17 1018 65530::2:16:1024
-rma/lock_dt_flushlocal::1 512 262144::2:16:1024
-rma/lock_dt_flushlocal::17 1018 65530::2:16:1024
-rma/lockall_dt::1 512 262144::4:16:1024
-rma/lockall_dt::17 1018 65530:timeLimit=600:4:16:1024
-rma/lockall_dt_flush::1 512 262144::4:16:1024
-rma/lockall_dt_flush::17 1018 65530:timeLimit=600:4:16:1024
-rma/lockall_dt_flushall::1 512 262144::4:16:1024
-rma/lockall_dt_flushall::17 1018 65530:timeLimit=600:4:16:1024
-rma/lockall_dt_flushlocal::1 512 262144::4:16:1024
-rma/lockall_dt_flushlocal::17 1018 65530:timeLimit=600:4:16:1024
-rma/lockall_dt_flushlocalall::1 512 262144::4:16:1024
-rma/lockall_dt_flushlocalall::17 1018 65530:timeLimit=600:4:16:1024
-rma/putfence1::1 512 262144::2:16:1024
-rma/putfence1::17 1018 65530::2:16:1024
-rma/putfence1::16000000:timeLimit=1800:2:4:
-rma/putpscw1::1 512 262144::4:16:1024
-rma/putpscw1::17 1018 65530::4:16:1024
+pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32
+pt2pt/sendrecv1::1 512 262144 17 1018 65530::2:32:1024
+pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024
+rma/accfence1::1 512 17 1018::4:16:1024
+rma/accfence1::65530 262144:mem=1.2:4:16:
+rma/accpscw1::1 512 17 1018::4:16:1024
+rma/accpscw1::65530 262144:mem=1.7:4:16:
+rma/epochtest::1 512 17 1018::4:16:1024
+rma/epochtest::65530 262144:timeLimit=300 mem=5:4:16:
+rma/getfence1::1 512 17 1018::2:16:1024
+rma/getfence1::65530 262144:mem=2:2:16:
+rma/getfence1::16000000:timeLimit=1800 mem=3:2:4:
+rma/lock_contention_dt::1 512 17 1018::4:16:1024
+rma/lock_contention_dt::65530 262144:timeLimit=600 mem=2.1:4:16:
+rma/lock_dt::1 512 262144 17 1018 65530::2:16:1024
+rma/lock_dt_flush::1 512 262144 17 1018 65530::2:16:1024
+rma/lock_dt_flushlocal::1 512 262144 17 1018 65530::2:16:1024
+rma/lockall_dt::1 512 17 1018::4:16:1024
+rma/lockall_dt::65530 262144:timeLimit=600 mem=1.1:4:16:
+rma/lockall_dt_flush::1 512 262144 17 1018::4:16:1024
+rma/lockall_dt_flush::65530:timeLimit=600:4:16:
+rma/lockall_dt_flushall::1 512 262144 17 1018::4:16:1024
+rma/lockall_dt_flushall::65530:timeLimit=600:4:16:
+rma/lockall_dt_flushlocal::1 512 17 1018::4:16:1024
+rma/lockall_dt_flushlocal::65530 262144:timeLimit=600 mem=5:4:16:
+rma/lockall_dt_flushlocalall::1 512 17 1018::4:16:1024
+rma/lockall_dt_flushlocalall::65530 262144:timeLimit=600 mem=3:4:16:
+rma/putfence1::1 512 262144 17 1018 65530::2:16:1024
+rma/putfence1::16000000:timeLimit=1800 mem=2:2:4:
+rma/putpscw1::1 512 17 1018::4:16:1024
+rma/putpscw1::65530 262144:mem=4:4:16:

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -4,7 +4,10 @@
 # This file is used by autogen.sh to generate multiple binary files for datatype testing.
 # Every line must have the format:
 #
-# <test pathname>:<ssv args>:<ssv counts>:timeLimit=<seconds>:<procs#>:<mintestsize>:<maxtestsize>:<maxbufsize>
+# <test pathname>:<ssv args>:<ssv counts>:<passthru args>:<procs#>:<mintestsize>:<maxtestsize>:<maxbufsize>
+#
+# <passthru args> are space separated arguments that directly passed to testlist files.
+# It can be used to add attributes such as "timeLimit=<seconds>" and "mem=<GB>".
 #
 # The autogen.sh script generates a single binary for every line. Each binary will appear in
 # the testlist file multiple times, corresponding to different combinations of basic datatypes

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -30,19 +30,6 @@
 
 ################################################################################
 
-# gather_big uses around 16GB of memory for the user buffers.  That
-# already puts the test outside of the memory capacity of our FreeBSD
-# nodes.  It is technically with the memory capacity of our remaining
-# nodes, but the MPICH algorithm for large Gathers allocates too much
-# temporary buffer space causing the remaining configurations to
-# intermittently fail too (see issue 3770 for more details).
-* * * * * sed -i "s+\(^gather_big .*\)+\1 xfail=issue3770+g" test/mpi/coll/testlist
-
-################################################################################
-# other failures on FreeBSD because of memory limits in our jenkins
-# infrastructure
-* * * * freebsd64 sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
-################################################################################
 # xfail ch4 bugs
 ch4 * * * * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
 ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -36,7 +36,7 @@ waittestnull 1
 waitany_null 1
 # this should be run only on machines with large amount of memory (>=8GB)
 # perhaps disable in the release tarball
-large_message 3
+large_message 3 mem=6.5
 mprobe 2 mpiversion=3.0
 big_count_status 1 mpiversion=3.0
 many_isend 3

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -413,8 +413,6 @@ sub ProcessDir {
 sub RunList { 
     my $LIST = "LIST$depth"; $depth++;
     my $listfile = $_[0];
-    my $ResultTest = "";
-    my $InitForRun = "";
     my @TYPES = "";
     my $DTP_SWITCH = "@DTP_SWITCH@";
 
@@ -464,18 +462,13 @@ sub RunList {
             # See files errhan/testlist, init/testlist, and spawn/testlist
             # for examples of using the key=value form
             my @args = split(/\s+/,$_);
+            my $test_opt = {args=>[], envs=>[], mpiexecargs=>[]};
+
             my $programname = $args[0];
             my $np = "";
-            my $ResultTest = "";
-            my $InitForRun = "";
-            my $timeLimit  = "";
-            my $progArgs   = "";
-            my $mpiexecArgs = "";
             my $requiresStrict = "";
             my $requiresMPIX   = "";
-            my $progEnv    = "";
             my $mpiVersion = "";
-            my $xfail = "";
 
             my $dtp_match_type = 0;
             my $dtp_test_type = "";    # this test type
@@ -491,14 +484,8 @@ sub RunList {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
                     my $key = $1;
                     my $value = $2;
-                    if ($key eq "resultTest") {
-                        $ResultTest = $value;
-                    }
-                    elsif ($key eq "init") {
-                        $InitForRun = $value;
-                    }
-                    elsif ($key eq "timeLimit") {
-                        $timeLimit = $value;
+                    if ($key =~ /^(resultTest|init|timeLimit|xfail)$/) {
+                        $test_opt->{$key} = $value;
                     }
                     elsif ($key eq "arg") {
                         # match allowed datatypes here
@@ -509,18 +496,13 @@ sub RunList {
                             }
                         }
 
-                        $progArgs = "$progArgs $value";
+                        push @{$test_opt->{args}}, $value;
                     }
                     elsif ($key eq "mpiexecarg") {
-                        $mpiexecArgs = "$mpiexecArgs $value";
+                        push @{$test_opt->{mpiexecargs}}, $value;
                     }
                     elsif ($key eq "env") {
-                        if ($progEnv eq "") {
-                            $progEnv = "$value";
-                        }
-                        else {
-                            $progEnv = "$progEnv $value";
-                        }
+                        push @{$test_opt->{envs}}, $value;
                     }
                     elsif ($key eq "mpiversion") {
                         $mpiVersion = $value;
@@ -531,16 +513,14 @@ sub RunList {
                     elsif ($key eq "mpix") {
                         $requiresMPIX = $value
                     }
-                    elsif ($key eq "xfail") {
-                        if ($value eq "") {
-                            print STDERR "\"xfail=\" requires an argument\n";
-                        }
-                        $xfail = $value;
-                    }
                     else {
                         print STDERR "Unrecognized key $key in $listfileSource\n";
                     }
                 }
+            }
+
+            if (defined $test_opt->{xfail} and !$test_opt->{xfail}) {
+                print STDERR "\"xfail=\" requires an argument\n";
             }
 
             if ($DTP_SWITCH eq "ON") {
@@ -581,7 +561,7 @@ sub RunList {
                     ($majorReq == $MPIMajorVersion && $minorReq > $MPIMinorVersion))
                 {
                     unless (-d $programname) {
-                        SkippedTest($programname, $np, $progArgs, $progEnv, $curdir, "requires MPI version $mpiVersion");
+                        SkippedTest($programname, $np, $test_opt, $curdir, "requires MPI version $mpiVersion");
                     }
                     next;
                 }
@@ -590,7 +570,7 @@ sub RunList {
             # test (use strict=false for tests that use non-standard extensions)
             if (lc($requiresStrict) eq "false" && lc($testIsStrict) eq "true") {
                 unless (-d $programname) {
-                    SkippedTest($programname, $np, $progArgs, $progEnv, $curdir, "non-strict test, strict MPI mode requested");
+                    SkippedTest($programname, $np, $test_opt, $curdir, "non-strict test, strict MPI mode requested");
                 }
                 next;
             }
@@ -599,21 +579,21 @@ sub RunList {
                 # Strict MPI testing was requested, so assume that a non-MPICH MPI
                 # implementation is being tested and the "xfail" implementation
                 # assumptions do not hold.
-                $xfail = '';
+                delete($test_opt->{xfail});
             }
 
-            if ($xfail ne '' && $runxfail eq "false") {
+            if ($test_opt->{xfail} && $runxfail eq "false") {
                 # Skip xfail tests if they are not configured. Strict MPI tests that are
                 # marked xfail will still run with --enable-strictmpi.
                 unless (-d $programname) {
-                    SkippedTest($programname, $np, $progArgs, $progEnv, $curdir, "xfail tests disabled");
+                    SkippedTest($programname, $np, $test_opt, $curdir, "xfail tests disabled");
                 }
                 next;
             }
 
             if (lc($requiresMPIX) eq "true" && lc($MPIHasMPIX) eq "no") {
                 unless (-d $programname) {
-                    SkippedTest($programname, $np, $progArgs, $progEnv, $curdir, "tests MPIX extensions, MPIX testing disabled");
+                    SkippedTest($programname, $np, $test_opt, $curdir, "tests MPIX extensions, MPIX testing disabled");
                 }
                 next;
             }
@@ -632,19 +612,15 @@ sub RunList {
                     $programname = $2;
                     chdir $1 or warn "Can't chdir $1\n";
                 }
-                if (&BuildMPIProgram( $programname, $xfail ) == 0) {
+                if (&BuildMPIProgram( $programname, $test_opt ) == 0) {
                     if ($batchRun == 1) {
-                        &AddMPIProgram( $programname, $np, $ResultTest, 
-                                        $InitForRun, $timeLimit, $progArgs,
-                                        $progEnv, $mpiexecArgs, $xfail );
+                        &AddMPIProgram( $programname, $np, $test_opt );
                     }
                     else {
-                        &RunMPIProgram( $programname, $np, $ResultTest, 
-                                        $InitForRun, $timeLimit, $progArgs, 
-                                        $progEnv, $mpiexecArgs, $xfail );
+                        &RunMPIProgram( $programname, $np, $test_opt );
                     }
                 }
-                elsif ($xfail eq '') {
+                elsif ($test_opt->{xfail} eq '') {
                     # We expected to run this program, so failure to build
                     # is an error
                     $found_error = 1;
@@ -685,6 +661,7 @@ sub ProcessImplicitList {
     }
     close PGMS;
     
+    my $default_test_opt = {args=>[], envs=>[], mpiexecargs=>[]};
     if ($found_exec) {
         print "Found executables\n" if $debug;
         open (PGMS, "ls -1 |" ) || die "Cannot list programs\n";
@@ -701,7 +678,7 @@ sub ProcessImplicitList {
             if ($programname eq "runtests") { next; } # Ignore self
             if (-x $programname) {
                 $total_run++;
-                &RunMPIProgram( $programname, $np_default, "", "", "", "", "", "", "" );
+                &RunMPIProgram( $programname, $np_default, $default_test_opt);
             }
         }
         close PGMS;
@@ -722,7 +699,7 @@ sub ProcessImplicitList {
             $programname =~ s/\.c//;
             $total_run++;
             if (&BuildMPIProgram( $programname, "") == 0) {
-                &RunMPIProgram( $programname, $np_default, "", "", "", "", "", "", "" );
+                &RunMPIProgram( $programname, $np_default, $default_test_opt);
             }
             else {
                 # We expected to run this program, so failure to build
@@ -743,21 +720,25 @@ sub ProcessImplicitList {
 # If the 3rd arg is not present, the a default that simply checks that the
 # return status is 0 and that the output is " No Errors" is used.
 sub RunMPIProgram {
-    my ($programname,$np,$ResultTest,$InitForTest,$timeLimit,$progArgs,$progEnv,$mpiexecArgs,$xfail) = @_;
+    my ($programname,$np,$test_opt) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+    my $progEnv = join(' ', @{$test_opt->{envs}});
+    my $mpiexecArgs = join(' ', @{$test_opt->{mpiexecargs}});
+
     my $found_error   = 0;
     my $found_noerror = 0;
     my $inline = "";
     my $extraArgs = "";
     my $runtime = 0;
 
-    &RunPreMsg( $programname, $np, $progArgs, $curdir );
+    &RunPreMsg( $programname, $np, $test_opt, $curdir );
 
     unlink "err";
 
     # Set a default timeout on tests (3 minutes for now)
     my $timeout = $defaultTimeLimit;
-    if (defined($timeLimit) && $timeLimit =~ /^\d+$/) {
-        $timeout = $timeLimit;
+    if (defined($test_opt->{timeLimit}) && $test_opt->{timeLimit} =~ /^\d+$/) {
+        $timeout = $test_opt->{timeLimit};
     }
     $timeout *= $defaultTimeLimitMultiplier;
     $ENV{"MPIEXEC_TIMEOUT"} = $timeout;
@@ -784,16 +765,18 @@ sub RunMPIProgram {
 
     # Run the optional setup routine. For example, the timeout tests could
     # be set to a shorter timeout.
-    if ($InitForTest ne "") {
-        &$InitForTest();
+    # FIXME: bad practice, remove
+    if ($test_opt->{init}) {
+        $test_opt->{init}->();
     }
     print STDOUT "Env includes $progEnv\n" if $verbose;
     print STDOUT "$mpiexec $np_arg $np $extraArgs $mpiexecArgs $program_wrapper ./$programname $progArgs\n" if $verbose;
     print STDOUT "." if $showProgress;
     # Save and restore the environment if necessary before running mpiexec.
-    if ($progEnv ne "") {
+    my %saveEnv;
+    if ($test_opt->{envs}) {    
         %saveEnv = %ENV;
-        foreach $val (split(/\s+/, $progEnv)) {
+        foreach my $val (@{$test_opt->{envs}}) {
             if ($val =~ /([^=]+)=(.*)/) {
                 $ENV{$1} = $2;
             }
@@ -805,12 +788,23 @@ sub RunMPIProgram {
     my $start_time = gettimeofday();
     open ( MPIOUT, "$mpiexec $np_arg $np $extraArgs $mpiexecArgs $program_wrapper ./$programname $progArgs 2>&1 |" ) ||
         die "Could not run ./$programname\n";
-    if ($progEnv ne "") {
+    if ($test_opt->{envs}) {    
         %ENV = %saveEnv;
     }
-    if ($ResultTest ne "") {
+    if ($test_opt->{resultTest}) {
         # Read and process the output
-        ($found_error, $inline) = &$ResultTest( MPIOUT, $programname );
+        my %test_actions = (
+            TestStatus => \&TestStatus,
+            TestStatusNoErrors => \&TestStatusNoErrors,
+            TestErrFatal => \&TestErrFatal,
+        );
+
+        my $F = $test_actions{$test_opt->{resultTest}};
+        if ($F) {
+            ($found_error, $inline) = $F->( MPIOUT, $programname );
+        } else {
+            die "resultTest $test_opt->{resultTest} not defined!\n";
+        }
     }
     else {
         if ($verbose) {
@@ -866,46 +860,50 @@ sub RunMPIProgram {
         }
     }
     if ($found_error) {
-        &RunTestFailed( $programname, $np, $progArgs, $progEnv, $timeout, $curdir, $inline, $xfail, $runtime );
+        &RunTestFailed( $programname, $np, $test_opt, $timeout, $curdir, $inline, $runtime );
     }
     else { 
-        &RunTestPassed( $programname, $np, $progArgs, $progEnv, $curdir, $xfail, $runtime );
+        &RunTestPassed( $programname, $np, $test_opt, $curdir, $runtime );
     }
-    &RunPostMsg( $programname, $np, $curdir );
+    &RunPostMsg( $programname, $np, $test_opt, $curdir );
 }
 
 # This version simply writes the mpiexec command out, with the output going
 # into a file, and recording the output status of the run.
 sub AddMPIProgram {
-    my ($programname,$np,$ResultTest,$InitForTest,$timeLimit,$progArgs,$progEnv,$mpiexecArgs, $xfail) = @_;
+    my ($programname,$np,$test_opt) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+    my $progEnv = join(' ', @{$test_opt->{envs}});
+    my $mpiexecArgs = join(' ', @{$test_opt->{mpiexecargs}});
 
     if (! -x $programname) {
         print STDERR "Could not find $programname!";
         return;
     }
 
-    if ($ResultTest ne "") {
+    if ($test_opt->{resultTest}) {
         # This test really needs to be run manually, with this test
         # Eventually, we can update this to include handleing in checktests.
-        print STDERR "Run $curdir/$programname with $np processes and use $ResultTest to check the results\n";
+        print STDERR "Run $curdir/$programname with $np processes and use $test_opt->{resultTest} to check the results\n";
         return;
     }
 
     # Set a default timeout on tests (3 minutes for now)
     my $timeout = $defaultTimeLimit;
-    if (defined($timeLimit) && $timeLimit =~ /^\d+$/) {
+    if (defined($test_opt->{timeLimit}) && $test_opt->{timeLimit} =~ /^\d+$/) {
         # On some systems, there is no effective time limit on 
         # individual mpi program runs.  In that case, we may
         # want to treat these also as "run manually".
-        $timeout = $timeLimit;
+        $timeout = $test_opt->{timeLimit};
     }
     $timeout *= $defaultTimeLimitMultiplier;
     print BATOUT "export MPIEXEC_TIMEOUT=$timeout\n";
     
     # Run the optional setup routine. For example, the timeout tests could
     # be set to a shorter timeout.
-    if ($InitForTest ne "") {
-        &$InitForTest();
+    # FIXME: very bad practice, remove.
+    if ($test_opt->{init}) {
+        $test_opt->{init}->();
     }
 
     # For non-MPICH versions of mpiexec, a timeout may require a different
@@ -967,8 +965,8 @@ sub AddMPIProgram {
 # 
 # Return value is 0 on success, non zero on failure
 sub BuildMPIProgram {
-    my $programname = shift;
-    my $xfail = shift;
+    my ($programname, $test_opt) = @_;
+
     my $rc = 0;
     if ($verbose) { print STDERR "making $programname\n"; }
     if (! -x $programname) { $remove_this_pgm = 1; }
@@ -985,9 +983,9 @@ sub BuildMPIProgram {
         # This will ensure that failures to build will end up 
         # in the summary file (which is otherwise written by the
         # RunMPIProgram step)
-        &RunPreMsg( $programname, $np, $curdir );
-    &RunTestFailed( $programname, $np, "", "", $timeout, $curdir, "Failed to build $programname; $output", $xfail );
-        &RunPostMsg( $programname, $np, $curdir );
+        &RunPreMsg( $programname, $np, $test_opt, $curdir );
+        &RunTestFailed( $programname, $np, $test_opt, $timeout, $curdir, "Failed to build $programname; $output" );
+        &RunPostMsg( $programname, $np, $test_opt, $curdir );
     }
     return $rc;
 }
@@ -1186,22 +1184,27 @@ sub TestErrFatal {
 #  RunPostMsg               - Call at end of each test
 #
 sub RunPreMsg {
-    my ($programname,$np,$progArgs,$workdir) = @_;
+    my ($programname,$np,$test_opt,$workdir) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+
     if ($xmloutput) {
         print XMLOUT "<MPITEST>$newline<NAME>$programname</NAME>$newline";
-    print XMLOUT "<ARGS>$progArgs</ARGS>$newline";
+        print XMLOUT "<ARGS>$progArgs</ARGS>$newline";
         print XMLOUT "<NP>$np</NP>$newline";
         print XMLOUT "<WORKDIR>$workdir</WORKDIR>$newline";
     }
 }
 sub RunPostMsg {
-    my ($programname, $np, $workdir) = @_;
+    my ($programname, $np, $test_opt, $workdir) = @_;
     if ($xmloutput) {
         print XMLOUT "</MPITEST>$newline";
     }
 }
 sub RunTestPassed {
-    my ($programname, $np, $progArgs, $progEnv, $workdir, $xfail, $runtime) = @_;
+    my ($programname, $np, $test_opt, $workdir, $runtime) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+    my $progEnv = join(' ', @{$test_opt->{envs}});
+
     if ($xmloutput) {
         print XMLOUT "<STATUS>pass</STATUS>$newline";
     print XMLOUT "<TIME>$runtime</TIME>$newline";
@@ -1214,15 +1217,9 @@ sub RunTestPassed {
     }
 }
 sub RunTestFailed {
-    my $programname = shift;
-    my $np = shift;
-    my $progArgs = shift;
-    my $progEnv = shift;
-    my $timeout = shift;
-    my $workdir = shift;
-    my $output = shift;
-    my $xfail = shift;
-    my $runtime = shift;
+    my ($programname, $np, $test_opt, $timeout, $workdir, $output, $runtime) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+    my $progEnv = join(' ', @{$test_opt->{envs}});
 
     if ($xmloutput) {
         my $xout = $output;
@@ -1240,8 +1237,8 @@ sub RunTestFailed {
 
     if ($tapoutput) {
         my $xfailstr = '';
-        if ($xfail ne '') {
-            $xfailstr = " # TODO $xfail";
+        if ($test_opt->{xfail}) {
+            $xfailstr = " # TODO $test_opt->{xfail}";
         }
         print TAPOUT "not ok ${total_run} - $workdir/$programname ${np}${xfailstr} # time=$runtime\n";
         print TAPOUT "  ---\n";
@@ -1279,8 +1276,8 @@ sub RunTestFailed {
     if ($junitoutput) {
         my $xfailstr = '';
         my $testtag = "failure";
-        if ($xfail ne '') {
-            $xfailstr = " # TODO $xfail";
+        if ($test_opt->{xfail}) {
+            $xfailstr = " # TODO $test_opt->{xfail}";
             $testtag  = "skipped";
         }
         print JUNITOUT "    <testcase name=\"${total_run} - $workdir/$programname ${np} ${progArgs} ${progEnv}\" time=\"$runtime\">\n";
@@ -1311,12 +1308,9 @@ sub RunTestFailed {
 }
 
 sub SkippedTest {
-    my $programname = shift;
-    my $np = shift;
-    my $progArgs = shift;
-    my $progEnv = shift;
-    my $workdir = shift;
-    my $reason = shift;
+    my ($programname, $np, $test_opt, $workdir, $reason) = @_;
+    my $progArgs = join(' ', @{$test_opt->{args}});
+    my $progEnv = join(' ', @{$test_opt->{envs}});
 
     # simply omit from the XML output
 

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -782,16 +782,20 @@ sub RunMPIProgram {
     }
 
     # acquire lock if requested
-    my $lockfile="/tmp/runtests-mem.lock";
+    my ($lockfile, $got_lock);
     my ($lock_sh, $lock_ex) = (1, 2);
-    my $got_lock;
     if ($test_opt->{lock}) {
-        if ($test_opt->{lock} eq "shared") {
+        # explict lock by setting "lock=[shared|name]" on testline directly
+        my $name = $test_opt->{lock};
+        $lockfile = "/tmp/runtests-$name.lock"
+        if ($name eq "shared") {
             $got_lock = get_lock($lockfile, $lock_sh);
         } else {
             $got_lock = get_lock($lockfile, $lock_ex);
         }
     } elsif ($test_opt->{mem}) {
+        # implicit lock by checking memory annotation
+        $lockfile="/tmp/runtests-mem.lock";
         if ($test_opt->{mem} > $g_opt->{memory_total}) {
             SkippedTest($programname, $np, $test_opt, $curdir, "xfail due to memory requirement");
             next;
@@ -805,7 +809,6 @@ sub RunMPIProgram {
     print STDOUT "Env includes $progEnv\n" if $verbose;
     print STDOUT "$mpiexec $np_arg $np $extraArgs $mpiexecArgs $program_wrapper ./$programname $progArgs\n" if $verbose;
     print STDOUT "." if $showProgress;
-
     # Save and restore the environment if necessary before running mpiexec.
     my %saveEnv;
     if ($test_opt->{envs}) {    
@@ -1376,14 +1379,16 @@ sub InitQuickTimeout {
 # ----------------------------------------------------------------------------
 # util routines
 
+# file locking using flock: the lock is acquired while the file is open and
+#     released when file is closed (or process is terminated and OS closes the file)
 sub get_lock {
     my ($lockfile, $lock_type) = @_;
     if ($verbose) {
         print "Taking lock [$lockfile], type $lock_type\n";
     }
     if(open LOCK, ">$lockfile"){
+        # flock blocks until the lock is taken
         flock(LOCK, $lock_type);
-        print LOCK "$$\n";
         return 1;
     }
     else{

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -44,6 +44,10 @@ use File::Copy qw(move);
 use Time::HiRes qw(gettimeofday tv_interval);
 
 # Global variables
+our $g_opt = {};   # global options. TODO: migrate global option vars into the hash
+$g_opt->{memory_total} = 20;      # Total memory in GB
+$g_opt->{memory_multiplier} = 1;  # No of simutaneous jobs
+
 $MPIMajorVersion = "@MPI_VERSION@";
 $MPIMinorVersion = "@MPI_SUBVERSION@";
 $mpiexec = "@MPIEXEC@";    # Name of mpiexec program (including path, if necessary)
@@ -141,6 +145,13 @@ if (defined($ENV{"MPITEST_TIMEOUT"})) {
  
 if (defined($ENV{"MPITEST_TIMEOUT_MULTIPLIER"})) {
     $defaultTimeLimitMultiplier = $ENV{"MPITEST_TIMEOUT_MULTIPLIER"};
+}
+
+for my $key ("memory_total", "memory_multiplier") {
+    my $k = "MPITEST_".uc($key);
+    if (defined($ENV{$k})) {
+        $g_opt->{$key} = $ENV{$k};
+    }
 }
 
 # Define this to leave the XML output file open to receive additional data
@@ -484,7 +495,7 @@ sub RunList {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
                     my $key = $1;
                     my $value = $2;
-                    if ($key =~ /^(resultTest|init|timeLimit|xfail)$/) {
+                    if ($key =~ /^(resultTest|init|timeLimit|xfail|lock|mem)$/) {
                         $test_opt->{$key} = $value;
                     }
                     elsif ($key eq "arg") {
@@ -769,9 +780,32 @@ sub RunMPIProgram {
     if ($test_opt->{init}) {
         $test_opt->{init}->();
     }
+
+    # acquire lock if requested
+    my $lockfile="/tmp/runtests-mem.lock";
+    my ($lock_sh, $lock_ex) = (1, 2);
+    my $got_lock;
+    if ($test_opt->{lock}) {
+        if ($test_opt->{lock} eq "shared") {
+            $got_lock = get_lock($lockfile, $lock_sh);
+        } else {
+            $got_lock = get_lock($lockfile, $lock_ex);
+        }
+    } elsif ($test_opt->{mem}) {
+        if ($test_opt->{mem} > $g_opt->{memory_total}) {
+            SkippedTest($programname, $np, $test_opt, $curdir, "xfail due to memory requirement");
+            next;
+        } elsif ($test_opt->{mem} * $g_opt->{memory_multiplier} > $g_opt->{memory_total} ) {
+            $got_lock = get_lock($lockfile, $lock_ex);
+        } else {
+            $got_lock = get_lock($lockfile, $lock_sh);
+        }
+    }
+
     print STDOUT "Env includes $progEnv\n" if $verbose;
     print STDOUT "$mpiexec $np_arg $np $extraArgs $mpiexecArgs $program_wrapper ./$programname $progArgs\n" if $verbose;
     print STDOUT "." if $showProgress;
+
     # Save and restore the environment if necessary before running mpiexec.
     my %saveEnv;
     if ($test_opt->{envs}) {    
@@ -859,6 +893,12 @@ sub RunMPIProgram {
             }
         }
     }
+
+    # release lock if needed
+    if ($got_lock) {
+        relese_lock($lockfile);
+    }
+
     if ($found_error) {
         &RunTestFailed( $programname, $np, $test_opt, $timeout, $curdir, $inline, $runtime );
     }
@@ -1331,4 +1371,31 @@ sub SkippedTest {
 # Alternate init routines
 sub InitQuickTimeout {
     $ENV{"MPIEXEC_TIMEOUT"} = 10;
+}
+
+# ----------------------------------------------------------------------------
+# util routines
+
+sub get_lock {
+    my ($lockfile, $lock_type) = @_;
+    if ($verbose) {
+        print "Taking lock [$lockfile], type $lock_type\n";
+    }
+    if(open LOCK, ">$lockfile"){
+        flock(LOCK, $lock_type);
+        print LOCK "$$\n";
+        return 1;
+    }
+    else{
+        warn "failed to open lockfile $lockfile\n";
+        return 0;
+    }
+}
+
+sub relese_lock {
+    my ($lockfile) = @_;
+    if ($verbose) {
+        print "Releasing lock [$lockfile]\n";
+    }
+    close(LOCK);
 }


### PR DESCRIPTION
## Pull Request Description

This PR adds a `lock=name` option to tests so big tests can be configured to avoid running simultaneously.

The larger commit is a refactor so adding new options to runtests are easier.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
