### PR TITLE
mpif: add back the initializer to make it work with pgi compiler

### DIFF
--- a/src/binding/fortran/mpif_h/setbot.c.in
+++ b/src/binding/fortran/mpif_h/setbot.c.in
@@ -102,7 +102,7 @@ struct mpif_cmblk1_t_ {
 };
 typedef struct mpif_cmblk1_t_ mpif_cmblk1_t;
 /* *INDENT-OFF* */
-mpif_cmblk1_t mpifcmb1r @CMB_STATUS_ALIGNMENT@ = {};
+mpif_cmblk1_t mpifcmb1r @CMB_STATUS_ALIGNMENT@ = {{0}};
 /* *INDENT-ON* */
 extern mpif_cmblk1_t _CMPIFCMB1 __attribute__ ((alias("mpifcmb1r")));
 extern mpif_cmblk1_t MPIFCMB1 __attribute__ ((alias("mpifcmb1r")));
@@ -116,7 +116,7 @@ struct mpif_cmblk2_t_ {
 };
 typedef struct mpif_cmblk2_t_ mpif_cmblk2_t;
 /* *INDENT-OFF* */
-mpif_cmblk2_t mpifcmb2r @CMB_STATUS_ALIGNMENT@ = {};
+mpif_cmblk2_t mpifcmb2r @CMB_STATUS_ALIGNMENT@ = {{{0}}};
 /* *INDENT-ON* */
 extern mpif_cmblk2_t _CMPIFCMB2 __attribute__ ((alias("mpifcmb2r")));
 extern mpif_cmblk2_t MPIFCMB2 __attribute__ ((alias("mpifcmb2r")));
@@ -130,7 +130,7 @@ struct mpif_cmblk3_t_ {
 };
 typedef struct mpif_cmblk3_t_ mpif_cmblk3_t;
 /* *INDENT-OFF* */
-mpif_cmblk3_t mpifcmb3r @CMB_1INT_ALIGNMENT@ = {};
+mpif_cmblk3_t mpifcmb3r @CMB_1INT_ALIGNMENT@ = {0};
 /* *INDENT-ON* */
 extern mpif_cmblk3_t _CMPIFCMB3 __attribute__ ((alias("mpifcmb3r")));
 extern mpif_cmblk3_t MPIFCMB3 __attribute__ ((alias("mpifcmb3r")));
@@ -144,7 +144,7 @@ struct mpif_cmblk4_t_ {
 };
 typedef struct mpif_cmblk4_t_ mpif_cmblk4_t;
 /* *INDENT-OFF* */
-mpif_cmblk4_t mpifcmb4r @CMB_1INT_ALIGNMENT@ = {};
+mpif_cmblk4_t mpifcmb4r @CMB_1INT_ALIGNMENT@ = {0};
 /* *INDENT-ON* */
 extern mpif_cmblk4_t _CMPIFCMB4 __attribute__ ((alias("mpifcmb4r")));
 extern mpif_cmblk4_t MPIFCMB4 __attribute__ ((alias("mpifcmb4r")));
@@ -158,7 +158,7 @@ struct mpif_cmblk5_t_ {
 };
 typedef struct mpif_cmblk5_t_ mpif_cmblk5_t;
 /* *INDENT-OFF* */
-FORT_DLL_SPEC mpif_cmblk5_t mpifcmb5r @CMB_1INT_ALIGNMENT@ = {};
+FORT_DLL_SPEC mpif_cmblk5_t mpifcmb5r @CMB_1INT_ALIGNMENT@ = {0};
 /* *INDENT-ON* */
 extern FORT_DLL_SPEC mpif_cmblk5_t _CMPIFCMB5 __attribute__ ((alias("mpifcmb5r")));
 extern FORT_DLL_SPEC mpif_cmblk5_t MPIFCMB5 __attribute__ ((alias("mpifcmb5r")));
@@ -172,7 +172,7 @@ struct mpif_cmblk6_t_ {
 };
 typedef struct mpif_cmblk6_t_ mpif_cmblk6_t;
 /* *INDENT-OFF* */
-mpif_cmblk6_t mpifcmb6r @CMB_1INT_ALIGNMENT@ = {};
+mpif_cmblk6_t mpifcmb6r @CMB_1INT_ALIGNMENT@ = {{0}};
 /* *INDENT-ON* */
 extern mpif_cmblk6_t _CMPIFCMB6 __attribute__ ((alias("mpifcmb6r")));
 extern mpif_cmblk6_t MPIFCMB6 __attribute__ ((alias("mpifcmb6r")));
@@ -187,7 +187,7 @@ struct mpif_cmblk7_t_ {
 };
 typedef struct mpif_cmblk7_t_ mpif_cmblk7_t;
 /* *INDENT-OFF* */
-mpif_cmblk7_t mpifcmb7r @CMB_1INT_ALIGNMENT@ = {};
+mpif_cmblk7_t mpifcmb7r @CMB_1INT_ALIGNMENT@ = {{{0}}};
 /* *INDENT-ON* */
 extern mpif_cmblk7_t _CMPIFCMB7 __attribute__ ((alias("mpifcmb7r")));
 extern mpif_cmblk7_t MPIFCMB7 __attribute__ ((alias("mpifcmb7r")));
@@ -202,7 +202,7 @@ struct mpif_cmblk8_t_ {
 };
 typedef struct mpif_cmblk8_t_ mpif_cmblk8_t;
 /* *INDENT-OFF* */
-mpif_cmblk8_t mpifcmb8r @CMB_1INT_ALIGNMENT@ = {};
+mpif_cmblk8_t mpifcmb8r @CMB_1INT_ALIGNMENT@ = {{0}};
 /* *INDENT-ON* */
 extern mpif_cmblk8_t _CMPIFCMB8 __attribute__ ((alias("mpifcmb8r")));
 extern mpif_cmblk8_t MPIFCMB8 __attribute__ ((alias("mpifcmb8r")));
@@ -216,7 +216,7 @@ struct mpif_cmblk9_t_ {
 };
 typedef struct mpif_cmblk9_t_ mpif_cmblk9_t;
 /* *INDENT-OFF* */
-FORT_DLL_SPEC mpif_cmblk9_t mpifcmb9r @CMB_1INT_ALIGNMENT@ = {};
+FORT_DLL_SPEC mpif_cmblk9_t mpifcmb9r @CMB_1INT_ALIGNMENT@ = {0};
 /* *INDENT-ON* */
 extern FORT_DLL_SPEC mpif_cmblk9_t _CMPIFCMB9 __attribute__ ((alias("mpifcmb9r")));
 extern FORT_DLL_SPEC mpif_cmblk9_t MPIFCMB9 __attribute__ ((alias("mpifcmb9r")));

--- a/src/binding/fortran/mpif_h/setbot.c.in
+++ b/src/binding/fortran/mpif_h/setbot.c.in
@@ -102,6 +102,10 @@ struct mpif_cmblk1_t_ {
 };
 typedef struct mpif_cmblk1_t_ mpif_cmblk1_t;
 /* *INDENT-OFF* */
+/* The initializer is necessary for the alias to work -- cannot alias to a common symbol.
+ * The ugly double braces are necessary to silence warnings (due to the first element in
+ * the struct is of a compound type).
+ */
 mpif_cmblk1_t mpifcmb1r @CMB_STATUS_ALIGNMENT@ = {{0}};
 /* *INDENT-ON* */
 extern mpif_cmblk1_t _CMPIFCMB1 __attribute__ ((alias("mpifcmb1r")));


### PR DESCRIPTION
## Pull Request Description

Previously the double brace initializes were replaced with empty initializer for aesthetic reasons. Why it is valid in C++ and gcc would happily accept it in C, it is not pedantically valid in C99 and some compilers don't accept it. Revert the change and added a comment to clarify.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
