### PR TITLE
shm: cleanup MPIDU_Init_shm_init interface

### DIFF
--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -230,7 +230,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 #endif  /*FORCE_ASYM */
 
     /* Initialize core shared memory segment */
-    mpi_errno = MPIDU_Init_shm_init(MPIR_Process.rank, MPIR_Process.size, MPIR_Process.node_map);
+    mpi_errno = MPIDU_Init_shm_init();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Request fastboxes region */

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -341,7 +341,7 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     mpi_errno = MPIDIG_init(MPIR_Process.comm_world, MPIR_Process.comm_self);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIDU_Init_shm_init(rank, size, MPIDI_global.node_map[0]);
+    mpi_errno = MPIDU_Init_shm_init();
     MPIR_ERR_CHECK(mpi_errno);
 
     {

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -5,7 +5,6 @@
  */
 #include <mpidimpl.h>
 #include "mpidu_init_shm.h"
-#include "mpir_nodemap.h"
 #include "mpl_shm.h"
 #include "mpidimpl.h"
 #include "mpidu_shm.h"
@@ -76,10 +75,11 @@ static int Init_shm_barrier()
     return mpi_errno;
 }
 
-int MPIDU_Init_shm_init(int rank, int size, int *nodemap)
+int MPIDU_Init_shm_init(void)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
     int local_leader;
+    int rank;
 #ifdef OPA_USE_LOCK_BASE_PRIMITIVES
     int ret;
     int ipc_lock_offset;
@@ -93,7 +93,10 @@ int MPIDU_Init_shm_init(int rank, int size, int *nodemap)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDU_INIT_SHM_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDU_INIT_SHM_INIT);
 
-    MPIR_NODEMAP_get_local_info(rank, size, nodemap, &local_size, &my_local_rank, &local_leader);
+    rank = MPIR_Process.rank;
+    local_size = MPIR_Process.local_size;
+    my_local_rank = MPIR_Process.local_rank;
+    local_leader = MPIR_Process.node_local_map[0];
 
     char *serialized_hnd = NULL;
     int serialized_hnd_size = 0;

--- a/src/mpid/common/shm/mpidu_init_shm.h
+++ b/src/mpid/common/shm/mpidu_init_shm.h
@@ -14,7 +14,7 @@ typedef struct MPIDU_Init_shm_block {
     char block[MPIDU_SHM_CACHE_LINE_LEN * 16];
 } MPIDU_Init_shm_block_t;
 
-int MPIDU_Init_shm_init(int rank, int size, int *nodemap);
+int MPIDU_Init_shm_init(void);
 int MPIDU_Init_shm_finalize(void);
 int MPIDU_Init_shm_barrier(void);
 int MPIDU_Init_shm_put(void *orig, size_t len);


### PR DESCRIPTION
`MPIDU_Init_shm_init` function currently uses `MPIR_NODEMAP_get_local_info`
to retrieve node information for local processes. However, such
information is also provided through MPIR_Process directly and thus
there is no need for calling `MPIR_NODEMAP_get_local_info`. Remove it and
use MPIR_Process info instead.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
