### PR TITLE
ofi: use MPIR_pmi_barrier in MPIDI_OFI_mpi_finalize_hook

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -45,12 +45,14 @@ const char *MPIR_pmi_job_id(void);
 
 /* PMI wrapper utilities */
 
-/* * barrier or kvs fence. "domain" is a hint for efficiency (eg PMIx) */
-int MPIR_pmi_barrier(MPIR_PMI_DOMAIN domain);
+/* * barrier or kvs fence. */
+int MPIR_pmi_barrier(void);
+/* * barrier over local set. More efficient for PMIx. Same as MPIR_pmi_barrier for PMI1/2. */
+int MPIR_pmi_barrier_local(void);
 /* * put, to global domain */
-int MPIR_pmi_kvs_put(char *key, char *val);
+int MPIR_pmi_kvs_put(const char *key, const char *val);
 /* * get. src in [0..size-1] or -1 for anysrc. val_size <= MPIR_pmi_max_val_size(). */
-int MPIR_pmi_kvs_get(int src, char *key, char *val, int val_size);
+int MPIR_pmi_kvs_get(int src, const char *key, char *val, int val_size);
 
 /* * bcast from rank 0 to ALL or NODE_ROOTS processes. Both are collective over ALL */
 int MPIR_pmi_bcast(void *buf, int size, MPIR_PMI_DOMAIN domain);

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -155,7 +155,7 @@ int MPIDI_UCX_mpi_finalize_hook(void)
         ucp_request_release(pending[i]);
     }
 
-    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    mpi_errno = MPIR_pmi_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIDI_UCX_global.worker != NULL)

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -130,7 +130,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmix_commit");
     }
 
-    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    mpi_errno = MPIR_pmi_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {
@@ -234,7 +234,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_kvsput");
     }
 
-    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    mpi_errno = MPIR_pmi_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {
@@ -347,7 +347,7 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_OTHER, "**pmi_kvs_commit");
     }
 
-    mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_ALL);
+    mpi_errno = MPIR_pmi_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!roots_only) {

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -314,7 +314,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
 
         /* we still need to call barrier
          * (for the case when node_local != clique_local, although fixable) */
-        mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_LOCAL);
+        mpi_errno = MPIR_pmi_barrier_local();
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         pmix_proc_t proc, *procs;
@@ -366,7 +366,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
                                  "**pmix_commit", "**pmix_commit %d", pmi_errno);
         }
 
-        mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_LOCAL);
+        mpi_errno = MPIR_pmi_barrier_local();
         MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank != 0) {
@@ -432,7 +432,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
         memory->symmetrical = 0;
 
         /* we still need to call barrier */
-        mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_LOCAL);
+        mpi_errno = MPIR_pmi_barrier_local();
         MPIR_ERR_CHECK(mpi_errno);
 
         /* must come before barrier_init since we use OPA in that function */
@@ -490,7 +490,7 @@ int MPIDU_shm_seg_commit(MPIDU_shm_seg_t * memory, MPIDU_shm_barrier_t ** barrie
             MPIR_ERR_CHECK(mpi_errno);
         }
 
-        mpi_errno = MPIR_pmi_barrier(MPIR_PMI_DOMAIN_LOCAL);
+        mpi_errno = MPIR_pmi_barrier_local();
         MPIR_ERR_CHECK(mpi_errno);
 
         if (local_rank > 0) {

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -188,7 +188,7 @@ int MPIR_pmi_kvs_put(char *key, char *val)
     pmix_value_t value;
     value.type = PMIX_STRING;
     value.data.string = val;
-    pmi_errno = PMIx_Put(PMIX_LOCAL, key, &value);
+    pmi_errno = PMIx_Put(PMIX_GLOBAL, key, &value);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_put", "**pmix_put %d", pmi_errno);
     pmi_errno = PMIx_Commit();

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -168,7 +168,7 @@ const char *MPIR_pmi_job_id(void)
 }
 
 /* wrapper functions */
-int MPIR_pmi_kvs_put(char *key, char *val)
+int MPIR_pmi_kvs_put(const char *key, const char *val)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -203,7 +203,7 @@ int MPIR_pmi_kvs_put(char *key, char *val)
 }
 
 /* NOTE: src is a hint, use src = -1 if not known */
-int MPIR_pmi_kvs_get(int src, char *key, char *val, int val_size)
+int MPIR_pmi_kvs_get(int src, const char *key, char *val, int val_size)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -245,7 +245,7 @@ int MPIR_pmi_kvs_get(int src, char *key, char *val, int val_size)
 
 /* ---- utils functions ---- */
 
-int MPIR_pmi_barrier(MPIR_PMI_DOMAIN domain)
+int MPIR_pmi_barrier(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -264,35 +264,10 @@ int MPIR_pmi_barrier(MPIR_PMI_DOMAIN domain)
     int flag = 1;
     PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
 
-    if (domain == MPIR_PMI_DOMAIN_LOCAL) {
-        /* use local proc set */
-        /* FIXME: we could simply construct the proc set from MPIR_Process.node_local_map */
-        pmix_proc_t *procs;
-        size_t nprocs;
-        pmix_value_t *pvalue = NULL;
-
-        pmi_errno = PMIx_Get(&pmix_proc, PMIX_HOSTNAME, NULL, 0, &pvalue);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_get",
-                             "**pmix_get %d", pmi_errno);
-        const char *nodename = (const char *) pvalue->data.string;
-
-        pmi_errno = PMIx_Resolve_peers(nodename, pmix_proc.nspace, &procs, &nprocs);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                             "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
-
-        pmi_errno = PMIx_Fence(procs, nprocs, info, 1);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence",
-                             "**pmix_fence %d", pmi_errno);
-
-        PMIX_VALUE_RELEASE(pvalue);
-        PMIX_PROC_FREE(procs, nprocs);
-
-    } else {
-        /* use global wildcard proc set */
-        pmi_errno = PMIx_Fence(&pmix_wcproc, 1, info, 1);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                             "**pmix_fence", "**pmix_fence %d", pmi_errno);
-    }
+    /* use global wildcard proc set */
+    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_fence", "**pmix_fence %d", pmi_errno);
     PMIX_INFO_FREE(info, 1);
 #endif
 
@@ -300,6 +275,40 @@ int MPIR_pmi_barrier(MPIR_PMI_DOMAIN domain)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+int MPIR_pmi_barrier_local(void)
+{
+#if defined(USE_PMIX_API)
+    int mpi_errno = MPI_SUCCESS;
+    /* FIXME: we could simply construct the proc set from MPIR_Process.node_local_map */
+    pmix_proc_t *procs;
+    size_t nprocs;
+    pmix_value_t *pvalue = NULL;
+
+    pmi_errno = PMIx_Get(&pmix_proc, PMIX_HOSTNAME, NULL, 0, &pvalue);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_get",
+                         "**pmix_get %d", pmi_errno);
+    const char *nodename = (const char *) pvalue->data.string;
+
+    pmi_errno = PMIx_Resolve_peers(nodename, pmix_proc.nspace, &procs, &nprocs);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
+
+    pmi_errno = PMIx_Fence(procs, nprocs, info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence",
+                         "**pmix_fence %d", pmi_errno);
+
+    PMIX_VALUE_RELEASE(pvalue);
+    PMIX_PROC_FREE(procs, nprocs);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#else
+    return MPIR_pmi_barrier();
+#endif
 }
 
 /* ---- static functions ---- */


### PR DESCRIPTION

## Pull Request Description
Using PMI barrier removes all runtime dependency during finalize. As
long as the PMI barrier performance is not too slow, say, less than 0.1
second, there shouldn't be any real impact even for large amount of
nodes.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
