### PR TITLE
test/rma: Fix origin buffer size

### DIFF
--- a/test/mpi/rma/manyrma2.c
+++ b/test/mpi/rma/manyrma2.c
@@ -229,72 +229,85 @@ int main(int argc, char *argv[])
 
 void RunAccFence(MPI_Win win, int destRank, int cnt, int sz)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Win_fence(0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Accumulate(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
+            MPI_Accumulate(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
             j += sz;
         }
         MPI_Win_fence(0, win);
     }
+
+    free(buf);
 }
 
 void RunAccLock(MPI_Win win, int destRank, int cnt, int sz)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Win_lock(MPI_LOCK_SHARED, destRank, 0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Accumulate(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
+            MPI_Accumulate(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
             j += sz;
         }
         MPI_Win_unlock(destRank, win);
     }
+
+    free(buf);
 }
 
 void RunPutFence(MPI_Win win, int destRank, int cnt, int sz)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Win_fence(0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Put(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
+            MPI_Put(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
             j += sz;
         }
         MPI_Win_fence(0, win);
     }
+
+    free(buf);
 }
 
 void RunPutLock(MPI_Win win, int destRank, int cnt, int sz)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
         MPI_Win_lock(MPI_LOCK_SHARED, destRank, 0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Put(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
+            MPI_Put(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
             j += sz;
         }
         MPI_Win_unlock(destRank, win);
     }
+
+    free(buf);
 }
 
 void RunPutPSCW(MPI_Win win, int destRank, int cnt, int sz,
                 MPI_Group exposureGroup, MPI_Group accessGroup)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
@@ -302,18 +315,21 @@ void RunPutPSCW(MPI_Win win, int destRank, int cnt, int sz,
         MPI_Win_start(accessGroup, 0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Put(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
+            MPI_Put(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, win);
             j += sz;
         }
         MPI_Win_complete(win);
         MPI_Win_wait(win);
     }
+
+    free(buf);
 }
 
 void RunAccPSCW(MPI_Win win, int destRank, int cnt, int sz,
                 MPI_Group exposureGroup, MPI_Group accessGroup)
 {
-    int k, i, j, one = 1;
+    int k, i, j;
+    int *buf = malloc(sz * sizeof(int));
 
     for (k = 0; k < MAX_RUNS; k++) {
         MPI_Barrier(MPI_COMM_WORLD);
@@ -321,10 +337,12 @@ void RunAccPSCW(MPI_Win win, int destRank, int cnt, int sz,
         MPI_Win_start(accessGroup, 0, win);
         j = 0;
         for (i = 0; i < cnt; i++) {
-            MPI_Accumulate(&one, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
+            MPI_Accumulate(buf, sz, MPI_INT, destRank, j, sz, MPI_INT, MPI_SUM, win);
             j += sz;
         }
         MPI_Win_complete(win);
         MPI_Win_wait(win);
     }
+
+    free(buf);
 }


### PR DESCRIPTION
## Pull Request Description

Avoid reading beyond stack allocation by dynamically allocating RMA
origin buffer based on provided size. This buffer had no meaningful
value, so we omit any data initialization.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Avoid address sanitizer warning.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
