### PR TITLE
ch4/xpmem: implement XPMEM cooperative copy

### DIFF
--- a/src/mpid/ch4/shm/src/shm_control.c
+++ b/src/mpid/ch4/shm/src/shm_control.c
@@ -16,11 +16,20 @@ int MPIDI_SHM_ctrl_dispatch(int ctrl_id, void *ctrl_hdr)
 
     switch (ctrl_id) {
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
-        case MPIDI_SHM_XPMEM_SEND_LMT_REQ:
-            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_req_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+        case MPIDI_SHM_XPMEM_SEND_LMT_RTS:
+            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_rts_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
             break;
-        case MPIDI_SHM_XPMEM_SEND_LMT_ACK:
-            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_ack_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+        case MPIDI_SHM_XPMEM_SEND_LMT_CTS:
+            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_cts_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+        case MPIDI_SHM_XPMEM_SEND_LMT_SEND_FIN:
+            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_send_fin_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+        case MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN:
+            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_recv_fin_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+        case MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE:
+            mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_cnt_free_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
             break;
 #endif
         default:

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -162,7 +162,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
 
     MPIDI_Datatype_check_contig_size(datatype, count, dt_contig, data_sz);
     if (MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE > -1 &&
-        dt_contig && data_sz > MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE) {
+        dt_contig && data_sz > MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE && rank != comm->rank) {
         /* SHM only issues contig large message through XPMEM.
          * TODO: support noncontig send message */
         mpi_errno = MPIDI_XPMEM_lmt_isend(buf, count, datatype, rank, tag, comm,

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -68,6 +68,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mmods_try_matched_recv(void *buf,
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     /* XPMEM special receive */
     if (MPIDI_SHM_REQUEST(message, status) & MPIDI_SHM_REQ_XPMEM_SEND_LMT) {
+        MPIR_Comm *root_comm = MPIDIG_context_id_to_comm(MPIDIG_REQUEST(message, context_id));
+
         /* Matching XPMEM LMT receive is now posted */
         MPIR_Datatype_add_ref_if_not_builtin(datatype); /* will -1 once completed in handle_lmt_recv */
         MPIDIG_REQUEST(message, datatype) = datatype;
@@ -77,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mmods_try_matched_recv(void *buf,
         MPIDI_XPMEM_am_unexp_rreq_t *unexp_rreq = &MPIDI_XPMEM_REQUEST(message, unexp_rreq);
         mpi_errno = MPIDI_XPMEM_handle_lmt_recv(unexp_rreq->src_offset,
                                                 unexp_rreq->data_sz, unexp_rreq->sreq_ptr,
-                                                unexp_rreq->src_lrank, message);
+                                                unexp_rreq->src_lrank, root_comm, message);
         MPIR_ERR_CHECK(mpi_errno);
 
         *recvd_flag = true;

--- a/src/mpid/ch4/shm/src/shm_types.h
+++ b/src/mpid/ch4/shm/src/shm_types.h
@@ -14,15 +14,17 @@
 
 typedef enum {
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
-    MPIDI_SHM_XPMEM_SEND_LMT_REQ,       /* issued by sender to initialize a LMT;
-                                         * receiver transfers data in callback.  */
-    MPIDI_SHM_XPMEM_SEND_LMT_ACK,       /* issued by receiver to notify completion of LMT */
+    MPIDI_SHM_XPMEM_SEND_LMT_RTS,       /* issued by sender to initialize XPMEM protocol with sbuf info */
+    MPIDI_SHM_XPMEM_SEND_LMT_CTS,       /* issued by receiver with rbuf info after receiving RTS if it performs coop copy. */
+    MPIDI_SHM_XPMEM_SEND_LMT_SEND_FIN,  /* issued by sender to notify completion of coop copy */
+    MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN,  /* issued by receiver to notify completion of coop copy or single copy */
+    MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE,  /* issued by sender to notify free counter obj in coop copy */
 #endif
     MPIDI_SHM_CTRL_IDS_MAX
 } MPIDI_SHM_ctrl_id_t;
 
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
-typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_req {
+typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_rts {
     uint64_t src_offset;        /* send data starting address (buffer + true_lb) */
     uint64_t data_sz;           /* data size in bytes */
     uint64_t sreq_ptr;          /* send request pointer */
@@ -32,22 +34,41 @@ typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_req {
     int src_rank;
     int tag;
     MPIR_Context_id_t context_id;
-} MPIDI_SHM_ctrl_xpmem_send_lmt_req_t;
+} MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t;
 
-typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_ack {
-    uint64_t sreq_ptr;
-} MPIDI_SHM_ctrl_xpmem_send_lmt_ack_t;
+typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_cts {
+    uint64_t dest_offset;       /* receiver buffer starting address (buffer + true_lb) */
+    uint64_t data_sz;           /* receiver buffer size in bytes */
+    uint64_t sreq_ptr;          /* send request pointer */
+    uint64_t rreq_ptr;          /* recv request pointer */
+    int dest_lrank;             /* receiver rank on local node */
+
+    /* counter info */
+    int coop_counter_direct_flag;
+    uint64_t coop_counter_offset;
+} MPIDI_SHM_ctrl_xpmem_send_lmt_cts_t;
+
+typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin {
+    uint64_t req_ptr;
+} MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t;
+
+typedef struct MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free {
+    int coop_counter_direct_flag;
+    uint64_t coop_counter_offset;
+} MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free_t;
+
+typedef MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t MPIDI_SHM_ctrl_xpmem_send_lmt_recv_fin_t;
 #endif
 
-typedef struct {
-    union {
+typedef union {
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
-        MPIDI_SHM_ctrl_xpmem_send_lmt_req_t xpmem_slmt_req;
-        MPIDI_SHM_ctrl_xpmem_send_lmt_ack_t xpmem_slmt_ack;
-#else
-        char dummy;             /* some compilers (suncc) does not like empty struct */
+    MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t xpmem_slmt_rts;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_cts_t xpmem_slmt_cts;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t xpmem_slmt_send_fin;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_recv_fin_t xpmem_slmt_recv_fin;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free_t xpmem_slmt_cnt_free;
+    char dummy;                 /* some compilers (suncc) does not like empty struct */
 #endif
-    };
 } MPIDI_SHM_ctrl_hdr_t;
 
 #endif /* SHM_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/xpmem/globals.c
+++ b/src/mpid/ch4/shm/xpmem/globals.c
@@ -18,7 +18,16 @@ MPL_dbg_class MPIDI_CH4_SHM_XPMEM_GENERAL;
 MPIDI_XPMEM_seg_t MPIDI_XPMEM_seg_mem_direct[MPIDI_XPMEM_SEG_PREALLOC] = { {0}
 };
 
+/* Preallocated counter objects */
+MPIDI_XPMEM_cnt_t MPIDI_XPMEM_cnt_mem_direct[MPIDI_XPMEM_CNT_PREALLOC] = { {0}
+};
+
 MPIR_Object_alloc_t MPIDI_XPMEM_seg_mem = { 0, 0, 0, 0, MPIR_INTERNAL,
     sizeof(MPIDI_XPMEM_seg_t), MPIDI_XPMEM_seg_mem_direct,
     MPIDI_XPMEM_SEG_PREALLOC
+};
+
+MPIR_Object_alloc_t MPIDI_XPMEM_cnt_mem = { 0, 0, 0, 0, MPIR_INTERNAL,
+    sizeof(MPIDI_XPMEM_cnt_t), MPIDI_XPMEM_cnt_mem_direct,
+    MPIDI_XPMEM_CNT_PREALLOC
 };

--- a/src/mpid/ch4/shm/xpmem/xpmem_control.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_control.c
@@ -180,7 +180,7 @@ int MPIDI_XPMEM_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
     mpi_errno =
         MPIDI_XPMEM_seg_regist(slmt_cts_hdr->dest_lrank, slmt_cts_hdr->data_sz,
                                (void *) slmt_cts_hdr->dest_offset, &seg_ptr, &dest_buf,
-                               &MPIDI_XPMEM_global.segmaps[slmt_cts_hdr->dest_lrank].segcache);
+                               &MPIDI_XPMEM_global.segmaps[slmt_cts_hdr->dest_lrank].segcache_ubuf);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIDI_Datatype_check_size_lb(MPIDIG_REQUEST(sreq, datatype), MPIDIG_REQUEST(sreq, count),

--- a/src/mpid/ch4/shm/xpmem/xpmem_control.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_control.c
@@ -10,31 +10,58 @@
 #include "xpmem_recv.h"
 #include "xpmem_control.h"
 
-int MPIDI_XPMEM_ctrl_send_lmt_ack_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+int MPIDI_XPMEM_ctrl_send_lmt_recv_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq = (MPIR_Request *) ctrl_hdr->xpmem_slmt_ack.sreq_ptr;
+    MPIR_Request *sreq = (MPIR_Request *) ctrl_hdr->xpmem_slmt_recv_fin.req_ptr;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_CTRL_SEND_LMT_ACK_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_CTRL_SEND_LMT_ACK_CB);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_CTRL_SEND_LMT_RECV_FIN_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
 
-    XPMEM_TRACE("send_lmt_ack_cb: complete sreq %p\n", sreq);
+    XPMEM_TRACE("send_lmt_recv_fin_cb: complete sreq %p\n", sreq);
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
 
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_CTRL_SEND_LMT_ACK_CB);
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_CTRL_SEND_LMT_RECV_FIN_CB);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
-int MPIDI_XPMEM_ctrl_send_lmt_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+int MPIDI_XPMEM_ctrl_send_lmt_send_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_SHM_ctrl_xpmem_send_lmt_req_t *slmt_req_hdr = &ctrl_hdr->xpmem_slmt_req;
+    MPIR_Request *rreq = (MPIR_Request *) ctrl_hdr->xpmem_slmt_send_fin.req_ptr;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
+
+    XPMEM_TRACE("send_lmt_send_fin_cb: complete rreq %p\n", rreq);
+
+    /* send_fin_cb can only be triggered in cooperative copy, so
+     * MPIDI_XPMEM_REQUEST(rreq, counter_ptr) must be set by receiver */
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+    MPIR_Handle_obj_free(&MPIDI_XPMEM_cnt_mem, MPIDI_XPMEM_REQUEST(rreq, counter_ptr));
+    MPID_Request_complete(rreq);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_XPMEM_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t *slmt_req_hdr = &ctrl_hdr->xpmem_slmt_rts;
     MPIR_Request *rreq = NULL;
     MPIR_Comm *root_comm;
     MPIR_Request *anysource_partner;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_CTRL_SEND_LMT_REQ_CB);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_CTRL_SEND_LMT_REQ_CB);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RTS_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RTS_CB);
 
     XPMEM_TRACE("send_lmt_req_cb: received src_offset 0x%lx, data_sz 0x%lx, sreq_ptr 0x%lx, "
                 "src_lrank %d, match info[src_rank %d, tag %d, context_id 0x%x]\n",
@@ -89,7 +116,7 @@ int MPIDI_XPMEM_ctrl_send_lmt_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
         /* Complete XPMEM receive */
         mpi_errno = MPIDI_XPMEM_handle_lmt_recv(slmt_req_hdr->src_offset, slmt_req_hdr->data_sz,
                                                 slmt_req_hdr->sreq_ptr, slmt_req_hdr->src_lrank,
-                                                rreq);
+                                                root_comm, rreq);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Enqueue unexpected receive request */
@@ -124,7 +151,138 @@ int MPIDI_XPMEM_ctrl_send_lmt_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
     }
 
   fn_exit:
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_CTRL_SEND_LMT_REQ_CB);
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RTS_CB);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_XPMEM_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *sreq;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_cts_t *slmt_cts_hdr = &ctrl_hdr->xpmem_slmt_cts;
+    MPIDI_XPMEM_seg_t *seg_ptr = NULL;
+    MPIDI_XPMEM_seg_t *counter_seg_ptr = NULL;
+    void *dest_buf = NULL;
+    void *src_buf = NULL;
+    size_t data_sz ATTRIBUTE((unused));
+    MPI_Aint dt_true_lb;
+    MPIDI_XPMEM_cnt_t *counter_ptr = NULL;
+    int fin_type, copy_type;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CTS_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CTS_CB);
+
+    /* Sender gets the CTS packet from receiver and need to perform copy */
+    sreq = (MPIR_Request *) slmt_cts_hdr->sreq_ptr;
+
+    mpi_errno =
+        MPIDI_XPMEM_seg_regist(slmt_cts_hdr->dest_lrank, slmt_cts_hdr->data_sz,
+                               (void *) slmt_cts_hdr->dest_offset, &seg_ptr, &dest_buf,
+                               &MPIDI_XPMEM_global.segmaps[slmt_cts_hdr->dest_lrank].segcache);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIDI_Datatype_check_size_lb(MPIDIG_REQUEST(sreq, datatype), MPIDIG_REQUEST(sreq, count),
+                                 data_sz, dt_true_lb);
+
+    src_buf = (void *) ((char *) MPIDIG_REQUEST(sreq, buffer) + dt_true_lb);
+
+    if (slmt_cts_hdr->coop_counter_direct_flag) {
+        counter_ptr = (MPIDI_XPMEM_cnt_t *) ((char *)
+                                             MPIDI_XPMEM_global.
+                                             coop_counter_direct[slmt_cts_hdr->dest_lrank] +
+                                             slmt_cts_hdr->coop_counter_offset);
+    } else {
+        MPIDI_XPMEM_seg_regist(slmt_cts_hdr->dest_lrank,
+                               sizeof(MPIDI_XPMEM_cnt_t),
+                               (void *) slmt_cts_hdr->coop_counter_offset,
+                               &counter_seg_ptr, (void **) &counter_ptr,
+                               &MPIDI_XPMEM_global.segmaps[slmt_cts_hdr->dest_lrank].segcache_cnt);
+    }
+
+    /* sender and receiver datatypes are both continuous, perform cooperative copy. */
+    mpi_errno =
+        MPIDI_XPMEM_do_lmt_coop_copy(src_buf, slmt_cts_hdr->data_sz, dest_buf,
+                                     &counter_ptr->obj.counter, slmt_cts_hdr->rreq_ptr, sreq,
+                                     &fin_type, &copy_type);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* - For sender:
+     *     case copy_type == LOCAL_FIN:
+     *        case fin_type == COPY_ALL: complete sreq; receiver complete rreq without sending RECV_FIN
+     *        case fin_type == COPY_ZERO: waits RECV_FIN from receiver to complete sreq;
+     *                                    receiver detects completion of copy, send RECV_FIN to sender
+     *        case fin_type == MIXED_COPIED: waits RECV_FIN from receiver to complete sreq;
+     *                                       receiver detects completion of copy, send RECV_FIN to sender
+     *     case copy_type == BOTH_FIN:
+     *        case fin_type == COPY_ALL: sends SEND_FIN to receiver and complete sreq
+     *        case fin_type == COPY_ZERO: sends FREE_CNT to receiver with counter info and complete sreq;
+     *                                    receiver does not free counter obj and needs to know sender
+     *                                    finishes cooperative copy
+     *        case fin_type == MIXED_COPIED: sends SEND_FIN to receiver and complete sreq;
+     *                                       receiver is waiting SEND_FIN to complete rreq */
+    if ((fin_type == MPIDI_XPMEM_LOCAL_FIN && copy_type == MPIDI_XPMEM_COPY_ALL) ||
+        fin_type == MPIDI_XPMEM_BOTH_FIN) {
+        if (fin_type == MPIDI_XPMEM_BOTH_FIN) {
+            int ctrl_id;
+            MPIDI_SHM_ctrl_hdr_t ack_ctrl_hdr;
+
+            if (copy_type == MPIDI_XPMEM_COPY_ZERO) {
+                ack_ctrl_hdr.xpmem_slmt_cnt_free.coop_counter_direct_flag =
+                    slmt_cts_hdr->coop_counter_direct_flag;
+                ack_ctrl_hdr.xpmem_slmt_cnt_free.coop_counter_offset =
+                    slmt_cts_hdr->coop_counter_offset;
+                ctrl_id = MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE;
+            } else {
+                ack_ctrl_hdr.xpmem_slmt_send_fin.req_ptr = slmt_cts_hdr->rreq_ptr;
+                ctrl_id = MPIDI_SHM_XPMEM_SEND_LMT_SEND_FIN;
+            }
+
+            mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(sreq, rank),
+                                               MPIDIG_context_id_to_comm(MPIDIG_REQUEST
+                                                                         (sreq, context_id)),
+                                               ctrl_id, &ack_ctrl_hdr);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+        MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
+        MPID_Request_complete(sreq);
+    }
+
+    mpi_errno = MPIDI_XPMEM_seg_deregist(seg_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (counter_seg_ptr) {
+        mpi_errno = MPIDI_XPMEM_seg_deregist(counter_seg_ptr);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CTS_CB);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_XPMEM_ctrl_send_lmt_cnt_free_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS, c;
+    MPIDI_XPMEM_cnt_t *counter_ptr;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_cnt_free_t *xpmem_slmt_cnt_free = &ctrl_hdr->xpmem_slmt_cnt_free;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CNT_FREE_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CNT_FREE_CB);
+
+    if (xpmem_slmt_cnt_free->coop_counter_direct_flag)
+        counter_ptr = (MPIDI_XPMEM_cnt_t *) ((char *) MPIDI_XPMEM_cnt_mem_direct +
+                                             xpmem_slmt_cnt_free->coop_counter_offset);
+    else
+        counter_ptr = (MPIDI_XPMEM_cnt_t *) xpmem_slmt_cnt_free->coop_counter_offset;
+    MPIR_Handle_obj_free(&MPIDI_XPMEM_cnt_mem, counter_ptr);
+    MPIR_cc_decr(&MPIDI_XPMEM_global.num_pending_cnt, &c);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_CNT_FREE_CB);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/xpmem/xpmem_control.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_control.h
@@ -9,7 +9,10 @@
 
 #include "shm_types.h"
 
-int MPIDI_XPMEM_ctrl_send_lmt_ack_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
-int MPIDI_XPMEM_ctrl_send_lmt_req_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_XPMEM_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_XPMEM_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_XPMEM_ctrl_send_lmt_send_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_XPMEM_ctrl_send_lmt_recv_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_XPMEM_ctrl_send_lmt_cnt_free_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
 
 #endif /* XPMEM_CONTROL_H_INCLUDED */

--- a/src/mpid/ch4/shm/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_init.c
@@ -83,7 +83,7 @@ int MPIDI_XPMEM_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
     MPIDU_Init_shm_barrier();
     for (i = 0; i < num_local; ++i) {
         /* Init AVL tree based segment cache */
-        MPIDI_XPMEM_segtree_init(&MPIDI_XPMEM_global.segmaps[i].segcache);      /* Initialize user buffer tree */
+        MPIDI_XPMEM_segtree_init(&MPIDI_XPMEM_global.segmaps[i].segcache_ubuf); /* Initialize user buffer tree */
         MPIDI_XPMEM_segtree_init(&MPIDI_XPMEM_global.segmaps[i].segcache_cnt);
         if (i != MPIDI_XPMEM_global.local_rank) {
             MPIDU_Init_shm_get(i, sizeof(uint64_t), &remote_cnt_mem_addr);
@@ -138,7 +138,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     for (i = 0; i < MPIDI_XPMEM_global.num_local; i++) {
         /* should be called before xpmem_release
          * MPIDI_XPMEM_segtree_tree_delete_all will call xpmem_detach */
-        MPIDI_XPMEM_segtree_delete_all(&MPIDI_XPMEM_global.segmaps[i].segcache);
+        MPIDI_XPMEM_segtree_delete_all(&MPIDI_XPMEM_global.segmaps[i].segcache_ubuf);
         MPIDI_XPMEM_segtree_delete_all(&MPIDI_XPMEM_global.segmaps[i].segcache_cnt);
         if (MPIDI_XPMEM_global.segmaps[i].apid != -1) {
             XPMEM_TRACE("finalize: release apid: node_rank %d, 0x%lx\n",

--- a/src/mpid/ch4/shm/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_pre.h
@@ -57,7 +57,7 @@ typedef struct MPIDI_XPMEM_segtree {
 typedef struct {
     xpmem_segid_t remote_segid;
     xpmem_apid_t apid;
-    MPIDI_XPMEM_segtree_t segcache;     /* AVL tree based segment cache for user buffer */
+    MPIDI_XPMEM_segtree_t segcache_ubuf;        /* AVL tree based segment cache for user buffer */
     MPIDI_XPMEM_segtree_t segcache_cnt; /* AVL tree based segment cache for XPMEM counter buffer */
 } MPIDI_XPMEM_segmap_t;
 

--- a/src/mpid/ch4/shm/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_pre.h
@@ -13,6 +13,7 @@
 #define MPIDI_XPMEM_SEG_PREALLOC 8      /* Number of segments to preallocate in the "direct" block */
 
 typedef struct MPIDI_XPMEM_seg {
+    MPIR_OBJECT_HEADER;
     /* AVL-tree internal components start */
     struct MPIDI_XPMEM_seg *parent;
     struct MPIDI_XPMEM_seg *left;
@@ -23,7 +24,6 @@ typedef struct MPIDI_XPMEM_seg {
     uint64_t low;               /* page aligned low address of remote seg */
     uint64_t high;              /* page aligned high address of remote seg */
     void *vaddr;                /* virtual address attached in current process */
-    MPIR_cc_t refcount;         /* reference count of this seg */
 } MPIDI_XPMEM_seg_t;
 
 typedef struct MPIDI_XPMEM_segtree {

--- a/src/mpid/ch4/shm/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_pre.h
@@ -11,6 +11,20 @@
 
 #define MPIDI_XPMEM_PERMIT_VALUE ((void *)0600)
 #define MPIDI_XPMEM_SEG_PREALLOC 8      /* Number of segments to preallocate in the "direct" block */
+#define MPIDI_XPMEM_CNT_PREALLOC 64     /* Number of shm counter to preallocate in the "direct" block */
+
+/* Variables used to indicate coop copy completion cases.
+ *  See more explanation in xpmem_recv.h and xpmem_control.c */
+typedef enum {
+    MPIDI_XPMEM_COPY_ALL,       /* local process copied all chunks */
+    MPIDI_XPMEM_COPY_ZERO,      /* local process copied zero chunk */
+    MPIDI_XPMEM_COPY_MIX        /* both sides copied a part of chunks */
+} MPIDI_XPMEM_copy_type_t;
+
+typedef enum {
+    MPIDI_XPMEM_LOCAL_FIN,      /* local copy is done but the other side may be still copying */
+    MPIDI_XPMEM_BOTH_FIN        /* both sides finished copy */
+} MPIDI_XPMEM_fin_type_t;
 
 typedef struct MPIDI_XPMEM_seg {
     MPIR_OBJECT_HEADER;
@@ -26,6 +40,14 @@ typedef struct MPIDI_XPMEM_seg {
     void *vaddr;                /* virtual address attached in current process */
 } MPIDI_XPMEM_seg_t;
 
+typedef union MPIDI_XPMEM_cnt {
+    MPIR_Handle_common common;  /* ensure sufficient bytes required for MPIR_Handle_common */
+    struct {
+        MPIR_OBJECT_HEADER;
+        OPA_int_t counter;
+    } obj;
+} MPIDI_XPMEM_cnt_t;
+
 typedef struct MPIDI_XPMEM_segtree {
     MPIDI_XPMEM_seg_t *root;
     int tree_size;
@@ -35,7 +57,8 @@ typedef struct MPIDI_XPMEM_segtree {
 typedef struct {
     xpmem_segid_t remote_segid;
     xpmem_apid_t apid;
-    MPIDI_XPMEM_segtree_t segcache;     /* AVL tree based segment cache */
+    MPIDI_XPMEM_segtree_t segcache;     /* AVL tree based segment cache for user buffer */
+    MPIDI_XPMEM_segtree_t segcache_cnt; /* AVL tree based segment cache for XPMEM counter buffer */
 } MPIDI_XPMEM_segmap_t;
 
 typedef struct {
@@ -45,6 +68,10 @@ typedef struct {
     xpmem_segid_t segid;        /* my local segid associated with entire address space */
     MPIDI_XPMEM_segmap_t *segmaps;      /* remote seg info for every local processes. */
     size_t sys_page_sz;
+    MPIDI_XPMEM_seg_t **coop_counter_seg_direct;        /* original direct cooperative counter array segments,
+                                                         * used for detach in finalize */
+    MPIDI_XPMEM_cnt_t **coop_counter_direct;    /* direct cooperative counter array attached in init */
+    MPIR_cc_t num_pending_cnt;
 } MPIDI_XPMEM_global_t;
 
 typedef struct {
@@ -61,10 +88,14 @@ typedef struct {
 
 typedef struct {
     MPIDI_XPMEM_am_unexp_rreq_t unexp_rreq;
+    MPIDI_XPMEM_cnt_t *counter_ptr;
 } MPIDI_XPMEM_am_request_t;
 
 extern MPIDI_XPMEM_global_t MPIDI_XPMEM_global;
 extern MPIR_Object_alloc_t MPIDI_XPMEM_seg_mem;
+
+extern MPIR_Object_alloc_t MPIDI_XPMEM_cnt_mem;
+extern MPIDI_XPMEM_cnt_t MPIDI_XPMEM_cnt_mem_direct[MPIDI_XPMEM_CNT_PREALLOC];
 
 #ifdef MPL_USE_DBG_LOGGING
 extern MPL_dbg_class MPIDI_CH4_SHM_XPMEM_GENERAL;

--- a/src/mpid/ch4/shm/xpmem/xpmem_recv.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_recv.h
@@ -167,7 +167,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_coop_recv(uint64_t src_offse
 
     mpi_errno =
         MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset, &seg_ptr, &src_buf,
-                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
+                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache_ubuf);
     MPIR_ERR_CHECK(mpi_errno);
 
     XPMEM_TRACE("handle_lmt_coop_recv: handle matched rreq %p [source %d, tag %d, context_id 0x%x],"
@@ -256,7 +256,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_single_recv(uint64_t src_off
 
     mpi_errno =
         MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset, &seg_ptr, &src_buf,
-                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
+                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache_ubuf);
     MPIR_ERR_CHECK(mpi_errno);
 
     XPMEM_TRACE("handle_lmt_single_recv: handle matched rreq %p [source %d, tag %d, "

--- a/src/mpid/ch4/shm/xpmem/xpmem_recv.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_recv.h
@@ -31,7 +31,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_recv(uint64_t src_offset, ui
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
 
     mpi_errno = MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset,
-                                       &seg_ptr, &attached_sbuf);
+                                       &seg_ptr, &attached_sbuf,
+                                       &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);

--- a/src/mpid/ch4/shm/xpmem/xpmem_recv.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_recv.h
@@ -13,68 +13,309 @@
 #include "xpmem_seg.h"
 #include "xpmem_impl.h"
 
-/* Handle and complete a matched XPMEM LMT receive request. Input parameters
- * include send buffer info (see definition in MPIDI_SHM_ctrl_xpmem_send_lmt_req_t)
- * and receive request. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_recv(uint64_t src_offset, uint64_t src_data_sz,
-                                                         uint64_t sreq_ptr, int src_lrank,
-                                                         MPIR_Request * rreq)
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE
+      category    : CH4
+      type        : int
+      default     : 32768
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Chunk size is used in XPMEM cooperative copy based point-to-point
+        communication. It determines the concurrency of copy and overhead of
+        atomic per chunk copy. Best chunk size should balance these two factors.
+
+    - name        : MPIR_CVAR_CH4_XPMEM_COOP_COPY_THRESHOLD
+      category    : CH4
+      type        : int
+      default     : 32768
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        When data size is larger than this threshold, cooperative copy is used;
+        if not, we need to fall back to single-side XPMEM copy.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_do_lmt_coop_copy(const void *src_buf,
+                                                          size_t data_sz, void *dest_buf,
+                                                          OPA_int_t * counter_ptr,
+                                                          uint64_t req_ptr,
+                                                          MPIR_Request * local_req, int *fin_type,
+                                                          int *copy_type)
 {
     int mpi_errno = MPI_SUCCESS;
+    size_t copy_sz;
+    int cur_chunk = 0, total_chunk = 0, num_local_copy = 0;
+    uint64_t cur_offset;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_DO_LMT_COOP_COPY);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_DO_LMT_COOP_COPY);
+
+    total_chunk =
+        data_sz / MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE +
+        (data_sz % MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE == 0 ? 0 : 1);
+
+    MPIR_Assert(total_chunk > 1);
+
+    /* TODO: implement OPA_fetch_and_incr_int uint64_t to directly change cur_offset
+     * instead of computing it in each copy */
+    while ((cur_chunk = OPA_fetch_and_incr_int(counter_ptr)) < total_chunk) {
+        cur_offset = ((uint64_t) cur_chunk) * MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE;
+        copy_sz =
+            cur_offset + MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE <=
+            data_sz ? MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE : data_sz - cur_offset;
+        mpi_errno =
+            MPIR_Localcopy(((char *) src_buf + cur_offset), copy_sz, MPI_BYTE,
+                           ((char *) dest_buf + cur_offset), copy_sz, MPI_BYTE);
+        MPIR_ERR_CHECK(mpi_errno);
+        num_local_copy++;
+    }
+
+    if (cur_chunk == total_chunk)
+        *fin_type = MPIDI_XPMEM_LOCAL_FIN;      /* copy is only locally complete */
+    else
+        *fin_type = MPIDI_XPMEM_BOTH_FIN;       /* copy is done by both sides */
+
+    if (num_local_copy == total_chunk)
+        *copy_type = MPIDI_XPMEM_COPY_ALL;      /* the process copies all chunks */
+    else if (num_local_copy == 0)
+        *copy_type = MPIDI_XPMEM_COPY_ZERO;     /* the process copies zero chunk */
+    else
+        *copy_type = MPIDI_XPMEM_COPY_MIX;      /* both processes copy a part of chunks */
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_DO_LMT_COOP_COPY);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_coop_recv(uint64_t src_offset,
+                                                              size_t src_data_sz,
+                                                              uint64_t sreq_ptr, int src_lrank,
+                                                              MPIR_Comm * comm, MPIR_Request * rreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPI_Aint dt_true_lb;
     MPIDI_XPMEM_seg_t *seg_ptr = NULL;
-    void *attached_sbuf = NULL;
+    void *src_buf = NULL;
+    void *dest_buf = NULL;
     size_t data_sz, recv_data_sz;
-    MPIDI_SHM_ctrl_hdr_t ack_ctrl_hdr;
-    MPIDI_SHM_ctrl_xpmem_send_lmt_ack_t *slmt_ack_hdr = &ack_ctrl_hdr.xpmem_slmt_ack;
+    int fin_type, copy_type;
+    MPIDI_SHM_ctrl_hdr_t ctrl_hdr;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_cts_t *slmt_cts_hdr = &ctrl_hdr.xpmem_slmt_cts;
 
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_HANDLE_LMT_COOP_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_HANDLE_LMT_COOP_RECV);
 
-    mpi_errno = MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset,
-                                       &seg_ptr, &attached_sbuf,
-                                       &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
-    MPIR_ERR_CHECK(mpi_errno);
+    MPIDI_Datatype_check_size_lb(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count),
+                                 data_sz, dt_true_lb);
 
-    MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);
+    /* Data truncation checking */
+    recv_data_sz = MPL_MIN(src_data_sz, data_sz);
     if (src_data_sz > data_sz)
         rreq->status.MPI_ERROR = MPI_ERR_TRUNCATE;
 
-    /* Copy data to receive buffer */
-    recv_data_sz = MPL_MIN(src_data_sz, data_sz);
-    mpi_errno = MPIR_Localcopy(attached_sbuf, recv_data_sz,
-                               MPI_BYTE, (char *) MPIDIG_REQUEST(rreq, buffer),
-                               MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype));
+    /* XPMEM internal info */
+    slmt_cts_hdr->dest_offset = (uint64_t) MPIDIG_REQUEST(rreq, buffer) + dt_true_lb;
+    slmt_cts_hdr->data_sz = recv_data_sz;
+    slmt_cts_hdr->dest_lrank = MPIDI_XPMEM_global.local_rank;
 
-    XPMEM_TRACE("handle_lmt_recv: handle matched rreq %p [source %d, tag %d, context_id 0x%x],"
-                " copy dst %p, src %p, bytes %ld\n", rreq, MPIDIG_REQUEST(rreq, rank),
-                MPIDIG_REQUEST(rreq, tag), MPIDIG_REQUEST(rreq, context_id),
-                (char *) MPIDIG_REQUEST(rreq, buffer), attached_sbuf, recv_data_sz);
+    /* Receiver replies CTS packet */
+    slmt_cts_hdr->sreq_ptr = sreq_ptr;
+    slmt_cts_hdr->rreq_ptr = (uint64_t) rreq;
 
-    mpi_errno = MPIDI_XPMEM_seg_deregist(seg_ptr);
+    /* allocate shm counter */
+    MPIDI_XPMEM_REQUEST(rreq, counter_ptr) =
+        (MPIDI_XPMEM_cnt_t *) MPIR_Handle_obj_alloc(&MPIDI_XPMEM_cnt_mem);
+    OPA_store_int(&MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.counter, 0);
+    if (HANDLE_GET_KIND(MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.handle) == HANDLE_KIND_DIRECT) {
+        slmt_cts_hdr->coop_counter_direct_flag = 1;
+        slmt_cts_hdr->coop_counter_offset =
+            (uint64_t) MPIDI_XPMEM_REQUEST(rreq, counter_ptr) -
+            (uint64_t) (&MPIDI_XPMEM_cnt_mem_direct);
+    } else {
+        slmt_cts_hdr->coop_counter_direct_flag = 0;
+        slmt_cts_hdr->coop_counter_offset = (uint64_t) MPIDI_XPMEM_REQUEST(rreq, counter_ptr);
+    }
+
+    XPMEM_TRACE("handle_lmt_coop_recv: shm ctrl_id %d, buf_offset 0x%lx, data_sz 0x%lx, "
+                "sreq_ptr 0x%lx, rreq_ptr 0x%lx, coop_counter_offset 0x%lx, "
+                " local_rank %d, dest %d\n",
+                MPIDI_SHM_XPMEM_SEND_LMT_CTS, slmt_cts_hdr->dest_offset, slmt_cts_hdr->data_sz,
+                slmt_cts_hdr->sreq_ptr, slmt_cts_hdr->rreq_ptr, slmt_cts_hdr->coop_counter_offset,
+                slmt_cts_hdr->dest_lrank, MPIDIG_REQUEST(rreq, rank));
+
+    /* Receiver sends CTS packet to sender */
+    mpi_errno =
+        MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank), comm, MPIDI_SHM_XPMEM_SEND_LMT_CTS,
+                               &ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Set receive status */
     MPIR_STATUS_SET_COUNT(rreq->status, recv_data_sz);
     rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
     rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
+    dest_buf = MPIDIG_REQUEST(rreq, buffer);
 
-    /* Send ack to sender */
-    slmt_ack_hdr->sreq_ptr = sreq_ptr;
     mpi_errno =
-        MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
-                               MPIDIG_context_id_to_comm(MPIDIG_REQUEST(rreq, context_id)),
-                               MPIDI_SHM_XPMEM_SEND_LMT_ACK, &ack_ctrl_hdr);
+        MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset, &seg_ptr, &src_buf,
+                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    XPMEM_TRACE("handle_lmt_coop_recv: handle matched rreq %p [source %d, tag %d, context_id 0x%x],"
+                " copy dst %p, src %lx, bytes %ld\n", rreq, MPIDIG_REQUEST(rreq, rank),
+                MPIDIG_REQUEST(rreq, tag), MPIDIG_REQUEST(rreq, context_id),
+                (char *) MPIDIG_REQUEST(rreq, buffer), src_offset, recv_data_sz);
+    /* sender and receiver datatypes are both continuous, perform cooperative copy. */
+    mpi_errno =
+        MPIDI_XPMEM_do_lmt_coop_copy(src_buf, recv_data_sz,
+                                     (char *) dest_buf + dt_true_lb,
+                                     &MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.counter, sreq_ptr,
+                                     rreq, &fin_type, &copy_type);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* - For receiver:
+     *     case copy_type == LOCAL_FIN:
+     *        case fin_type == COPY_ALL: complete rreq and free counter obj when receiving FREE_CNT;
+     *        case fin_type == COPY_ZERO: waits SEND_FIN from sender to complete rreq and free counter obj;
+     *                                    receiver needs to be notified the completion of sender
+     *        case fin_type == MIXED_COPIED: waits SEND_FIN from sender to complete rreq and free counter obj;
+     *                                       receiver needs to be notified the completion of sender
+     *     case copy_type == BOTH_FIN:
+     *        case fin_type == COPY_ALL: complete rreq and free counter obj; send RECV_FIN to sender
+     *        case fin_type == COPY_ZERO: complete rreq and free counter obj
+     *        case fin_type == MIXED_COPIED: complete rreq and free counter obj; send RECV_FIN to sender */
+    if ((fin_type == MPIDI_XPMEM_LOCAL_FIN && copy_type == MPIDI_XPMEM_COPY_ALL) ||
+        fin_type == MPIDI_XPMEM_BOTH_FIN) {
+        if (fin_type == MPIDI_XPMEM_BOTH_FIN) {
+            if (copy_type != MPIDI_XPMEM_COPY_ZERO) {
+                MPIDI_SHM_ctrl_hdr_t ack_ctrl_hdr;
+                MPIDI_SHM_ctrl_xpmem_send_lmt_recv_fin_t *slmt_fin_hdr =
+                    &ack_ctrl_hdr.xpmem_slmt_recv_fin;
+                slmt_fin_hdr->req_ptr = sreq_ptr;
+                mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
+                                                   MPIDIG_context_id_to_comm(MPIDIG_REQUEST
+                                                                             (rreq, context_id)),
+                                                   MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN,
+                                                   &ack_ctrl_hdr);
+                MPIR_ERR_CHECK(mpi_errno);
+            }
+            MPIR_Handle_obj_free(&MPIDI_XPMEM_cnt_mem, MPIDI_XPMEM_REQUEST(rreq, counter_ptr));
+        } else {
+            int c;
+            MPIR_cc_incr(&MPIDI_XPMEM_global.num_pending_cnt, &c);
+        }
+        MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+        MPID_Request_complete(rreq);
+    }
+
+    mpi_errno = MPIDI_XPMEM_seg_deregist(seg_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_HANDLE_LMT_COOP_RECV);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_single_recv(uint64_t src_offset,
+                                                                size_t src_data_sz,
+                                                                uint64_t sreq_ptr, int src_lrank,
+                                                                MPIR_Request * rreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_XPMEM_seg_t *seg_ptr = NULL;
+    void *src_buf = NULL;
+    size_t data_sz, recv_data_sz;
+    MPIDI_SHM_ctrl_hdr_t ack_ctrl_hdr;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_HANDLE_LMT_SINGLE_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_HANDLE_LMT_SINGLE_RECV);
+
+    MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, datatype), MPIDIG_REQUEST(rreq, count), data_sz);
+
+    /* Data truncation checking */
+    recv_data_sz = MPL_MIN(src_data_sz, data_sz);
+    if (src_data_sz > data_sz)
+        rreq->status.MPI_ERROR = MPI_ERR_TRUNCATE;
+
+    /* Set receive status */
+    MPIR_STATUS_SET_COUNT(rreq->status, recv_data_sz);
+    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank);
+    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag);
+    MPIDI_XPMEM_REQUEST(rreq, counter_ptr) = NULL;
+
+    mpi_errno =
+        MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset, &seg_ptr, &src_buf,
+                               &MPIDI_XPMEM_global.segmaps[src_lrank].segcache);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    XPMEM_TRACE("handle_lmt_single_recv: handle matched rreq %p [source %d, tag %d, "
+                " context_id 0x%x], copy dst %p, src %lx, bytes %ld\n", rreq,
+                MPIDIG_REQUEST(rreq, rank), MPIDIG_REQUEST(rreq, tag),
+                MPIDIG_REQUEST(rreq, context_id), (char *) MPIDIG_REQUEST(rreq, buffer),
+                src_offset, recv_data_sz);
+
+    /* Copy data to receive buffer */
+    mpi_errno = MPIR_Localcopy(src_buf, recv_data_sz, MPI_BYTE,
+                               MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
+                               MPIDIG_REQUEST(rreq, datatype));
+    MPIR_ERR_CHECK(mpi_errno);
+
+    ack_ctrl_hdr.xpmem_slmt_send_fin.req_ptr = sreq_ptr;
+    mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank),
+                                       MPIDIG_context_id_to_comm(MPIDIG_REQUEST
+                                                                 (rreq, context_id)),
+                                       MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN, &ack_ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
     MPID_Request_complete(rreq);
 
+    mpi_errno = MPIDI_XPMEM_seg_deregist(seg_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_HANDLE_LMT_SINGLE_RECV);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_recv(uint64_t src_offset, size_t data_sz,
+                                                         uint64_t sreq_ptr, int src_lrank,
+                                                         MPIR_Comm * comm, MPIR_Request * rreq)
+{
+
+    int mpi_errno = MPI_SUCCESS;
+    int recvtype_iscontig;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
+    /* TODO: need to support cooperative copy on non-contig datatype on receiver side. */
+    MPIR_Datatype_is_contig(MPIDIG_REQUEST(rreq, datatype), &recvtype_iscontig);
+    if (recvtype_iscontig && data_sz > MPIR_CVAR_CH4_XPMEM_COOP_COPY_THRESHOLD) {
+        /* Cooperative XPMEM copy */
+        mpi_errno =
+            MPIDI_XPMEM_handle_lmt_coop_recv(src_offset, data_sz, sreq_ptr, src_lrank, comm, rreq);
+    } else {
+        mpi_errno =
+            MPIDI_XPMEM_handle_lmt_single_recv(src_offset, data_sz, sreq_ptr, src_lrank, rreq);
+    }
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_XPMEM_HANDLE_LMT_RECV);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
-
 
 #endif /* XPMEM_RECV_H_INCLUDED */

--- a/src/mpid/ch4/shm/xpmem/xpmem_send.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_send.h
@@ -23,14 +23,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_lmt_isend(const void *buf, MPI_Aint cou
     MPI_Aint true_lb;
     bool is_contig ATTRIBUTE((unused)) = 0;
     MPIDI_SHM_ctrl_hdr_t ctrl_hdr;
-    MPIDI_SHM_ctrl_xpmem_send_lmt_req_t *slmt_req_hdr = &ctrl_hdr.xpmem_slmt_req;
+    MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t *slmt_req_hdr = &ctrl_hdr.xpmem_slmt_rts;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_LMT_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_LMT_ISEND);
 
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
     sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
+    MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
+    MPIDIG_REQUEST(sreq, datatype) = datatype;
+    MPIDIG_REQUEST(sreq, rank) = rank;
+    MPIDIG_REQUEST(sreq, count) = count;
+    MPIDIG_REQUEST(sreq, context_id) = comm->context_id + context_offset;
+    MPIDI_XPMEM_REQUEST(sreq, counter_ptr) = NULL;
 
     MPIDI_Datatype_check_contig_size_lb(datatype, count, is_contig, data_sz, true_lb);
 
@@ -49,11 +56,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_lmt_isend(const void *buf, MPI_Aint cou
 
     XPMEM_TRACE("lmt_isend: shm ctrl_id %d, src_offset 0x%lx, data_sz 0x%lx, sreq_ptr 0x%lx, "
                 "src_lrank %d, match info[dest %d, src_rank %d, tag %d, context_id 0x%x]\n",
-                MPIDI_SHM_XPMEM_SEND_LMT_REQ, slmt_req_hdr->src_offset,
+                MPIDI_SHM_XPMEM_SEND_LMT_RTS, slmt_req_hdr->src_offset,
                 slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr, slmt_req_hdr->src_lrank,
                 rank, slmt_req_hdr->src_rank, slmt_req_hdr->tag, slmt_req_hdr->context_id);
 
-    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_SHM_XPMEM_SEND_LMT_REQ, &ctrl_hdr);
+    mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_SHM_XPMEM_SEND_LMT_RTS, &ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/shm/xpmem/xpmem_win.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_win.c
@@ -123,7 +123,8 @@ int MPIDI_XPMEM_mpi_win_create_hook(MPIR_Win * win)
                                                remote_vaddr,
                                                &xpmem_win->regist_segs[i],
                                                &shared_table[i].shm_base_addr,
-                                               &MPIDI_XPMEM_global.segmaps[node_rank].segcache);
+                                               &MPIDI_XPMEM_global.
+                                               segmaps[node_rank].segcache_ubuf);
             MPIR_ERR_CHECK(mpi_errno);
         } else if (shared_table[i].size == 0)
             shared_table[i].shm_base_addr = NULL;

--- a/src/mpid/ch4/shm/xpmem/xpmem_win.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_win.c
@@ -122,7 +122,8 @@ int MPIDI_XPMEM_mpi_win_create_hook(MPIR_Win * win)
             mpi_errno = MPIDI_XPMEM_seg_regist(node_rank, shared_table[i].size,
                                                remote_vaddr,
                                                &xpmem_win->regist_segs[i],
-                                               &shared_table[i].shm_base_addr);
+                                               &shared_table[i].shm_base_addr,
+                                               &MPIDI_XPMEM_global.segmaps[node_rank].segcache);
             MPIR_ERR_CHECK(mpi_errno);
         } else if (shared_table[i].size == 0)
             shared_table[i].shm_base_addr = NULL;


### PR DESCRIPTION
## Pull Request Description
This PR implements the XPMEM cooperative copy for send/recv MPI routines. The main purpose of this PR is to improve the performance of single-copy XPMEM.

The corresponding performance analyses are put here and will be updated frequently:
Update at 10-17-2019
[XPMEM, POSIX(ch4, ch3) performance analysis.pptx](https://github.com/pmodels/mpich/files/3739677/XPMEM.POSIX.ch4.ch3.performance.analysis.pptx)

## Todo
- Support non-contiguous cooperative copy
- Support 64bits `fetch_and_add atomic` operation to reduce unnecessary offset address computation during copy
