### PR TITLE
hydra2: Base implementation of timeout functionality

### DIFF
--- a/src/pm/hydra2/libhydra/Makefile.mk
+++ b/src/pm/hydra2/libhydra/Makefile.mk
@@ -27,3 +27,4 @@ include libhydra/hostfile/Makefile.mk
 include libhydra/rmk/Makefile.mk
 include libhydra/hash/Makefile.mk
 include libhydra/debugger/Makefile.mk
+include libhydra/timeout/Makefile.mk

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.c.in
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.c.in
@@ -14,6 +14,7 @@
 #include "hydra_err.h"
 #include "hydra_mem.h"
 #include "hydra_hash.h"
+#include "hydra_timeout.h"
 #include "utlist.h"
 
 /* *INDENT-OFF* */
@@ -113,7 +114,7 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
                             struct HYD_int_hash **downstream_stdout_hash,
                             struct HYD_int_hash **downstream_stderr_hash,
                             struct HYD_int_hash **downstream_fd_hash, int **downstream_proxy_id,
-                            int **downstream_pid, int debug, int tree_width)
+                            int **downstream_pid, int debug, int tree_width, int time_left)
 {
     char *targs[HYD_NUM_TMP_STRINGS] = { NULL };
     char *tmp[HYD_NUM_TMP_STRINGS] = { NULL };
@@ -131,9 +132,12 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
     struct HYD_int_hash *hash, *thash;
     struct HYD_int_hash *fd_stdout_hash = NULL;
     struct HYD_int_hash *fd_stderr_hash = NULL;
+    struct timeout_s timeout;
     HYD_status status = HYD_SUCCESS;
 
     HYD_FUNC_ENTER();
+
+    HYD_init_timeout(time_left, &timeout);
 
     /* create the bstrap proxy string */
     i = 0;
@@ -257,6 +261,8 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
             targs[i++] = HYD_str_from_int(subtree_size);
             targs[i++] = MPL_strdup("--tree-width");
             targs[i++] = HYD_str_from_int(tree_width);
+            targs[i++] = MPL_strdup("--time-left");
+            targs[i++] = HYD_str_from_int(HYD_get_time_left(&timeout));
             if (debug)
                 targs[i++] = MPL_strdup("--debug");
             if (pmi_args)
@@ -311,6 +317,8 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
             targs[i++] = HYD_str_from_int(subtree_size);
             targs[i++] = MPL_strdup("--tree-width");
             targs[i++] = HYD_str_from_int(tree_width);
+            targs[i++] = MPL_strdup("--time-left");
+            targs[i++] = HYD_str_from_int(HYD_get_time_left(&timeout));
             if (debug)
                 targs[i++] = MPL_strdup("--debug");
             if (pmi_args)
@@ -352,7 +360,14 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
     /* our immediate children have been launched.  wait for them to
      * connect back. */
     while (bstrap_control->current_downstreams < bstrap_control->total_downstreams) {
-        status = HYD_dmx_wait_for_event(-1);
+        status = HYD_dmx_wait_for_event(HYD_get_time_left(&timeout));
+
+        if (status == HYD_ERR_TIMED_OUT) {
+            HYD_dmx_deregister_fd(listen_fd);
+            close(listen_fd);
+            goto fn_fail;
+        }
+
         HYD_ERR_POP(status, "error waiting for event\n");
     }
 

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.h
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap.h
@@ -21,7 +21,7 @@ HYD_status HYD_bstrap_setup(const char *path, const char *launcher, const char *
                             struct HYD_int_hash **downstream_stderr_hash,
                             struct HYD_int_hash **downstream_control_hash,
                             int **downstream_proxy_id, int **downstream_pid, int debug,
-                            int tree_width);
+                            int tree_width, int time_left);
 
 HYD_status HYD_bstrap_finalize(const char *launcher);
 

--- a/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
+++ b/src/pm/hydra2/libhydra/bstrap/src/hydra_bstrap_proxy.c
@@ -13,6 +13,7 @@
 #include "hydra_mem.h"
 #include "hydra_node.h"
 #include "hydra_hash.h"
+#include "hydra_timeout.h"
 
 static const char *upstream_host = NULL;
 static int upstream_port = -1;
@@ -40,6 +41,7 @@ static int *downstream_pid = NULL;
 static int debug = 0;
 
 static const char *localhost = NULL;
+static struct timeout_s timeout;
 
 static HYD_status get_params(int argc, char **argv)
 {
@@ -94,6 +96,10 @@ static HYD_status get_params(int argc, char **argv)
             ++argv;
             --argc;
             tree_width = atoi(*argv);
+        } else if (!strcmp(*argv, "--time-left")) {
+            ++argv;
+            --argc;
+            HYD_init_timeout(atoi(*argv), &timeout);
         } else if (!strcmp(*argv, "--debug")) {
             debug = 1;
         } else {
@@ -204,6 +210,7 @@ static HYD_status upstream_cb(int fd, HYD_dmx_event_t events, void *userp)
         /* launch the remaining bstrap proxies in this subtree */
         if (subtree_size > 1) {
             struct HYD_int_hash *hash, *thash;
+            int time_left = HYD_get_time_left(&timeout);
 
             status =
                 HYD_bstrap_setup(base_path, launcher, launcher_exec, subtree_size - 1,
@@ -211,7 +218,12 @@ static HYD_status upstream_cb(int fd, HYD_dmx_event_t events, void *userp)
                                  &num_downstream_proxies, &downstream_stdin,
                                  &downstream_stdout_hash, &downstream_stderr_hash,
                                  &downstream_control_hash, &downstream_proxy_id, &downstream_pid,
-                                 debug, tree_width);
+                                 debug, tree_width, time_left);
+
+            if (status == HYD_ERR_TIMED_OUT) {
+                goto fn_fail;
+            }
+
             HYD_ERR_POP(status, "error setting up the bstrap proxies\n");
 
             HYD_MALLOC(downstream_control, int *, num_downstream_proxies * sizeof(int), status);

--- a/src/pm/hydra2/libhydra/timeout/Makefile.mk
+++ b/src/pm/hydra2/libhydra/timeout/Makefile.mk
@@ -1,0 +1,8 @@
+## -*- Mode: Makefile; -*-
+
+AM_CPPFLAGS += -I$(top_srcdir)/libhydra/timeout
+
+noinst_HEADERS += libhydra/timeout/hydra_timeout.h
+
+libhydra_la_SOURCES += \
+	libhydra/timeout/hydra_timeout.c

--- a/src/pm/hydra2/libhydra/timeout/hydra_timeout.c
+++ b/src/pm/hydra2/libhydra/timeout/hydra_timeout.c
@@ -1,0 +1,82 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+/*
+    Copyright 2019 Intel Corporation.
+
+    This software and the related documents are Intel copyrighted materials, and
+    your use of them is governed by the express license under which they were
+    provided to you (License). Unless the License provides otherwise, you may
+    not use, modify, copy, publish, distribute, disclose or transmit this
+    software or the related documents without Intel's prior written permission.
+
+    This software and the related documents are provided as is, with no express
+    or implied warranties, other than those that are expressly stated in the
+    License.
+*/
+
+#include "hydra_timeout.h"
+#include "hydra_err.h"
+
+static time_t get_current_time(void)
+{
+    return time(NULL);
+}
+
+void HYD_init_timeout(int sec, struct timeout_s *timeout)
+{
+    timeout->sec = sec;
+
+    if (timeout->sec >= 0) {
+        timeout->start_time = get_current_time();
+    }
+}
+
+void HYD_set_alarm(struct timeout_s *timeout)
+{
+#ifdef HAVE_ALARM
+    alarm(timeout->sec);
+#endif /* HAVE_ALARM */
+    timeout->start_time = get_current_time();
+}
+
+void HYD_handle_sigalrm(struct timeout_s *timeout)
+{
+    timeout->timed_out = 1;
+}
+
+int HYD_get_timeout_signal(struct timeout_s *timeout)
+{
+    return (timeout->signal > 0) ? timeout->signal : SIGKILL;
+}
+
+int HYD_get_time_left(struct timeout_s *timeout)
+{
+    if (timeout->start_time <= 0) {
+        return -1;
+    }
+
+    int time_diff = (int) difftime(get_current_time(), timeout->start_time);
+
+    int time_left = timeout->sec - time_diff;
+    return (time_left > 0) ? time_left : 0;
+}
+
+void HYD_check_timed_out(struct timeout_s *timeout, int *exit_status)
+{
+    if (!timeout->timed_out) {
+        return;
+    }
+
+    HYD_print_timeout_message(timeout);
+    *exit_status |= 1;
+}
+
+void HYD_print_timeout_message(struct timeout_s *timeout)
+{
+    HYD_PRINT_NOPREFIX(stdout,
+                       "MPIEXEC_TIMEOUT = %d second(s): job ending due to application timeout\n",
+                       timeout->sec);
+}

--- a/src/pm/hydra2/libhydra/timeout/hydra_timeout.h
+++ b/src/pm/hydra2/libhydra/timeout/hydra_timeout.h
@@ -1,0 +1,42 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2017 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+/*
+    Copyright 2019 Intel Corporation.
+
+    This software and the related documents are Intel copyrighted materials, and
+    your use of them is governed by the express license under which they were
+    provided to you (License). Unless the License provides otherwise, you may
+    not use, modify, copy, publish, distribute, disclose or transmit this
+    software or the related documents without Intel's prior written permission.
+
+    This software and the related documents are provided as is, with no express
+    or implied warranties, other than those that are expressly stated in the
+    License.
+*/
+
+#ifndef HYDRA_TIMEOUT_H
+#define HYDRA_TIMEOUT_H
+
+#include <time.h>
+
+#include "hydra_base.h"
+
+struct timeout_s {
+    int sec;
+    int signal;
+    int timed_out;
+    time_t start_time;
+};
+
+void HYD_init_timeout(int sec, struct timeout_s *timeout);
+void HYD_set_alarm(struct timeout_s *timeout);
+void HYD_handle_sigalrm(struct timeout_s *timeout);
+int HYD_get_time_left(struct timeout_s *timeout);
+int HYD_get_timeout_signal(struct timeout_s *timeout);
+void HYD_check_timed_out(struct timeout_s *timeout, int *exit_status);
+void HYD_print_timeout_message(struct timeout_s *timeout);
+
+#endif /* HYDRA_TIMEOUT_H */

--- a/src/pm/hydra2/mpiexec/mpiexec.c
+++ b/src/pm/hydra2/mpiexec/mpiexec.c
@@ -38,7 +38,13 @@ struct mpiexec_params_s mpiexec_params = {
 
     .ppn = -1,
     .print_all_exitcodes = -1,
-    .timeout = -1,
+
+    .timeout = {
+        .sec = -1,
+        .signal = -1,
+        .timed_out = 0,
+        .start_time = 0,
+    },
 
     .envprop = MPIEXEC_ENVPROP__UNSET,
     .envlist_count = 0,
@@ -87,19 +93,23 @@ static void signal_cb(int signum)
     /* SIGINT is a partially special signal. The first time we see it,
      * we will send it to the processes. The next time, we will treat
      * it as a SIGKILL (user convenience to force kill processes). */
-    if (signum == SIGINT && ++sigint_count > 1)
+    if (signum == SIGINT && ++sigint_count > 1) {
         exit(1);
-    else if (signum == SIGINT) {
+    } else if (signum == SIGINT) {
         /* First Ctrl-C */
         HYD_PRINT(stdout, "Sending Ctrl-C to processes as requested\n");
         HYD_PRINT(stdout, "Press Ctrl-C again to force abort\n");
+    } else if (signum == SIGALRM) {
+        HYD_handle_sigalrm(&mpiexec_params.timeout);
+        if (mpiexec_params.timeout.timed_out) {
+            cmd.signum = HYD_get_timeout_signal(&mpiexec_params.timeout);
+        }
     }
 
     HYD_sock_write(mpiexec_params.signal_pipe[0], &cmd, sizeof(cmd), &sent, &closed,
                    HYD_SOCK_COMM_TYPE__BLOCKING);
 
     HYD_FUNC_EXIT();
-    return;
 }
 
 static HYD_status cmd_bcast_root(struct MPX_cmd cmd, struct mpiexec_pg *pg, void *buf)
@@ -744,7 +754,9 @@ int main(int argc, char **argv)
     status = mpiexec_get_parameters(argv);
     HYD_ERR_POP(status, "error parsing parameters\n");
 
-    MPL_env2int("MPIEXEC_TIMEOUT", &mpiexec_params.timeout);
+    if (mpiexec_params.timeout.sec > 0) {
+        HYD_set_alarm(&mpiexec_params.timeout);
+    }
 
     if (MPL_env2str("MPIEXEC_PORTRANGE", (const char **) &mpiexec_params.port_range) ||
         MPL_env2str("MPIEXEC_PORT_RANGE", (const char **) &mpiexec_params.port_range))
@@ -835,6 +847,8 @@ int main(int argc, char **argv)
     args[i++] = HYD_str_from_int(mpiexec_params.usize);
     args[i++] = NULL;
 
+    int time_left = HYD_get_time_left(&mpiexec_params.timeout);
+
     status =
         HYD_bstrap_setup(mpiexec_params.base_path, mpiexec_params.launcher,
                          mpiexec_params.launcher_exec, pg->node_count, pg->node_list, -1,
@@ -842,7 +856,15 @@ int main(int argc, char **argv)
                          &pg->downstream.fd_stdin, &pg->downstream.fd_stdout_hash,
                          &pg->downstream.fd_stderr_hash, &pg->downstream.fd_control_hash,
                          &pg->downstream.proxy_id, &pg->downstream.pid, mpiexec_params.debug,
-                         mpiexec_params.tree_width);
+                         mpiexec_params.tree_width, time_left);
+
+    if (status == HYD_ERR_TIMED_OUT) {
+        mpiexec_params.timeout.timed_out = 1;
+        HYD_print_timeout_message(&mpiexec_params.timeout);
+        exit_status |= 1;
+        goto fn_fail;
+    }
+
     HYD_ERR_POP(status, "error setting up the boostrap proxies\n");
 
     HYD_str_free_list(args);
@@ -928,13 +950,20 @@ int main(int argc, char **argv)
         }
     }
 
+    HYD_check_timed_out(&mpiexec_params.timeout, &exit_status);
+
     /* Print exitcodes if necessary */
     if (mpiexec_params.print_all_exitcodes) {
         HYD_PRINT(stdout, "Exit codes: ");
     }
-    exit_status = 0;
+
     for (i = 0; i < pg->num_downstream; i++) {
         char *curr_nodename = NULL;
+
+        /* Time out could occur at startup. So, exitcodes might not be collected */
+        if (mpiexec_params.timeout.timed_out && !exitcodes) {
+            break;
+        }
 
         /* We didn't receive the exit status for this proxy */
         HYD_ASSERT(exitcodes != NULL, status);

--- a/src/pm/hydra2/mpiexec/mpiexec.h
+++ b/src/pm/hydra2/mpiexec/mpiexec.h
@@ -7,6 +7,7 @@
 #ifndef MPIEXEC_H_INCLUDED
 #define MPIEXEC_H_INCLUDED
 
+#include "hydra_timeout.h"
 #include "uthash.h"
 
 #define MPIEXEC_USIZE__UNSET     (0)
@@ -54,7 +55,7 @@ struct mpiexec_params_s {
     int ppn;
     int print_all_exitcodes;
 
-    int timeout;
+    struct timeout_s timeout;
 
     enum {
         MPIEXEC_ENVPROP__UNSET = 0,

--- a/src/pm/hydra2/mpiexec/mpiexec_params.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_params.c
@@ -843,13 +843,57 @@ static HYD_status tree_width_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
+static HYD_status read_default_env()
+{
+    char *tstr;
+    HYD_status status = HYD_SUCCESS;
+
+    /* check if there is an environment set for the hostfile */
+    if (mpiexec_params.global_node_count == 0) {
+        tstr = NULL;
+        MPL_env2str("HYDRA_HOST_FILE", (const char **) &tstr);
+        if (tstr) {
+            status =
+                HYD_hostfile_parse(tstr, &mpiexec_params.global_node_count,
+                                   &mpiexec_params.global_node_list, HYD_hostfile_process_tokens);
+            HYD_ERR_POP(status, "error parsing hostfile\n");
+        }
+    }
+
+    /* check if there is an environment set for the RMK */
+    if (mpiexec_params.rmk == NULL) {
+        if (MPL_env2str("HYDRA_RMK", (const char **) &mpiexec_params.rmk))
+            mpiexec_params.rmk = MPL_strdup(mpiexec_params.rmk);
+    }
+
+    /* check if there's an environment set for PPN */
+    if (mpiexec_params.ppn == -1) {
+        tstr = NULL;
+        if (MPL_env2str("HYDRA_PPN", (const char **) &tstr))
+            mpiexec_params.ppn = atoi(tstr);
+    }
+
+    if (mpiexec_params.timeout.sec == -1) {
+        MPL_env2int("MPIEXEC_TIMEOUT", &mpiexec_params.timeout.sec);
+    }
+
+    if (mpiexec_params.timeout.signal == -1) {
+        MPL_env2int("MPIEXEC_TIMEOUT_SIGNAL", &mpiexec_params.timeout.signal);
+    }
+
+  fn_exit:
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 HYD_status mpiexec_get_parameters(char **t_argv)
 {
     char **argv = t_argv;
     char *progname = *argv;
     char *post, *loc, *tmp[HYD_NUM_TMP_STRINGS];
     struct HYD_exec *exec;
-    char *tstr;
     int i;
     HYD_status status = HYD_SUCCESS;
 
@@ -890,35 +934,10 @@ HYD_status mpiexec_get_parameters(char **t_argv)
         } while (++argv && *argv);
     } while (1);
 
-
-
     /***** ENVIRONMENT-SET PARAMETERS ****/
 
-    /* check if there is an environment set for the hostfile */
-    if (mpiexec_params.global_node_count == 0) {
-        tstr = NULL;
-        MPL_env2str("HYDRA_HOST_FILE", (const char **) &tstr);
-        if (tstr) {
-            status =
-                HYD_hostfile_parse(tstr, &mpiexec_params.global_node_count,
-                                   &mpiexec_params.global_node_list, HYD_hostfile_process_tokens);
-            HYD_ERR_POP(status, "error parsing hostfile\n");
-        }
-    }
-
-    /* check if there is an environment set for the RMK */
-    if (mpiexec_params.rmk == NULL) {
-        if (MPL_env2str("HYDRA_RMK", (const char **) &mpiexec_params.rmk))
-            mpiexec_params.rmk = MPL_strdup(mpiexec_params.rmk);
-    }
-
-    /* check if there's an environment set for PPN */
-    if (mpiexec_params.ppn == -1) {
-        tstr = NULL;
-        if (MPL_env2str("HYDRA_PPN", (const char **) &tstr))
-            mpiexec_params.ppn = atoi(tstr);
-    }
-
+    status = read_default_env();
+    HYD_ERR_POP(status, "read default env error\n");
 
     /***** AUTO-DETECT/COMPUTE PARAMETERS ****/
 


### PR DESCRIPTION
Calling alarm function to get SIGALRM signal if timed out and sending signal to proxies to kill application's processes. Also time left is passed to HYD_bstrap_setup() to check timed out in startup.

