### PR TITLE
Init comm create 2

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -241,6 +241,7 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
 int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Comm ** newcomm_ptr);
 
 
+int MPIR_Comm_create_subcomms(MPIR_Comm * comm);
 int MPIR_Comm_commit(MPIR_Comm *);
 
 int MPIR_Comm_is_node_aware(MPIR_Comm *);

--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -34,7 +34,7 @@ extern MPIDIG_global_t MPIDIG_global;
 
 int MPIDIG_am_reg_cb(int handler_id,
                      MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self);
+int MPIDIG_init();
 void MPIDIG_finalize(void);
 
 int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code);

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -27,7 +27,7 @@ int MPIDIG_am_reg_cb(int handler_id,
     return mpi_errno;
 }
 
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
+int MPIDIG_init()
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT);
@@ -178,12 +178,6 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
                                  &MPIDIG_comm_abort_origin_cb, &MPIDIG_comm_abort_target_msg_cb);
     MPIR_ERR_CHECK(mpi_errno);
 
-
-    mpi_errno = MPIDIG_init_comm(comm_world);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIDIG_init_comm(comm_self);
-    MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIU_map_create((void **) &(MPIDI_global.win_map), MPL_MEM_RMA);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -29,24 +29,6 @@ int MPIDI_OFI_mpi_comm_create_hook(MPIR_Comm * comm)
     /* eagain defaults to off */
     MPIDI_OFI_COMM(comm).eagain = FALSE;
 
-    /* if this is MPI_COMM_WORLD, finish bc exchange */
-    if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        void *table;
-        int *rank_map;
-        int recv_bc_len;
-        MPIDU_bc_allgather(MPIDI_OFI_global.addrname,
-                           MPIDI_OFI_global.addrnamelen, TRUE, &table, &rank_map, &recv_bc_len);
-
-        int i;
-        for (i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                mpi_errno = MPIDI_OFI_av_insert(i, (char *) table + recv_bc_len * rank_map[i]);
-                MPIR_ERR_CHECK(mpi_errno);
-            }
-        }
-        MPIDU_bc_table_destroy();
-    }
-
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_CREATE_HOOK);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -20,30 +20,6 @@ int MPIDI_UCX_mpi_comm_create_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_MPI_COMM_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_MPI_COMM_CREATE_HOOK);
 
-    /* if this is MPI_COMM_WORLD, finish bc exchange */
-    if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        void *table;
-        int *rank_map;
-        int recv_bc_len;
-        MPIDU_bc_allgather(MPIDI_UCX_global.if_address, (int) MPIDI_UCX_global.addrname_len, FALSE,
-                           (void **) &table, &rank_map, &recv_bc_len);
-
-        /* insert new addresses, skipping over node roots */
-        int i;
-        for (i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                ucs_status_t ucx_status;
-                ucp_ep_params_t ep_params;
-
-                ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-                ep_params.address = (ucp_address_t *) ((char *) table + i * recv_bc_len);
-                ucx_status = ucp_ep_create(MPIDI_UCX_global.worker, &ep_params,
-                                           &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest);
-                MPIDI_UCX_CHK_STATUS(ucx_status);
-            }
-        }
-        MPIDU_bc_table_destroy();
-    }
 #if defined HAVE_LIBHCOLL
     hcoll_comm_create(comm, NULL);
 #endif

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -191,6 +191,8 @@ int MPID_Comm_create_hook(MPIR_Comm * comm)
     mpi_errno = MPIDI_SHM_mpi_comm_create_hook(comm);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
+    mpi_errno = MPIDIG_init_comm(comm);
+    MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef HAVE_DEBUGGER_SUPPORT
 #ifndef MPIDI_CH4U_USE_PER_COMM_QUEUE

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -338,6 +338,9 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 #endif
 
     mpi_errno = MPIDIG_init(MPIR_Process.comm_world, MPIR_Process.comm_self);
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
+    MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_Init_shm_init(rank, size, MPIDI_global.node_map[0]);
@@ -371,11 +374,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_Process.attrs.appnum = appnum;
     MPIR_Process.attrs.wtime_is_global = 1;
     MPIR_Process.attrs.io = MPI_ANY_SOURCE;
-
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
-    MPIR_ERR_CHECK(mpi_errno);
 
     /* -------------------------------- */
     /* Return MPICH Parameters          */

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -84,6 +84,8 @@ cvars:
 
 static int choose_netmod(void);
 static const char *get_mt_model_name(int mt);
+static int init_av_table(int world_rank, int world_size);
+static void finalize_av_table(void);
 static void print_runtime_configurations(void);
 #ifdef MPIDI_CH4_USE_MT_RUNTIME
 static int parse_mt_model(const char *name);
@@ -200,6 +202,43 @@ static int set_runtime_configurations(void)
     return mpi_errno;
 }
 
+static int init_av_table(int world_rank, int world_size)
+{
+    int i;
+    int avtid = -1;
+
+    MPIDIU_avt_init();
+    MPIDIU_get_next_avtid(&avtid);
+    MPIR_Assert(avtid == 0);
+
+    MPIDI_av_table[0] = (MPIDI_av_table_t *)
+        MPL_malloc(world_size * sizeof(MPIDI_av_entry_t)
+                   + sizeof(MPIDI_av_table_t), MPL_MEM_ADDRESS);
+
+    MPIDI_av_table[0]->size = world_size;
+    MPIR_Object_set_ref(MPIDI_av_table[0], 1);
+
+    MPIDI_global.node_map[0] = MPIR_Process.node_map;
+
+    MPIDI_av_table0 = MPIDI_av_table[0];
+
+#ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
+    MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;
+
+    for (i = 0; i < world_size; i++) {
+        MPIDI_av_table0->table[i].is_local = (MPIDI_global.node_map[0][i]
+                                              == MPIDI_global.node_map[0][world_rank]) ? 1 : 0;
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE, (MPL_DBG_FDEST, "WORLD RANK %d %s local", i,
+                                                         MPIDI_av_table0->
+                                                         table[i].is_local ? "is" : "is not"));
+        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                        (MPL_DBG_FDEST, "Node id (i) (me) %d %d", MPIDI_global.node_map[0][i],
+                         MPIDI_global.node_map[0][world_rank]));
+    }
+#endif
+    return avtid;
+}
+
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum, thr_err;
@@ -258,6 +297,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     if (MPIR_CVAR_CH4_RUNTIME_CONF_DEBUG && rank == 0)
         print_runtime_configurations();
 
+    avtid = init_av_table(rank, size);
     /* ---------------------------------- */
     /* Initialize MPI_COMM_SELF           */
     /* ---------------------------------- */
@@ -271,21 +311,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_Process.comm_world->rank = rank;
     MPIR_Process.comm_world->remote_size = size;
     MPIR_Process.comm_world->local_size = size;
-
-    MPIDIU_avt_init();
-    MPIDIU_get_next_avtid(&avtid);
-    MPIR_Assert(avtid == 0);
-
-    MPIDI_av_table[0] = (MPIDI_av_table_t *)
-        MPL_malloc(size * sizeof(MPIDI_av_entry_t)
-                   + sizeof(MPIDI_av_table_t), MPL_MEM_ADDRESS);
-
-    MPIDI_av_table[0]->size = size;
-    MPIR_Object_set_ref(MPIDI_av_table[0], 1);
-
-    MPIDI_global.node_map[0] = MPIR_Process.node_map;
-
-    MPIDI_av_table0 = MPIDI_av_table[0];
 
     /* initialize rank_map */
     MPIDI_COMM(MPIR_Process.comm_world, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
@@ -314,30 +339,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     mpi_errno = MPIDIG_recvq_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-#ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
-    int i;
-    for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
-        MPIDI_av_table0->table[i].is_local = 0;
-    }
-    MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;
-
-    MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    (MPL_DBG_FDEST, "MPIDI_global.max_node_id = %d", MPIDI_global.max_node_id));
-
-    for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
-        MPIDI_av_table0->table[i].is_local =
-            (MPIDI_global.node_map[0][i] ==
-             MPIDI_global.node_map[0][MPIR_Process.comm_world->rank]) ? 1 : 0;
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "WORLD RANK %d %s local", i,
-                         MPIDI_av_table0->table[i].is_local ? "is" : "is not"));
-        MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                        (MPL_DBG_FDEST, "Node id (i) (me) %d %d", MPIDI_global.node_map[0][i],
-                         MPIDI_global.node_map[0][MPIR_Process.comm_world->rank]));
-    }
-#endif
-
-    mpi_errno = MPIDIG_init(MPIR_Process.comm_world, MPIR_Process.comm_self);
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
@@ -431,6 +432,19 @@ int MPID_InitCompleted(void)
     return MPI_SUCCESS;
 }
 
+static void finalize_av_table(void)
+{
+    int i;
+    int max_n_avts;
+    max_n_avts = MPIDIU_get_max_n_avts();
+    for (i = 0; i < max_n_avts; i++) {
+        if (MPIDI_av_table[i] != NULL) {
+            MPIDIU_avt_release_ref(i);
+        }
+    }
+    MPIDIU_avt_destroy();
+}
+
 int MPID_Finalize(void)
 {
     int mpi_errno;
@@ -444,22 +458,9 @@ int MPID_Finalize(void)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
-    /* Release builtin comms */
-    MPIR_Comm_release_always(MPIR_Process.comm_world);
-    MPIR_Comm_release_always(MPIR_Process.comm_self);
-
+    finalize_builtin_comms();
     MPIDIG_finalize();
-
-    int i;
-    int max_n_avts;
-    max_n_avts = MPIDIU_get_max_n_avts();
-    for (i = 0; i < max_n_avts; i++) {
-        if (MPIDI_av_table[i] != NULL) {
-            MPIDIU_avt_release_ref(i);
-        }
-    }
-
-    MPIDIU_avt_destroy();
+    finalize_av_table();
 
     MPIR_pmi_finalize();
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -89,6 +89,8 @@ static int init_av_table(int world_rank, int world_size);
 static void finalize_av_table(void);
 static int init_builtin_comms(int world_rank, int world_size);
 static void finalize_builtin_comms(void);
+static int create_init_comm(int world_rank, int world_size, MPIR_Comm **);
+static void destroy_init_comm(MPIR_Comm **);
 static void print_runtime_configurations(void);
 #ifdef MPIDI_CH4_USE_MT_RUNTIME
 static int parse_mt_model(const char *name);
@@ -293,10 +295,76 @@ static int init_builtin_comms(int world_rank, int world_size)
 
 }
 
+static int create_init_comm(int world_rank, int world_size, MPIR_Comm ** comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Comm *init_comm = NULL;
+    MPIR_Comm_create(&init_comm);
+    init_comm->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+    init_comm->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+    init_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+    init_comm->rank = world_rank;
+    init_comm->remote_size = world_size;
+    init_comm->local_size = world_size;
+    init_comm->coll.pof2 = MPL_pof2(world_size);
+    MPIDI_COMM(init_comm, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
+    MPIDI_COMM(init_comm, map).avtid = 0;
+    MPIDI_COMM(init_comm, map).size = world_size;
+    MPIDI_COMM(init_comm, local_map).mode = MPIDI_RANK_MAP_NONE;
+    mpi_errno = MPIR_Comm_create_subcomms(init_comm);
+    MPIR_ERR_CHECK(mpi_errno);
+    if (init_comm->node_comm != NULL) {
+        init_comm->node_comm->coll.pof2 = MPL_pof2(init_comm->node_comm->local_size);
+        MPIDI_comm_create_rank_map(init_comm->node_comm);
+        MPIR_Comm_map_free(init_comm->node_comm);
+    }
+    if (init_comm->node_roots_comm != NULL) {
+        init_comm->node_roots_comm->coll.pof2 = MPL_pof2(init_comm->node_roots_comm->local_size);
+        MPIDI_comm_create_rank_map(init_comm->node_roots_comm);
+        MPIR_Comm_map_free(init_comm->node_roots_comm);
+    }
+    MPIR_Comm_map_free(init_comm);
+
+    *comm = init_comm;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void destroy_init_comm(MPIR_Comm ** comm_ptr)
+{
+    int in_use;
+    MPIR_Comm *comm = *comm_ptr;
+    MPIR_Object_release_ref(comm, &in_use);
+    MPIR_Assert(MPIR_Object_get_ref(comm) == 0);
+    if (comm->node_comm) {
+        MPIR_Object_release_ref(comm->node_comm, &in_use);
+        MPII_COMML_FORGET(comm->node_comm);
+        MPIR_Handle_obj_free(&MPIR_Comm_mem, comm->node_comm);
+    }
+    if (comm->node_roots_comm) {
+        MPIR_Object_release_ref(comm->node_roots_comm, &in_use);
+        MPII_COMML_FORGET(comm->node_roots_comm);
+        MPIR_Handle_obj_free(&MPIR_Comm_mem, comm->node_roots_comm);
+    }
+    if (comm->intranode_table) {
+        MPL_free(comm->intranode_table);
+    }
+    if (comm->internode_table) {
+        MPL_free(comm->internode_table);
+    }
+    MPII_COMML_FORGET(comm);
+    MPIR_Handle_obj_free(&MPIR_Comm_mem, comm);
+    *comm_ptr = NULL;
+}
+
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum, thr_err;
     int avtid;
+    MPIR_Comm *init_comm = NULL;
     int n_nm_vcis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int n_shm_vcis_provided;
@@ -352,14 +420,13 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
         print_runtime_configurations();
 
     avtid = init_av_table(rank, size);
+    mpi_errno = create_init_comm(rank, size, &init_comm);
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDIG_init();
     MPIR_ERR_CHECK(mpi_errno);
     /* setup receive queue statistics */
     mpi_errno = MPIDIG_recvq_init();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = init_builtin_comms(rank, size);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_Init_shm_init(rank, size, MPIDI_global.node_map[0]);
@@ -376,8 +443,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 #endif
 
         mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits,
-                                           MPIR_Process.comm_world, MPIR_Process.comm_self,
-                                           &n_nm_vcis_provided);
+                                           init_comm, NULL, &n_nm_vcis_provided);
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);
         }
@@ -385,6 +451,10 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
         /* Use the minimum tag_bits from the netmod and shmod */
         MPIR_Process.tag_bits = MPL_MIN(shm_tag_bits, nm_tag_bits);
     }
+
+    destroy_init_comm(&init_comm);
+    mpi_errno = init_builtin_comms(rank, size);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Override split_type */
     MPIDI_global.MPIR_Comm_fns_store.split_type = MPIDI_Comm_split_type;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -11,6 +11,7 @@
 
 #include "mpidimpl.h"
 #include "mpidch4r.h"
+#include "ch4i_comm.h"
 #include "datatype.h"
 #include "mpidu_init_shm.h"
 
@@ -86,6 +87,8 @@ static int choose_netmod(void);
 static const char *get_mt_model_name(int mt);
 static int init_av_table(int world_rank, int world_size);
 static void finalize_av_table(void);
+static int init_builtin_comms(int world_rank, int world_size);
+static void finalize_builtin_comms(void);
 static void print_runtime_configurations(void);
 #ifdef MPIDI_CH4_USE_MT_RUNTIME
 static int parse_mt_model(const char *name);
@@ -239,6 +242,57 @@ static int init_av_table(int world_rank, int world_size)
     return avtid;
 }
 
+static int init_builtin_comms(int world_rank, int world_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    /* ---------------------------------- */
+    /* Initialize MPI_COMM_SELF           */
+    /* ---------------------------------- */
+    MPIR_Process.comm_self->rank = 0;
+    MPIR_Process.comm_self->remote_size = 1;
+    MPIR_Process.comm_self->local_size = 1;
+
+    /* ---------------------------------- */
+    /* Initialize MPI_COMM_WORLD          */
+    /* ---------------------------------- */
+    MPIR_Process.comm_world->rank = world_rank;
+    MPIR_Process.comm_world->remote_size = world_size;
+    MPIR_Process.comm_world->local_size = world_size;
+
+    /* initialize rank_map */
+    MPIDI_COMM(MPIR_Process.comm_world, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
+    MPIDI_COMM(MPIR_Process.comm_world, map).avtid = 0;
+    MPIDI_COMM(MPIR_Process.comm_world, map).size = world_size;
+    MPIDI_COMM(MPIR_Process.comm_world, local_map).mode = MPIDI_RANK_MAP_NONE;
+    MPIDIU_avt_add_ref(0);
+
+    MPIDI_COMM(MPIR_Process.comm_self, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
+    MPIDI_COMM(MPIR_Process.comm_self, map).avtid = 0;
+    MPIDI_COMM(MPIR_Process.comm_self, map).size = 1;
+    MPIDI_COMM(MPIR_Process.comm_self, map).reg.offset = world_rank;
+    MPIDI_COMM(MPIR_Process.comm_self, local_map).mode = MPIDI_RANK_MAP_NONE;
+    MPIDIU_avt_add_ref(0);
+
+#ifdef MPL_USE_DBG_LOGGING
+    int counter_;
+    if (world_size < 16) {
+        for (counter_ = 0; counter_ < world_size; ++counter_) {
+            MPIDIU_comm_rank_to_av(MPIR_Process.comm_world, counter_);
+        }
+    }
+#endif
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
+    MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+
+}
+
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum, thr_err;
@@ -298,50 +352,14 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
         print_runtime_configurations();
 
     avtid = init_av_table(rank, size);
-    /* ---------------------------------- */
-    /* Initialize MPI_COMM_SELF           */
-    /* ---------------------------------- */
-    MPIR_Process.comm_self->rank = 0;
-    MPIR_Process.comm_self->remote_size = 1;
-    MPIR_Process.comm_self->local_size = 1;
 
-    /* ---------------------------------- */
-    /* Initialize MPI_COMM_WORLD          */
-    /* ---------------------------------- */
-    MPIR_Process.comm_world->rank = rank;
-    MPIR_Process.comm_world->remote_size = size;
-    MPIR_Process.comm_world->local_size = size;
-
-    /* initialize rank_map */
-    MPIDI_COMM(MPIR_Process.comm_world, map).mode = MPIDI_RANK_MAP_DIRECT_INTRA;
-    MPIDI_COMM(MPIR_Process.comm_world, map).avtid = 0;
-    MPIDI_COMM(MPIR_Process.comm_world, map).size = size;
-    MPIDI_COMM(MPIR_Process.comm_world, local_map).mode = MPIDI_RANK_MAP_NONE;
-    MPIDIU_avt_add_ref(0);
-
-    MPIDI_COMM(MPIR_Process.comm_self, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
-    MPIDI_COMM(MPIR_Process.comm_self, map).avtid = 0;
-    MPIDI_COMM(MPIR_Process.comm_self, map).size = 1;
-    MPIDI_COMM(MPIR_Process.comm_self, map).reg.offset = rank;
-    MPIDI_COMM(MPIR_Process.comm_self, local_map).mode = MPIDI_RANK_MAP_NONE;
-    MPIDIU_avt_add_ref(0);
-
-#ifdef MPL_USE_DBG_LOGGING
-    int counter_;
-    if (size < 16) {
-        for (counter_ = 0; counter_ < size; ++counter_) {
-            MPIDIU_comm_rank_to_av(MPIR_Process.comm_world, counter_);
-        }
-    }
-#endif
-
+    mpi_errno = MPIDIG_init();
+    MPIR_ERR_CHECK(mpi_errno);
     /* setup receive queue statistics */
     mpi_errno = MPIDIG_recvq_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_self);
-    MPIR_ERR_CHECK(mpi_errno);
-    mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
+    mpi_errno = init_builtin_comms(rank, size);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_Init_shm_init(rank, size, MPIDI_global.node_map[0]);
@@ -443,6 +461,12 @@ static void finalize_av_table(void)
         }
     }
     MPIDIU_avt_destroy();
+}
+
+static void finalize_builtin_comms(void)
+{
+    MPIR_Comm_release_always(MPIR_Process.comm_world);
+    MPIR_Comm_release_always(MPIR_Process.comm_self);
 }
 
 int MPID_Finalize(void)

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -20,17 +20,6 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT_COMM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_INIT_COMM);
 
-    /*
-     * Prevents double initialization of some special communicators.
-     *
-     * comm_world and comm_self may exhibit this function twice, first during MPIDIG_init
-     * and the second during MPIR_Comm_commit in MPID_Init.
-     * If there is an early arrival of an unexpected message before the second visit,
-     * the following code will wipe out the unexpected queue andthe message is lost forever.
-     */
-    if (unlikely(MPIDI_global.is_ch4u_initialized &&
-                 (comm == MPIR_Process.comm_world || comm == MPIR_Process.comm_self)))
-        goto fn_exit;
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
 


### PR DESCRIPTION
## Pull Request Description

This PR is a set of commits that addresses the dependency mess in MPID_Init_hook. It introduces an init_comm that is manually initialized just for init time communication. It is removed before creating the builtin communicators. With this special comm, all the BC exchange can be done on it without introducing weird dependencies with other parts of the code.

I have to recreate the PR because the testing has problems with the old PR after I force pushed it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
