### PR TITLE
runtests: allow custom testlist via environment variable

### DIFF
--- a/test/mpi/Makefile.mtest
+++ b/test/mpi/Makefile.mtest
@@ -31,10 +31,11 @@ $(top_builddir)/util/mtest_common.$(OBJEXT): $(top_srcdir)/util/mtest_common.c
 $(top_builddir)/dtpools/src/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
+TESTLIST ?= testlist,testlist.dtp,testlist.cvar
 SUMMARY_BASENAME ?= summary
 
 testing:
-	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=testlist,testlist.dtp,testlist.cvar \
+	$(top_builddir)/runtests -srcdir=$(srcdir) -tests=$(TESTLIST) \
 		-mpiexec="${MPIEXEC}" -xmlfile=$(SUMMARY_BASENAME).xml \
 		-tapfile=$(SUMMARY_BASENAME).tap -junitfile=$(SUMMARY_BASENAME).junit.xml
 

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -47,6 +47,7 @@ use Time::HiRes qw(gettimeofday tv_interval);
 our $g_opt = {};   # global options. TODO: migrate global option vars into the hash
 $g_opt->{memory_total} = 20;      # Total memory in GB
 $g_opt->{memory_multiplier} = 1;  # No of simutaneous jobs
+$g_opt->{cleanup} = 1;            # Whether to remove the compiled programs
 
 # Total number of tests checked and run
 our $g_total_run = 0;
@@ -113,8 +114,6 @@ $debug = 1;
 $depth = 0;              # This is used to manage multiple open list files
 
 # Build flags
-$remove_this_pgm = 0;
-$clean_pgms      = 1;
 
 my $program_wrapper = '';
 
@@ -154,7 +153,7 @@ if (defined($ENV{"MPITEST_TIMEOUT_MULTIPLIER"})) {
     $defaultTimeLimitMultiplier = $ENV{"MPITEST_TIMEOUT_MULTIPLIER"};
 }
 
-for my $key ("memory_total", "memory_multiplier") {
+for my $key ("memory_total", "memory_multiplier", "cleanup") {
     my $k = "MPITEST_".uc($key);
     if (defined($ENV{$k})) {
         $g_opt->{$key} = $ENV{$k};
@@ -650,7 +649,7 @@ sub RunList {
                     $err_count++;
                 }
                 if ($batchRun == 0) {
-                    &CleanUpAfterRun( $programname );
+                    &CleanUpAfterRun( $programname, $test_opt );
                 }
                 if ($save_dir) {
                     chdir $save_dir;
@@ -730,7 +729,7 @@ sub ProcessImplicitList {
                 $found_error = 1;
                 $err_count++;
             }
-            &CleanUpAfterRun( $programname );
+            &CleanUpAfterRun( $programname, $default_test_opt );
         }
         close PGMS;
     }
@@ -1031,8 +1030,11 @@ sub BuildMPIProgram {
 
     my $rc = 0;
     if ($verbose) { print STDERR "making $programname\n"; }
-    if (! -x $programname) { $remove_this_pgm = 1; }
-    else { $remove_this_pgm = 0; }
+    if (! -x $programname) {
+        $test_opt->{need_remove} = 1;
+    } else {
+        $test_opt->{need_remove} = 0;
+    }
     my $output = `make $programname 2>&1`;
     $rc = $?;
     if ($rc > 255) { $rc >>= 8; }
@@ -1053,7 +1055,7 @@ sub BuildMPIProgram {
 }
 
 sub CleanUpAfterRun {
-    my $programname = $_[0];
+    my ($programname, $test_opt) = @_;
     
     # Check for that this program has exited.  If it is still running,
     # issue a warning and leave the application.  Of course, this
@@ -1075,10 +1077,10 @@ sub CleanUpAfterRun {
         }
     }
     else {
-        if ($remove_this_pgm && $clean_pgms) {
+        if ($test_opt->{need_remove} && $g_opt->{cleanup}) {
             unlink $programname, "$programname.o";
         }
-        $remove_this_pgm = 0;
+        $test_opt->{need_remove} = 0;
     }
 }
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Description
For example,  
```
TESTLIST=testlist.custom make testing
```
runs `testlist.custom` instead of the default `testlist,testlist.dtp,testlist.cvar`.

```
MPITEST_CLEANUP=0 make testing
```
will leave compiled test prog behind so we can check the exact binary for debugging purpose.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Allow custom testlist

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
