### PR TITLE
nodemap: remove reference to MPIR_NODEMAP_ utils

### DIFF
--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -849,18 +849,14 @@ int MPIDI_Populate_vc_node_ids(MPIDI_PG_t *pg, int our_pg_rank)
     int mpi_errno = MPI_SUCCESS;
     int i;
     int *out_nodemap;
-    out_nodemap = (int *) MPL_malloc(pg->size * sizeof(int), MPL_MEM_ADDRESS);
-
-    mpi_errno = MPIR_NODEMAP_build_nodemap(pg->size, our_pg_rank, out_nodemap, &g_max_node_id);
-    MPIR_ERR_CHECK(mpi_errno);
-    MPIR_Assert(g_max_node_id >= 0);
+    out_nodemap = MPIR_Process.node_map;
+    g_max_node_id = MPIR_Process.size - 1;
 
     for (i = 0; i < pg->size; i++) {
         pg->vct[i].node_id = out_nodemap[i];
     }
 
 fn_exit:
-    MPL_free(out_nodemap);
     return mpi_errno;
 fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -875,9 +875,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         /* Table is constructed.  Map it    */
         /* -------------------------------- */
         if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-            int *node_roots, num_nodes;
-
-            MPIR_NODEMAP_get_node_roots(MPIDI_global.node_map[0], size, &node_roots, &num_nodes);
+            int num_nodes = MPIR_Process.num_nodes;
+            int *node_roots = MPIR_Process.node_root_map;
             mapped_table = (fi_addr_t *) MPL_malloc(num_nodes * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
             MPIDI_OFI_CALL(fi_av_insert
                            (MPIDI_OFI_global.av, table, num_nodes, mapped_table, 0ULL, NULL),
@@ -894,7 +893,6 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 #endif
             }
             MPL_free(mapped_table);
-            MPL_free(node_roots);
         } else {
             mapped_table = (fi_addr_t *) MPL_malloc(size * sizeof(fi_addr_t), MPL_MEM_ADDRESS);
             MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.av, table, size, mapped_table, 0ULL, NULL),

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -79,9 +79,9 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
     MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        int *node_roots, num_nodes;
+        int *node_roots = MPIR_Process.node_root_map;
+        int num_nodes = MPIR_Process.num_nodes;
 
-        MPIR_NODEMAP_get_node_roots(MPIDI_global.node_map[0], size, &node_roots, &num_nodes);
         for (i = 0; i < num_nodes; i++) {
             ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
             ep_params.address = (ucp_address_t *) ((char *) table + i * recv_bc_len);
@@ -90,7 +90,6 @@ int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                               &MPIDI_UCX_AV(&MPIDIU_get_av(0, node_roots[i])).dest);
             MPIDI_UCX_CHK_STATUS(ucx_status);
         }
-        MPL_free(node_roots);
     } else {
         for (i = 0; i < size; i++) {
             ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;

--- a/src/mpid/ch4/shm/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_init.c
@@ -13,8 +13,7 @@
 int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag_bits)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i, my_local_rank = -1, num_local = 0;
-    int local_rank_0 = -1;
+    int i;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_INIT_HOOK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_INIT_HOOK);
@@ -31,10 +30,9 @@ int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     MPIR_ERR_CHKANDJUMP(MPIDI_XPMEM_global.segid == -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_make");
     XPMEM_TRACE("init: make segid: 0x%lx\n", (uint64_t) MPIDI_XPMEM_global.segid);
 
-    MPIR_NODEMAP_get_local_info(rank, size, MPIDI_global.node_map[0], &num_local,
-                                &my_local_rank, &local_rank_0);
+    int num_local = MPIR_Process.local_size;
     MPIDI_XPMEM_global.num_local = num_local;
-    MPIDI_XPMEM_global.local_rank = my_local_rank;
+    MPIDI_XPMEM_global.local_rank = MPIR_Process.local_rank;
     MPIDI_XPMEM_global.node_group_ptr = NULL;
 
     MPIDU_Init_shm_put(&MPIDI_XPMEM_global.segid, sizeof(xpmem_segid_t));

--- a/src/mpid/ch4/src/ch4r_proc.c
+++ b/src/mpid/ch4/src/ch4r_proc.c
@@ -48,7 +48,8 @@ int MPIDIU_build_nodemap(int myrank, MPIR_Comm * comm, int sz, int *out_nodemap,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIU_BUILD_NODEMAP);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIU_BUILD_NODEMAP);
 
-    ret = MPIR_NODEMAP_build_nodemap(sz, myrank, out_nodemap, sz_out);
+    /* The nodemap is built in MPIR_pmi_init. Runtime rebuilding node_map not supported */
+    MPIR_Assert(0);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIU_BUILD_NODEMAP);
     return ret;


### PR DESCRIPTION
## Pull Request Description
MPIR_pmi_init already built node_map, so we no longer need
MPIR_NODEMAP_build_nodemap. Building the nodemap twice will crash
process managers that doesn't support process_mappings, such as gforker,
due to "put"ing the same key twice.

The remaining places that we still reference `MPIR_NODEMAP_` routines directly are also outdated. So they are either replaced or removed.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
