### PR TITLE
config: add AM_COND_IF for ch4 posix subconfigure

### DIFF
--- a/src/mpid/ch4/shm/posix/subconfigure.m4
+++ b/src/mpid/ch4/shm/posix/subconfigure.m4
@@ -3,6 +3,7 @@ dnl MPICH_SUBCFG_BEFORE=src/mpid/common/shm
 dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+    AM_COND_IF([BUILD_CH4], [
     # always enable POSIX
     build_ch4_shm_posix=yes
     
@@ -107,6 +108,7 @@ MPIDI_POSIX_eager_${posix_eager}_recv_transaction_t ${posix_eager};"
 
     # the POSIX shmmod depends on the common shm code
     build_mpid_common_shm=yes
+    ])
     AM_CONDITIONAL([BUILD_SHM_POSIX],[test "X$build_ch4_shm_posix" = "Xyes"])
 ])dnl
 


### PR DESCRIPTION
## Pull Request Description
Previously the ch4 posix configure is always configured even in ch3 build. This patch fixes that.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
