### PR TITLE
xfail: Remove manyrma2 failures for ch3:ofi

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -76,8 +76,6 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 ################################################################################
 #ch3:ofi
 ofi * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ofi * * ch3:ofi * sed -i  "s+\(^manyrma2 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ofi * * ch3:ofi * sed -i  "s+\(^manyrma2_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 ################################################################################
 # f08 related problems xfail them for easy testing
 * intel * * * sed -i "s+\(^commattrf08 .*\)+\1 xfail=issue3820+g" test/mpi/f08/attr/testlist


### PR DESCRIPTION
## Pull Request Description

See if updates to manyrma2 test (or Jenkins env) affect failure behavior.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

?

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
