### PR TITLE
coll: Rename variable for clarity

### DIFF
--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -20,7 +20,7 @@
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
-    int context_id;
+    int context_offset;
     MPIR_Comm *comm_ptr;
 
     /* Return immediately for dummy process */
@@ -31,10 +31,10 @@ int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status)
 
     MPIR_Comm_get_ptr(comm, comm_ptr);
 
-    context_id = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
-    mpi_errno = MPID_Probe(source, tag, comm_ptr, context_id, status);
+    mpi_errno = MPID_Probe(source, tag, comm_ptr, context_offset, status);
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 
@@ -108,7 +108,7 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
               MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int context_id;
+    int context_offset;
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_SEND);
 
@@ -124,10 +124,10 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
     MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", count);
 
-    context_id = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
-    mpi_errno = MPID_Send_coll(buf, count, datatype, dest, tag, comm_ptr, context_id,
+    mpi_errno = MPID_Send_coll(buf, count, datatype, dest, tag, comm_ptr, context_offset,
                                &request_ptr, errflag);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
@@ -161,7 +161,7 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
               MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int context_id;
+    int context_offset;
     MPI_Status mystatus;
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_RECV);
@@ -179,14 +179,14 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
     MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", count);
 
-    context_id = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     if (status == MPI_STATUS_IGNORE)
         status = &mystatus;
 
     mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr,
-                          context_id, status, &request_ptr);
+                          context_offset, status, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr, errflag);
@@ -223,7 +223,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
                MPIR_Comm * comm_ptr, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int context_id;
+    int context_offset;
     MPIR_Request *request_ptr = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_SSEND);
 
@@ -239,7 +239,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", count);
 
-    context_id = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     switch (*errflag) {
@@ -252,7 +252,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
             MPIR_TAG_SET_ERROR_BIT(tag);
     }
 
-    mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr, context_id, &request_ptr);
+    mpi_errno = MPID_Ssend(buf, count, datatype, dest, tag, comm_ptr, context_offset, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr, errflag);
@@ -287,7 +287,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
                   MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t * errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int context_id;
+    int context_offset;
     MPI_Status mystatus;
     MPIR_Request *recv_req_ptr = NULL, *send_req_ptr = NULL;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIC_SENDRECV);
@@ -301,7 +301,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
     MPIR_ERR_CHKANDJUMP1((recvcount < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", recvcount);
 
-    context_id = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     if (status == MPI_STATUS_IGNORE)
@@ -315,7 +315,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
         MPIR_Status_set_procnull(&recv_req_ptr->status);
     } else {
         mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag,
-                               comm_ptr, context_id, &recv_req_ptr);
+                               comm_ptr, context_offset, &recv_req_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -326,7 +326,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
                             "**nomemreq");
     } else {
         mpi_errno = MPID_Isend_coll(sendbuf, sendcount, sendtype, dest, sendtag,
-                                    comm_ptr, context_id, &send_req_ptr, errflag);
+                                    comm_ptr, context_offset, &send_req_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -374,7 +374,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Status mystatus;
-    MPIR_Context_id_t context_id_offset;
+    int context_offset;
     MPIR_Request *sreq = NULL;
     MPIR_Request *rreq = NULL;
     void *tmpbuf = NULL;
@@ -402,7 +402,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
             MPIR_TAG_SET_ERROR_BIT(sendtag);
     }
 
-    context_id_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
+    context_offset = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) ?
         MPIR_CONTEXT_INTRA_COLL : MPIR_CONTEXT_INTER_COLL;
 
     if (count > 0 && dest != MPI_PROC_NULL) {
@@ -422,7 +422,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_Status_set_procnull(&rreq->status);
     } else {
         mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag,
-                               comm_ptr, context_id_offset, &rreq);
+                               comm_ptr, context_offset, &rreq);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -432,7 +432,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         mpi_errno = MPID_Isend_coll(tmpbuf, actual_pack_bytes, MPI_PACKED, dest,
-                                    sendtag, comm_ptr, context_id_offset, &sreq, errflag);
+                                    sendtag, comm_ptr, context_offset, &sreq, errflag);
         MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */


### PR DESCRIPTION
## Pull Request Description

Use `context_offset` to more accurately describe the value passed to
the device to separate collective messages from regular pt2pt. Also
make consistent the variable type in one instance.

Reported-by: Gengbin Zheng <gengbin.zheng@intel.com>

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
