### PR TITLE
ch4/xpmem: fix build_nodemap.h reference

### DIFF
--- a/src/mpid/ch4/shm/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_init.c
@@ -6,7 +6,7 @@
 
 #include "xpmem_impl.h"
 #include "xpmem_noinline.h"
-#include "build_nodemap.h"
+#include "mpir_nodemap.h"
 #include "mpidu_init_shm.h"
 #include "xpmem_seg.h"
 


### PR DESCRIPTION
The header build_nodemap.h has been replaced with mpir_nodemap.h.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->
The header `build_nodemap.h` has been replaced with `mpir_nodemap.h`. However, the xpmem module still uses the old header. Thus, MPICH cannot be built when xpmem is enabled.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
