### PR TITLE
pmi: fix bug in MPIR_NODEMAP_build_nodemap_fallback

### DIFF
--- a/src/util/mpir_nodemap.h
+++ b/src/util/mpir_nodemap.h
@@ -390,6 +390,8 @@ static inline int MPIR_NODEMAP_build_nodemap_fallback(int sz, int myrank, int *o
         out_nodemap[i] = j;
     }
 
+    *out_max_node_id = max_node_id;
+
   fn_exit:
     MPL_free(key);
     MPL_free(node_names);


### PR DESCRIPTION


## Pull Request Description
Previous change neglected to update the out_max_node_id. Since the fallback is called
when process_mapping is not supported in the pm such as gforker, the bug
only manifests when such pm is being used.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
