### PR TITLE
ch4: probe external libfabric/ucx and default netmod selection

### DIFF
--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -36,22 +36,9 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     AC_SUBST([ofilib])
 
     ofi_embedded=""
-    dnl Use embedded libfabric if we specify to do so or we didn't specify and the source is present
-    if test "${with_libfabric}" = "embedded" ; then
+    if test $have_libfabric = no ; then
         ofi_embedded="yes"
-    elif test -z "${with_libfabric}" && test -z "${with_libfabric_lib}" && test -z "${with_libfabric_include}" ; then
-        if test -f ${use_top_srcdir}/src/mpid/ch4/netmod/ofi/libfabric/configure ; then
-            ofi_embedded="yes"
-        else
-            ofi_embedded="no"
-            PAC_SET_HEADER_LIB_PATH(libfabric)
-        fi
-    else
-        ofi_embedded="no"
-        PAC_SET_HEADER_LIB_PATH(libfabric)
-        AC_SUBST([with_libfabric])
     fi
-    AC_SUBST([ofi_embedded])
 
     runtime_capabilities="no"
     no_providers="no"
@@ -270,15 +257,8 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         ofisrcdir="${master_top_builddir}/src/mpid/ch4/netmod/ofi/libfabric"
         ofilib="src/mpid/ch4/netmod/ofi/libfabric/src/libfabric.la"
     else
-        PAC_PUSH_FLAG(LIBS)
-        PAC_CHECK_HEADER_LIB([rdma/fabric.h], [fabric], [fi_getinfo], [have_libfabric=yes], [have_libfabric=no])
-        PAC_POP_FLAG(LIBS)
-        if test "${have_libfabric}" = "yes" ; then
-            AC_MSG_NOTICE([CH4 OFI Netmod:  Using an external libfabric])
-            PAC_APPEND_FLAG([-lfabric],[WRAPPER_LIBS])
-        else
-            AC_MSG_ERROR([Provided libfabric installation (--with-libfabric=${with_libfabric}) could not be configured.])
-        fi
+        AC_MSG_NOTICE([CH4 OFI Netmod:  Using an external libfabric])
+        PAC_APPEND_FLAG([-lfabric],[WRAPPER_LIBS])
     fi
 
     # check for libfabric depedence libs

--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -55,19 +55,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
     AC_SUBST([ucxlib])
 
     ucx_embedded=""
-    dnl Use embedded libfabric if we specify to do so or we didn't specify and the source is present
-    if test "${with_ucx}" = "embedded" ; then
+    if test $have_ucx = no ; then
         ucx_embedded="yes"
-    elif test -z ${with_ucx} ; then
-        if test -f ${use_top_srcdir}/src/mpid/ch4/netmod/ucx/ucx/configure ; then
-            ucx_embedded="yes"
-        else
-            ucx_embedded="no"
-        fi
-    else
-        ucx_embedded="no"
     fi
-
+    
     if test "${ucx_embedded}" = "yes" ; then
         PAC_PUSH_FLAG(CPPFLAGS)
         PAC_CONFIG_SUBDIR_ARGS([src/mpid/ch4/netmod/ucx/ucx],[--disable-static --enable-embedded],[],[AC_MSG_ERROR(ucx configure failed)])
@@ -82,9 +73,6 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
         have_ucp_put_nb=yes
         have_ucp_get_nb=yes
     else
-        PAC_PUSH_FLAG(LIBS)
-        PAC_CHECK_HEADER_LIB_FATAL(ucx, ucp/api/ucp.h, ucp, ucp_config_read)
-        PAC_POP_FLAG(LIBS)
         PAC_APPEND_FLAG([-lucp -lucs],[WRAPPER_LIBS])
 
         # ucp_put_nb and ucp_get_nb are added only from ucx 1.4.

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -65,6 +65,7 @@ else
 fi
 export ch4_netmods
 export netmod_args
+AC_MSG_NOTICE([CH4 select netmod: $ch4_netmods $netmod_args])
 
 #
 # reset DEVICE so that it (a) always includes the channel name, and (b) does not include channel options

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -12,6 +12,26 @@ AM_CONDITIONAL([BUILD_CH4],[test "$device_name" = "ch4"])
 AM_COND_IF([BUILD_CH4],[
 AC_MSG_NOTICE([RUNNING PREREQ FOR CH4 DEVICE])
 
+# check availability of libfabric
+if test x"$with_libfabric" != x"embedded" ; then
+    PAC_SET_HEADER_LIB_PATH(libfabric)
+    PAC_PUSH_FLAG(LIBS)
+    PAC_CHECK_HEADER_LIB([rdma/fabric.h], [fabric], [fi_getinfo], [have_libfabric=yes], [have_libfabric=no])
+    PAC_POP_FLAG(LIBS)
+else
+    have_libfabric=no
+fi
+
+# check availability of ucx
+if test x"$with_ucx" != x"embedded" ; then
+    PAC_SET_HEADER_LIB_PATH(ucx)
+    PAC_PUSH_FLAG(LIBS)
+    PAC_CHECK_HEADER_LIB([ucp/api/ucp.h], [ucp], [ucp_config_read], [have_ucx=yes], [have_ucx=no])
+    PAC_POP_FLAG(LIBS)
+else
+    have_ucx=no
+fi
+
 # the CH4 device depends on the common NBC scheduler code
 build_mpid_common_sched=yes
 build_mpid_common_datatype=yes
@@ -24,7 +44,19 @@ MPID_MAX_ERROR_STRING=512
 
 # $device_args - contains the netmods
 if test -z "${device_args}" ; then
-    ch4_netmods="ofi"
+    # need pick a netmod
+    if test $have_libfabric = yes ; then
+        ch4_netmods="ofi"
+    elif test $have_ucx = yes ; then
+        ch4_netmods="ucx"
+    elif test -n $with_libfabric ; then
+        ch4_netmods="ofi"
+    elif test -n $with_ucx ; then
+        ch4_netmods="ucx"
+    else
+        ch4_netmods="ofi"
+        with_libfabric=embedded
+    fi
 else
     changequote(<<,>>)
     netmod_args=`echo ${device_args} | sed -e 's/^[^:]*//' -e 's/^://' -e 's/,/ /g'`


### PR DESCRIPTION
## Pull Request Description

Always probe external libfabric and ucx. If found, use them as a preference.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
