### PR TITLE
pmi: hack to support long business cards

### DIFF
--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -79,7 +79,7 @@ int MPIDU_bc_allgather(MPIR_Comm * comm, int *nodemap, void *bc, int bc_len, int
 
 #ifdef USE_PMIX_API
 
-#define VALLEN 1024
+#define VALLEN 2048
 #define KEYLEN 64
 
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,


### PR DESCRIPTION
## Pull Request Description

Fix bootstrap when running on machines which produce long business cards. This is not a comprehensive solution, but is enough to get running. The new MPIR_pmi abstraction is probably the right place for eventual support of arbitrary value lengths. See #4029.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
