### PR TITLE
shm/init: bug fix in shared memory segment size

### DIFF
--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -85,8 +85,6 @@ int MPIDU_Init_shm_init(void)
     int ipc_lock_offset;
     OPA_emulation_ipl_t *ipc_lock;
 #endif
-    size_t segment_len = MPIDU_SHM_CACHE_LINE_LEN + sizeof(MPIDU_Init_shm_block_t);
-
     MPIR_CHKPMEM_DECL(1);
     MPIR_CHKLMEM_DECL(1);
 
@@ -97,6 +95,8 @@ int MPIDU_Init_shm_init(void)
     local_size = MPIR_Process.local_size;
     my_local_rank = MPIR_Process.local_rank;
     local_leader = MPIR_Process.node_local_map[0];
+
+    size_t segment_len = MPIDU_SHM_CACHE_LINE_LEN + sizeof(MPIDU_Init_shm_block_t) * local_size;
 
     char *serialized_hnd = NULL;
     int serialized_hnd_size = 0;

--- a/src/mpid/common/shm/mpidu_init_shm.h
+++ b/src/mpid/common/shm/mpidu_init_shm.h
@@ -10,8 +10,11 @@
 
 #include "mpidu_shm.h"
 
+/* One cache line per process should be enough for all cases */
+#define MPIDU_INIT_SHM_BLOCK_SIZE MPIDU_SHM_CACHE_LINE_LEN
+
 typedef struct MPIDU_Init_shm_block {
-    char block[MPIDU_SHM_CACHE_LINE_LEN * 16];
+    char block[MPIDU_INIT_SHM_BLOCK_SIZE];
 } MPIDU_Init_shm_block_t;
 
 int MPIDU_Init_shm_init(void);


### PR DESCRIPTION
## Pull Request Description

`MPIDU_Init_shm_init` should allocate a block of memory for every process
in the node. Currently we allocate only one block of size
`MPIDU_Init_shm_block_t`. This bug was introduced by #3989.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
