### PR TITLE
xfail: rma/rget_testall on solaris

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -164,3 +164,5 @@ valgrind * * * * sed -i "s+\(^accfence1 .*\)+\1 xfail=ticket0+g" test/mpi/rma/te
 # hwloc is unable to detect topology info on FreeBSD in strict mode with GCC
 * gnu strict * freebsd64 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist
 * gnu strict * freebsd32 sed -i "s+\(^cmsplit_type .*\)+\1 xfail=ticket3972+g" test/mpi/comm/testlist
+# misc issues that haven't been resolved
+* * * * solaris sed -i "s+\(^rget_testall .*\)+\1 xfail=ticket4011+g" test/mpi/errors/rma/testlist


### PR DESCRIPTION

## Pull Request Description
Refference github issue 4011. Intermittent on Solaris jenkins tests,
around 1/5 chance of triggering.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
