### PR TITLE
runtests: missing semicolons

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -787,7 +787,7 @@ sub RunMPIProgram {
     if ($test_opt->{lock}) {
         # explict lock by setting "lock=[shared|name]" on testline directly
         my $name = $test_opt->{lock};
-        $lockfile = "/tmp/runtests-$name.lock"
+        $lockfile = "/tmp/runtests-$name.lock";
         if ($name eq "shared") {
             $got_lock = get_lock($lockfile, $lock_sh);
         } else {


### PR DESCRIPTION


## Pull Request Description
Forgot a semicolon in the last commit
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
