### PR TITLE
dtp: clamp the testsize at the maximum size

### DIFF
--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -134,6 +134,7 @@ while read -r line ; do
             else
                 testsize=$((testsize * count / sendcount))
                 if [ $testsize -lt $mintestsize ] ; then testsize=$mintestsize; fi
+                if [ $testsize -gt $maxtestsize ] ; then testsize=$maxtestsize; fi
             fi
 
             if [ $testdir = "pt2pt" ] ; then # only send/recv comm can use types from different pools


### PR DESCRIPTION

## Pull Request Description
The maximum testsize was not checked previously, assuming the testsize
always go down. This is an unnecessary assumption, and it is more
intuitive to clamp at both minimum size and maximum size.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
