### PR TITLE
ch4/ofi: Remove redundant request field

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -144,11 +144,11 @@ static int recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq, int ev
         uint64_t ss_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_REQUEST(rreq, util_id),
                                                   rreq->status.MPI_TAG,
                                                   MPIDI_OFI_SYNC_SEND_ACK);
-        MPIR_Comm *c = MPIDI_OFI_REQUEST(rreq, util_comm);
+        MPIR_Comm *c = rreq->comm;
         int r = rreq->status.MPI_SOURCE;
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[0].tx, NULL /* buf */ ,
                                             0 /* len */ ,
-                                            MPIDI_OFI_REQUEST(rreq, util_comm->rank),
+                                            MPIR_Comm_rank(c),
                                             MPIDI_OFI_comm_to_phys(c, r),
                                             ss_bits), tinjectdata, FALSE /* eagain */);
     }
@@ -180,7 +180,7 @@ static int recv_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
         return recv_event(wc, rreq, MPIDI_OFI_REQUEST(rreq, event_id));
     }
 
-    comm_ptr = MPIDI_OFI_REQUEST(rreq, util_comm);
+    comm_ptr = rreq->comm;
 
     /* Check to see if the tracker is already in the unexpected list.
      * Otherwise, allocate one. */
@@ -288,7 +288,7 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
         void *ptr;
         struct fid_mr *huge_send_mr;
 
-        comm = MPIDI_OFI_REQUEST(sreq, util_comm);
+        comm = sreq->comm;
 
         /* Look for the memory region using the sreq handle */
         ptr = MPIDIU_map_lookup(MPIDI_OFI_COMM(comm).huge_send_counters, sreq->handle);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -139,7 +139,6 @@ typedef struct {
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     int util_id;
-    struct MPIR_Comm *util_comm;
     MPI_Datatype datatype;
     union {
         MPIDI_OFI_pack_t *pack;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -140,7 +140,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
         oout = k;
     }
 
-    MPIDI_OFI_REQUEST(rreq, util_comm) = comm;
+    if (rreq->comm == NULL) {
+        rreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
+    }
     MPIDI_OFI_REQUEST(rreq, util_id) = context_id;
 
     MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_NOPACK;
@@ -245,7 +248,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         MPIDI_OFI_REQUEST(rreq, noncontig.nopack) = NULL;
     }
 
-    MPIDI_OFI_REQUEST(rreq, util_comm) = comm;
+    if (rreq->comm == NULL) {
+        rreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
+    }
     MPIDI_OFI_REQUEST(rreq, util_id) = context_id;
 
     if (unlikely(data_sz > MPIDI_OFI_global.max_msg_size)) {

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -354,7 +354,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
          * started, then do the rest using the MR below. This can be confirmed
          * in the MPIDI_OFI_get_huge code where we start the offset at
          * MPIDI_OFI_global.max_msg_size */
-        MPIDI_OFI_REQUEST(sreq, util_comm) = comm;
+        sreq->comm = comm;
+        MPIR_Comm_add_ref(comm);
         MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,


### PR DESCRIPTION
## Pull Request Description

A communicator pointer is already available in the MPIR-level request
struct. Remove an extra pointer in the ofi private area. While we are
here, add proper reference counting so the communicator will not be
prematurely freed. Release happens automatically during request free.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Reduce ofi private struct size, correct error handling. No expected performance impact.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
