### PR TITLE
Enable mismatched data size check only when HAVE_ERROR_CHECKING is defined

### DIFF
--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -261,6 +261,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
         i++;
     }
 
+#ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
     if (curr_size != nbytes) {
         if (*errflag == MPIR_ERR_NONE)
@@ -270,6 +271,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                       "**collective_size_mismatch %d %d", curr_size, nbytes);
         MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
     }
+#endif
 
     if (!is_contig) {
         if (rank != root) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -132,6 +132,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
         jnext = (comm_size + jnext - 1) % comm_size;
     }
 
+#ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
     if (curr_size != nbytes) {
         if (*errflag == MPIR_ERR_NONE)
@@ -141,6 +142,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
                       "**collective_size_mismatch %d %d", curr_size, nbytes);
         MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
     }
+#endif
 
     if (!is_contig) {
         if (rank != root) {

--- a/src/mpi/coll/ibcast/ibcast_intra_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_smp.c
@@ -58,8 +58,10 @@ int MPIR_Ibcast_sched_intra_smp(void *buffer, int count, MPI_Datatype datatype, 
         }
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
+#ifdef HAVE_ERROR_CHECKING
         mpi_errno = MPIR_Sched_cb(&sched_test_length, ibcast_state, s);
         MPIR_ERR_CHECK(mpi_errno);
+#endif
         MPIR_SCHED_BARRIER(s);
     }
 


### PR DESCRIPTION
Checking of amount of data received and expected should be done only
when HAVE_ERROR_CHECKING is defined

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
