### PR TITLE
hydra2: Fixed some compiler warnings

### DIFF
--- a/src/pm/hydra2/libhydra/bstrap/ll/ll_finalize.c
+++ b/src/pm/hydra2/libhydra/bstrap/ll/ll_finalize.c
@@ -8,11 +8,5 @@
 
 HYD_status HYDI_bstrap_ll_finalize(void)
 {
-    HYD_status status = HYD_SUCCESS;
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }

--- a/src/pm/hydra2/libhydra/bstrap/rsh/rsh_finalize.c
+++ b/src/pm/hydra2/libhydra/bstrap/rsh/rsh_finalize.c
@@ -8,11 +8,5 @@
 
 HYD_status HYDI_bstrap_rsh_finalize(void)
 {
-    HYD_status status = HYD_SUCCESS;
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }

--- a/src/pm/hydra2/libhydra/bstrap/sge/sge_finalize.c
+++ b/src/pm/hydra2/libhydra/bstrap/sge/sge_finalize.c
@@ -8,11 +8,5 @@
 
 HYD_status HYDI_bstrap_sge_finalize(void)
 {
-    HYD_status status = HYD_SUCCESS;
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }

--- a/src/pm/hydra2/libhydra/bstrap/slurm/slurm_finalize.c
+++ b/src/pm/hydra2/libhydra/bstrap/slurm/slurm_finalize.c
@@ -8,11 +8,5 @@
 
 HYD_status HYDI_bstrap_slurm_finalize(void)
 {
-    HYD_status status = HYD_SUCCESS;
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_common.h
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_common.h
@@ -13,7 +13,7 @@
 struct HYDI_bstrap_cmd {
     enum {
         HYDI_BSTRAP_CMD__PROXY_ID = 0,
-        HYDI_BSTRAP_CMD__HOSTLIST,
+        HYDI_BSTRAP_CMD__HOSTLIST
     } type;
 
     union {

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
@@ -331,7 +331,9 @@ int main(int argc, char **argv)
     /* if we did not already get an upstream fd, we should have gotten
      * a hostname and port; connect to it. */
     if (upstream_fd == -1) {
-        status = HYD_sock_connect(upstream_host, upstream_port, &upstream_fd, 0, HYD_CONNECT_DELAY);
+        status =
+            HYD_sock_connect(upstream_host, (uint16_t) upstream_port, &upstream_fd, 0,
+                             HYD_CONNECT_DELAY);
         HYD_ERR_POP(status, "unable to connect to server %s at port %d (check for firewalls!)\n",
                     upstream_host, upstream_port);
     }

--- a/src/pm/hydra2/libhydra/bstrap/ssh/ssh_internal.c
+++ b/src/pm/hydra2/libhydra/bstrap/ssh/ssh_internal.c
@@ -115,7 +115,6 @@ HYD_status HYDI_ssh_store_launch_time(const char *hostname)
 HYD_status HYDI_ssh_free_launch_elements(void)
 {
     struct ssh_time_hash *e, *tmp;
-    HYD_status status = HYD_SUCCESS;
 
     HASH_ITER(hh, ssh_time_hash, e, tmp) {
         HASH_DEL(ssh_time_hash, e);
@@ -123,9 +122,5 @@ HYD_status HYDI_ssh_free_launch_elements(void)
         MPL_free(e);
     }
 
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }

--- a/src/pm/hydra2/libhydra/demux/hydra_demux_poll.c
+++ b/src/pm/hydra2/libhydra/demux/hydra_demux_poll.c
@@ -11,7 +11,8 @@
 
 HYD_status HYDI_dmx_poll_wait_for_event(int wtime)
 {
-    int total_fds, i, events, ret, work_done;
+    int total_fds, i, ret, work_done;
+    HYD_dmx_event_t events;
     struct HYDI_dmx_callback *run, *tmp;
     struct pollfd *pollfds = NULL;
     HYD_status status = HYD_SUCCESS;

--- a/src/pm/hydra2/libhydra/demux/hydra_demux_select.c
+++ b/src/pm/hydra2/libhydra/demux/hydra_demux_select.c
@@ -14,7 +14,8 @@
 HYD_status HYDI_dmx_select_wait_for_event(int wtime)
 {
     fd_set readfds, writefds;
-    int nfds, ret, work_done, events;
+    int nfds, ret, work_done;
+    HYD_dmx_event_t events;
     struct timeval timeout;
     struct HYDI_dmx_callback *run, *tmp;
     HYD_status status = HYD_SUCCESS;

--- a/src/pm/hydra2/libhydra/include/hydra_base.h
+++ b/src/pm/hydra2/libhydra/include/hydra_base.h
@@ -148,7 +148,7 @@ typedef enum {
     HYD_ERR_SOCK,
     HYD_ERR_INVALID_PARAM,
     HYD_ERR_INTERNAL,
-    HYD_ERR_PORT_IN_USE,
+    HYD_ERR_PORT_IN_USE
 } HYD_status;
 
 #endif /* HYDRA_BASE_H_INCLUDED */

--- a/src/pm/hydra2/libhydra/rmk/sge/sge_query_node_list.c
+++ b/src/pm/hydra2/libhydra/rmk/sge/sge_query_node_list.c
@@ -10,19 +10,13 @@
 
 static HYD_status process_mfile_tokens(char **tokens, struct HYD_node *node)
 {
-    HYD_status status = HYD_SUCCESS;
-
     MPL_strncpy(node->hostname, tokens[0], HYD_MAX_HOSTNAME_LEN);
     node->core_count = atoi(tokens[1]);
 
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    return HYD_SUCCESS;
 }
 
-HYD_status HYDI_rmk_sge_query_node_list(int *node_count, struct HYD_node **nodes)
+HYD_status HYDI_rmk_sge_query_node_list(int *node_count, struct HYD_node ** nodes)
 {
     char *hostfile;
     HYD_status status = HYD_SUCCESS;

--- a/src/pm/hydra2/libhydra/rmk/src/hydra_rmk.c.in
+++ b/src/pm/hydra2/libhydra/rmk/src/hydra_rmk.c.in
@@ -48,10 +48,6 @@ HYD_status HYD_rmk_query_node_list(const char *rmk, int *node_count, struct HYD_
     else
         status = rmk_query_node_list_fns[i] (node_count, nodes);
 
-  fn_exit:
     HYD_FUNC_EXIT();
     return status;
-
-  fn_fail:
-    goto fn_exit;
 }

--- a/src/pm/hydra2/proxy/proxy.h
+++ b/src/pm/hydra2/proxy/proxy.h
@@ -92,8 +92,8 @@ HYD_status proxy_process_pmi_cb(int fd, HYD_dmx_event_t events, void *userp);
 HYD_status proxy_barrier_in(int fd, struct proxy_kv_hash *hash);
 HYD_status proxy_barrier_out(int fd, struct proxy_kv_hash *hash);
 HYD_status proxy_pmi_kvcache_out(int num_blocks, int *kvlen, char *kvcache, int buflen);
-HYD_status proxy_send_pids_upstream();
-HYD_status proxy_send_exitcodes_upstream();
+HYD_status proxy_send_pids_upstream(void);
+HYD_status proxy_send_exitcodes_upstream(void);
 
 struct proxy_pmi_handle {
     const char *cmd;

--- a/src/pm/hydra2/proxy/proxy_cb.c
+++ b/src/pm/hydra2/proxy/proxy_cb.c
@@ -437,7 +437,7 @@ HYD_status proxy_process_stderr_cb(int fd, HYD_dmx_event_t events, void *userp)
     goto fn_exit;
 }
 
-HYD_status proxy_send_pids_upstream()
+HYD_status proxy_send_pids_upstream(void)
 {
     HYD_status status = HYD_SUCCESS;
     struct MPX_cmd cmd;
@@ -493,7 +493,7 @@ HYD_status proxy_send_pids_upstream()
     goto fn_exit;
 }
 
-HYD_status proxy_send_exitcodes_upstream()
+HYD_status proxy_send_exitcodes_upstream(void)
 {
     HYD_status status = HYD_SUCCESS;
     struct MPX_cmd cmd;

--- a/src/pm/hydra2/proxy/proxy_pmi.c
+++ b/src/pm/hydra2/proxy/proxy_pmi.c
@@ -82,7 +82,7 @@ HYD_status proxy_process_pmi_cb(int fd, HYD_dmx_event_t events, void *userp)
             pmi_stash[count - 1] = 0;
             delim = " ";
         } else if (!strncmp(pmi_stash, "mcmd=", strlen("mcmd="))) {
-            if (count < strlen("endcmd") ||
+            if (count < (int) strlen("endcmd") ||
                 strncmp(&pmi_stash[count - strlen("endcmd")], "endcmd", strlen("endcmd"))) {
                 /* if we reached the end of the buffer we read and did
                  * not yet get a full comamnd, wait till we get at


### PR DESCRIPTION
Fixed some warnings reported by compiler in hydra2:
1. Data types correctness.
2. Unused labels.
3. Extra commas in enum definition.
4. Void parameter for functions without arguments.