### PR TITLE
ch4_init: check whether MPIDI_global.comm_req_lists is already freed

### DIFF
--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -211,6 +211,7 @@ void MPIDIG_finalize(void)
     MPIDIU_map_destroy(MPIDI_global.win_map);
     MPIDIU_destroy_buf_pool(MPIDI_global.buf_pool);
     MPL_free(MPIDI_global.comm_req_lists);
+    MPIDI_global.comm_req_lists = NULL;
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_FINALIZE);
 }


### PR DESCRIPTION

## Pull Request Description

PR #4013, while a refactor in a good direction, breaks the current subtle dependency due to the built-in comms, especially `MPI_COMM_WORLD`, weaving throughout the `init/finailze`. A work-in-progress PR #3958 should address it by separating the `MPI_COMM_WORLD` from `init/finalize` process. This PR provides a temporary patch for the interim. 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
