### PR TITLE
OFI LMT Probe Fix

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -104,6 +104,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
  * MPIDI_OFI_SYNC_SEND                 The bit to indicate a sync send
  * MPIDI_OFI_SYNC_SEND_ACK             The bit to indicate a sync send ack
  * MPIDI_OFI_DYNPROC_SEND              The bit to indicate a dynamic process send
+ * MPIDI_OFI_HUGE_SEND                 The bit to indicate a huge messge
  * MPIDI_OFI_CONTEXT_STRUCTS           The number of fi_context structs needed for the provider
  */
 
@@ -156,7 +157,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS  MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_PSM2
 #define MPIDI_OFI_ENABLE_PT2PT_NOPACK       MPIDI_OFI_ENABLE_PT2PT_NOPACK_PSM2
 #define MPIDI_OFI_NUM_AM_BUFFERS            MPIDI_OFI_NUM_AM_BUFFERS_PSM2
-#define MPIDI_OFI_PROTOCOL_MASK             (0x0060000000000000ULL)
+#define MPIDI_OFI_PROTOCOL_MASK             (0x00E0000000000000ULL)
 #define MPIDI_OFI_CONTEXT_MASK              (0x000FFFFF00000000ULL)
 #define MPIDI_OFI_SOURCE_MASK               (0x0000000000000000ULL)     /* PSM2 does support immediate data
                                                                          * so this field is zeroed */
@@ -167,6 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_ACK             (0x0010000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND                 (0x0020000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND              (0x0040000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND                 (0x0080000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_PSM2
 #define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_PSM2
 #define MPIDI_OFI_CONTEXT_STRUCTS           1
@@ -221,7 +223,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS  MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_SOCKETS
 #define MPIDI_OFI_ENABLE_PT2PT_NOPACK       MPIDI_OFI_ENABLE_PT2PT_NOPACK_SOCKETS
 #define MPIDI_OFI_NUM_AM_BUFFERS            MPIDI_OFI_NUM_AM_BUFFERS_SOCKETS
-#define MPIDI_OFI_PROTOCOL_MASK             (0x0060000000000000ULL)
+#define MPIDI_OFI_PROTOCOL_MASK             (0x00E0000000000000ULL)
 #define MPIDI_OFI_CONTEXT_MASK              (0x000FFFFF00000000ULL)
 #define MPIDI_OFI_SOURCE_MASK               (0x0000000000000000ULL)     /* Sockets does support immediate data
                                                                          * so this field is zeroed */
@@ -232,6 +234,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_ACK             (0x0010000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND                 (0x0020000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND              (0x0040000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND                 (0x0080000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_SOCKETS
 #define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_SOCKETS
 #define MPIDI_OFI_CONTEXT_STRUCTS           1
@@ -286,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS  MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_BGQ
 #define MPIDI_OFI_ENABLE_PT2PT_NOPACK       MPIDI_OFI_ENABLE_PT2PT_NOPACK_BGQ
 #define MPIDI_OFI_NUM_AM_BUFFERS            MPIDI_OFI_NUM_AM_BUFFERS_BGQ
-#define MPIDI_OFI_PROTOCOL_MASK             (0x0060000000000000ULL)
+#define MPIDI_OFI_PROTOCOL_MASK             (0x00E0000000000000ULL)
 #define MPIDI_OFI_CONTEXT_MASK              (0x000FFFFF00000000ULL)
 #define MPIDI_OFI_SOURCE_MASK               (0x0000000000000000ULL)     /* BGQ does support immediate data
                                                                          * so this field is zeroed */
@@ -297,6 +300,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_ACK             (0x0010000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND                 (0x0020000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND              (0x0040000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND                 (0x0080000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION             MPIDI_OFI_MAJOR_VERSION_BGQ
 #define MPIDI_OFI_MINOR_VERSION             MPIDI_OFI_MINOR_VERSION_BGQ
 #define MPIDI_OFI_CONTEXT_STRUCTS           2
@@ -351,7 +355,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS  MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_RXM
 #define MPIDI_OFI_ENABLE_PT2PT_NOPACK           MPIDI_OFI_ENABLE_PT2PT_NOPACK_RXM
 #define MPIDI_OFI_NUM_AM_BUFFERS                MPIDI_OFI_NUM_AM_BUFFERS_RXM
-#define MPIDI_OFI_PROTOCOL_MASK                 (0x0060000000000000ULL)
+#define MPIDI_OFI_PROTOCOL_MASK                 (0x00E0000000000000ULL)
 #define MPIDI_OFI_CONTEXT_MASK                  (0x000FFFFF00000000ULL)
 #define MPIDI_OFI_SOURCE_MASK                   (0x0000000000000000ULL) /* RxM does support immediate data
                                                                          * so this field is zeroed */
@@ -362,6 +366,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_ACK                 (0x0010000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND                     (0x0020000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND                  (0x0040000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND                     (0x0080000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION                 MPIDI_OFI_MAJOR_VERSION_RXM
 #define MPIDI_OFI_MINOR_VERSION                 MPIDI_OFI_MINOR_VERSION_RXM
 #define MPIDI_OFI_CONTEXT_STRUCTS                1
@@ -387,7 +392,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_CONTROL_AUTO_PROGRESS_DEFAULT  MPIDI_OFI_OFF
 #define MPIDI_OFI_ENABLE_PT2PT_NOPACK_DEFAULT       MPIDI_OFI_ON
 #define MPIDI_OFI_NUM_AM_BUFFERS_DEFAULT            MPIDI_OFI_MAX_NUM_AM_BUFFERS
-#define MPIDI_OFI_PROTOCOL_MASK_DEFAULT             (0x0060000000000000ULL)
+#define MPIDI_OFI_PROTOCOL_MASK_DEFAULT             (0x00E0000000000000ULL)
 #define MPIDI_OFI_CONTEXT_MASK_DEFAULT              (0x000FFFFF00000000ULL)
 #define MPIDI_OFI_SOURCE_MASK_DEFAULT               (0x0000000000000000ULL)     /* We require support for immediate data
                                                                                  * so this field is zeroed */
@@ -398,6 +403,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_ACK_DEFAULT             (0x0010000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND_DEFAULT                 (0x0020000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND_DEFAULT              (0x0040000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND_DEFAULT                 (0x0080000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION_DEFAULT             FI_MAJOR_VERSION
 #define MPIDI_OFI_MINOR_VERSION_DEFAULT             FI_MINOR_VERSION
 
@@ -431,6 +437,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SYNC_SEND_MINIMAL                 (0x1000000000000000ULL)
 #define MPIDI_OFI_SYNC_SEND_ACK_MINIMAL             (0x2000000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND_MINIMAL              (0x4000000000000000ULL)
+#define MPIDI_OFI_HUGE_SEND_MINIMAL                 (0x8000000000000000ULL)
 #define MPIDI_OFI_MAJOR_VERSION_MINIMAL             FI_MAJOR_VERSION
 #define MPIDI_OFI_MINOR_VERSION_MINIMAL             FI_MINOR_VERSION
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -237,6 +237,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     /* Plug the information for the huge event into the receive request and go
      * to the MPIDI_OFI_get_huge_event function. */
     recv_elem->event_id = MPIDI_OFI_EVENT_GET_HUGE;
+    recv_elem->comm_ptr = comm_ptr;
     recv_elem->localreq = rreq;
     recv_elem->done_fn = recv_event;
     recv_elem->wc = *wc;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -39,17 +39,74 @@ static int cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
 
 static int peek_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
-    size_t count;
+    int mpi_errno = MPI_SUCCESS;
+    size_t count = 0;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_PEEK_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_PEEK_EVENT);
-    MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_FOUND;
     rreq->status.MPI_SOURCE = cqe_get_source(wc, false);
     rreq->status.MPI_TAG = MPIDI_OFI_init_get_tag(wc->tag);
-    count = wc->len;
     rreq->status.MPI_ERROR = MPI_SUCCESS;
+
+    if (MPIDI_OFI_HUGE_SEND & wc->tag) {
+        MPIDI_OFI_huge_recv_t *list_ptr;
+        bool found_msg = false;
+
+        /* If this is a huge message, find the control message on the unexpected list that matches
+         * with this and return the size in that. */
+        LL_FOREACH(MPIDI_unexp_huge_recv_head, list_ptr) {
+            uint64_t context_id = MPIDI_OFI_CONTEXT_MASK & wc->tag;
+            uint64_t tag = MPIDI_OFI_TAG_MASK & wc->tag;
+            if (list_ptr->remote_info.comm_id == context_id &&
+                list_ptr->remote_info.origin_rank == cqe_get_source(wc, false) &&
+                list_ptr->remote_info.tag == tag) {
+                count = list_ptr->remote_info.msgsize;
+                found_msg = true;
+            }
+        }
+        if (!found_msg) {
+            MPIDI_OFI_huge_recv_t *recv_elem;
+            MPIDI_OFI_huge_recv_list_t *huge_list_ptr;
+
+            /* Create an element in the posted list that only indicates a peek and will be
+             * deleted as soon as it's fulfilled without being matched. */
+            recv_elem = (MPIDI_OFI_huge_recv_t *) MPL_calloc(sizeof(*recv_elem), 1, MPL_MEM_COMM);
+            MPIR_ERR_CHKANDJUMP(recv_elem == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem");
+            recv_elem->peek = true;
+            MPIR_Comm *comm_ptr = MPIDIG_context_id_to_comm(MPIDI_OFI_CONTEXT_MASK & wc->tag);
+            recv_elem->comm_ptr = comm_ptr;
+            MPIDIU_map_set(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters, rreq->handle, recv_elem,
+                           MPL_MEM_BUFFER);
+
+            huge_list_ptr =
+                (MPIDI_OFI_huge_recv_list_t *) MPL_calloc(sizeof(*huge_list_ptr), 1, MPL_MEM_COMM);
+            MPIR_ERR_CHKANDJUMP(huge_list_ptr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem");
+            recv_elem->remote_info.comm_id = huge_list_ptr->comm_id =
+                MPIDI_OFI_CONTEXT_MASK & wc->tag;
+            recv_elem->remote_info.origin_rank = huge_list_ptr->rank = cqe_get_source(wc, false);
+            recv_elem->remote_info.tag = huge_list_ptr->tag = MPIDI_OFI_TAG_MASK & wc->tag;
+            recv_elem->localreq = huge_list_ptr->rreq = rreq;
+            recv_elem->event_id = MPIDI_OFI_EVENT_GET_HUGE;
+            recv_elem->done_fn = recv_event;
+            recv_elem->wc = *wc;
+            recv_elem->cur_offset = MPIDI_OFI_global.max_msg_size;
+
+            LL_APPEND(MPIDI_posted_huge_recv_head, MPIDI_posted_huge_recv_tail, huge_list_ptr);
+            goto fn_exit;
+        }
+    } else {
+        /* Otherwise just get the size of the message we've already received. */
+        count = wc->len;
+    }
     MPIR_STATUS_SET_COUNT(rreq->status, count);
+    /* util_id should be the last thing to change in rreq. Reason is
+     * we use util_id to indicate peek_event has completed and all the
+     * relevant values have been copied to rreq. */
+    MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_FOUND;
+  fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_PEEK_EVENT);
-    return MPI_SUCCESS;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 static int peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
@@ -237,6 +294,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
     /* Plug the information for the huge event into the receive request and go
      * to the MPIDI_OFI_get_huge_event function. */
     recv_elem->event_id = MPIDI_OFI_EVENT_GET_HUGE;
+    recv_elem->peek = false;
     recv_elem->comm_ptr = comm_ptr;
     recv_elem->localreq = rreq;
     recv_elem->done_fn = recv_event;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1249,7 +1249,13 @@ static int open_fabric(void)
 
     MPIDI_OFI_global.max_buffered_send = prov->tx_attr->inject_size;
     MPIDI_OFI_global.max_buffered_write = prov->tx_attr->inject_size;
-    MPIDI_OFI_global.max_msg_size = prov->ep_attr->max_msg_size;
+    if (MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE > 0 &&
+        MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE <= prov->ep_attr->max_msg_size) {
+        /* Truncate max_msg_size to a user-selected value */
+        MPIDI_OFI_global.max_msg_size = MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE;
+    } else {
+        MPIDI_OFI_global.max_msg_size = prov->ep_attr->max_msg_size;
+    }
     MPIDI_OFI_global.max_order_raw = prov->ep_attr->max_order_raw_size;
     MPIDI_OFI_global.max_order_war = prov->ep_attr->max_order_war_size;
     MPIDI_OFI_global.max_order_waw = prov->ep_attr->max_order_waw_size;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -357,6 +357,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         sreq->comm = comm;
         MPIR_Comm_add_ref(comm);
         MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
+        match_bits |= MPIDI_OFI_HUGE_SEND;      /* Add the bit for a huge message */
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,
                                           comm->rank,

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -76,7 +76,7 @@ static inline int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 }
 
 
-#define MPIDI_OFI_PROTOCOL_BITS (2)     /* This is set to 2 event though we actually use 3. The ssend
+#define MPIDI_OFI_PROTOCOL_BITS (3)     /* This is set to 3 even though we actually use 4. The ssend
                                          * ack bit needs to live outside the protocol bit space to avoid
                                          * accidentally matching unintended messages. Because of this,
                                          * we shift the PROTOCOL_MASK one extra bit to the left to take
@@ -86,6 +86,7 @@ static inline int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #define MPIDI_OFI_SYNC_SEND_ACK      (1ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SYNC_SEND          (2ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_DYNPROC_SEND       (4ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
+#define MPIDI_OFI_HUGE_SEND          (8ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_PROTOCOL_MASK      (((1ULL << MPIDI_OFI_PROTOCOL_BITS) - 1) << 1 << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_CONTEXT_MASK       (((1ULL << MPIDI_OFI_CONTEXT_BITS) - 1) << (MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_SOURCE_MASK        (((1ULL << MPIDI_OFI_SOURCE_BITS) - 1) << MPIDI_OFI_TAG_BITS)

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -531,6 +531,8 @@ typedef struct MPIDI_OFI_huge_recv {
     int event_id;               /* fixed field, do not move */
     int (*done_fn) (struct fi_cq_tagged_entry * wc, MPIR_Request * req, int event_id);
     MPIDI_OFI_send_control_t remote_info;
+    bool peek;                  /* Flag to indicate whether this struct has been created to track an uncompleted peek
+                                 * operation. */
     size_t cur_offset;
     MPIR_Comm *comm_ptr;
     MPIR_Request *localreq;

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -149,6 +149,17 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
                     MPIDIU_map_lookup(MPIDI_OFI_COMM(comm_ptr).huge_recv_counters,
                                       list_ptr->rreq->handle);
 
+                /* If this is a "peek" element for an MPI_Probe, it shouldn't be matched. Grab the
+                 * important information and remove the element from the list. */
+                if (recv_elem->peek) {
+                    MPIR_STATUS_SET_COUNT(recv_elem->localreq->status, info->msgsize);
+                    MPIDI_OFI_REQUEST(recv_elem->localreq, util_id) = MPIDI_OFI_PEEK_FOUND;
+                    MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters,
+                                     recv_elem->localreq->handle);
+                    MPL_free(recv_elem);
+                    recv_elem = NULL;
+                }
+
                 MPL_free(list_ptr);
                 break;
             }

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -297,7 +297,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_
 
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
-        MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_Comm_add_ref(root_comm);   /* +1 for queuing into posted_list */
         MPIDIG_enqueue_posted(rreq, &MPIDIG_COMM(root_comm, posted_list));

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -79,6 +79,18 @@ cvars:
         handoff
         trylock
 
+    - name        : MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE
+      category    : CH4
+      type        : int
+      default     : -1
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If set to positive number, this cvar controls the message size at which CH4 switches from eager to rendezvous mode.
+        If the number is negative, underlying netmod or shmmod automatically uses an optimal number depending on
+        the underlying fabric or shared memory architecture.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -21,7 +21,9 @@ rqstatus 2
 rqfreeb 4
 greq1 1
 probe_unexp 4
+probe_unexp 4 env=MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE=16384
 probenull 1
+probenull 1 env=MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE=16384
 # For testing, scancel will run with 1 process as well
 scancel 2 xfail=ticket2266 xfail=ticket2270
 scancel2 2 xfail=ticket2266 xfail=ticket2270


### PR DESCRIPTION
## Pull Request Description

Fix `MPI_PROBE` when probing a large message using OFI. Previously, probe would only return the size of the first chunk, not the entire message. This branch adds code to get the size from the control message that is sent at the beginning of the LMT and keeps track of it in a separate queue for OFI LMT operations.

The queue already existed, but I added a field to it to indicate if the tracker in the queue was being used explicitly for a probe (peek in OFI terms) so it could be handled differently when the control message actually showed up.

This also adds a new CVAR to set the eager/rendezvous threshold to enforce a lower threshold than OFI/sockets would normally.

## Expected Performance Changes

None.

## Known Issues

This fixes the `pt2pt/probe_unexp` test when `MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE` is set to something low and adds that test to the testlist.

Fixes #4259 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
