### PR TITLE
MPL/atomic: statically initialize the emulation lock

### DIFF
--- a/src/mpl/include/mpl_atomic.h
+++ b/src/mpl/include/mpl_atomic.h
@@ -80,12 +80,6 @@ static void MPL_atomic_read_barrier(void);
 static void MPL_atomic_read_write_barrier(void);
 static void MPL_atomic_compiler_barrier(void);
 
-#ifdef MPL_HAVE_PTHREAD_H
-#include <pthread.h>
-typedef pthread_mutex_t MPL_atomic_emulation_ipl_t;
-int MPL_atomic_interprocess_lock_init(MPL_atomic_emulation_ipl_t * shm_lock, int isLeader);
-#endif /* HAVE_PTHREAD_H */
-
 #if defined(MPL_USE_NO_ATOMIC_PRIMITIVES)
 #include "mpl_atomic_none.h"
 #elif defined(MPL_HAVE_C11_ATOMICS)

--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -12,18 +12,16 @@
 #include <pthread.h>
 
 /* defined in mpl_atomic.c */
-extern pthread_mutex_t *MPL_emulation_lock;
+extern pthread_mutex_t MPL_emulation_lock;
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()        \
-    do {                                        \
-        assert(MPL_emulation_lock);             \
-        pthread_mutex_lock(MPL_emulation_lock); \
+#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()         \
+    do {                                         \
+        pthread_mutex_lock(&MPL_emulation_lock); \
     } while (0)
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()             \
-    do {                                            \
-        assert(MPL_emulation_lock);                 \
-        pthread_mutex_unlock(MPL_emulation_lock);   \
+#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()              \
+    do {                                             \
+        pthread_mutex_unlock(&MPL_emulation_lock);   \
     } while (0)
 
 

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -14,24 +14,6 @@
 #ifdef MPL_HAVE_PTHREAD_H
 #include <pthread.h>
 
-pthread_mutex_t *MPL_emulation_lock = NULL;
+pthread_mutex_t MPL_emulation_lock = PTHREAD_MUTEX_INITIALIZER;
 
-int MPL_atomic_interprocess_lock_init(MPL_atomic_emulation_ipl_t * shm_lock, int isLeader)
-{
-    int mpi_errno = 0;          /*MPI_SUCCESS */
-    pthread_mutexattr_t attr;
-    MPL_emulation_lock = shm_lock;
-
-    if (isLeader) {
-        /* Set the mutex attributes to work correctly on inter-process
-         * shared memory as well. This is required for some compilers
-         * (such as SUN Studio) that don't enable it by default. */
-        if (pthread_mutexattr_init(&attr) ||
-            pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) ||
-            pthread_mutex_init(MPL_emulation_lock, &attr))
-            mpi_errno = 16;     /* MPI_ERR_INTERN */
-    }
-
-    return mpi_errno;
-}
 #endif /* MPL_HAVE_PTHREAD_H */


### PR DESCRIPTION
`MPL_emulation_lock` has not been initialized, so if MPICH falls back to the emulation lock, it invokes an uninitialization error.  This patch fixes this issue by initializing the emulation lock statically.

Note that under the emulation lock, the interprocess atomicity of MPL/atomic operations is not guaranteed; previously the emulation lock is created as an interprocess mutex on the shared memory, but the current lock does not guarantee this since the mutex of the emulation lock is not shared with other processes.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
