### PR TITLE
mpl/atomic: Suppress Warnings with Solaris Studio

### DIFF
--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -9,6 +9,12 @@
 
 #include <stdint.h>
 
+#ifdef __SUNPRO_C
+/* Solaris Studio 12.6 shows warnings if an argument of __atomic builtins is
+ * qualified with const or volatile.  The following pragma suppresses it. */
+#pragma error_messages (off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
+#endif
+
 #define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
 
 #define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
@@ -107,5 +113,9 @@ static inline void MPL_atomic_compiler_barrier(void)
     /* atomic_signal_fence performs a compiler barrier without any overhead */
     __atomic_signal_fence(__ATOMIC_ACQ_REL);
 }
+
+#ifdef __SUNPRO_C
+#pragma error_messages (default, E_ARG_INCOMPATIBLE_WITH_ARG_L)
+#endif
 
 #endif /* MPL_ATOMIC_GCC_ATOMIC_H_INCLUDED */

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -9,6 +9,12 @@
 
 #include <stdint.h>
 
+#ifdef __SUNPRO_C
+/* Solaris Studio 12.6 shows warnings if an argument of __sync builtins is
+ * qualified with const or volatile.  The following pragma suppresses it. */
+#pragma error_messages (off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
+#endif
+
 #define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
 
 #define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
@@ -121,5 +127,9 @@ static inline void MPL_atomic_compiler_barrier(void)
 {
     __asm__ __volatile__("":::"memory");
 }
+
+#ifdef __SUNPRO_C
+#pragma error_messages (default, E_ARG_INCOMPATIBLE_WITH_ARG_L)
+#endif
 
 #endif /* MPL_ATOMIC_GCC_SYNC_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

This patch suppresses warnings in MPL/atomic when Solaris compilers are used.
The Solaris compiler shows the warnings on GCC builtins if arguments are const or volatile.
```c
  // gcc __atomic
  const int a = 0; // "int a" is okay with suncc
  int b = __atomic_load_n(&a, __ATOMIC_RELAXED);
  // gcc __sync
  volatile int c = 0; // "int c" is okay with suncc
  __sync_lock_test_and_set(&c, 1);
```
```
# suncc atomic.c // Oracle Developer Studio 12.6
"atomic.c", line *: warning: argument #2 is incompatible with prototype:
	prototype: pointer to void : "atomic.c", line 0
	argument : pointer to const int
"atomic.c", line *: warning: argument #2 is incompatible with prototype:
	prototype: pointer to void : "atomic.c", line 0
	argument : pointer to volatile int
```
Note that there is no problem with gcc/clang/icc.

This PR fixes it by adding a warning-suppression pragma as follows:
```c
#ifdef __SUNPRO_C
#pragma error_messages (off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
#endif
// atomic.h
#ifdef __SUNPRO_C
#pragma error_messages (default, E_ARG_INCOMPATIBLE_WITH_ARG_L)
#endif
```

We can remove these pragmas if the Solaris compiler changes this behavior.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Warnings are suppressed with Solaris compilers. There is no effect with other compilers

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
