### PR TITLE
config: only try -Werror if the compiler accepts it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4515,7 +4515,7 @@ AC_SUBST([MPI_F77_CXX_LONG_DOUBLE_COMPLEX])
 # does not help, since only the latest type_tag definition is used. Type tags are defined in mpi.h,
 # therefore, they must be also be activated/deavtivated there
 PAC_PUSH_FLAG([CFLAGS])
-PAC_APPEND_FLAG([-Werror],[CFLAGS])
+PAC_C_CHECK_COMPILER_OPTION([-Werror],[CFLAGS="$CFLAGS -Werror"])
 AC_TRY_COMPILE([
 typedef int TEST_Datatype;
 #define TEST_INT ((TEST_Datatype)0x44)

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -826,8 +826,6 @@ AC_DEFUN([MPL_TRY_ATOMIC_HEADER],[
     checked_specified_primitive=yes
     AC_MSG_CHECKING([for support for $3])
 
-    PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$CFLAGS -I${srcdir}/include -Werror"
     AC_LINK_IFELSE([MPL_ATOMIC_TEST_PROGRAM([$1])],
         [AC_DEFINE([HAVE_$2], [1], [Define to 1 if we have support for $3])]
         [AC_MSG_RESULT([yes])]
@@ -835,11 +833,15 @@ AC_DEFUN([MPL_TRY_ATOMIC_HEADER],[
     ,
         [AC_MSG_RESULT([no])]
     )
-    PAC_POP_FLAG([CFLAGS])
 ])
 
 AC_CHECK_SIZEOF([void *])
 
+PAC_PUSH_FLAG([CFLAGS])
+CFLAGS="$CFLAGS -I${srcdir}/include"
+# Add -Werror to favor the option that does not result in warnings.
+# Do not add the flag if the compiler doesn't accept -Werror
+PAC_C_CHECK_COMPILER_OPTION([-Werror],[CFLAGS="$CFLAGS -Werror"],)
 mpl_atomic_primitives_set=false
 if test "$with_mpl_atomic_primitives" = "auto" \
         -o "$with_mpl_atomic_primitives" = "gcc_sync"; then
@@ -861,6 +863,7 @@ if test "$with_mpl_atomic_primitives" = "auto" \
     MPL_TRY_ATOMIC_HEADER([mpl_atomic_nt_intrinsics.h], [NT_INTRINSICS],
                           [Windows NT atomic intrinsics])
 fi
+PAC_POP_FLAG([CFLAGS])
 
 if test "$with_mpl_atomic_primitives" = "auto" \
         -o "$with_mpl_atomic_primitives" = "lock" ; then


### PR DESCRIPTION

## Pull Request Description
For example, pgi compiler and suncc won't accept -Werror. Adding it only
result in test failures.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
