### PR TITLE
init: hack to touch tls globals

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -170,6 +170,9 @@ int MPI_Finalize(void)
      * for atomic file updates makes this harder. */
     MPII_final_coverage_delay(rank);
 
+    /* destroy fine-grained mutex (including dynamic ones) */
+    MPIR_Thread_CS_Finalize();
+
     /* All memory should be freed at this point */
     MPII_finalize_memory_tracing();
 

--- a/src/mpi/init/globals.c
+++ b/src/mpi/init/globals.c
@@ -32,3 +32,20 @@ MPIR_Thread_sync_list_t sync_wait_list;
    MPI_Init and MPI_Finalize) */
 MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUS_IGNORE MPL_USED = 0;
 MPIU_DLL_SPEC MPI_Fint *MPI_F_STATUSES_IGNORE MPL_USED = 0;
+
+/* ** HACK **
+ * Hack to workaround an Intel compiler bug on macOS. Touching
+ * MPIR_Per_thread in this file forces the compiler to allocate it as TLS.
+ * See https://github.com/pmodels/mpich/issues/3437.
+ */
+void _dummy_touch_tls(void);
+void _dummy_touch_tls(void)
+{
+    MPIR_Per_thread_t *per_thread = NULL;
+    int err;
+
+    MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
+                                 MPIR_Per_thread, per_thread, &err);
+    MPIR_Assert(err == 0);
+    memset(per_thread, 0, sizeof(MPIR_Per_thread_t));
+}

--- a/src/mpi/init/init_global.c
+++ b/src/mpi/init/init_global.c
@@ -158,6 +158,8 @@ int MPII_post_init_global(int thread_provided)
     /* Assert: tag_ub is at least the minimum asked for in the MPI spec */
     MPIR_Assert(MPIR_Process.attrs.tag_ub >= 32767);
 
+    MPII_Timer_init(MPIR_Process.comm_world->rank, MPIR_Process.comm_world->local_size);
+
     return mpi_errno;
 }
 

--- a/src/mpi/init/init_thread_cs.c
+++ b/src/mpi/init/init_thread_cs.c
@@ -144,20 +144,6 @@ void MPIR_Thread_CS_Init(void)
 
     MPID_THREADPRIV_KEY_CREATE;
 
-    {
-        /*
-         * Hack to workaround an Intel compiler bug on macOS. Touching
-         * MPIR_Per_thread in this file forces the compiler to allocate it as TLS.
-         * See https://github.com/pmodels/mpich/issues/3437.
-         */
-        MPIR_Per_thread_t *per_thread = NULL;
-
-        MPID_THREADPRIV_KEY_GET_ADDR(MPIR_ThreadInfo.isThreaded, MPIR_Per_thread_key,
-                                     MPIR_Per_thread, per_thread, &err);
-        MPIR_Assert(err == 0);
-        memset(per_thread, 0, sizeof(MPIR_Per_thread_t));
-    }
-
     MPL_DBG_MSG(MPIR_DBG_INIT, TYPICAL, "Created global mutex and private storage");
 }
 

--- a/src/mpi/init/init_thread_cs.c
+++ b/src/mpi/init/init_thread_cs.c
@@ -41,9 +41,6 @@ void MPII_init_thread_and_enter_cs(int thread_required)
 
 void MPII_init_thread_and_exit_cs(int thread_provided)
 {
-    /* create the rest of the mutexes */
-    MPIR_Thread_CS_Init();
-
     /* need to ensure consistency here */
     int save_is_threaded = MPIR_ThreadInfo.isThreaded;
     MPIR_ThreadInfo.isThreaded = required_is_threaded;
@@ -63,9 +60,6 @@ void MPII_init_thread_failed_exit_cs(void)
 void MPII_finalize_thread_and_enter_cs(void)
 {
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-
-    /* destroy all other mutex locks */
-    MPIR_Thread_CS_Finalize();
 }
 
 void MPII_finalize_thread_and_exit_cs(void)
@@ -108,13 +102,12 @@ MPID_Thread_mutex_t MPIR_THREAD_POBJ_HANDLE_MUTEX;
 /* These routine handle any thread initialization that my be required */
 void MPIR_Thread_CS_Init(void)
 {
-    int err;
-
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__GLOBAL
     /* Use the single MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX for all MPI calls */
 
 #elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__POBJ
     /* MPICH_THREAD_GRANULARITY__POBJ: Multiple locks */
+    int err;
     MPID_Thread_mutex_create(&MPIR_THREAD_POBJ_HANDLE_MUTEX, &err);
     MPIR_Assert(err == 0);
     MPID_Thread_mutex_create(&MPIR_THREAD_POBJ_MSGQ_MUTEX, &err);
@@ -127,6 +120,7 @@ void MPIR_Thread_CS_Init(void)
     MPIR_Assert(err == 0);
 
 #elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
+    int err;
     MPID_Thread_mutex_create(&MPIR_THREAD_POBJ_HANDLE_MUTEX, &err);
     MPIR_Assert(err == 0);
 

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -140,6 +140,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPII_init_async(thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* create fine-grained mutexes */
+    MPIR_Thread_CS_Init();
+
     /* Let the device know that the rest of the init process is completed */
     mpi_errno = MPID_InitCompleted();
 

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -77,17 +77,12 @@ static inline void MPII_pre_init_memory_tracing(void)
 
 static inline void MPII_post_init_memory_tracing(void)
 {
-    MPII_Timer_init(MPIR_Process.comm_world->rank, MPIR_Process.comm_world->local_size);
 #ifdef USE_MEMORY_TRACING
 #ifdef MPICH_IS_THREADED
     MPL_trconfig(MPIR_Process.comm_world->rank, MPIR_ThreadInfo.isThreaded);
 #else
     MPL_trconfig(MPIR_Process.comm_world->rank, 0);
 #endif
-    /* Indicate that we are near the end of the init step; memory
-     * allocated already will have an id of zero; this helps
-     * separate memory leaks in the initialization code from
-     * leaks in the "active" code */
 #endif
 }
 


### PR DESCRIPTION

## Pull Request Description

The last init refactor broke a previous hack on global TLS variable: issue #3437, PR #3909.

This PR restores the hack.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
