### PR TITLE
runtests: use read permission when obtaining the filelock

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -1386,7 +1386,10 @@ sub get_lock {
     if ($verbose) {
         print "Taking lock [$lockfile], type $lock_type\n";
     }
-    if(open LOCK, ">$lockfile"){
+    if (! -e $lockfile) {
+        system "touch $lockfile";
+    }
+    if(open LOCK, "$lockfile"){
         # flock blocks until the lock is taken
         flock(LOCK, $lock_type);
         return 1;


### PR DESCRIPTION

## Pull Request Description
When the lockfile is already exist and owned by another user, typical
permission will not allow the file to be opened with write permission.
Since we don't really need write permission for flock, change it to read
permission to have a better chance succeeding.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
