### PR TITLE
runtests: check and abort if too many tests fails in timeout

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -48,6 +48,12 @@ our $g_opt = {};   # global options. TODO: migrate global option vars into the h
 $g_opt->{memory_total} = 20;      # Total memory in GB
 $g_opt->{memory_multiplier} = 1;  # No of simutaneous jobs
 
+# When every tests result in timeout, it means the code has deadlocks or some major issues,
+# waiting for all tests to finish is rather unnecessary. We'll keep a counter for number
+# of timeouts, and abore after too many timeout failure.
+our $g_num_timeout;
+our $g_num_timeout_thresh = 5;
+
 $MPIMajorVersion = "@MPI_VERSION@";
 $MPIMinorVersion = "@MPI_SUBVERSION@";
 $mpiexec = "@MPIEXEC@";    # Name of mpiexec program (including path, if necessary)
@@ -71,7 +77,7 @@ $total_seen = 0;         # Number of programs considered for testing
 $np_default = 2;         # Default number of processes to use
 $np_max     = -1;        # Maximum number of processes to use (overrides any
                          # value in the test list files.  -1 is Infinity
-$defaultTimeLimit = 180; # default timeout
+$defaultTimeLimit = 180; # default timeout in seconds
 $defaultTimeLimitMultiplier = 1.0; # default multiplier for timeout limit
 
 $srcdir = ".";           # Used to set the source dir for testlist files
@@ -454,6 +460,11 @@ sub RunList {
                 print STDERR "Terminating test because stopfile $stopfile found\n";
                 last;
             }
+            if ($g_num_timeout >= $g_num_timeout_thresh) {
+                # Too many timeout failures
+                print STDERR "Terminating test because of too many timeout failures\n";
+                last;
+            }
             # Skip comments
             s/#.*//g;
             # Remove any trailing newlines/returns
@@ -752,6 +763,7 @@ sub RunMPIProgram {
         $timeout = $test_opt->{timeLimit};
     }
     $timeout *= $defaultTimeLimitMultiplier;
+    $test_opt->{_timeout} = $timeout;
     $ENV{"MPIEXEC_TIMEOUT"} = $timeout;
 
     # Handle the ppn (processes per node) option.
@@ -877,8 +889,14 @@ sub RunMPIProgram {
             }
         }
         $rc = close ( MPIOUT );
-        my $end_time = gettimeofday();
+        my $end_time = gettimeofday();  # seconds in floating point
         $runtime = $end_time - $start_time;
+        # count # of timeout when tests are configured with sufficient timeLimit
+        if ($test_opt->{_timeout} > 60) {
+            if ($runtime - $test_opt->{_timeout} >= -10) {
+                $g_num_timeout++;
+            }
+        }
         print STDOUT "Runtime: $runtime\n" if $verbose;
         if ($rc == 0) {
             # Only generate a message if we think that the program

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -48,6 +48,9 @@ our $g_opt = {};   # global options. TODO: migrate global option vars into the h
 $g_opt->{memory_total} = 20;      # Total memory in GB
 $g_opt->{memory_multiplier} = 1;  # No of simutaneous jobs
 
+# Total number of tests checked and run
+our $g_total_run = 0;
+our $g_total_seen = 0;
 # When every tests result in timeout, it means the code has deadlocks or some major issues,
 # waiting for all tests to finish is rather unnecessary. We'll keep a counter for number
 # of timeouts, and abore after too many timeout failure.
@@ -72,8 +75,6 @@ $runxfail     = "@RUN_XFAIL@";
 $np_arg  = "-n";         # Name of argument to specify the number of processes
 $err_count = 0;          # Number of programs that failed.
 $skip_count = 0;         # Number of programs skipped
-$total_run = 0;          # Number of programs tested
-$total_seen = 0;         # Number of programs considered for testing
 $np_default = 2;         # Default number of processes to use
 $np_max     = -1;        # Maximum number of processes to use (overrides any
                          # value in the test list files.  -1 is Infinity
@@ -336,7 +337,7 @@ if ($xmloutput && $closeXMLOutput) {
 }
 
 if ($tapoutput) {
-    print TAPOUT "1..$total_seen\n";
+    print TAPOUT "1..$g_total_seen\n";
     close TAPOUT;
 }
 
@@ -357,7 +358,7 @@ if ($junitoutput) {
     print $JUNITOUTNEW "  <testsuite failures=\"$err_count\"\n";
     print $JUNITOUTNEW "             errors=\"0\"\n";
     print $JUNITOUTNEW "             skipped=\"$skip_count\"\n";
-    print $JUNITOUTNEW "             tests=\"$total_run\"\n";
+    print $JUNITOUTNEW "             tests=\"$g_total_run\"\n";
     print $JUNITOUTNEW "             date=\"${date}\"\n";
     print $JUNITOUTNEW "             name=\"summary_junit_xml\">\n";
     while( <$JUNITIN> ) {
@@ -375,13 +376,13 @@ if ($batchRun) {
 }
 else {
     if ($err_count) {
-        print "$err_count tests failed out of $total_run\n";
+        print "$err_count tests failed out of $g_total_run\n";
         if ($xmloutput) {
             print "Details in $xmlfullfile\n";
         }
     }
     else {
-        print " All $total_run tests passed!\n";
+        print " All $g_total_run tests passed!\n";
     }
     if ($tapoutput) {
         print "TAP formatted results in $tapfullfile\n";
@@ -570,7 +571,7 @@ sub RunList {
             # criteria for directories as well without counting directories as tests
             # in our XML/TAP output.
             unless (-d $programname) {
-                $total_seen++;
+                $g_total_seen++;
             }
 
             # If a minimum MPI version is specified, check against the
@@ -626,7 +627,7 @@ sub RunList {
                 &ProcessDir( $programname, $listfile );
             }
             else {
-                $total_run++;
+                $g_total_run++;
                 my $save_dir;
                 if ($programname =~/^(\S+)\/(\S+)$/) {
                     $save_dir = `pwd`;
@@ -699,7 +700,7 @@ sub ProcessImplicitList {
             if (-d $programname) { next; }  # Ignore directories
             if ($programname eq "runtests") { next; } # Ignore self
             if (-x $programname) {
-                $total_run++;
+                $g_total_run++;
                 &RunMPIProgram( $programname, $np_default, $default_test_opt);
             }
         }
@@ -719,7 +720,7 @@ sub ProcessImplicitList {
             # Skip messages from ls about no files
             if (! -s $programname) { next; }
             $programname =~ s/\.c//;
-            $total_run++;
+            $g_total_run++;
             if (&BuildMPIProgram( $programname, "") == 0) {
                 &RunMPIProgram( $programname, $np_default, $default_test_opt);
             }

--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -461,7 +461,7 @@ sub RunList {
                 print STDERR "Terminating test because stopfile $stopfile found\n";
                 last;
             }
-            if ($g_num_timeout >= $g_num_timeout_thresh) {
+            if ($g_num_timeout >= $g_num_timeout_thresh && $g_num_timeout / $g_total_run > 0.5) {
                 # Too many timeout failures
                 print STDERR "Terminating test because of too many timeout failures\n";
                 last;


### PR DESCRIPTION
## Pull Request Description

When code results in deadlocks, most tests will fail in timeout. It is not necessary to run all the tests if the pattern of failures are clear. Currently, we have a per-job timeout (2-3 hours) for selected jenkins tests. It does not work well. First some node run slow and per-job timeout is either too long or too small. Second, configuring per-job is tedious. Third, in the case we want early abort, 2-3 hours are still too much.

This PR adds timeout checks inside the `runtests` so it automatically works for all test jobs that uses `runtests`. It also can provide more sophisticated mechanism on detecting failure patterns and opt for early abortions.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
