### PR TITLE
ch4: default to VCI thread granularity

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1456,6 +1456,9 @@ fi
 # Check for value thread_cs choice; set the refcount default if necessary
 thread_granularity=MPICH_THREAD_GRANULARITY__SINGLE
 thread_refcount=MPICH_REFCOUNT__NONE
+if test "$device_name" = "ch4" ; then
+    enable_thread_cs="per-vci"
+fi
 if test "$enable_threads" = "multiple" ; then
     case $enable_thread_cs in
     global)

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -19,6 +19,24 @@
 #define DYNPROC_RECEIVER 0
 #define DYNPROC_SENDER 1
 
+/* The normal progress is protected with vci_lock, the progress here is not and it needs to.
+ * We customized the OFI PROGRESS macros here to add the vci_locks as a work-around.
+ * FIXME: what is wrong is the yielding of MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX. Lower-layer
+ *        does not know and should not know what outer-layer lock has been taken.
+ *        If structured properly, there shouldn't be yield.
+ */
+#define _fixme_MPIDI_OFI_PROGRESS()                                      \
+    do {                                                          \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);         \
+        mpi_errno = MPIDI_OFI_progress(0, 0);                     \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
+        MPIR_ERR_CHECK(mpi_errno);                                \
+        MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
+    } while (0)
+
+#define _fixme_MPIDI_OFI_PROGRESS_WHILE(cond)                 \
+    while (cond) _fixme_MPIDI_OFI_PROGRESS()
+
 static void free_port_name_tag(int tag);
 static int get_port_name_tag(int *port_name_tag);
 static int get_tag_from_port(const char *port_name, int *port_name_tag);
@@ -320,7 +338,7 @@ static int dynproc_handshake(int root, int phase, int timeout, int port_id, fi_a
                                           match_bits,
                                           (void *) &req.context), tsenddata, FALSE /* eagain */);
 
-        MPIDI_OFI_PROGRESS_WHILE(!req.done);
+        _fixme_MPIDI_OFI_PROGRESS_WHILE(!req.done);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DYNPROC_HANDSHAKE);
@@ -377,7 +395,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
             MPIDI_OFI_CALL(fi_trecvmsg
                            (MPIDI_OFI_global.ctx[0].rx, &msg,
                             FI_PEEK | FI_COMPLETION | FI_REMOTE_CQ_DATA), trecv);
-            MPIDI_OFI_PROGRESS_WHILE(req[0].done == MPIDI_OFI_PEEK_START);
+            _fixme_MPIDI_OFI_PROGRESS_WHILE(req[0].done == MPIDI_OFI_PEEK_START);
         }
 
         *remote_size = req[0].msglen / sizeof(size_t);
@@ -401,7 +419,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                       NULL,
                                       FI_ADDR_UNSPEC,
                                       match_bits, mask_bits, &req[0].context), trecv, FALSE);
-        MPIDI_OFI_PROGRESS_WHILE(!req[0].done);
+        _fixme_MPIDI_OFI_PROGRESS_WHILE(!req[0].done);
 
         for (i = 0; i < (*remote_size); i++)
             remote_upid_recvsize += (*remote_upid_size)[i];
@@ -422,7 +440,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                       FI_ADDR_UNSPEC,
                                       match_bits, mask_bits, &req[2].context), trecv, FALSE);
 
-        MPIDI_OFI_PROGRESS_WHILE(!req[1].done || !req[2].done);
+        _fixme_MPIDI_OFI_PROGRESS_WHILE(!req[1].done || !req[2].done);
         size_t disp = 0;
         for (i = 0; i < req[0].source; i++)
             disp += (*remote_upid_size)[i];
@@ -479,7 +497,7 @@ static int dynproc_exchange_map(int root, int phase, int port_id, fi_addr_t * co
                                           (void *) &req[2].context),
                              tsenddata, FALSE /* eagain */);
 
-        MPIDI_OFI_PROGRESS_WHILE(!req[0].done || !req[1].done || !req[2].done);
+        _fixme_MPIDI_OFI_PROGRESS_WHILE(!req[0].done || !req[1].done || !req[2].done);
 
     }
 

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -214,7 +214,7 @@ M*/
                     mutex.count++;                                      \
                 }                                                       \
             } else {                                                    \
-                cs_req = 1;                                             \
+                cs_acq = 1;                                             \
                 mutex.count++;                                          \
             }                                                           \
         }                                                               \


### PR DESCRIPTION
## Pull Request Description

Making `MPICH_THREAD_GRANULARITY__VCI` default in `ch4`.

Once stablized, the granularity models may be removed altogether, to further clarify the code.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact
No impact for `ch3`.

For `ch4`, we'll have the `per-vci` code more thoroughly tested from this point on. The other thread model will get less tested and breakage (with __GLOBAL) may seep in.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Passes tests (included warning check)
* [x] Confirm whitespace/style checkers are happy (or has a good reason for being bad)
* [x] Commits are self-contained and do not do two things at once
* [x] Remove xfail from the test suite when fixing a test
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
