### PR TITLE
mpl: bypass mac .local hostname by resetting to localhost

### DIFF
--- a/src/mpl/src/sock/mpl_sockaddr.c
+++ b/src/mpl/src/sock/mpl_sockaddr.c
@@ -76,6 +76,15 @@ int MPL_get_sockaddr(const char *s_hostname, MPL_sockaddr_t * p_addr)
     struct addrinfo *ai_list;
     int ret;
 
+    /* Macos adds .local to hostname when network is unavailable or limited.
+     * This will result in long timeout in getaddrinfo below.
+     * Bypass it by resetting the hostname to "localhost"
+     */
+    int n = strlen(s_hostname);
+    if (n > 6 && strcmp(s_hostname + n - 6, ".local") == 0) {
+        s_hostname = "localhost";
+    }
+
     /* NOTE: there is report that getaddrinfo implementations will call kernel
      * even when s_hostname is entirely numerical string and it may cause
      * problems when host is configured with thousands of ip addresses.


### PR DESCRIPTION

## Pull Request Description
Macos will generate hostname ends .local, which will result in long
timeout in getaddrinfo as well as not able to recognize hostname and
failures in ch3:tcp business card exchange.

This patch fixes it by resetting ".local" hostname to "localhost".

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fixes #3315 

The original issue is on an old version of MPICH and it is for freeBSD. The Apple laptop issues have long been experienced but seems there is no direct ticket for it.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
