### PR TITLE
Adding macro for checking if a handle is builtin

### DIFF
--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -81,7 +81,7 @@ int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype)
     MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+    if (!HANDLE_IS_BUILTIN(datatype)) {
         MPIR_Datatype *datatype_ptr = NULL;
         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
 

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -194,7 +194,7 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr);
      * a builtin type, it must be a pair type composed of different \
      * builtin types, so we return MPI_DATATYPE_NULL here.          \
      */                                                             \
-    if (HANDLE_GET_KIND(basic_type_) != HANDLE_KIND_BUILTIN)        \
+    if (!HANDLE_IS_BUILTIN((basic_type_)))                          \
         basic_type_ = MPI_DATATYPE_NULL;                            \
  } while (0)
 
@@ -253,7 +253,7 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr);
  * (*is_config_) if the type is contiguous */
 #define MPIR_Datatype_is_contig(dtype_, is_contig_)                            \
     do {                                                                       \
-        if (HANDLE_GET_KIND(dtype_) == HANDLE_KIND_BUILTIN) {                  \
+        if (HANDLE_IS_BUILTIN((dtype_))) {                                     \
             *(is_contig_) = TRUE;                                              \
         }                                                                      \
         else {                                                                 \
@@ -296,7 +296,7 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr);
  * (*true_lb_) */
 #define MPIR_Datatype_get_true_lb(dtype_, true_lb_)                            \
     do {                                                                       \
-        if (HANDLE_GET_KIND(dtype_) == HANDLE_KIND_BUILTIN) {                  \
+        if (HANDLE_IS_BUILTIN((dtype_))) {                                     \
             *(true_lb_) = 0;                                                   \
         }                                                                      \
         else {                                                                 \
@@ -313,7 +313,7 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr);
 #define MPIR_Datatype_add_ref_if_not_builtin(datatype_)             \
     do {                                                            \
     if ((datatype_) != MPI_DATATYPE_NULL &&                         \
-        HANDLE_GET_KIND((datatype_)) != HANDLE_KIND_BUILTIN)        \
+        !HANDLE_IS_BUILTIN((datatype_)))                            \
     {                                                               \
         MPIR_Datatype *dtp_ = NULL;                                 \
         MPIR_Datatype_get_ptr((datatype_), dtp_);                   \
@@ -325,7 +325,7 @@ void MPIR_Datatype_free(MPIR_Datatype * ptr);
 #define MPIR_Datatype_release_if_not_builtin(datatype_)             \
     do {                                                            \
     if ((datatype_) != MPI_DATATYPE_NULL &&                         \
-        HANDLE_GET_KIND((datatype_)) != HANDLE_KIND_BUILTIN)        \
+        !HANDLE_IS_BUILTIN((datatype_)))                            \
     {                                                               \
         MPIR_Datatype *dtp_ = NULL;                                 \
         MPIR_Datatype_get_ptr((datatype_), dtp_);                   \
@@ -349,7 +349,7 @@ static inline void MPIR_Datatype_free_contents(MPIR_Datatype * dtp)
     array_of_types = (MPI_Datatype *) ((char *) dtp->contents + struct_sz);
 
     for (i = 0; i < dtp->contents->nr_types; i++) {
-        if (HANDLE_GET_KIND(array_of_types[i]) != HANDLE_KIND_BUILTIN) {
+        if (!HANDLE_IS_BUILTIN(array_of_types[i])) {
             MPIR_Datatype_get_ptr(array_of_types[i], old_dtp);
             MPIR_Datatype_ptr_release(old_dtp);
         }
@@ -446,7 +446,7 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
 
     /* increment reference counts on all the derived types used here */
     for (i = 0; i < nr_types; i++) {
-        if (HANDLE_GET_KIND(array_of_types[i]) != HANDLE_KIND_BUILTIN) {
+        if (!HANDLE_IS_BUILTIN(array_of_types[i])) {
             MPIR_Datatype_get_ptr(array_of_types[i], old_dtp);
             MPIR_Datatype_ptr_add_ref(old_dtp);
         }
@@ -467,7 +467,7 @@ void MPII_Datatype_attr_finalize(void);
 int MPII_Type_zerolen(MPI_Datatype * newtype);
 
 #define MPIR_DATATYPE_IS_PREDEFINED(type) \
-    ((HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN) || \
+    ((HANDLE_IS_BUILTIN((type))) || \
      (type == MPI_FLOAT_INT) || (type == MPI_DOUBLE_INT) || \
      (type == MPI_LONG_INT) || (type == MPI_SHORT_INT) || \
      (type == MPI_LONG_DOUBLE_INT))

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -458,7 +458,7 @@ cvars:
 #define MPIR_ERRTEST_USERBUFFER(buf,count,dtype,err)                    \
     if (count > 0 && buf == 0) {                                        \
         int ferr = 0;                                                   \
-        if (HANDLE_GET_KIND(dtype) == HANDLE_KIND_BUILTIN) { ferr=1; }  \
+        if (HANDLE_IS_BUILTIN((dtype))) { ferr=1; }  \
         else {                                                          \
             MPI_Aint errsize;                                           \
             MPIR_Datatype *errdtypeptr;                                 \
@@ -520,7 +520,7 @@ cvars:
         else {                                                          \
             MPIR_ERRTEST_VALID_HANDLE(op,MPIR_OP,err,MPI_ERR_OP,"**op"); \
         }                                                               \
-        if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {               \
+        if (!HANDLE_IS_BUILTIN((op))) {               \
             MPIR_ERR_SETANDSTMT(err,MPI_ERR_OP,goto fn_fail,"**opnotpredefined"); \
         }                                                               \
     } while (0)
@@ -533,7 +533,7 @@ cvars:
         else {                                                          \
             MPIR_ERRTEST_VALID_HANDLE(op,MPIR_OP,err,MPI_ERR_OP,"**op"); \
         }                                                               \
-        if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {               \
+        if (!HANDLE_IS_BUILTIN((op))) {               \
             MPIR_ERR_SETANDSTMT(err,MPI_ERR_OP,goto fn_fail,"**opnotpredefined"); \
         }                                                               \
     } while (0)
@@ -656,7 +656,7 @@ cvars:
 #define MPIR_ERRTEST_KEYVAL_PERM(keyval_, err_)                         \
     {                                                                   \
         if (HANDLE_GET_MPI_KIND(keyval_) == MPIR_KEYVAL &&              \
-            HANDLE_GET_KIND(keyval_) == HANDLE_KIND_BUILTIN)            \
+            HANDLE_IS_BUILTIN((keyval_)))            \
         {                                                               \
             MPIR_ERR_SETANDSTMT(err_, MPI_ERR_KEYVAL,goto fn_fail, "**permattr"); \
         }                                                               \

--- a/src/include/mpir_errhandler.h
+++ b/src/include/mpir_errhandler.h
@@ -78,13 +78,13 @@ extern MPIR_Errhandler MPIR_Errhandler_direct[];
  * for BUILTIN down in the MPIR_Object_* routines. */
 #define MPIR_Errhandler_add_ref(_errhand)                               \
     do {                                                                  \
-        if (HANDLE_GET_KIND((_errhand)->handle) != HANDLE_KIND_BUILTIN) { \
+        if (!HANDLE_IS_BUILTIN((_errhand)->handle)) { \
             MPIR_Object_add_ref(_errhand);                              \
         }                                                                 \
     } while (0)
 #define MPIR_Errhandler_release_ref(_errhand, _inuse)                   \
     do {                                                                  \
-        if (HANDLE_GET_KIND((_errhand)->handle) != HANDLE_KIND_BUILTIN) { \
+        if (!HANDLE_IS_BUILTIN((_errhand)->handle)) { \
             MPIR_Object_release_ref((_errhand), (_inuse));              \
         }                                                                 \
         else {                                                            \

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -179,6 +179,7 @@ const char *MPIR_Handle_get_kind_str(int kind);
 #define HANDLE_KIND_SHIFT 30
 #define HANDLE_GET_KIND(a) (((unsigned)(a)&HANDLE_KIND_MASK)>>HANDLE_KIND_SHIFT)
 #define HANDLE_SET_KIND(a,kind) ((a)|((kind)<<HANDLE_KIND_SHIFT))
+#define HANDLE_IS_BUILTIN(a) (HANDLE_GET_KIND((a)) == HANDLE_KIND_BUILTIN)
 
 /* For indirect, the remainder of the handle has a block and index within that
  * block */

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -160,7 +160,7 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
 
 #define MPIR_Op_add_ref_if_not_builtin(op)               \
     do {                                                 \
-        if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {\
+        if (!HANDLE_IS_BUILTIN((op))) {\
             MPIR_Op *op_ptr = NULL;                      \
             MPIR_Op_get_ptr(op, op_ptr);                 \
             MPIR_Assert(op_ptr != NULL);                 \
@@ -171,7 +171,7 @@ int MPIR_NO_OP_check_dtype(MPI_Datatype);
 
 #define MPIR_Op_release_if_not_builtin(op)               \
     do {                                                 \
-        if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {\
+        if (!HANDLE_IS_BUILTIN((op))) {\
             MPIR_Op *op_ptr = NULL;                      \
             MPIR_Op_get_ptr(op, op_ptr);                 \
             MPIR_Assert(op_ptr != NULL);                 \

--- a/src/mpi/attr/comm_get_attr.c
+++ b/src/mpi/attr/comm_get_attr.c
@@ -85,7 +85,7 @@ int MPII_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val,
      * a pointer to a copy */
     /* Note that if we are called from Fortran, we must return the values,
      * not the addresses, of these attributes */
-    if (HANDLE_GET_KIND(comm_keyval) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(comm_keyval)) {
         int attr_idx = comm_keyval & 0x0000000f;
         void **attr_val_p = (void **) attribute_val;
 #ifdef HAVE_FORTRAN_BINDING

--- a/src/mpi/attr/win_get_attr.c
+++ b/src/mpi/attr/win_get_attr.c
@@ -77,7 +77,7 @@ int MPII_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val,
      * a pointer to a copy */
     /* Note that if we are called from Fortran, we must return the values,
      * not the addresses, of these attributes */
-    if (HANDLE_GET_KIND(win_keyval) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(win_keyval)) {
         void **attr_val_p = (void **) attribute_val;
 #ifdef HAVE_FORTRAN_BINDING
         /* Note that this routine only has a Fortran 90 binding,

--- a/src/mpi/coll/allgather/allgather.c
+++ b/src/mpi/coll/allgather/allgather.c
@@ -349,7 +349,7 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                 MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
                     MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                     MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)
@@ -364,7 +364,7 @@ int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, recvcount, mpi_errno);
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
             MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/allgatherv/allgatherv.c
+++ b/src/mpi/coll/allgatherv/allgatherv.c
@@ -361,7 +361,7 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                 MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
                     MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                     MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)
@@ -393,7 +393,7 @@ int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -398,8 +398,7 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
             if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/allreduce/allreduce.c
+++ b/src/mpi/coll/allreduce/allreduce.c
@@ -180,7 +180,7 @@ int MPIR_Allreduce_intra_auto(const void *sendbuf,
 
     pof2 = comm_ptr->coll.pof2;
     if ((nbytes <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-        (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+        (!HANDLE_IS_BUILTIN(op)) || (count < pof2)) {
         mpi_errno =
             MPIR_Allreduce_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
                                                     comm_ptr, errflag);
@@ -372,7 +372,7 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -395,11 +395,11 @@ int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, count, mpi_errno);
             MPIR_ERRTEST_USERBUFFER(recvbuf, count, datatype, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -137,7 +137,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
      * using recursive doubling in that case.) */
 
 #ifdef HAVE_ERROR_CHECKING
-    MPIR_Assert(HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN);
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
     MPIR_Assert(count >= pof2);
 #endif /* HAVE_ERROR_CHECKING */
 

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -120,7 +120,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, int count,
 
     if (newrank != -1) {
         if ((count * type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-            (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+            (!HANDLE_IS_BUILTIN(op)) || (count < pof2)) {
             /* use recursive doubling */
             mask = 0x1;
             while (mask < pof2) {

--- a/src/mpi/coll/alltoall/alltoall.c
+++ b/src/mpi/coll/alltoall/alltoall.c
@@ -340,7 +340,7 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                 MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
                     MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                     MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)
@@ -358,7 +358,7 @@ int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
 
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
             MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/alltoallv/alltoallv.c
+++ b/src/mpi/coll/alltoallv/alltoallv.c
@@ -308,7 +308,7 @@ int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
                 MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                 MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
             }
-            if (check_send && HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (check_send && !HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -317,7 +317,7 @@ int MPI_Alltoallv(const void *sendbuf, const int *sendcounts,
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
             }
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/alltoallw/alltoallw.c
+++ b/src/mpi/coll/alltoallw/alltoallw.c
@@ -307,8 +307,7 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
                     if (sendcounts[i] > 0) {
                         MPIR_ERRTEST_DATATYPE(sendtypes[i], "sendtype[i]", mpi_errno);
                     }
-                    if ((sendcounts[i] > 0) &&
-                        (HANDLE_GET_KIND(sendtypes[i]) != HANDLE_KIND_BUILTIN)) {
+                    if ((sendcounts[i] > 0) && (!HANDLE_IS_BUILTIN(sendtypes[i]))) {
                         MPIR_Datatype_get_ptr(sendtypes[i], sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -323,7 +322,7 @@ int MPI_Alltoallw(const void *sendbuf, const int sendcounts[],
                 if (recvcounts[i] > 0) {
                     MPIR_ERRTEST_DATATYPE(recvtypes[i], "recvtype[i]", mpi_errno);
                 }
-                if ((recvcounts[i] > 0) && (HANDLE_GET_KIND(recvtypes[i]) != HANDLE_KIND_BUILTIN)) {
+                if ((recvcounts[i] > 0) && (!HANDLE_IS_BUILTIN(recvtypes[i]))) {
                     MPIR_Datatype_get_ptr(recvtypes[i], recvtype_ptr);
                     MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/bcast/bcast.c
+++ b/src/mpi/coll/bcast/bcast.c
@@ -391,7 +391,7 @@ int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm
                 MPIR_ERRTEST_INTER_ROOT(comm_ptr, root, mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -42,7 +42,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     if (comm_size == 1)
         goto fn_exit;
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;
     else {
         MPIR_Datatype_is_contig(datatype, &is_contig);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -63,7 +63,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     MPIR_Assert(MPL_is_pof2(comm_size, NULL));
 #endif /* HAVE_ERROR_CHECKING */
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;
     else {
         MPIR_Datatype_is_contig(datatype, &is_contig);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -49,7 +49,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     if (comm_size == 1)
         goto fn_exit;
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;
     else {
         MPIR_Datatype_is_contig(datatype, &is_contig);

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -209,7 +209,7 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -230,13 +230,13 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
 
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/exscan/exscan.c
+++ b/src/mpi/coll/exscan/exscan.c
@@ -235,8 +235,7 @@ int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/gather/gather.c
+++ b/src/mpi/coll/gather/gather.c
@@ -298,7 +298,7 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -314,7 +314,7 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -346,7 +346,7 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -362,7 +362,7 @@ int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/gatherv/gatherv.c
+++ b/src/mpi/coll/gatherv/gatherv.c
@@ -276,7 +276,7 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -295,7 +295,7 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -335,7 +335,7 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -354,7 +354,7 @@ int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iallgather/iallgather.c
+++ b/src/mpi/coll/iallgather/iallgather.c
@@ -420,7 +420,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (sendbuf != MPI_IN_PLACE && HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (sendbuf != MPI_IN_PLACE && !HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -431,7 +431,7 @@ int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_recursive_doubling.c
@@ -68,7 +68,7 @@ int MPIR_Iallgather_sched_intra_recursive_doubling(const void *sendbuf, int send
 #endif /* HAVE_ERROR_CHECKING */
 
     recv_dtp = NULL;
-    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+    if (!HANDLE_IS_BUILTIN(recvtype)) {
         MPIR_Datatype_get_ptr(recvtype, recv_dtp);
     }
 

--- a/src/mpi/coll/iallgatherv/iallgatherv.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv.c
@@ -437,7 +437,7 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
                 goto fn_fail;
 
             if (sendbuf != MPI_IN_PLACE) {
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
                     MPIR_Datatype *sendtype_ptr = NULL;
                     MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                     MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -461,7 +461,7 @@ int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, v
 
             MPIR_ERRTEST_ARGNULL(recvcounts, "recvcounts", mpi_errno);
             MPIR_ERRTEST_ARGNULL(displs, "displs", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -161,7 +161,7 @@ int MPIR_Iallreduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int cou
      * using recursive doubling in that case.) */
 
     if ((count * type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-        (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+        (!HANDLE_IS_BUILTIN(op)) || (count < pof2)) {
         /* use recursive doubling */
         mpi_errno =
             MPIR_Iallreduce_sched_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
@@ -426,7 +426,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -437,11 +437,11 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iallreduce/iallreduce.c
+++ b/src/mpi/coll/iallreduce/iallreduce.c
@@ -441,7 +441,7 @@ int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count,
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_reduce_scatter_allgather.c
@@ -24,7 +24,7 @@ int MPIR_Iallreduce_sched_intra_reduce_scatter_allgather(const void *sendbuf, vo
 #ifdef HAVE_ERROR_CHECKING
     /* we only support builtin datatypes for now, breaking up user types to do
      * the reduce-scatter is tricky */
-    MPIR_Assert(HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN);
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
 #endif
 
     comm_size = comm_ptr->local_size;

--- a/src/mpi/coll/ialltoall/ialltoall.c
+++ b/src/mpi/coll/ialltoall/ialltoall.c
@@ -400,7 +400,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
 
-            if (sendbuf != MPI_IN_PLACE && HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (sendbuf != MPI_IN_PLACE && !HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -411,7 +411,7 @@ int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ialltoallv/ialltoallv.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv.c
@@ -370,7 +370,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
             if (sendbuf != MPI_IN_PLACE) {
                 MPIR_ERRTEST_ARGNULL(sendcounts, "sendcounts", mpi_errno);
                 MPIR_ERRTEST_ARGNULL(sdispls, "sdispls", mpi_errno);
-                if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(sendtype)) {
                     MPIR_Datatype *sendtype_ptr = NULL;
                     MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                     MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -384,7 +384,7 @@ int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispl
 
             MPIR_ERRTEST_ARGNULL(recvcounts, "recvcounts", mpi_errno);
             MPIR_ERRTEST_ARGNULL(rdispls, "rdispls", mpi_errno);
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ibcast/ibcast.c
+++ b/src/mpi/coll/ibcast/ibcast.c
@@ -404,7 +404,7 @@ int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Com
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_recursive_doubling_allgather.c
@@ -78,7 +78,7 @@ int MPIR_Ibcast_sched_intra_scatter_recursive_doubling_allgather(void *buffer, i
     if (comm_size == 1)
         goto fn_exit;
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         is_contig = 1;
     } else {
         MPIR_Datatype_is_contig(datatype, &is_contig);

--- a/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_scatter_ring_allgather.c
@@ -46,7 +46,7 @@ int MPIR_Ibcast_sched_intra_scatter_ring_allgather(void *buffer, int count, MPI_
     if (comm_size == 1)
         goto fn_exit;
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;
     else {
         MPIR_Datatype_is_contig(datatype, &is_contig);

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -232,7 +232,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iexscan/iexscan.c
+++ b/src/mpi/coll/iexscan/iexscan.c
@@ -217,7 +217,7 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -228,11 +228,11 @@ int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/igather/igather.c
+++ b/src/mpi/coll/igather/igather.c
@@ -342,7 +342,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -358,7 +358,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -390,7 +390,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -406,7 +406,7 @@ int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/igatherv/igatherv.c
+++ b/src/mpi/coll/igatherv/igatherv.c
@@ -313,7 +313,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
                 if (sendbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -332,7 +332,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -372,7 +372,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
                         MPIR_ERRTEST_COUNT(recvcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -391,7 +391,7 @@ int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather.c
@@ -316,7 +316,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -327,7 +327,7 @@ int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sen
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv.c
@@ -323,7 +323,7 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -334,7 +334,7 @@ int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype se
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall.c
@@ -319,7 +319,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -330,7 +330,7 @@ int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype send
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv.c
@@ -334,7 +334,7 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
@@ -345,7 +345,7 @@ int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const i
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -149,7 +149,7 @@ int MPIR_Ireduce_sched_intra_auto(const void *sendbuf, void *recvbuf, int count,
     pof2 = comm_ptr->coll.pof2;
 
     if ((count * type_size > MPIR_CVAR_REDUCE_SHORT_MSG_SIZE) &&
-        (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) && (count >= pof2)) {
+        (HANDLE_IS_BUILTIN(op)) && (count >= pof2)) {
         /* do a reduce-scatter followed by gather to root. */
         mpi_errno =
             MPIR_Ireduce_sched_intra_reduce_scatter_gather(sendbuf, recvbuf, count, datatype, op,
@@ -384,7 +384,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
             int rank;
 
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -395,11 +395,11 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ireduce/ireduce.c
+++ b/src/mpi/coll/ireduce/ireduce.c
@@ -399,7 +399,7 @@ int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype data
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_reduce_scatter_gather.c
@@ -70,7 +70,7 @@ int MPIR_Ireduce_sched_intra_reduce_scatter_gather(const void *sendbuf, void *re
     pof2 = comm_ptr->coll.pof2;
 
 #ifdef HAVE_ERROR_CHECKING
-    MPIR_Assert(HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN);
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
     MPIR_Assert(count >= pof2);
 #endif /* HAVE_ERROR_CHECKING */
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -388,7 +388,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter.c
@@ -373,7 +373,7 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
                 goto fn_fail;
 
             MPIR_ERRTEST_ARGNULL(recvcounts, "recvcounts", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -384,11 +384,11 @@ int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -383,7 +383,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block.c
@@ -368,7 +368,7 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
         MPID_BEGIN_ERROR_CHECKS;
         {
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, FALSE);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -379,11 +379,11 @@ int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -243,7 +243,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
                 goto fn_fail;
 
             MPIR_ERRTEST_COMM_INTRA(comm_ptr, mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
@@ -254,11 +254,11 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            } else if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iscan/iscan.c
+++ b/src/mpi/coll/iscan/iscan.c
@@ -258,7 +258,7 @@ int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype dataty
                 MPIR_Op *op_ptr = NULL;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            } else if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iscatter/iscatter.c
+++ b/src/mpi/coll/iscatter/iscatter.c
@@ -355,7 +355,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (comm_ptr->rank == root) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -383,7 +383,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -402,7 +402,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -416,7 +416,7 @@ int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/iscatterv/iscatterv.c
+++ b/src/mpi/coll/iscatterv/iscatterv.c
@@ -327,7 +327,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -364,7 +364,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -385,7 +385,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -404,7 +404,7 @@ int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
+++ b/src/mpi/coll/neighbor_allgather/neighbor_allgather.c
@@ -229,14 +229,14 @@ int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype send
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                 MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
+++ b/src/mpi/coll/neighbor_allgatherv/neighbor_allgatherv.c
@@ -232,14 +232,14 @@ int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sen
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                 MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
+++ b/src/mpi/coll/neighbor_alltoall/neighbor_alltoall.c
@@ -231,14 +231,14 @@ int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendt
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                 MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
+++ b/src/mpi/coll/neighbor_alltoallv/neighbor_alltoallv.c
@@ -242,14 +242,14 @@ int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const in
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *sendtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                 MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                 MPIR_Datatype_committed_ptr(sendtype_ptr, mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *recvtype_ptr = NULL;
                 MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                 MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);

--- a/src/mpi/coll/op/op_commutative.c
+++ b/src/mpi/coll/op/op_commutative.c
@@ -36,7 +36,7 @@ int MPIR_Op_is_commutative(MPI_Op op)
 {
     MPIR_Op *op_ptr;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         return TRUE;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -471,8 +471,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
             if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce/reduce.c
+++ b/src/mpi/coll/reduce/reduce.c
@@ -208,7 +208,7 @@ int MPIR_Reduce_intra_auto(const void *sendbuf,
     pof2 = comm_ptr->coll.pof2;
 
     if ((count * type_size > MPIR_CVAR_REDUCE_SHORT_MSG_SIZE) &&
-        (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) && (count >= pof2)) {
+        (HANDLE_IS_BUILTIN(op)) && (count >= pof2)) {
         /* do a reduce-scatter followed by gather to root. */
         mpi_errno =
             MPIR_Reduce_intra_reduce_scatter_gather(sendbuf, recvbuf, count, datatype, op, root,
@@ -404,7 +404,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
 
                 MPIR_ERRTEST_COUNT(count, mpi_errno);
                 MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+                if (!HANDLE_IS_BUILTIN(datatype)) {
                     MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                     MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)
@@ -434,7 +434,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(count, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(datatype)) {
                         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                         MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -450,7 +450,7 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
                 else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(count, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-                    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(datatype)) {
                         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                         MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -468,11 +468,11 @@ int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datat
 
             if (mpi_errno != MPI_SUCCESS)
                 goto fn_fail;
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -86,7 +86,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     pof2 = comm_ptr->coll.pof2;
 
 #ifdef HAVE_ERROR_CHECKING
-    MPIR_Assert(HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN);
+    MPIR_Assert(HANDLE_IS_BUILTIN(op));
     MPIR_Assert(count >= pof2);
 #endif /* HAVE_ERROR_CHECKING */
 

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -150,8 +150,7 @@ int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype 
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -44,7 +44,7 @@ int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype
     if (count == 0)
         goto fn_exit;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         /* --BEGIN ERROR HANDLING-- */
         mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
         if (mpi_errno != MPI_SUCCESS)
@@ -144,14 +144,14 @@ int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype 
         {
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op *op_ptr;
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
                 if (mpi_errno != MPI_SUCCESS)
                     goto fn_fail;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -409,8 +409,7 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
             if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce_scatter/reduce_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter.c
@@ -386,7 +386,7 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
             }
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -406,11 +406,11 @@ int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[
             MPIR_ERRTEST_USERBUFFER(sendbuf, sum, datatype, mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -344,7 +344,7 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
             MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -365,11 +365,11 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
 
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block.c
@@ -368,8 +368,7 @@ int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
             if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -230,8 +230,7 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatyp
             if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
-            }
-            if (HANDLE_IS_BUILTIN(op)) {
+            } else {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/scan/scan.c
+++ b/src/mpi/coll/scan/scan.c
@@ -212,7 +212,7 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatyp
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
             MPIR_ERRTEST_OP(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)
@@ -227,11 +227,11 @@ int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatyp
             MPIR_ERRTEST_RECVBUF_INPLACE(recvbuf, count, mpi_errno);
             MPIR_ERRTEST_USERBUFFER(recvbuf, count, datatype, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_Op_get_ptr(op, op_ptr);
                 MPIR_Op_valid_ptr(op_ptr, mpi_errno);
             }
-            if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(op)) {
                 mpi_errno = (*MPIR_OP_HDL_TO_DTYPE_FN(op)) (datatype);
             }
             if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/scatter/scatter.c
+++ b/src/mpi/coll/scatter/scatter.c
@@ -304,7 +304,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (rank == root) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -332,7 +332,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -351,7 +351,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (root == MPI_ROOT) {
                     MPIR_ERRTEST_COUNT(sendcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -365,7 +365,7 @@ int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/coll/scatterv/scatterv.c
+++ b/src/mpi/coll/scatterv/scatterv.c
@@ -277,7 +277,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -313,7 +313,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                 if (recvbuf != MPI_IN_PLACE) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -334,7 +334,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                         MPIR_ERRTEST_COUNT(sendcounts[i], mpi_errno);
                         MPIR_ERRTEST_DATATYPE(sendtype, "sendtype", mpi_errno);
                     }
-                    if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(sendtype)) {
                         MPIR_Datatype_get_ptr(sendtype, sendtype_ptr);
                         MPIR_Datatype_valid_ptr(sendtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)
@@ -353,7 +353,7 @@ int MPI_Scatterv(const void *sendbuf, const int *sendcounts, const int *displs,
                 } else if (root != MPI_PROC_NULL) {
                     MPIR_ERRTEST_COUNT(recvcount, mpi_errno);
                     MPIR_ERRTEST_DATATYPE(recvtype, "recvtype", mpi_errno);
-                    if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+                    if (!HANDLE_IS_BUILTIN(recvtype)) {
                         MPIR_Datatype_get_ptr(recvtype, recvtype_ptr);
                         MPIR_Datatype_valid_ptr(recvtype_ptr, mpi_errno);
                         if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/comm/comm_free.c
+++ b/src/mpi/comm/comm_free.c
@@ -102,7 +102,7 @@ int MPI_Comm_free(MPI_Comm * comm)
             /* If comm_ptr is not valid, it will be reset to null */
 
             /* Cannot free the predefined communicators */
-            if (HANDLE_GET_KIND(*comm) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(*comm)) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
                                                  MPIR_ERR_RECOVERABLE, __func__, __LINE__,
                                                  MPI_ERR_COMM, "**commperm", "**commperm %s",

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -780,8 +780,7 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
         }
 #endif
         /* We need to release the error handler */
-        if (comm_ptr->errhandler &&
-            !(HANDLE_GET_KIND(comm_ptr->errhandler->handle) == HANDLE_KIND_BUILTIN)) {
+        if (comm_ptr->errhandler && !(HANDLE_IS_BUILTIN(comm_ptr->errhandler->handle))) {
             int errhInuse;
             MPIR_Errhandler_release_ref(comm_ptr->errhandler, &errhInuse);
             if (!errhInuse) {
@@ -797,7 +796,7 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
 
         /* Check for predefined communicators - these should not
          * be freed */
-        if (!(HANDLE_GET_KIND(comm_ptr->handle) == HANDLE_KIND_BUILTIN))
+        if (!(HANDLE_IS_BUILTIN(comm_ptr->handle)))
             MPIR_Handle_obj_free(&MPIR_Comm_mem, comm_ptr);
     } else {
         /* If the user attribute free function returns an error,

--- a/src/mpi/datatype/get_count.c
+++ b/src/mpi/datatype/get_count.c
@@ -102,7 +102,7 @@ int MPI_Get_count(const MPI_Status * status, MPI_Datatype datatype, int *count)
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype_ptr */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno)

--- a/src/mpi/datatype/get_elements.c
+++ b/src/mpi/datatype/get_elements.c
@@ -86,7 +86,7 @@ int MPI_Get_elements(const MPI_Status * status, MPI_Datatype datatype, int *coun
             /* Convert MPI object handles to object pointers */
             MPIR_Datatype_get_ptr(datatype, datatype_ptr);
             /* Validate datatype_ptr */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -163,7 +163,7 @@ PMPI_LOCAL MPI_Count MPIR_Type_get_elements(MPI_Count * bytes_p,
     /* if we have gotten down to a type with only one element type,
      * call MPIR_Type_get_basic_type_elements() and return.
      */
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN ||
+    if (HANDLE_IS_BUILTIN(datatype) ||
         datatype == MPI_FLOAT_INT ||
         datatype == MPI_DOUBLE_INT ||
         datatype == MPI_LONG_INT || datatype == MPI_SHORT_INT || datatype == MPI_LONG_DOUBLE_INT) {
@@ -277,7 +277,7 @@ int MPIR_Get_elements_x_impl(MPI_Count * byte_count, MPI_Datatype datatype, MPI_
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *datatype_ptr = NULL;
 
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+    if (!HANDLE_IS_BUILTIN(datatype)) {
         MPIR_Datatype_get_ptr(datatype, datatype_ptr);
     }
 
@@ -286,7 +286,7 @@ int MPIR_Get_elements_x_impl(MPI_Count * byte_count, MPI_Datatype datatype, MPI_
      * - derived type with a zero size
      * - type with multiple element types (nastiest)
      */
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN ||
+    if (HANDLE_IS_BUILTIN(datatype) ||
         (datatype_ptr->builtin_element_size != -1 && datatype_ptr->size > 0)) {
         /* QUESTION: WHAT IF SOMEONE GAVE US AN MPI_UB OR MPI_LB???
          */
@@ -294,7 +294,7 @@ int MPIR_Get_elements_x_impl(MPI_Count * byte_count, MPI_Datatype datatype, MPI_
         /* in both cases we do not limit the number of types that might
          * be in bytes
          */
-        if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+        if (!HANDLE_IS_BUILTIN(datatype)) {
             MPI_Datatype basic_type = MPI_DATATYPE_NULL;
             MPIR_Datatype_get_basic_type(datatype_ptr->basic_type, basic_type);
             *elements = MPIR_Type_get_basic_type_elements(byte_count, -1, basic_type);
@@ -387,7 +387,7 @@ int MPI_Get_elements_x(const MPI_Status * status, MPI_Datatype datatype, MPI_Cou
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/pack.c
+++ b/src/mpi/datatype/pack.c
@@ -108,7 +108,7 @@ int MPI_Pack(const void *inbuf,
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/datatype/pack_external.c
+++ b/src/mpi/datatype/pack_external.c
@@ -84,7 +84,7 @@ int MPI_Pack_external(const char datarep[],
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/datatype/pack_size.c
+++ b/src/mpi/datatype/pack_size.c
@@ -106,7 +106,7 @@ int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size)
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 MPIR_Datatype_committed_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/status_set_elements_x.c
+++ b/src/mpi/datatype/status_set_elements_x.c
@@ -92,7 +92,7 @@ int MPI_Status_set_elements_x(MPI_Status * status, MPI_Datatype datatype, MPI_Co
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/type_blockindexed.c
+++ b/src/mpi/datatype/type_blockindexed.c
@@ -66,7 +66,7 @@ int MPIR_Type_blockindexed(int count,
 
     new_dtp->typerep = NULL;
 
-    is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
+    is_builtin = (HANDLE_IS_BUILTIN(oldtype));
 
     if (is_builtin) {
         el_sz = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);

--- a/src/mpi/datatype/type_commit.c
+++ b/src/mpi/datatype/type_commit.c
@@ -30,7 +30,7 @@ int MPIR_Type_commit(MPI_Datatype * datatype_p)
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *datatype_ptr;
 
-    MPIR_Assert(HANDLE_GET_KIND(*datatype_p) != HANDLE_KIND_BUILTIN);
+    MPIR_Assert(!HANDLE_IS_BUILTIN(*datatype_p));
 
     MPIR_Datatype_get_ptr(*datatype_p, datatype_ptr);
 
@@ -52,7 +52,7 @@ int MPIR_Type_commit_impl(MPI_Datatype * datatype)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (HANDLE_GET_KIND(*datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(*datatype))
         goto fn_exit;
 
     /* pair types stored as real types are a special case */

--- a/src/mpi/datatype/type_contiguous.c
+++ b/src/mpi/datatype/type_contiguous.c
@@ -58,7 +58,7 @@ int MPIR_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype
 
     new_dtp->typerep = NULL;
 
-    is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
+    is_builtin = (HANDLE_IS_BUILTIN(oldtype));
 
     if (is_builtin) {
         el_sz = MPIR_Datatype_get_basic_size(oldtype);
@@ -238,7 +238,7 @@ int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype * newtype)
             MPIR_ERRTEST_COUNT(count, mpi_errno);
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/type_create_hindexed.c
+++ b/src/mpi/datatype/type_create_hindexed.c
@@ -86,7 +86,7 @@ int MPI_Type_create_hindexed(int count,
 
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/type_create_hindexed_block.c
+++ b/src/mpi/datatype/type_create_hindexed_block.c
@@ -112,7 +112,7 @@ int MPI_Type_create_hindexed_block(int count,
             }
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             }

--- a/src/mpi/datatype/type_create_hvector.c
+++ b/src/mpi/datatype/type_create_hvector.c
@@ -77,7 +77,7 @@ int MPI_Type_create_hvector(int count,
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/type_create_indexed_block.c
+++ b/src/mpi/datatype/type_create_indexed_block.c
@@ -142,7 +142,7 @@ int MPI_Type_create_indexed_block(int count,
             }
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             }

--- a/src/mpi/datatype/type_create_resized.c
+++ b/src/mpi/datatype/type_create_resized.c
@@ -64,7 +64,7 @@ int MPIR_Type_create_resized(MPI_Datatype oldtype,
     new_dtp->typerep = NULL;
 
     /* if oldtype is a basic, we build a contiguous typerep of count = 1 */
-    if (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(oldtype)) {
         int oldsize = MPIR_Datatype_get_basic_size(oldtype);
 
         new_dtp->size = oldsize;

--- a/src/mpi/datatype/type_create_struct.c
+++ b/src/mpi/datatype/type_create_struct.c
@@ -128,8 +128,7 @@ int MPI_Type_create_struct(int count,
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[j], "blocklen", mpi_errno);
                 MPIR_ERRTEST_DATATYPE(array_of_types[j], "datatype[j]", mpi_errno);
 
-                if (array_of_types[j] != MPI_DATATYPE_NULL &&
-                    HANDLE_GET_KIND(array_of_types[j]) != HANDLE_KIND_BUILTIN) {
+                if (array_of_types[j] != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(array_of_types[j])) {
                     MPIR_Datatype_get_ptr(array_of_types[j], datatype_ptr);
                     MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                     if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -40,7 +40,7 @@ void MPII_Datatype_printf(MPI_Datatype type,
     MPI_Aint size;
     MPI_Aint extent, true_lb, true_ub, lb, ub, sticky_lb, sticky_ub;
 
-    if (HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(type)) {
         string = MPIR_Datatype_builtin_to_string(type);
         MPIR_Assert(string != NULL);
         if (type == MPI_LB)
@@ -308,7 +308,7 @@ void MPIR_Datatype_debug(MPI_Datatype type, int array_ct)
 #endif
     MPIR_Datatype *dtp ATTRIBUTE((unused));
 
-    is_builtin = (HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN);
+    is_builtin = (HANDLE_IS_BUILTIN(type));
 
     /* can get a NULL type a number of different ways, including not having
      * fortran support included.
@@ -406,7 +406,7 @@ static void contents_printf(MPI_Datatype type, int depth, int acount)
     int *ints = NULL;
 
 #if (defined HAVE_ERROR_CHECKING) || (defined MPL_USE_DBG_LOGGING)
-    if (HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(type)) {
         const char *string = MPIR_Datatype_builtin_to_string(type);
         MPIR_Assert(string != NULL);
         MPL_DBG_OUT_FMT(MPIR_DBG_DATATYPE, (MPL_DBG_FDEST, "# %stype: %s\n",

--- a/src/mpi/datatype/type_dup.c
+++ b/src/mpi/datatype/type_dup.c
@@ -33,7 +33,7 @@ int MPIR_Type_dup(MPI_Datatype oldtype, MPI_Datatype * newtype)
     int mpi_errno = MPI_SUCCESS;
     MPIR_Datatype *new_dtp = 0, *old_dtp;
 
-    if (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(oldtype)) {
         /* create a new type and commit it. */
         mpi_errno = MPIR_Type_contiguous(1, oldtype, newtype);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/datatype/type_free.c
+++ b/src/mpi/datatype/type_free.c
@@ -94,7 +94,7 @@ int MPI_Type_free(MPI_Datatype * datatype)
             MPIR_Datatype *datatype_ptr = NULL;
 
             /* Check for built-in type */
-            if (HANDLE_GET_KIND(*datatype) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(*datatype)) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
                                                  MPIR_ERR_RECOVERABLE,
                                                  __func__, __LINE__, MPI_ERR_TYPE, "**dtypeperm",

--- a/src/mpi/datatype/type_get_contents.c
+++ b/src/mpi/datatype/type_get_contents.c
@@ -46,7 +46,7 @@ int MPIR_Type_get_contents(MPI_Datatype datatype,
     /* these are checked at the MPI layer, so I feel that asserts
      * are appropriate.
      */
-    MPIR_Assert(HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN);
+    MPIR_Assert(!HANDLE_IS_BUILTIN(datatype));
     MPIR_Assert(datatype != MPI_FLOAT_INT &&
                 datatype != MPI_DOUBLE_INT &&
                 datatype != MPI_LONG_INT &&
@@ -79,7 +79,7 @@ int MPIR_Type_get_contents(MPI_Datatype datatype,
     }
 
     for (i = 0; i < cp->nr_types; i++) {
-        if (HANDLE_GET_KIND(array_of_datatypes[i]) != HANDLE_KIND_BUILTIN) {
+        if (!HANDLE_IS_BUILTIN(array_of_datatypes[i])) {
             MPIR_Datatype_get_ptr(array_of_datatypes[i], dtp);
             MPIR_Datatype_ptr_add_ref(dtp);
         }
@@ -146,7 +146,7 @@ int MPI_Type_get_contents(MPI_Datatype datatype,
             MPIR_Datatype *datatype_ptr = NULL;
 
             /* Check for built-in type */
-            if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+            if (HANDLE_IS_BUILTIN(datatype)) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
                                                  MPIR_ERR_RECOVERABLE,
                                                  __func__, __LINE__,

--- a/src/mpi/datatype/type_get_envelope.c
+++ b/src/mpi/datatype/type_get_envelope.c
@@ -31,7 +31,7 @@ void MPIR_Type_get_envelope(MPI_Datatype datatype,
                             int *num_integers,
                             int *num_addresses, int *num_datatypes, int *combiner)
 {
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN ||
+    if (HANDLE_IS_BUILTIN(datatype) ||
         datatype == MPI_FLOAT_INT ||
         datatype == MPI_DOUBLE_INT ||
         datatype == MPI_LONG_INT || datatype == MPI_SHORT_INT || datatype == MPI_LONG_DOUBLE_INT) {

--- a/src/mpi/datatype/type_get_extent_x.c
+++ b/src/mpi/datatype/type_get_extent_x.c
@@ -33,7 +33,7 @@ void MPIR_Type_get_extent_x_impl(MPI_Datatype datatype, MPI_Count * lb, MPI_Coun
 
     MPIR_Datatype_get_ptr(datatype, datatype_ptr);
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         *lb = 0;
         *extent = MPIR_Datatype_get_basic_size(datatype);
     } else {
@@ -90,7 +90,7 @@ int MPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count * lb, MPI_Count * ext
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/type_get_true_extent_x.c
+++ b/src/mpi/datatype/type_get_true_extent_x.c
@@ -34,7 +34,7 @@ void MPIR_Type_get_true_extent_x_impl(MPI_Datatype datatype, MPI_Count * true_lb
 
     MPIR_Datatype_get_ptr(datatype, datatype_ptr);
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         *true_lb = 0;
         *true_extent = MPIR_Datatype_get_basic_size(datatype);
     } else {
@@ -91,7 +91,7 @@ int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count * true_lb, MPI_C
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/type_hindexed.c
+++ b/src/mpi/datatype/type_hindexed.c
@@ -109,7 +109,7 @@ int MPI_Type_hindexed(int count,
                 MPIR_ERRTEST_ARGNULL(array_of_displacements, "array_of_displacements", mpi_errno);
             }
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno != MPI_SUCCESS)

--- a/src/mpi/datatype/type_hvector.c
+++ b/src/mpi/datatype/type_hvector.c
@@ -100,7 +100,7 @@ int MPI_Type_hvector(int count,
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklength", mpi_errno);
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 if (mpi_errno)

--- a/src/mpi/datatype/type_indexed.c
+++ b/src/mpi/datatype/type_indexed.c
@@ -73,7 +73,7 @@ int MPIR_Type_indexed(int count,
 
     new_dtp->typerep = NULL;
 
-    is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
+    is_builtin = (HANDLE_IS_BUILTIN(oldtype));
 
     if (is_builtin) {
         /* builtins are handled differently than user-defined types because
@@ -330,7 +330,7 @@ int MPI_Type_indexed(int count,
             }
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
             }

--- a/src/mpi/datatype/type_lb.c
+++ b/src/mpi/datatype/type_lb.c
@@ -28,7 +28,7 @@ int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint * displacement)
 
 void MPIR_Type_lb_impl(MPI_Datatype datatype, MPI_Aint * displacement)
 {
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         *displacement = 0;
     } else {
         MPIR_Datatype *datatype_ptr = NULL;

--- a/src/mpi/datatype/type_size.c
+++ b/src/mpi/datatype/type_size.c
@@ -69,7 +69,7 @@ int MPI_Type_size(MPI_Datatype datatype, int *size)
 #endif /* HAVE_ERROR_CHECKING */
 
     /* If this is a built-in datatype, then get the size out of the handle */
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         MPIR_Datatype_get_size_macro(datatype, *size);
         goto fn_exit;
     }

--- a/src/mpi/datatype/type_size_x.c
+++ b/src/mpi/datatype/type_size_x.c
@@ -83,7 +83,7 @@ int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count * size)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/datatype/type_struct.c
+++ b/src/mpi/datatype/type_struct.c
@@ -66,7 +66,7 @@ static MPI_Aint MPII_Type_struct_alignsize(int count,
         /* shouldn't be called with an LB or UB, but we'll handle it nicely */
         if (oldtype_array[i] == MPI_LB || oldtype_array[i] == MPI_UB)
             continue;
-        else if (HANDLE_GET_KIND(oldtype_array[i]) == HANDLE_KIND_BUILTIN) {
+        else if (HANDLE_IS_BUILTIN(oldtype_array[i])) {
             tmp_alignsize = MPIR_Datatype_get_basic_size(oldtype_array[i]);
 
 #ifdef HAVE_DOUBLE_ALIGNMENT_EXCEPTION
@@ -192,7 +192,7 @@ int MPIR_Type_struct(int count,
 
     new_dtp->max_contig_blocks = 0;
     for (i = 0; i < count; i++) {
-        int is_builtin = (HANDLE_GET_KIND(oldtype_array[i]) == HANDLE_KIND_BUILTIN);
+        int is_builtin = (HANDLE_IS_BUILTIN(oldtype_array[i]));
         MPI_Aint tmp_lb, tmp_ub, tmp_true_lb, tmp_true_ub;
         MPI_Aint tmp_el_sz;
         MPI_Datatype tmp_el_type;
@@ -508,8 +508,7 @@ int MPI_Type_struct(int count,
                 MPIR_ERRTEST_ARGNEG(array_of_blocklengths[i], "blocklength", mpi_errno);
                 MPIR_ERRTEST_DATATYPE(array_of_types[i], "datatype[i]", mpi_errno);
 
-                if (array_of_types[i] != MPI_DATATYPE_NULL &&
-                    HANDLE_GET_KIND(array_of_types[i]) != HANDLE_KIND_BUILTIN) {
+                if (array_of_types[i] != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(array_of_types[i])) {
                     MPIR_Datatype_get_ptr(array_of_types[i], datatype_ptr);
                     MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
                 }

--- a/src/mpi/datatype/type_ub.c
+++ b/src/mpi/datatype/type_ub.c
@@ -92,7 +92,7 @@ int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * displacement)
 
     /* ... body of routine ...  */
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         *displacement = MPIR_Datatype_get_basic_size(datatype);
     else
         *displacement = datatype_ptr->ub;

--- a/src/mpi/datatype/type_vector.c
+++ b/src/mpi/datatype/type_vector.c
@@ -62,7 +62,7 @@ int MPIR_Type_vector(int count,
 
     new_dtp->typerep = NULL;
 
-    is_builtin = (HANDLE_GET_KIND(oldtype) == HANDLE_KIND_BUILTIN);
+    is_builtin = (HANDLE_IS_BUILTIN(oldtype));
 
     if (is_builtin) {
         el_sz = (MPI_Aint) MPIR_Datatype_get_basic_size(oldtype);
@@ -223,7 +223,7 @@ int MPI_Type_vector(int count,
             MPIR_ERRTEST_ARGNEG(blocklength, "blocklen", mpi_errno);
             MPIR_ERRTEST_DATATYPE(oldtype, "datatype", mpi_errno);
 
-            if (oldtype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(oldtype) != HANDLE_KIND_BUILTIN) {
+            if (oldtype != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(oldtype)) {
                 MPIR_Datatype_get_ptr(oldtype, old_ptr);
                 MPIR_Datatype_valid_ptr(old_ptr, mpi_errno);
                 if (mpi_errno)

--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -520,7 +520,7 @@ void MPIR_Dataloop_dup(void *old_loop_, void **new_loop_p_)
 
 MPI_Aint MPIR_Datatype_size_external32(MPI_Datatype type)
 {
-    if (HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(type)) {
         return MPII_Datatype_get_basic_size_external32(type);
     } else {
         MPII_Dataloop *dlp = NULL;

--- a/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_debug.c
@@ -201,7 +201,7 @@ static void dot_printf(MPII_Dataloop * loop_p, int depth, int header)
 
 void MPIR_Dataloop_printf(MPI_Datatype type, int depth, int header)
 {
-    if (HANDLE_GET_KIND(type) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(type)) {
         MPL_DBG_OUT(MPIR_DBG_DATATYPE, "type_dot_printf: type is a basic");
         return;
     } else {

--- a/src/mpi/datatype/typerep/dataloop/dataloop_internal.h
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_internal.h
@@ -12,7 +12,7 @@
 #include "dataloop.h"
 
 #define MPII_DATALOOP_HANDLE_HASLOOP(handle_)                           \
-    ((HANDLE_GET_KIND(handle_) == HANDLE_KIND_BUILTIN) ? 0 : 1)
+    ((HANDLE_IS_BUILTIN(handle_)) ? 0 : 1)
 
 #define MPII_DATALOOP_FINAL_MASK  0x00000008
 #define MPII_DATALOOP_KIND_MASK   0x00000007

--- a/src/mpi/datatype/typerep/src/typerep_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_pack.c
@@ -24,7 +24,7 @@ int MPIR_Typerep_pack(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype
         goto fn_exit;
     }
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         contig = TRUE;
         dt_true_lb = 0;
         data_sz = incount * MPIR_Datatype_get_basic_size(datatype);
@@ -80,7 +80,7 @@ int MPIR_Typerep_unpack(const void *inbuf, MPI_Aint insize,
         goto fn_exit;
     }
 
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(datatype)) {
         contig = TRUE;
         dt_true_lb = 0;
         data_sz = outcount * MPIR_Datatype_get_basic_size(datatype);

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -243,7 +243,7 @@ int MPIR_Datatype_commit_pairtypes(void)
 /* This will eventually be removed once ROMIO knows more about MPICH */
 void MPIR_Datatype_iscontig(MPI_Datatype datatype, int *flag)
 {
-    if (HANDLE_GET_KIND(datatype) == HANDLE_KIND_BUILTIN)
+    if (HANDLE_IS_BUILTIN(datatype))
         *flag = 1;
     else {
         MPIR_Datatype_is_contig(datatype, flag);

--- a/src/mpi/datatype/unpack.c
+++ b/src/mpi/datatype/unpack.c
@@ -103,7 +103,7 @@ int MPI_Unpack(const void *inbuf, int insize, int *position,
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            if (datatype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (datatype != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/datatype/unpack_external.c
+++ b/src/mpi/datatype/unpack_external.c
@@ -81,7 +81,7 @@ int MPI_Unpack_external(const char datarep[],
 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
-            if (datatype != MPI_DATATYPE_NULL && HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (datatype != MPI_DATATYPE_NULL && !HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/errhan/comm_set_errhandler.c
+++ b/src/mpi/errhan/comm_set_errhandler.c
@@ -106,7 +106,7 @@ int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler)
             /* Validate comm_ptr; if comm_ptr is not valid, it will be reset to null */
             MPIR_Comm_valid_ptr(comm_ptr, mpi_errno, TRUE);
 
-            if (HANDLE_GET_KIND(errhandler) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(errhandler)) {
                 MPIR_Errhandler_valid_ptr(errhan_ptr, mpi_errno);
             }
             MPIR_ERRTEST_ERRHANDLER(errhandler, mpi_errno);

--- a/src/mpi/errhan/errhandler_set.c
+++ b/src/mpi/errhan/errhandler_set.c
@@ -88,7 +88,7 @@ int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler)
                 goto fn_fail;
             MPIR_ERRTEST_ERRHANDLER(errhandler, mpi_errno);
 
-            if (HANDLE_GET_KIND(errhandler) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(errhandler)) {
                 MPIR_Errhandler_valid_ptr(errhan_ptr, mpi_errno);
                 if (mpi_errno)
                     goto fn_fail;

--- a/src/mpi/errhan/file_set_errhandler.c
+++ b/src/mpi/errhan/file_set_errhandler.c
@@ -79,7 +79,7 @@ int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler)
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(errhandler) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(errhandler)) {
                 MPIR_Errhandler_valid_ptr(errhan_ptr, mpi_errno);
                 /* Also check for a valid errhandler kind */
                 if (!mpi_errno) {

--- a/src/mpi/errhan/win_set_errhandler.c
+++ b/src/mpi/errhan/win_set_errhandler.c
@@ -80,7 +80,7 @@ int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler)
             MPIR_Win_valid_ptr(win_ptr, mpi_errno);
             /* If win_ptr is not value, it will be reset to null */
 
-            if (HANDLE_GET_KIND(errhandler) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(errhandler)) {
                 MPIR_Errhandler_valid_ptr(errhan_ptr, mpi_errno);
                 /* Also check for a valid errhandler kind */
                 if (!mpi_errno) {

--- a/src/mpi/group/group_free.c
+++ b/src/mpi/group/group_free.c
@@ -99,7 +99,7 @@ int MPI_Group_free(MPI_Group * group)
 
             /* Cannot free the predefined groups, but allow GROUP_EMPTY
              * because otherwise many tests fail */
-            if ((HANDLE_GET_KIND(*group) == HANDLE_KIND_BUILTIN) && *group != MPI_GROUP_EMPTY) {
+            if ((HANDLE_IS_BUILTIN(*group)) && *group != MPI_GROUP_EMPTY) {
                 mpi_errno = MPIR_Err_create_code(MPI_SUCCESS,
                                                  MPIR_ERR_RECOVERABLE, __func__, __LINE__,
                                                  MPI_ERR_GROUP, "**groupperm", 0);

--- a/src/mpi/init/init_global.c
+++ b/src/mpi/init/init_global.c
@@ -191,7 +191,7 @@ int MPII_finalize_global(void)
      * comm self and comm world
      */
     if (MPIR_Process.comm_world->errhandler &&
-        !(HANDLE_GET_KIND(MPIR_Process.comm_world->errhandler->handle) == HANDLE_KIND_BUILTIN)) {
+        !(HANDLE_IS_BUILTIN(MPIR_Process.comm_world->errhandler->handle))) {
         int in_use;
         MPIR_Errhandler_release_ref(MPIR_Process.comm_world->errhandler, &in_use);
         if (!in_use) {
@@ -201,7 +201,7 @@ int MPII_finalize_global(void)
         MPIR_Process.comm_world->errhandler = NULL;
     }
     if (MPIR_Process.comm_self->errhandler &&
-        !(HANDLE_GET_KIND(MPIR_Process.comm_self->errhandler->handle) == HANDLE_KIND_BUILTIN)) {
+        !(HANDLE_IS_BUILTIN(MPIR_Process.comm_self->errhandler->handle))) {
         int in_use;
         MPIR_Errhandler_release_ref(MPIR_Process.comm_self->errhandler, &in_use);
         if (!in_use) {

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -46,8 +46,7 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
         copy_sz = sdata_sz;
 
     /* Builtin types is the common case; optimize for it */
-    if ((HANDLE_GET_KIND(sendtype) == HANDLE_KIND_BUILTIN) &&
-        HANDLE_GET_KIND(recvtype) == HANDLE_KIND_BUILTIN) {
+    if ((HANDLE_IS_BUILTIN(sendtype)) && HANDLE_IS_BUILTIN(recvtype)) {
         MPIR_Memcpy(recvbuf, sendbuf, copy_sz);
         goto fn_exit;
     }

--- a/src/mpi/pt2pt/bsend.c
+++ b/src/mpi/pt2pt/bsend.c
@@ -129,7 +129,7 @@ int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/bsend_init.c
+++ b/src/mpi/pt2pt/bsend_init.c
@@ -101,7 +101,7 @@ int MPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype,
             MPIR_ERRTEST_ARGNULL(request, "request", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/ibsend.c
+++ b/src/mpi/pt2pt/ibsend.c
@@ -194,7 +194,7 @@ int MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/imrecv.c
+++ b/src/mpi/pt2pt/imrecv.c
@@ -82,7 +82,7 @@ int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * messag
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/pt2pt/irecv.c
+++ b/src/mpi/pt2pt/irecv.c
@@ -100,7 +100,7 @@ int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/irsend.c
+++ b/src/mpi/pt2pt/irsend.c
@@ -102,7 +102,7 @@ int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/isend.c
+++ b/src/mpi/pt2pt/isend.c
@@ -99,7 +99,7 @@ int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/issend.c
+++ b/src/mpi/pt2pt/issend.c
@@ -100,7 +100,7 @@ int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int 
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/mrecv.c
+++ b/src/mpi/pt2pt/mrecv.c
@@ -81,7 +81,7 @@ int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message * message
     {
         MPID_BEGIN_ERROR_CHECKS;
         {
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);
                 MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);

--- a/src/mpi/pt2pt/recv.c
+++ b/src/mpi/pt2pt/recv.c
@@ -108,7 +108,7 @@ int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/recv_init.c
+++ b/src/mpi/pt2pt/recv_init.c
@@ -104,7 +104,7 @@ int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/rsend.c
+++ b/src/mpi/pt2pt/rsend.c
@@ -96,7 +96,7 @@ int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/rsend_init.c
+++ b/src/mpi/pt2pt/rsend_init.c
@@ -104,7 +104,7 @@ int MPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/send.c
+++ b/src/mpi/pt2pt/send.c
@@ -100,7 +100,7 @@ int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int ta
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/send_init.c
+++ b/src/mpi/pt2pt/send_init.c
@@ -104,7 +104,7 @@ int MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -125,7 +125,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
             MPIR_ERRTEST_DATATYPE(recvtype, "datatype", mpi_errno);
 
             /* Validate datatype objects */
-            if (HANDLE_GET_KIND(sendtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(sendtype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(sendtype, datatype_ptr);
@@ -136,7 +136,7 @@ int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                 if (mpi_errno)
                     goto fn_fail;
             }
-            if (HANDLE_GET_KIND(recvtype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(recvtype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(recvtype, datatype_ptr);

--- a/src/mpi/pt2pt/sendrecv_rep.c
+++ b/src/mpi/pt2pt/sendrecv_rep.c
@@ -107,7 +107,7 @@ int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/ssend.c
+++ b/src/mpi/pt2pt/ssend.c
@@ -94,7 +94,7 @@ int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int t
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/pt2pt/ssend_init.c
+++ b/src/mpi/pt2pt/ssend_init.c
@@ -101,7 +101,7 @@ int MPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest,
             MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
 
             /* Validate datatype object */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(datatype, datatype_ptr);

--- a/src/mpi/rma/accumulate.c
+++ b/src/mpi/rma/accumulate.c
@@ -111,7 +111,7 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -123,7 +123,7 @@ int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/fetch_and_op.c
+++ b/src/mpi/rma/fetch_and_op.c
@@ -135,7 +135,7 @@ int MPI_Fetch_and_op(const void *origin_addr, void *result_addr,
 
             MPIR_ERRTEST_OP_GACC(op, mpi_errno);
 
-            if (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(op)) {
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OP, "**opnotpredefined");
             }
         }

--- a/src/mpi/rma/get.c
+++ b/src/mpi/rma/get.c
@@ -104,7 +104,7 @@ int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -116,7 +116,7 @@ int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/get_accumulate.c
+++ b/src/mpi/rma/get_accumulate.c
@@ -151,7 +151,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count,
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (op != MPI_NO_OP && HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (op != MPI_NO_OP && !HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -163,7 +163,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(result_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(result_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(result_datatype, datatype_ptr);
@@ -175,7 +175,7 @@ int MPI_Get_accumulate(const void *origin_addr, int origin_count,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/put.c
+++ b/src/mpi/rma/put.c
@@ -104,7 +104,7 @@ int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -116,7 +116,7 @@ int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/raccumulate.c
+++ b/src/mpi/rma/raccumulate.c
@@ -124,7 +124,7 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -136,7 +136,7 @@ int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/rget.c
+++ b/src/mpi/rma/rget.c
@@ -118,7 +118,7 @@ int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -130,7 +130,7 @@ int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/rget_accumulate.c
+++ b/src/mpi/rma/rget_accumulate.c
@@ -140,7 +140,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count,
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (op != MPI_NO_OP && HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (op != MPI_NO_OP && !HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -152,7 +152,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(result_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(result_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -164,7 +164,7 @@ int MPI_Rget_accumulate(const void *origin_addr, int origin_count,
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/rput.c
+++ b/src/mpi/rma/rput.c
@@ -120,7 +120,7 @@ int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype
             if (win_ptr->create_flavor != MPI_WIN_FLAVOR_DYNAMIC)
                 MPIR_ERRTEST_DISP(target_disp, mpi_errno);
 
-            if (HANDLE_GET_KIND(origin_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(origin_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(origin_datatype, datatype_ptr);
@@ -132,7 +132,7 @@ int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype
                     goto fn_fail;
             }
 
-            if (HANDLE_GET_KIND(target_datatype) != HANDLE_KIND_BUILTIN) {
+            if (!HANDLE_IS_BUILTIN(target_datatype)) {
                 MPIR_Datatype *datatype_ptr = NULL;
 
                 MPIR_Datatype_get_ptr(target_datatype, datatype_ptr);

--- a/src/mpi/rma/win_free.c
+++ b/src/mpi/rma/win_free.c
@@ -102,8 +102,7 @@ int MPI_Win_free(MPI_Win * win)
         goto fn_fail;
 
     /* We need to release the error handler */
-    if (win_ptr->errhandler &&
-        !(HANDLE_GET_KIND(win_ptr->errhandler->handle) == HANDLE_KIND_BUILTIN)) {
+    if (win_ptr->errhandler && !(HANDLE_IS_BUILTIN(win_ptr->errhandler->handle))) {
         int in_use;
         MPIR_Errhandler_release_ref(win_ptr->errhandler, &in_use);
         if (!in_use) {

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -160,7 +160,7 @@ extern MPIDI_Process_t MPIDI_Process;
    if we can */
 #define MPIDI_Datatype_get_info(count_, datatype_, dt_contig_out_, data_sz_out_, dt_ptr_, dt_true_lb_)\
 {									\
-    if (HANDLE_GET_KIND(datatype_) == HANDLE_KIND_BUILTIN)		\
+    if (HANDLE_IS_BUILTIN(datatype_))		\
     {									\
 	(dt_ptr_) = NULL;						\
 	(dt_contig_out_) = TRUE;					\

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -836,7 +836,7 @@ static inline int do_accumulate_op(void *source_buf, int source_count, MPI_Datat
         MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
     }
 
-    if ((HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN)
+    if ((HANDLE_IS_BUILTIN(acc_op))
         && ((*MPIR_OP_HDL_TO_DTYPE_FN(acc_op)) (source_dtp) == MPI_SUCCESS)){
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(acc_op);

--- a/src/mpid/ch3/src/mpid_imrecv.c
+++ b/src/mpid/ch3/src/mpid_imrecv.c
@@ -93,7 +93,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
             /* The data is still being transfered across the net.  We'll
                leave it to the progress engine to handle once the
                entire message has arrived. */
-            if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+            if (!HANDLE_IS_BUILTIN(datatype))
             {
                 MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
                 MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
@@ -107,7 +107,7 @@ int MPID_Imrecv(void *buf, int count, MPI_Datatype datatype,
 
         mpi_errno = vc->rndvRecv_fn(vc, rreq);
         MPIR_ERR_CHECK(mpi_errno);
-        if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+        if (!HANDLE_IS_BUILTIN(datatype))
         {
             MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
             MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);

--- a/src/mpid/ch3/src/mpid_irecv.c
+++ b/src/mpid/ch3/src/mpid_irecv.c
@@ -94,7 +94,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 		/* The data is still being transfered across the net.  We'll 
 		   leave it to the progress engine to handle once the
 		   entire message has arrived. */
-		if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+		if (!HANDLE_IS_BUILTIN(datatype))
 		{
 		    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
             MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
@@ -108,7 +108,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
 	
 	    mpi_errno = vc->rndvRecv_fn( vc, rreq );
 	    if (mpi_errno) MPIR_ERR_POP( mpi_errno );
-	    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+	    if (!HANDLE_IS_BUILTIN(datatype))
 	    {
 		MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
         MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
@@ -139,7 +139,7 @@ int MPID_Irecv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int 
            information supplied in the arguments. */
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"request allocated in posted queue");
 	
-	if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+	if (!HANDLE_IS_BUILTIN(datatype))
 	{
 	    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
         MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);

--- a/src/mpid/ch3/src/mpid_issend.c
+++ b/src/mpid/ch3/src/mpid_issend.c
@@ -78,7 +78,7 @@ int MPID_Issend(const void * buf, int count, MPI_Datatype datatype, int rank, in
                                                       context_offset );
 	/* If we're not complete and this is a derived datatype
          * communication, then add a reference to the datatype */
-	if (sreq && (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)) {
+	if (sreq && (!HANDLE_IS_BUILTIN(datatype))) {
 	    sreq->dev.datatype_ptr = dt_ptr;
         MPIR_Datatype_ptr_add_ref(dt_ptr);
 	}

--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -106,7 +106,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 		/* The data is still being transfered across the net.  
 		   We'll leave it to the progress engine to handle once the
 		   entire message has arrived. */
-		if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+		if (!HANDLE_IS_BUILTIN(datatype))
 		{
 		    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
             MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
@@ -119,7 +119,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
         MPIR_ERR_CHKANDJUMP1(vc->state == MPIDI_VC_STATE_MORIBUND, mpi_errno, MPIX_ERR_PROC_FAILED, "**comm_fail", "**comm_fail %d", rreq->dev.match.parts.rank);
 	    mpi_errno = vc->rndvRecv_fn( vc, rreq );
 	    MPIR_ERR_CHECK(mpi_errno);
-	    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+	    if (!HANDLE_IS_BUILTIN(datatype))
 	    {
 		MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
         MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
@@ -159,7 +159,7 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 	   of the actions that are taken when a request is freed. 
 	   (specifically, the datatype and comm both have their refs
 	   decremented, and are freed if the refs are zero) */
-	if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+	if (!HANDLE_IS_BUILTIN(datatype))
 	{
 	    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
         MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -168,7 +168,7 @@ int MPID_Send_init(const void * buf, int count, MPI_Datatype datatype, int rank,
 
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SEND);
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+    if (!HANDLE_IS_BUILTIN(datatype))
     {
 	MPIR_Datatype_get_ptr(datatype, sreq->dev.datatype_ptr);
     MPIR_Datatype_ptr_add_ref(sreq->dev.datatype_ptr);
@@ -194,7 +194,7 @@ int MPID_Ssend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_SSEND);
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+    if (!HANDLE_IS_BUILTIN(datatype))
     {
 	MPIR_Datatype_get_ptr(datatype, sreq->dev.datatype_ptr);
     MPIR_Datatype_ptr_add_ref(sreq->dev.datatype_ptr);
@@ -220,7 +220,7 @@ int MPID_Rsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_RSEND);
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+    if (!HANDLE_IS_BUILTIN(datatype))
     {
 	MPIR_Datatype_get_ptr(datatype, sreq->dev.datatype_ptr);
     MPIR_Datatype_ptr_add_ref(sreq->dev.datatype_ptr);
@@ -246,7 +246,7 @@ int MPID_Bsend_init(const void * buf, int count, MPI_Datatype datatype, int rank
 
     MPIDI_Request_create_psreq(sreq, mpi_errno, goto fn_exit);
     MPIDI_Request_set_type(sreq, MPIDI_REQUEST_TYPE_BSEND);
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+    if (!HANDLE_IS_BUILTIN(datatype))
     {
 	MPIR_Datatype_get_ptr(datatype, sreq->dev.datatype_ptr);
     MPIR_Datatype_ptr_add_ref(sreq->dev.datatype_ptr);
@@ -299,7 +299,7 @@ int MPID_Recv_init(void * buf, int count, MPI_Datatype datatype, int rank, int t
     rreq->dev.datatype = datatype;
     rreq->u.persist.real_request = NULL;
     MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_RECV);
-    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+    if (!HANDLE_IS_BUILTIN(datatype))
     {
 	MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
     MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);

--- a/src/mpid/ch3/src/mpidi_isend_self.c
+++ b/src/mpid/ch3/src/mpidi_isend_self.c
@@ -105,7 +105,7 @@ int MPIDI_Isend_self(const void * buf, MPI_Aint count, MPI_Datatype datatype, in
 
 	    MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,
           "added receive request to unexpected queue; attaching send request");
-	    if (HANDLE_GET_KIND(datatype) != HANDLE_KIND_BUILTIN)
+	    if (!HANDLE_IS_BUILTIN(datatype))
 	    {
 		MPIR_Datatype_get_ptr(datatype, sreq->dev.datatype_ptr);
         MPIR_Datatype_ptr_add_ref(sreq->dev.datatype_ptr);

--- a/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll_select.h
@@ -58,7 +58,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Allreduce_select(const void *sendbuf,
     MPIR_Datatype_get_size_macro(datatype, type_size);
     pof2 = comm->coll.pof2;
     if ((count * type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-        (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+        (!HANDLE_IS_BUILTIN(op)) || (count < pof2)) {
         return &MPIDI_OFI_Allreduce_intra_recursive_doubling_cnt;
     } else {
         return &MPIDI_OFI_Allreduce_intra_reduce_scatter_allgather_cnt;
@@ -84,7 +84,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Reduce_select(const void *sendbuf,
     MPIR_Datatype_get_size_macro(datatype, type_size);
     pof2 = comm->coll.pof2;
     if ((count * type_size > MPIR_CVAR_REDUCE_SHORT_MSG_SIZE) &&
-        (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) && (count >= pof2)) {
+        (HANDLE_IS_BUILTIN(op)) && (count >= pof2)) {
         return &MPIDI_OFI_Reduce_intra_reduce_scatter_gather_cnt;
     } else {
         return &MPIDI_OFI_Reduce_intra_binomial_cnt;
@@ -326,7 +326,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Reduce_scatter_select(const void *sen
 
     comm_size = comm->local_size;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
@@ -398,7 +398,7 @@ MPIDI_OFI_coll_algo_container_t *MPIDI_OFI_Reduce_scatter_block_select(const voi
 
     comm_size = comm->local_size;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpid/ch4/shm/posix/posix_coll_select.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_select.h
@@ -93,7 +93,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Allreduce_select(const void *send
     /* Choose from pt2pt based algorithms */
     pof2 = comm->coll.pof2;
     if ((count * type_size <= MPIR_CVAR_ALLREDUCE_SHORT_MSG_SIZE) ||
-        (HANDLE_GET_KIND(op) != HANDLE_KIND_BUILTIN) || (count < pof2)) {
+        (!HANDLE_IS_BUILTIN(op)) || (count < pof2)) {
         return &MPIDI_POSIX_Allreduce_intra_recursive_doubling_cnt;
     } else {
         return &MPIDI_POSIX_Allreduce_intra_reduce_scatter_allgather_cnt;
@@ -134,7 +134,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Reduce_select(const void *sendbuf
     MPIR_Datatype_get_size_macro(datatype, type_size);
     pof2 = comm->coll.pof2;
     if ((count * type_size > MPIR_CVAR_REDUCE_SHORT_MSG_SIZE) &&
-        (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) && (count >= pof2)) {
+        (HANDLE_IS_BUILTIN(op)) && (count >= pof2)) {
         return &MPIDI_POSIX_Reduce_intra_reduce_scatter_gather_cnt;
     } else {
         return &MPIDI_POSIX_Reduce_intra_binomial_cnt;
@@ -379,7 +379,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Reduce_scatter_select(const void 
 
     comm_size = comm->local_size;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);
@@ -450,7 +450,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Reduce_scatter_block_select(const
 
     comm_size = comm->local_size;
 
-    if (HANDLE_GET_KIND(op) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(op)) {
         is_commutative = 1;
     } else {
         MPIR_Op_get_ptr(op, op_ptr);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -381,7 +381,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
     } while (0)
 
 #define IS_BUILTIN(_datatype)                           \
-    (HANDLE_GET_KIND(_datatype) == HANDLE_KIND_BUILTIN)
+    (HANDLE_IS_BUILTIN(_datatype))
 
 /* We assume this routine is never called with rank=MPI_PROC_NULL. */
 static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group * grp)
@@ -914,7 +914,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_compute_acc_op(void *source_buf, int source_
         MPIR_Datatype_get_extent_macro(source_dtp, source_dtp_extent);
     }
 
-    if ((HANDLE_GET_KIND(acc_op) == HANDLE_KIND_BUILTIN)
+    if ((HANDLE_IS_BUILTIN(acc_op))
         && ((*MPIR_OP_HDL_TO_DTYPE_FN(acc_op)) (source_dtp) == MPI_SUCCESS)) {
         /* get the function by indexing into the op table */
         uop = MPIR_OP_HDL_TO_FN(acc_op);

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -87,7 +87,7 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
     MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
     MPIDIG_REQUEST(sreq, rank) = target_rank;
 
-    if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(target_datatype)) {
         am_hdr.n_iov = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDIG_REQUEST(sreq, req->preq.dt_iov) = NULL;
@@ -254,7 +254,7 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
      * counter in request, thus it can be decreased at request completion. */
     MPIDIG_win_cmpl_cnts_incr(win, target_rank, &sreq->completion_notification);
 
-    if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(target_datatype)) {
         am_hdr.n_iov = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDIG_REQUEST(sreq, req->greq.dt_iov) = NULL;
@@ -375,7 +375,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     am_hdr.req_ptr = sreq;
     am_hdr.origin_count = origin_count;
 
-    if (HANDLE_GET_KIND(origin_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(origin_datatype)) {
         am_hdr.origin_datatype = origin_datatype;
     } else {
         am_hdr.origin_datatype = (dt_ptr) ? dt_ptr->basic_type : MPI_DATATYPE_NULL;
@@ -398,7 +398,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 
     MPIDIG_REQUEST(sreq, rank) = target_rank;
     MPIDIG_REQUEST(sreq, req->areq.data_sz) = data_sz;
-    if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(target_datatype)) {
         am_hdr.n_iov = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDIG_REQUEST(sreq, req->areq.dt_iov) = NULL;
@@ -569,7 +569,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
     am_hdr.req_ptr = sreq;
     am_hdr.origin_count = origin_count;
 
-    if (HANDLE_GET_KIND(origin_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(origin_datatype)) {
         am_hdr.origin_datatype = origin_datatype;
     } else {
         am_hdr.origin_datatype = (dt_ptr) ? dt_ptr->basic_type : MPI_DATATYPE_NULL;
@@ -594,7 +594,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 
     MPIDIG_REQUEST(sreq, rank) = target_rank;
     MPIDIG_REQUEST(sreq, req->areq.data_sz) = data_sz;
-    if (HANDLE_GET_KIND(target_datatype) == HANDLE_KIND_BUILTIN) {
+    if (HANDLE_IS_BUILTIN(target_datatype)) {
         am_hdr.n_iov = 0;
         MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
         MPIDIG_REQUEST(sreq, req->areq.dt_iov) = NULL;


### PR DESCRIPTION
This PR adds macros for checking is a handle is builtin. This cleans up the code by avoiding writing the condition explicitly and provide more context for the condition.

Currently, I only added on alias for datatype as `MPIR_Datatype_is_builtin`. Not sure if we want similar aliases for other objecs (op, errhandler, etc.).

The second commit just remove some redundant checking that I noticed while working on the first commit.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
