### PR TITLE
init: create and use init_comm during init

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -241,6 +241,7 @@ int MPIR_Comm_create_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag
 int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Comm ** newcomm_ptr);
 
 
+int MPIR_Comm_create_subcomms(MPIR_Comm * comm);
 int MPIR_Comm_commit(MPIR_Comm *);
 
 int MPIR_Comm_is_node_aware(MPIR_Comm *);

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -321,17 +321,15 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
     MPIR_Assert(comm->node_roots_comm == NULL);
 
     /* Notify device of communicator creation */
-    if (comm != MPIR_Process.comm_world) {
-        mpi_errno = MPID_Comm_create_hook(comm);
-        MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPID_Comm_create_hook(comm);
+    MPIR_ERR_CHECK(mpi_errno);
 
-        /* Create collectives-specific infrastructure */
-        mpi_errno = MPIR_Coll_comm_init(comm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+    /* Create collectives-specific infrastructure */
+    mpi_errno = MPIR_Coll_comm_init(comm);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
 
-        MPIR_Comm_map_free(comm);
-    }
+    MPIR_Comm_map_free(comm);
 
     if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->context_id)) {  /*make sure this is not a subcomm */
 
@@ -450,18 +448,6 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
     }
 
   fn_exit:
-    if (comm == MPIR_Process.comm_world) {
-        mpi_errno = MPID_Comm_create_hook(comm);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        /* Create collectives-specific infrastructure */
-        mpi_errno = MPIR_Coll_comm_init(comm);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
-
-        MPIR_Comm_map_free(comm);
-    }
-
     MPL_free(external_procs);
     MPL_free(local_procs);
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -42,6 +42,7 @@ struct MPIR_Comm_hint_fn_elt {
     UT_hash_handle hh;
 };
 static struct MPIR_Comm_hint_fn_elt *MPID_hint_fns = NULL;
+static int MPIR_Comm_commit_internal(MPIR_Comm * comm);
 
 /* FIXME :
    Reusing context ids can lead to a race condition if (as is desirable)
@@ -299,6 +300,143 @@ int MPIR_Comm_map_free(MPIR_Comm * comm)
     return mpi_errno;
 }
 
+static int MPIR_Comm_commit_internal(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_COMM_COMMIT_INTERNAL);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_COMMIT_INTERNAL);
+
+    /* Notify device of communicator creation */
+    mpi_errno = MPID_Comm_create_hook(comm);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Create collectives-specific infrastructure */
+    mpi_errno = MPIR_Coll_comm_init(comm);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIR_Comm_map_free(comm);
+
+  fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_COMMIT_INTERNAL);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Comm_create_subcomms(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int num_local = -1, num_external = -1;
+    int local_rank = -1, external_rank = -1;
+    int *local_procs = NULL, *external_procs = NULL;
+
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_COMM_CREATE_SUBCOMMS);
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_CREATE_SUBCOMMS);
+
+    MPIR_Assert(comm->node_comm == NULL);
+    MPIR_Assert(comm->node_roots_comm == NULL);
+
+    mpi_errno = MPIR_Find_local(comm, &num_local, &local_rank, &local_procs,
+                                &comm->intranode_table);
+    /* --BEGIN ERROR HANDLING-- */
+    if (mpi_errno) {
+        if (MPIR_Err_is_fatal(mpi_errno))
+            MPIR_ERR_POP(mpi_errno);
+
+        /* Non-fatal errors simply mean that this communicator will not have
+         * any node awareness.  Node-aware collectives are an optimization. */
+        MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE, "MPIR_Find_local failed for comm_ptr=%p", comm);
+        MPL_free(comm->intranode_table);
+
+        mpi_errno = MPI_SUCCESS;
+        goto fn_exit;
+    }
+    /* --END ERROR HANDLING-- */
+
+    mpi_errno = MPIR_Find_external(comm, &num_external, &external_rank, &external_procs,
+                                   &comm->internode_table);
+    /* --BEGIN ERROR HANDLING-- */
+    if (mpi_errno) {
+        if (MPIR_Err_is_fatal(mpi_errno))
+            MPIR_ERR_POP(mpi_errno);
+
+        /* Non-fatal errors simply mean that this communicator will not have
+         * any node awareness.  Node-aware collectives are an optimization. */
+        MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE, "MPIR_Find_external failed for comm_ptr=%p", comm);
+        MPL_free(comm->internode_table);
+
+        mpi_errno = MPI_SUCCESS;
+        goto fn_exit;
+    }
+    /* --END ERROR HANDLING-- */
+
+    /* defensive checks */
+    MPIR_Assert(num_local > 0);
+    MPIR_Assert(num_local > 1 || external_rank >= 0);
+    MPIR_Assert(external_rank < 0 || external_procs != NULL);
+
+    /* if the node_roots_comm and comm would be the same size, then creating
+     * the second communicator is useless and wasteful. */
+    if (num_external == comm->remote_size) {
+        MPIR_Assert(num_local == 1);
+        goto fn_exit;
+    }
+
+    /* we don't need a local comm if this process is the only one on this node */
+    if (num_local > 1) {
+        mpi_errno = MPIR_Comm_create(&comm->node_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        comm->node_comm->context_id = comm->context_id + MPIR_CONTEXT_INTRANODE_OFFSET;
+        comm->node_comm->recvcontext_id = comm->node_comm->context_id;
+        comm->node_comm->rank = local_rank;
+        comm->node_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+        comm->node_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE;
+        comm->node_comm->local_comm = NULL;
+        MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_comm=%p\n", comm->node_comm);
+
+        comm->node_comm->local_size = num_local;
+        comm->node_comm->remote_size = num_local;
+
+        MPIR_Comm_map_irregular(comm->node_comm, comm, local_procs, num_local,
+                                MPIR_COMM_MAP_DIR__L2L, NULL);
+        mpi_errno = MPIR_Comm_commit_internal(comm->node_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    /* this process may not be a member of the node_roots_comm */
+    if (local_rank == 0) {
+        mpi_errno = MPIR_Comm_create(&comm->node_roots_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        comm->node_roots_comm->context_id = comm->context_id + MPIR_CONTEXT_INTERNODE_OFFSET;
+        comm->node_roots_comm->recvcontext_id = comm->node_roots_comm->context_id;
+        comm->node_roots_comm->rank = external_rank;
+        comm->node_roots_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+        comm->node_roots_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS;
+        comm->node_roots_comm->local_comm = NULL;
+        MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_roots_comm=%p\n", comm->node_roots_comm);
+
+        comm->node_roots_comm->local_size = num_external;
+        comm->node_roots_comm->remote_size = num_external;
+
+        MPIR_Comm_map_irregular(comm->node_roots_comm, comm, external_procs, num_external,
+                                MPIR_COMM_MAP_DIR__L2L, NULL);
+        mpi_errno = MPIR_Comm_commit_internal(comm->node_roots_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__PARENT;
+
+  fn_exit:
+    MPL_free(local_procs);
+    MPL_free(external_procs);
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_CREATE_SUBCOMMS);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 /* Provides a hook for the top level functions to perform some manipulation on a
    communicator just before it is given to the application level.
 
@@ -307,9 +445,6 @@ int MPIR_Comm_map_free(MPIR_Comm * comm)
 int MPIR_Comm_commit(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
-    int num_local = -1, num_external = -1;
-    int local_rank = -1, external_rank = -1;
-    int *local_procs = NULL, *external_procs = NULL;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIR_COMM_COMMIT);
 
     MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIR_COMM_COMMIT);
@@ -321,136 +456,15 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
     MPIR_Assert(comm->node_roots_comm == NULL);
 
     /* Notify device of communicator creation */
-    mpi_errno = MPID_Comm_create_hook(comm);
+    mpi_errno = MPIR_Comm_commit_internal(comm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Create collectives-specific infrastructure */
-    mpi_errno = MPIR_Coll_comm_init(comm);
-    if (mpi_errno)
-        MPIR_ERR_POP(mpi_errno);
-
-    MPIR_Comm_map_free(comm);
-
     if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->context_id)) {  /*make sure this is not a subcomm */
-
-        mpi_errno = MPIR_Find_local(comm, &num_local, &local_rank, &local_procs,
-                                    &comm->intranode_table);
-        /* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno) {
-            if (MPIR_Err_is_fatal(mpi_errno))
-                MPIR_ERR_POP(mpi_errno);
-
-            /* Non-fatal errors simply mean that this communicator will not have
-             * any node awareness.  Node-aware collectives are an optimization. */
-            MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE, "MPIR_Find_local failed for comm_ptr=%p", comm);
-            MPL_free(comm->intranode_table);
-
-            mpi_errno = MPI_SUCCESS;
-            goto fn_exit;
-        }
-        /* --END ERROR HANDLING-- */
-
-        mpi_errno = MPIR_Find_external(comm, &num_external, &external_rank, &external_procs,
-                                       &comm->internode_table);
-        /* --BEGIN ERROR HANDLING-- */
-        if (mpi_errno) {
-            if (MPIR_Err_is_fatal(mpi_errno))
-                MPIR_ERR_POP(mpi_errno);
-
-            /* Non-fatal errors simply mean that this communicator will not have
-             * any node awareness.  Node-aware collectives are an optimization. */
-            MPL_DBG_MSG_P(MPIR_DBG_COMM, VERBOSE,
-                          "MPIR_Find_external failed for comm_ptr=%p", comm);
-            MPL_free(comm->internode_table);
-
-            mpi_errno = MPI_SUCCESS;
-            goto fn_exit;
-        }
-        /* --END ERROR HANDLING-- */
-
-        /* defensive checks */
-        MPIR_Assert(num_local > 0);
-        MPIR_Assert(num_local > 1 || external_rank >= 0);
-        MPIR_Assert(external_rank < 0 || external_procs != NULL);
-
-        /* if the node_roots_comm and comm would be the same size, then creating
-         * the second communicator is useless and wasteful. */
-        if (num_external == comm->remote_size) {
-            MPIR_Assert(num_local == 1);
-            goto fn_exit;
-        }
-
-        /* we don't need a local comm if this process is the only one on this node */
-        if (num_local > 1) {
-            mpi_errno = MPIR_Comm_create(&comm->node_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            comm->node_comm->context_id = comm->context_id + MPIR_CONTEXT_INTRANODE_OFFSET;
-            comm->node_comm->recvcontext_id = comm->node_comm->context_id;
-            comm->node_comm->rank = local_rank;
-            comm->node_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-            comm->node_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE;
-            comm->node_comm->local_comm = NULL;
-            MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_comm=%p\n", comm->node_comm);
-
-            comm->node_comm->local_size = num_local;
-            comm->node_comm->remote_size = num_local;
-
-            MPIR_Comm_map_irregular(comm->node_comm, comm, local_procs,
-                                    num_local, MPIR_COMM_MAP_DIR__L2L, NULL);
-
-            /* Notify device of communicator creation */
-            mpi_errno = MPID_Comm_create_hook(comm->node_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-            /* don't call MPIR_Comm_commit here */
-
-            /* Create collectives-specific infrastructure */
-            mpi_errno = MPIR_Coll_comm_init(comm->node_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            MPIR_Comm_map_free(comm->node_comm);
-        }
-
-
-        /* this process may not be a member of the node_roots_comm */
-        if (local_rank == 0) {
-            mpi_errno = MPIR_Comm_create(&comm->node_roots_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            comm->node_roots_comm->context_id = comm->context_id + MPIR_CONTEXT_INTERNODE_OFFSET;
-            comm->node_roots_comm->recvcontext_id = comm->node_roots_comm->context_id;
-            comm->node_roots_comm->rank = external_rank;
-            comm->node_roots_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
-            comm->node_roots_comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS;
-            comm->node_roots_comm->local_comm = NULL;
-            MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Create node_roots_comm=%p\n",
-                          comm->node_roots_comm);
-
-            comm->node_roots_comm->local_size = num_external;
-            comm->node_roots_comm->remote_size = num_external;
-
-            MPIR_Comm_map_irregular(comm->node_roots_comm, comm,
-                                    external_procs, num_external, MPIR_COMM_MAP_DIR__L2L, NULL);
-
-            /* Notify device of communicator creation */
-            mpi_errno = MPID_Comm_create_hook(comm->node_roots_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-            /* don't call MPIR_Comm_commit here */
-
-            /* Create collectives-specific infrastructure */
-            mpi_errno = MPIR_Coll_comm_init(comm->node_roots_comm);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            MPIR_Comm_map_free(comm->node_roots_comm);
-        }
-
-        comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__PARENT;
+        mpi_errno = MPIR_Comm_create_subcomms(comm);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:
-    MPL_free(external_procs);
-    MPL_free(local_procs);
-
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_COMM_COMMIT);
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/generic/mpidig.h
+++ b/src/mpid/ch4/generic/mpidig.h
@@ -34,7 +34,7 @@ extern MPIDIG_global_t MPIDIG_global;
 
 int MPIDIG_am_reg_cb(int handler_id,
                      MPIDIG_am_origin_cb origin_cb, MPIDIG_am_target_msg_cb target_msg_cb);
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self);
+int MPIDIG_init(void);
 void MPIDIG_finalize(void);
 
 int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code);

--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -27,7 +27,7 @@ int MPIDIG_am_reg_cb(int handler_id,
     return mpi_errno;
 }
 
-int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
+int MPIDIG_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT);
@@ -176,13 +176,6 @@ int MPIDIG_init(MPIR_Comm * comm_world, MPIR_Comm * comm_self)
 
     mpi_errno = MPIDIG_am_reg_cb(MPIDIG_COMM_ABORT,
                                  &MPIDIG_comm_abort_origin_cb, &MPIDIG_comm_abort_target_msg_cb);
-    MPIR_ERR_CHECK(mpi_errno);
-
-
-    mpi_errno = MPIDIG_init_comm(comm_world);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = MPIDIG_init_comm(comm_self);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIU_map_create((void **) &(MPIDI_global.win_map), MPL_MEM_RMA);

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -17,8 +17,7 @@
 #define MPIDI_MAX_NETMOD_STRING_LEN 64
 
 typedef int (*MPIDI_NM_mpi_init_t) (int rank, int size, int appnum, int *tag_bits,
-                                    MPIR_Comm * comm_world, MPIR_Comm * comm_self,
-                                    int *n_vcis_provided);
+                                    MPIR_Comm * init_comm, int *n_vcis_provided);
 typedef int (*MPIDI_NM_mpi_finalize_t) (void);
 typedef int (*MPIDI_NM_get_vci_attr_t) (int vci);
 typedef int (*MPIDI_NM_progress_t) (int vci, int blocking);
@@ -641,8 +640,8 @@ extern MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 extern int MPIDI_num_netmods;
 extern char MPIDI_NM_strings[][MPIDI_MAX_NETMOD_STRING_LEN];
 
-int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                           MPIR_Comm * comm_self, int *n_vcis_provided);
+int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                           int *n_vcis_provided);
 int MPIDI_NM_mpi_finalize_hook(void);
 int MPIDI_NM_get_vci_attr(int vci);
 int MPIDI_NM_progress(int vci, int blocking);

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -29,24 +29,6 @@ int MPIDI_OFI_mpi_comm_create_hook(MPIR_Comm * comm)
     /* eagain defaults to off */
     MPIDI_OFI_COMM(comm).eagain = FALSE;
 
-    /* if this is MPI_COMM_WORLD, finish bc exchange */
-    if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        void *table;
-        int *rank_map;
-        int recv_bc_len;
-        MPIDU_bc_allgather(MPIDI_OFI_global.addrname,
-                           MPIDI_OFI_global.addrnamelen, TRUE, &table, &rank_map, &recv_bc_len);
-
-        int i;
-        for (i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                mpi_errno = MPIDI_OFI_av_insert(i, (char *) table + recv_bc_len * rank_map[i]);
-                MPIR_ERR_CHECK(mpi_errno);
-            }
-        }
-        MPIDU_bc_table_destroy();
-    }
-
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_MPI_COMM_CREATE_HOOK);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -482,8 +482,8 @@ static int dynproc_send_disconnect(int conn_id)
     goto fn_exit;
 }
 
-int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                            MPIR_Comm * comm_self, int *n_vcis_provided)
+int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                            int *n_vcis_provided)
 {
     int mpi_errno = MPI_SUCCESS, i, ofi_version;
     int thr_err = 0;

--- a/src/mpid/ch4/netmod/ofi/ofi_noinline.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_noinline.h
@@ -84,8 +84,8 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win);
 #endif
 
 /* ofi_init.h */
-int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                            MPIR_Comm * comm_self, int *n_vcis_provided);
+int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                            int *n_vcis_provided);
 int MPIDI_OFI_mpi_finalize_hook(void);
 int MPIDI_OFI_get_vci_attr(int vci);
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);

--- a/src/mpid/ch4/netmod/src/netmod_impl.c
+++ b/src/mpid/ch4/netmod/src/netmod_impl.c
@@ -344,16 +344,15 @@ int MPIDI_NM_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_Win
     return ret;
 }
 
-int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                           MPIR_Comm * comm_self, int *n_vcis_provided)
+int MPIDI_NM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                           int *n_vcis_provided)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
 
-    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, comm_world, comm_self,
-                                  n_vcis_provided);
+    ret = MPIDI_NM_func->mpi_init(rank, size, appnum, tag_bits, init_comm, n_vcis_provided);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_INIT_HOOK);
     return ret;

--- a/src/mpid/ch4/netmod/stubnm/stubnm_init.c
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_init.c
@@ -13,7 +13,7 @@
 #include "stubnm_impl.h"
 
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
-                               MPIR_Comm * comm_world, MPIR_Comm * comm_self, int *n_vcis_provided)
+                               MPIR_Comm * comm_world, int *n_vcis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_noinline.h
@@ -86,7 +86,7 @@ int MPIDI_STUBNM_mpi_win_free_hook(MPIR_Win * win);
 
 /* stubnm_init.h */
 int MPIDI_STUBNM_mpi_init_hook(int rank, int size, int appnum, int *tag_bits,
-                               MPIR_Comm * comm_world, MPIR_Comm * comm_self, int *n_vcis_provided);
+                               MPIR_Comm * init_comm, int *n_vcis_provided);
 int MPIDI_STUBNM_mpi_finalize_hook(void);
 int MPIDI_STUBNM_get_vci_attr(int vci);
 void *MPIDI_STUBNM_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -20,30 +20,6 @@ int MPIDI_UCX_mpi_comm_create_hook(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_MPI_COMM_CREATE_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_MPI_COMM_CREATE_HOOK);
 
-    /* if this is MPI_COMM_WORLD, finish bc exchange */
-    if (comm == MPIR_Process.comm_world && MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        void *table;
-        int *rank_map;
-        int recv_bc_len;
-        MPIDU_bc_allgather(MPIDI_UCX_global.if_address, (int) MPIDI_UCX_global.addrname_len, FALSE,
-                           (void **) &table, &rank_map, &recv_bc_len);
-
-        /* insert new addresses, skipping over node roots */
-        int i;
-        for (i = 0; i < MPIR_Process.size; i++) {
-            if (rank_map[i] >= 0) {
-                ucs_status_t ucx_status;
-                ucp_ep_params_t ep_params;
-
-                ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-                ep_params.address = (ucp_address_t *) ((char *) table + i * recv_bc_len);
-                ucx_status = ucp_ep_create(MPIDI_UCX_global.worker, &ep_params,
-                                           &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest);
-                MPIDI_UCX_CHK_STATUS(ucx_status);
-            }
-        }
-        MPIDU_bc_table_destroy();
-    }
 #if defined HAVE_LIBHCOLL
     hcoll_comm_create(comm, NULL);
 #endif

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -22,8 +22,8 @@ static void request_init_callback(void *request)
 
 }
 
-int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                            MPIR_Comm * comm_self, int *n_vcis_provided)
+int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                            int *n_vcis_provided)
 {
     int mpi_errno = MPI_SUCCESS;
     ucp_config_t *config;

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -81,6 +81,7 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
         int *node_roots = MPIR_Process.node_root_map;
         int num_nodes = MPIR_Process.num_nodes;
+        int *rank_map;
 
         for (i = 0; i < num_nodes; i++) {
             ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
@@ -90,6 +91,22 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                               &MPIDI_UCX_AV(&MPIDIU_get_av(0, node_roots[i])).dest);
             MPIDI_UCX_CHK_STATUS(ucx_status);
         }
+        MPIDU_bc_allgather(init_comm, MPIDI_UCX_global.if_address,
+                           (int) MPIDI_UCX_global.addrname_len, FALSE, (void **) &table, &rank_map,
+                           &recv_bc_len);
+
+        /* insert new addresses, skipping over node roots */
+        for (i = 0; i < MPIR_Process.size; i++) {
+            if (rank_map[i] >= 0) {
+
+                ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+                ep_params.address = (ucp_address_t *) ((char *) table + i * recv_bc_len);
+                ucx_status = ucp_ep_create(MPIDI_UCX_global.worker, &ep_params,
+                                           &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest);
+                MPIDI_UCX_CHK_STATUS(ucx_status);
+            }
+        }
+        MPIDU_bc_table_destroy();
     } else {
         for (i = 0; i < size; i++) {
             ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_noinline.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_noinline.h
@@ -84,8 +84,8 @@ int MPIDI_UCX_mpi_win_free_hook(MPIR_Win * win);
 #endif
 
 /* ucx_init.h */
-int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * comm_world,
-                            MPIR_Comm * comm_self, int *n_vcis_provided);
+int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm,
+                            int *n_vcis_provided);
 int MPIDI_UCX_mpi_finalize_hook(void);
 int MPIDI_UCX_get_vci_attr(int vci);
 void *MPIDI_UCX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -74,7 +74,7 @@ static int choose_posix_eager(void)
 int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i, num_local = 0, local_rank_0 = -1, my_local_rank = -1;
+    int i, local_rank_0 = -1;
 
 #ifdef MPL_USE_DBG_LOGGING
     MPIDI_CH4_SHM_POSIX_GENERAL = MPL_dbg_class_alloc("SHM_POSIX", "shm_posix");
@@ -83,7 +83,7 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     MPIDI_POSIX_global.am_buf_pool =
         MPIDIU_create_buf_pool(MPIDI_POSIX_BUF_POOL_NUM, MPIDI_POSIX_BUF_POOL_SIZE);
 
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL(1);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_INIT_HOOK);
@@ -91,15 +91,18 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     /* Populate these values with transformation information about each rank and its original
      * information in MPI_COMM_WORLD. */
 
-    mpi_errno = MPIR_Find_local(MPIR_Process.comm_world, &num_local, &my_local_rank,
-                                /* comm_world rank of each local process */
-                                &MPIDI_POSIX_global.local_procs,
-                                /* local rank of each process in comm_world if it is on the same node */
-                                &MPIDI_POSIX_global.local_ranks);
-
-    local_rank_0 = MPIDI_POSIX_global.local_procs[0];
-    MPIDI_POSIX_global.num_local = num_local;
-    MPIDI_POSIX_global.my_local_rank = my_local_rank;
+    MPIDI_POSIX_global.local_procs = MPIR_Process.node_local_map;
+    MPIDI_POSIX_global.local_ranks = (int *) MPL_malloc(MPIR_Process.size * sizeof(int),
+                                                        MPL_MEM_SHM);
+    for (i = 0; i < MPIR_Process.size; ++i) {
+        MPIDI_POSIX_global.local_ranks[i] = -1;
+    }
+    for (i = 0; i < MPIR_Process.local_size; i++) {
+        MPIDI_POSIX_global.local_ranks[MPIDI_POSIX_global.local_procs[i]] = i;
+    }
+    local_rank_0 = MPIR_Process.node_local_map[0];
+    MPIDI_POSIX_global.num_local = MPIR_Process.local_size;
+    MPIDI_POSIX_global.my_local_rank = MPIR_Process.local_rank;
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
     *n_vcis_provided = 1;
@@ -155,7 +158,7 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
     MPIR_ERR_CHECK(mpi_errno);
 
     MPL_free(MPIDI_POSIX_global.local_ranks);
-    MPL_free(MPIDI_POSIX_global.local_procs);
+    /* MPL_free(MPIDI_POSIX_global.local_procs); */
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_FINALIZE_HOOK);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -415,8 +415,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
         }
 #endif
 
-        mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits,
-                                           MPIR_Process.comm_world, MPIR_Process.comm_self,
+        mpi_errno = MPIDI_NM_mpi_init_hook(rank, size, appnum, &nm_tag_bits, init_comm,
                                            &n_nm_vcis_provided);
         if (mpi_errno != MPI_SUCCESS) {
             MPIR_ERR_POPFATAL(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -411,11 +411,11 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 
     init_av_table();
 
-    /* setup receive queue statistics */
-    mpi_errno = MPIDIG_recvq_init();
+    mpi_errno = MPIDIG_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIDIG_init();
+    /* setup receive queue statistics */
+    mpi_errno = MPIDIG_recvq_init();
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = create_init_comm(&init_comm);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -338,7 +338,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     }
 #endif
 
-    mpi_errno = MPIDIG_init(MPIR_Process.comm_world, MPIR_Process.comm_self);
+    mpi_errno = MPIDIG_init();
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDU_Init_shm_init();

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -89,6 +89,8 @@ static void print_runtime_configurations(void);
 static int parse_mt_model(const char *name);
 #endif /* #ifdef MPIDI_CH4_USE_MT_RUNTIME */
 static int set_runtime_configurations(void);
+static int create_init_comm(MPIR_Comm **);
+static void destroy_init_comm(MPIR_Comm **);
 
 static int choose_netmod(void)
 {
@@ -200,10 +202,69 @@ static int set_runtime_configurations(void)
     return mpi_errno;
 }
 
+static int create_init_comm(MPIR_Comm ** comm)
+{
+    int i, mpi_errno = MPI_SUCCESS;
+    int world_rank = MPIR_Process.rank;
+    int node_root_rank = MPIR_Process.node_root_map[MPIR_Process.node_map[world_rank]];
+
+    /* if the process is not a node root, exit */
+    if (node_root_rank == world_rank) {
+        int node_roots_comm_size = MPIR_Process.num_nodes;
+        int node_roots_comm_rank = MPIR_Process.node_map[world_rank];
+        MPIR_Comm *init_comm = NULL;
+        MPIDI_rank_map_lut_t *lut = NULL;
+        MPIR_Comm_create(&init_comm);
+        init_comm->context_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+        init_comm->recvcontext_id = 0 << MPIR_CONTEXT_PREFIX_SHIFT;
+        init_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+        init_comm->rank = node_roots_comm_rank;
+        init_comm->remote_size = node_roots_comm_size;
+        init_comm->local_size = node_roots_comm_size;
+        init_comm->coll.pof2 = MPL_pof2(node_roots_comm_size);
+        MPIDI_COMM(init_comm, map).mode = MPIDI_RANK_MAP_LUT_INTRA;
+        mpi_errno = MPIDIU_alloc_lut(&lut, node_roots_comm_size);
+        MPIR_ERR_CHECK(mpi_errno);
+        MPIDI_COMM(init_comm, map).size = node_roots_comm_size;
+        MPIDI_COMM(init_comm, map).avtid = 0;
+        MPIDI_COMM(init_comm, map).irreg.lut.t = lut;
+        MPIDI_COMM(init_comm, map).irreg.lut.lpid = lut->lpid;
+        MPIDI_COMM(init_comm, local_map).mode = MPIDI_RANK_MAP_NONE;
+        for (i = 0; i < node_roots_comm_size; ++i) {
+            lut->lpid[i] = MPIR_Process.node_root_map[i];
+        }
+        mpi_errno = MPIDIG_init_comm(init_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        *comm = init_comm;
+    }
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void destroy_init_comm(MPIR_Comm ** comm_ptr)
+{
+    int in_use;
+    MPIR_Comm *comm = NULL;
+    if (*comm_ptr != NULL) {
+        comm = *comm_ptr;
+        MPIDIU_release_lut(MPIDI_COMM(comm, map).irreg.lut.t);
+        MPIDIG_destroy_comm(comm);
+        MPIR_Object_release_ref(comm, &in_use);
+        MPIR_Assert(MPIR_Object_get_ref(comm) == 0);
+        MPII_COMML_FORGET(comm);
+        MPIR_Handle_obj_free(&MPIR_Comm_mem, comm);
+        *comm_ptr = NULL;
+    }
+}
+
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum, thr_err;
     int avtid;
+    MPIR_Comm *init_comm = NULL;
     int n_nm_vcis_provided;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     int n_shm_vcis_provided;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -378,7 +378,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     int i;
-    for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
+    for (i = 0; i < size; i++) {
         MPIDI_av_table0->table[i].is_local = 0;
     }
     MPIDI_global.max_node_id = MPIR_Process.num_nodes - 1;
@@ -386,16 +386,15 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "MPIDI_global.max_node_id = %d", MPIDI_global.max_node_id));
 
-    for (i = 0; i < MPIR_Process.comm_world->local_size; i++) {
+    for (i = 0; i < size; i++) {
         MPIDI_av_table0->table[i].is_local =
-            (MPIDI_global.node_map[0][i] ==
-             MPIDI_global.node_map[0][MPIR_Process.comm_world->rank]) ? 1 : 0;
+            (MPIDI_global.node_map[0][i] == MPIDI_global.node_map[0][rank]) ? 1 : 0;
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "WORLD RANK %d %s local", i,
                          MPIDI_av_table0->table[i].is_local ? "is" : "is not"));
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "Node id (i) (me) %d %d", MPIDI_global.node_map[0][i],
-                         MPIDI_global.node_map[0][MPIR_Process.comm_world->rank]));
+                         MPIDI_global.node_map[0][rank]));
     }
 #endif
 

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -20,17 +20,8 @@ int MPIDIG_init_comm(MPIR_Comm * comm)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_INIT_COMM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_INIT_COMM);
 
-    /*
-     * Prevents double initialization of some special communicators.
-     *
-     * comm_world and comm_self may exhibit this function twice, first during MPIDIG_init
-     * and the second during MPIR_Comm_commit in MPID_Init.
-     * If there is an early arrival of an unexpected message before the second visit,
-     * the following code will wipe out the unexpected queue andthe message is lost forever.
-     */
-    if (unlikely(MPIDI_global.is_ch4u_initialized &&
-                 (comm == MPIR_Process.comm_world || comm == MPIR_Process.comm_self)))
-        goto fn_exit;
+    MPIR_Assert(MPIDI_global.is_ch4u_initialized);
+
     if (MPIR_CONTEXT_READ_FIELD(DYNAMIC_PROC, comm->recvcontext_id))
         goto fn_exit;
 

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -37,7 +37,7 @@ int MPIDU_bc_table_destroy(void)
 }
 
 /* allgather (local_size - 1) bc over node roots */
-int MPIDU_bc_allgather(void *bc, int bc_len, int same_len,
+int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int same_len,
                        void **bc_table, int **bc_ranks, int *ret_bc_len)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -113,7 +113,6 @@ int MPIDU_bc_allgather(void *bc, int bc_len, int same_len,
     void *recv_buf = segment + local_size * recv_bc_len;
     if (rank == node_root) {
         MPIR_Errflag_t errflag = MPIR_ERR_NONE;
-        MPIR_Comm *allgather_comm = MPIR_Process.comm_world->node_roots_comm;
         MPIR_Allgatherv_fallback(segment, local_size * recv_bc_len, MPI_BYTE, recv_buf,
                                  recv_cnts, recv_offs, MPI_BYTE, allgather_comm, &errflag);
 

--- a/src/mpid/common/bc/mpidu_bc.h
+++ b/src/mpid/common/bc/mpidu_bc.h
@@ -13,7 +13,7 @@
 int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len, int same_len,
                           int roots_only, void **bc_table, int *ret_bc_len);
 int MPIDU_bc_table_destroy(void);
-int MPIDU_bc_allgather(void *bc, int bc_len, int same_len,
+int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int same_len,
                        void **bc_table, int **rank_map, int *ret_bc_len);
 
 #endif /* MPIDU_BC_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

This PR is a set of commits that addresses the dependency mess in MPID_Init_hook. It introduces an init_comm that is manually initialized just for init time communication. It is removed before creating the builtin communicators. With this special comm, all the BC exchange can be done on it without introducing weird dependencies with other parts of the code.

Third time's a charm.

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
