### PR TITLE
fixed spelling of guarantee

### DIFF
--- a/maint/docnotes
+++ b/maint/docnotes
@@ -183,7 +183,7 @@ Errors:
  RMA windows).  The MPI-1 routine 'MPI_Errhandler_set' may be used but
  its use is deprecated.  The predefined error handler 
  'MPI_ERRORS_RETURN' may be used to cause error values to be returned.
- Note that MPI does `not` guarentee that an MPI program can continue past
+ Note that MPI does `not` guarantee that an MPI program can continue past
  an error; however, MPI implementations will attempt to continue whenever
  possible.
 

--- a/src/mpi/coll/ireduce/ireduce_intra_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_binomial.c
@@ -63,7 +63,7 @@ int MPIR_Ireduce_sched_intra_binomial(const void *sendbuf, void *recvbuf, int co
      * node with that bit set and combine (as long as that node is within the
      * group)
      *
-     * Note that by receiving with source selection, we guarentee that we get
+     * Note that by receiving with source selection, we guarantee that we get
      * the same bits with the same input.  If we allowed the parent to receive
      * the children in any order, then timing differences could cause different
      * results (roundoff error, over/underflows in some cases, etc).

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -68,7 +68,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
      * node with that bit set and combine (as long as that node is within the
      * group)
      *
-     * Note that by receiving with source selection, we guarentee that we get
+     * Note that by receiving with source selection, we guarantee that we get
      * the same bits with the same input.  If we allowed the parent to receive
      * the children in any order, then timing differences could cause different
      * results (roundoff error, over/underflows in some cases, etc).


### PR DESCRIPTION
## Pull Request Description
Very slightly improved readability by fixing spelling of "guarantee". May help, especially in accessibility or translation use-cases. 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Performance Changes
N/A (only changed docs and comments)
## Known Issues
N/A (only changed docs and comments)
## Author Checklist
N/A (only changed docs and comments)
