### PR TITLE
romio: fix count calculation when setting up status object

### DIFF
--- a/src/mpi/romio/adio/common/ad_iwrite_fake.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_fake.c
@@ -31,8 +31,7 @@ void ADIOI_FAKE_IwriteContig(ADIO_File fd, const void *buf, int count,
     ADIOI_Assert(len == (int) len);     /* the count is an int parm */
     ADIO_WriteContig(fd, buf, (int) len, MPI_BYTE, file_ptr_type, offset, &status, error_code);
     if (*error_code == MPI_SUCCESS) {
-        MPI_Get_count(&status, MPI_BYTE, &write_count);
-        nbytes = (MPI_Offset) write_count *(MPI_Offset) typesize;
+        MPI_Get_count(&status, MPI_BYTE, &nbytes);
     }
     MPIO_Completed_request_create(&fd, nbytes, error_code, request);
 


### PR DESCRIPTION
 iwriteshx test fails in some scenario, the error message is like:
Wrong value from status; expected 1 but got 4.

It seems to be a bug in romio to track the number of bytes for MPI_Status object. the nbytes count for the status object is calculated by multiplying typesize twice.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
