### PR TITLE
xfail: add ssendf08 to xfail.conf

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -46,13 +46,9 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 # the below tests timeout with the ofi/sockets provider
 * * * ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 # am-only failures
-* * am-only ch4:ofi * sed -i "s+\(^ssendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^ssendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^issendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^issendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^pssendf .*\)+\1 xfail=issue3915+g" test/mpi/f77/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^pssendf90 .*\)+\1 xfail=issue3915+g" test/mpi/f90/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^pssendf08 .*\)+\1 xfail=issue3915+g" test/mpi/f08/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist
+* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf08 .*\)+\1 xfail=issue3915+g" test/mpi/f08/pt2pt/testlist
 
 * * am-only ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 * * am-only ch4:ofi * sed -i "s+\(^huge_anysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist


### PR DESCRIPTION
## Pull Request Description
ssend fortran test on am-only are already in the xfail list. Add two
more missing cases for f08 tests:
* ssendf08
* issendf08

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
      See #3915. Ref #4104
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
