### PR TITLE
hydra/topo: Add "package" binding/mapping option

### DIFF
--- a/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/tools/topo/hwloc/topo_hwloc.c
@@ -148,6 +148,7 @@ struct hwloc_obj_info_table {
 static struct hwloc_obj_info_table hwloc_obj_info[] = {
     {"machine", HWLOC_OBJ_MACHINE},
     {"socket", HWLOC_OBJ_PACKAGE},
+    {"package", HWLOC_OBJ_PACKAGE},
     {"numa", HWLOC_OBJ_NUMANODE},
     {"core", HWLOC_OBJ_CORE},
     {"hwthread", HWLOC_OBJ_PU},


### PR DESCRIPTION
## Pull Request Description

hwloc uses "package" in favor of "socket" now. Hydra should accept it
as an option.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
