### PR TITLE
ch4: Eliminate use of uint64_t for request pointers

### DIFF
--- a/src/mpid/ch4/generic/mpidig_recv.h
+++ b/src/mpid/ch4/generic/mpidig_recv.h
@@ -194,7 +194,7 @@ static inline int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Datatype dataty
         MPIDIG_enqueue_posted(rreq, &MPIDIG_COMM(root_comm, posted_list));
         /* MPIDI_CS_EXIT(); */
     } else {
-        MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = (uint64_t) rreq;
+        MPIDIG_REQUEST(unexp_req, req->rreq.match_req) = rreq;
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_IN_PROGRESS;
     }
   fn_exit:

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -69,7 +69,7 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
 #else
     if (type == MPIDIG_SSEND_REQ) {
         ssend_req.hdr = am_hdr;
-        ssend_req.sreq_ptr = (uint64_t) sreq;
+        ssend_req.sreq_ptr = sreq;
 
         /* Increment the completion counter once to account for the extra message that needs to come
          * back from the receiver to indicate completion. */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -96,16 +96,16 @@ typedef struct MPIDIG_rreq_t {
     MPI_Datatype mrcv_datatype;
 
     uint64_t ignore;
-    uint64_t peer_req_ptr;
-    uint64_t match_req;
-    uint64_t request;
+    MPIR_Request *peer_req_ptr;
+    MPIR_Request *match_req;
+    MPIR_Request *request;
 
     struct MPIDIG_rreq_t *prev, *next;
 } MPIDIG_rreq_t;
 
 typedef struct MPIDIG_put_req_t {
     MPIR_Win *win_ptr;
-    uint64_t preq_ptr;
+    MPIR_Request *preq_ptr;
     void *dt_iov;
     void *origin_addr;
     int origin_count;
@@ -116,7 +116,7 @@ typedef struct MPIDIG_put_req_t {
 
 typedef struct MPIDIG_get_req_t {
     MPIR_Win *win_ptr;
-    uint64_t greq_ptr;
+    MPIR_Request *greq_ptr;
     uint64_t addr;
     MPI_Datatype datatype;
     int count;
@@ -126,7 +126,7 @@ typedef struct MPIDIG_get_req_t {
 
 typedef struct MPIDIG_cswap_req_t {
     MPIR_Win *win_ptr;
-    uint64_t creq_ptr;
+    MPIR_Request *creq_ptr;
     uint64_t addr;
     MPI_Datatype datatype;
     void *data;
@@ -135,7 +135,7 @@ typedef struct MPIDIG_cswap_req_t {
 
 typedef struct MPIDIG_acc_req_t {
     MPIR_Win *win_ptr;
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
     MPI_Datatype origin_datatype;
     MPI_Datatype target_datatype;
     int origin_count;
@@ -166,7 +166,7 @@ typedef struct MPIDIG_req_ext_t {
     struct iovec *iov;
     void *target_cmpl_cb;
     uint64_t seq_no;
-    uint64_t request;
+    MPIR_Request *request;
     uint64_t status;
     struct MPIDIG_req_ext_t *next, *prev;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -176,7 +176,7 @@ static inline int MPIDI_NM_am_recv(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_RECV);
 
     msg.sreq_ptr = (MPIDIG_REQUEST(req, req->rreq.peer_req_ptr));
-    msg.rreq_ptr = (uint64_t) req;
+    msg.rreq_ptr = req;
     MPIR_Assert((void *) msg.sreq_ptr != NULL);
     mpi_errno =
         MPIDI_NM_am_send_hdr_reply(MPIDIG_REQUEST(req, context_id),

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -397,7 +397,7 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_HANDLE_LMT_ACK);
 
     ack_msg = (MPIDI_OFI_ack_msg_payload_t *) msg_hdr->payload;
-    sreq = (MPIR_Request *) ack_msg->sreq_ptr;
+    sreq = ack_msg->sreq_ptr;
 
     if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
         uint64_t mr_key = fi_mr_key(MPIDI_OFI_AMREQUEST_HDR(sreq, lmt_mr));
@@ -421,7 +421,8 @@ static inline int MPIDI_OFI_handle_lmt_ack(MPIDI_OFI_am_header_t * msg_hdr)
     goto fn_exit;
 }
 
-static inline int MPIDI_OFI_dispatch_ack(int rank, int context_id, uint64_t sreq_ptr, int am_type)
+static inline int MPIDI_OFI_dispatch_ack(int rank, int context_id, MPIR_Request * sreq_ptr,
+                                         int am_type)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_ack_msg_t msg;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -282,7 +282,7 @@ static inline int MPIDI_OFI_am_isend_long(int rank,
     lmt_info->context_id = comm->context_id;
     lmt_info->src_rank = comm->rank;
     lmt_info->src_offset = MPIDI_OFI_ENABLE_MR_SCALABLE ? (uint64_t) 0 /* MR_SCALABLE */ : (uint64_t) data;     /* MR_BASIC */
-    lmt_info->sreq_ptr = (uint64_t) sreq;
+    lmt_info->sreq_ptr = sreq;
     if (MPIDI_OFI_ENABLE_MR_SCALABLE) {
         lmt_info->rma_key = MPIDI_OFI_mr_key_alloc();
     } else {
@@ -407,7 +407,7 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
 
         MPIR_Memcpy(&lreq_hdr.hdr, am_hdr, am_hdr_sz);
         lreq_hdr.data_sz = data_sz;
-        lreq_hdr.sreq_ptr = (uint64_t) sreq;
+        lreq_hdr.sreq_ptr = sreq;
         MPIDIG_REQUEST(sreq, req->lreq).src_buf = buf;
         MPIDIG_REQUEST(sreq, req->lreq).count = count;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -60,13 +60,13 @@ typedef struct {
     int src_rank;
 
     uint64_t src_offset;
-    uint64_t sreq_ptr;
+    MPIR_Request *sreq_ptr;
     uint64_t am_hdr_src;
     uint64_t rma_key;
 } MPIDI_OFI_lmt_msg_payload_t;
 
 typedef struct {
-    uint64_t sreq_ptr;
+    MPIR_Request *sreq_ptr;
 } MPIDI_OFI_ack_msg_payload_t;
 
 typedef struct MPIDI_OFI_am_header_t {
@@ -105,7 +105,7 @@ typedef struct {
     uint64_t lmt_cntr;
     struct fid_mr *lmt_mr;
     void *pack_buffer;
-    void *rreq_ptr;
+    MPIR_Request *rreq_ptr;
     void *am_hdr;
     int (*target_cmpl_cb) (struct MPIR_Request * req);
     uint16_t am_hdr_sz;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -436,7 +436,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_recv(MPIR_Request * req)
     MPIDIG_send_long_ack_msg_t msg;
 
     msg.sreq_ptr = (MPIDIG_REQUEST(req, req->rreq.peer_req_ptr));
-    msg.rreq_ptr = (uint64_t) req;
+    msg.rreq_ptr = req;
     MPIR_Assert((void *) msg.sreq_ptr != NULL);
 
     mpi_errno =

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -132,25 +132,25 @@ typedef struct MPIDIG_hdr_t {
 typedef struct MPIDIG_send_long_req_mst_t {
     MPIDIG_hdr_t hdr;
     size_t data_sz;             /* Message size in bytes */
-    uint64_t sreq_ptr;          /* Pointer value of the request object at the sender side */
+    MPIR_Request *sreq_ptr;     /* Pointer value of the request object at the sender side */
 } MPIDIG_send_long_req_mst_t;
 
 typedef struct MPIDIG_send_long_ack_msg_t {
-    uint64_t sreq_ptr;
-    uint64_t rreq_ptr;
+    MPIR_Request *sreq_ptr;
+    MPIR_Request *rreq_ptr;
 } MPIDIG_send_long_ack_msg_t;
 
 typedef struct MPIDIG_send_long_lmt_msg_t {
-    uint64_t rreq_ptr;
+    MPIR_Request *rreq_ptr;
 } MPIDIG_send_long_lmt_msg_t;
 
 typedef struct MPIDIG_ssend_req_msg_t {
     MPIDIG_hdr_t hdr;
-    uint64_t sreq_ptr;
+    MPIR_Request *sreq_ptr;
 } MPIDIG_ssend_req_msg_t;
 
 typedef struct MPIDIG_ssend_ack_msg_t {
-    uint64_t sreq_ptr;
+    MPIR_Request *sreq_ptr;
 } MPIDIG_ssend_ack_msg_t;
 
 typedef struct MPIDIG_win_cntrl_msg_t {
@@ -162,7 +162,7 @@ typedef struct MPIDIG_win_cntrl_msg_t {
 typedef struct MPIDIG_put_msg_t {
     int src_rank;
     uint64_t win_id;
-    uint64_t preq_ptr;
+    MPIR_Request *preq_ptr;
     MPI_Aint target_disp;
     uint64_t count;
     MPI_Datatype datatype;
@@ -171,26 +171,26 @@ typedef struct MPIDIG_put_msg_t {
 
 typedef struct MPIDIG_put_iov_ack_msg_t {
     int src_rank;
-    uint64_t target_preq_ptr;
-    uint64_t origin_preq_ptr;
+    MPIR_Request *target_preq_ptr;
+    MPIR_Request *origin_preq_ptr;
 } MPIDIG_put_iov_ack_msg_t;
 typedef MPIDIG_put_iov_ack_msg_t MPIDIG_acc_iov_ack_msg_t;
 typedef MPIDIG_put_iov_ack_msg_t MPIDIG_get_acc_iov_ack_msg_t;
 
 typedef struct MPIDIG_put_dat_msg_t {
-    uint64_t preq_ptr;
+    MPIR_Request *preq_ptr;
 } MPIDIG_put_dat_msg_t;
 typedef MPIDIG_put_dat_msg_t MPIDIG_acc_dat_msg_t;
 typedef MPIDIG_put_dat_msg_t MPIDIG_get_acc_dat_msg_t;
 
 typedef struct MPIDIG_put_ack_msg_t {
-    uint64_t preq_ptr;
+    MPIR_Request *preq_ptr;
 } MPIDIG_put_ack_msg_t;
 
 typedef struct MPIDIG_get_msg_t {
     int src_rank;
     uint64_t win_id;
-    uint64_t greq_ptr;
+    MPIR_Request *greq_ptr;
     MPI_Aint target_disp;
     uint64_t count;
     MPI_Datatype datatype;
@@ -198,25 +198,25 @@ typedef struct MPIDIG_get_msg_t {
 } MPIDIG_get_msg_t;
 
 typedef struct MPIDIG_get_ack_msg_t {
-    uint64_t greq_ptr;
+    MPIR_Request *greq_ptr;
 } MPIDIG_get_ack_msg_t;
 
 typedef struct MPIDIG_cswap_req_msg_t {
     int src_rank;
     uint64_t win_id;
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
     MPI_Aint target_disp;
     MPI_Datatype datatype;
 } MPIDIG_cswap_req_msg_t;
 
 typedef struct MPIDIG_cswap_ack_msg_t {
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
 } MPIDIG_cswap_ack_msg_t;
 
 typedef struct MPIDIG_acc_req_msg_t {
     int src_rank;
     uint64_t win_id;
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
     int origin_count;
     MPI_Datatype origin_datatype;
     int target_count;
@@ -230,7 +230,7 @@ typedef struct MPIDIG_acc_req_msg_t {
 typedef struct MPIDIG_acc_req_msg_t MPIDIG_get_acc_req_msg_t;
 
 typedef struct MPIDIG_acc_ack_msg_t {
-    uint64_t req_ptr;
+    MPIR_Request *req_ptr;
 } MPIDIG_acc_ack_msg_t;
 
 typedef MPIDIG_acc_ack_msg_t MPIDIG_get_acc_ack_msg_t;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -34,7 +34,7 @@ int MPIDIG_check_cmpl_order(MPIR_Request * req, MPIDIG_am_target_cmpl_cb target_
     }
 
     MPIDIG_REQUEST(req, req->target_cmpl_cb) = (void *) target_cmpl_cb;
-    MPIDIG_REQUEST(req, req->request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->request) = req;
     /* MPIDI_CS_ENTER(); */
     DL_APPEND(MPIDI_global.cmpl_list, req->dev.ch4.am.req);
     /* MPIDI_CS_EXIT(); */

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_posted(MPIR_Request * req, MPIDIG_r
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, posted_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_POSTED);
@@ -57,7 +57,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_unexp(MPIR_Request * req, MPIDIG_rr
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
-    MPIDIG_REQUEST(req, req->rreq.request) = (uint64_t) req;
+    MPIDIG_REQUEST(req, req->rreq.request) = req;
     DL_APPEND(*list, &req->dev.ch4.am.req->rreq);
     MPIR_T_PVAR_LEVEL_INC(RECVQ, unexpected_recvq_length, 1);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ENQUEUE_UNEXP);
@@ -84,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_unexp_strict(int rank, int
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
-        req = (MPIR_Request *) curr->request;
+        req = curr->request;
         if (!(MPIDIG_REQUEST(req, req->status) & MPIDIG_REQ_BUSY) &&
             MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
@@ -110,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_unexp(int rank, int tag,
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
-        req = (MPIR_Request *) curr->request;
+        req = curr->request;
         if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, unexpected_recvq_length, 1);
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_find_unexp(int rank, int tag,
     MPIR_T_PVAR_TIMER_START(RECVQ, time_matching_unexpectedq);
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, unexpected_recvq_match_attempts, 1);
-        req = (MPIR_Request *) curr->request;
+        req = curr->request;
         if (MPIDIG_match_unexp(rank, tag, context_id, req)) {
             break;
         }
@@ -158,7 +158,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_posted(int rank, int tag,
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
-        req = (MPIR_Request *) curr->request;
+        req = curr->request;
         if (MPIDIG_match_posted(rank, tag, context_id, req)) {
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -91,7 +91,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_request_copy(MPIR_Request * dest, MPIR_Requ
 #endif
 
     MPIDIG_REQUEST(dest, req) = MPIDIG_REQUEST(src, req);;
-    MPIDIG_REQUEST(dest, req->rreq.request) = (uint64_t) dest;
+    MPIDIG_REQUEST(dest, req->rreq.request) = dest;
     MPIDIG_REQUEST(dest, datatype) = MPIDIG_REQUEST(src, datatype);
     MPIDIG_REQUEST(dest, buffer) = MPIDIG_REQUEST(src, buffer);
     MPIDIG_REQUEST(dest, count) = MPIDIG_REQUEST(src, count);

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -79,7 +79,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
     am_hdr.datatype = target_datatype;
-    am_hdr.preq_ptr = (uint64_t) sreq;
+    am_hdr.preq_ptr = sreq;
     am_hdr.win_id = MPIDIG_WIN(win, win_id);
 
     /* Increase local and remote completion counters and set the local completion
@@ -246,7 +246,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
     am_hdr.target_disp = target_disp;
     am_hdr.count = target_count;
     am_hdr.datatype = target_datatype;
-    am_hdr.greq_ptr = (uint64_t) sreq;
+    am_hdr.greq_ptr = sreq;
     am_hdr.win_id = MPIDIG_WIN(win, win_id);
     am_hdr.src_rank = win->comm_ptr->rank;
 
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     MPIR_cc_incr(sreq->cc_ptr, &c);
 
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
-    am_hdr.req_ptr = (uint64_t) sreq;
+    am_hdr.req_ptr = sreq;
     am_hdr.origin_count = origin_count;
 
     if (HANDLE_GET_KIND(origin_datatype) == HANDLE_KIND_BUILTIN) {
@@ -566,7 +566,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 
     /* TODO: have common routine for accumulate/get_accumulate */
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
-    am_hdr.req_ptr = (uint64_t) sreq;
+    am_hdr.req_ptr = sreq;
     am_hdr.origin_count = origin_count;
 
     if (HANDLE_GET_KIND(origin_datatype) == HANDLE_KIND_BUILTIN) {
@@ -932,7 +932,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
     MPIR_T_PVAR_TIMER_START(RMA, rma_amhdr_set);
     am_hdr.target_disp = target_disp;
     am_hdr.datatype = datatype;
-    am_hdr.req_ptr = (uint64_t) sreq;
+    am_hdr.req_ptr = sreq;
     am_hdr.win_id = MPIDIG_WIN(win, win_id);
     am_hdr.src_rank = win->comm_ptr->rank;
     MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -911,8 +911,8 @@ static int put_iov_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_PUT_IOV_TARGET_CMPL_CB);
 
     ack_msg.src_rank = MPIDIG_REQUEST(rreq, rank);
-    ack_msg.origin_preq_ptr = (uint64_t) MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
-    ack_msg.target_preq_ptr = (uint64_t) rreq;
+    ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->preq.preq_ptr);
+    ack_msg.target_preq_ptr = rreq;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
@@ -948,8 +948,8 @@ static int acc_iov_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ACC_IOV_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ACC_IOV_TARGET_CMPL_CB);
 
-    ack_msg.origin_preq_ptr = (uint64_t) MPIDIG_REQUEST(rreq, req->areq.req_ptr);
-    ack_msg.target_preq_ptr = (uint64_t) rreq;
+    ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
+    ack_msg.target_preq_ptr = rreq;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
@@ -985,8 +985,8 @@ static int get_acc_iov_target_cmpl_cb(MPIR_Request * rreq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACC_IOV_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACC_IOV_TARGET_CMPL_CB);
 
-    ack_msg.origin_preq_ptr = (uint64_t) MPIDIG_REQUEST(rreq, req->areq.req_ptr);
-    ack_msg.target_preq_ptr = (uint64_t) rreq;
+    ack_msg.origin_preq_ptr = MPIDIG_REQUEST(rreq, req->areq.req_ptr);
+    ack_msg.target_preq_ptr = rreq;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))


### PR DESCRIPTION
## Pull Request Description

Fix lots of warnings on 32-bit builds.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

none

## Known Issues

32-bit ch4 builds are still broken. This is just one issue that needs fixing.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
