### PR TITLE
test/mpi: make gentest-dtp bourne shell compliant

### DIFF
--- a/test/mpi/maint/gentests_dtp.sh
+++ b/test/mpi/maint/gentests_dtp.sh
@@ -62,7 +62,7 @@ types=$(echo $types | tr "," " ")
 seed=1
 
 while read -r line ; do
-    if [ ! `echo $line | head -c 1` = "#" ] ; then
+    if [ ! `echo $line | cut -c 1` = "#" ] ; then
         # the line is not a comment
         pathname=`echo $line | cut -f1 -d':'`
         args=`echo $line | cut -f2 -d':'`


### PR DESCRIPTION
## Pull Request Description

Currently comment lines in the `gentest-dtp.sh` script are detected by
using the `head` command. This however causes problems in Solaris. To
fix the issue we replace `head` with `cut`.

Fixes issue https://github.com/pmodels/mpich/issues/3911
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
