### PR TITLE
test/mpi/rma: fix rget_testall test

### DIFF
--- a/test/mpi/rma/rget_testall.c
+++ b/test/mpi/rma/rget_testall.c
@@ -39,6 +39,9 @@ int main(int argc, char **argv)
     baseptr[1] = 2;
     MPI_Win_unlock(rank, win);
 
+    /* Synchronize the processes before starting the second access epoch */
+    MPI_Barrier(MPI_COMM_WORLD);
+
     /* Issue request-based get with testall. */
     MPI_Win_lock_all(0, win);
     MPI_Rget(&val1, 1, MPI_INT, 0, 0, 1, MPI_INT, win, &reqs[0]);


### PR DESCRIPTION
The processes need to synchronize before starting the second access
epoch. This ensures that the data is actually written by Rank 0 when
issuing the MPI_Rget() operations.

Signed-off-by: Simon Pickartz <pickartz@par-tec.com>
Signed-off-by: Carsten Clauss <clauss@par-tec.com>

## Pull Request Description

This PR fixes #3558 by adding an additional `MPI_Barrier()` before calling `MPI_Win_lock_all()`.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
