### PR TITLE
runtests: silence the error output in CleanUpAfterRunning

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -1002,15 +1002,17 @@ sub CleanUpAfterRun {
     @stillRunning = &FindRunning( $programname );
 
     if ($#stillRunning > -1) {
-        print STDERR "Some programs ($programname) may still be running:\npids = ";
-        for (my $i=0; $i <= $#stillRunning; $i++ ) {
-            print STDERR $stillRunning[$i] . " ";
+        if ($verbose) {
+            print STDERR "Some programs ($programname) may still be running:\npids = ";
+            for (my $i=0; $i <= $#stillRunning; $i++ ) {
+                print STDERR $stillRunning[$i] . " ";
+            }
+            print STDERR "\n";
+            # Remind the user that the executable remains; we leave it around
+            # to allow the programmer to debug the running program, for which
+            # the executable is needed.
+            print STDERR "The executable ($programname) will not be removed.\n";
         }
-        print STDERR "\n";
-        # Remind the user that the executable remains; we leave it around
-        # to allow the programmer to debug the running program, for which
-        # the executable is needed.
-        print STDERR "The executable ($programname) will not be removed.\n";
     }
     else {
         if ($remove_this_pgm && $clean_pgms) {


### PR DESCRIPTION

## Pull Request Description
`runtests` checks for running processes at the end of each tests and outputs messages when it think processes are still running. This check is not robust, especially when multiple tests are running simultaneously. Disable the error output by default to reduce the noise. The error output is still enabled in verbose mode.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes

## Known Issues

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Passes tests (included warning check)
* [ ] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
