### PR TITLE
build: update libtool patch for oracle-fortran

### DIFF
--- a/confdb/config.rpath
+++ b/confdb/config.rpath
@@ -97,7 +97,7 @@ else
             *Sun\ Ceres\ Fortran* | *Sun*Fortran*\ [[1-7]].* | *Sun*Fortran*\ 8.[[0-4]]*)
               wl=
               ;;
-            *Sun\ F* | *Sun*Fortran*)
+            *Sun\ F* | *Sun*Fortran* | *Studio*Fortran*)
               wl='-Wl,'
               ;;
             *Sun\ C*)

--- a/confdb/config.rpath
+++ b/confdb/config.rpath
@@ -98,7 +98,7 @@ else
               wl=
               ;;
             *Sun\ F* | *Sun*Fortran* | *Studio*Fortran*)
-              wl='-Wl,'
+              wl='-Qoption ld '
               ;;
             *Sun\ C*)
               wl='-Wl,'

--- a/maint/patches/optional/confdb/oracle-fort.patch
+++ b/maint/patches/optional/confdb/oracle-fort.patch
@@ -1,6 +1,6 @@
---- libtool.m4	2018-10-03 15:25:03.000000000 -0500
-+++ libtool.m4.fix	2018-10-03 15:30:04.000000000 -0500
-@@ -4746,7 +4746,7 @@
+--- libtool.m4	2019-10-07 15:02:31.663018494 -0500
++++ libtool.m4.fix	2019-10-25 14:56:50.754298628 -0500
+@@ -4743,7 +4743,7 @@
  	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
  	  _LT_TAGVAR(lt_prog_compiler_wl, $1)=''
  	  ;;
@@ -9,3 +9,12 @@
  	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
  	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
  	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '
+@@ -5218,7 +5218,7 @@
+ 	  _LT_TAGVAR(whole_archive_flag_spec, $1)='$wl--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` $wl--no-whole-archive'
+ 	  _LT_TAGVAR(compiler_needs_object, $1)=yes
+ 	  tmp_sharedflag='-G' ;;
+-	*Sun\ F*)			# Sun Fortran 8.3
++	*Sun\ F* | *Sun*Fortran* | *Studio*Fortran*)
+ 	  tmp_sharedflag='-G' ;;
+ 	esac
+ 	_LT_TAGVAR(archive_cmds, $1)='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags $wl-soname $wl$soname -o $lib'

--- a/src/mpid/ch4/src/ch4_coll_globals_default.c.in
+++ b/src/mpid/ch4/src/ch4_coll_globals_default.c.in
@@ -59,15 +59,15 @@ const MPIDI_coll_algo_container_t MPIDI_Bcast_inter_composition_alpha_cnt = {
 const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_alpha_cnt = {
     .id = MPIDI_Reduce_intra_composition_alpha_id,
     .params.ch4_reduce_params.ch4_reduce_alpha = {
-                                                  .roots_reduce = MPIDI_COLL_AUTO_SELECT,
-                                                  .node_reduce = MPIDI_COLL_AUTO_SELECT}
+                                                  .node_reduce = MPIDI_COLL_AUTO_SELECT,
+                                                  .roots_reduce = MPIDI_COLL_AUTO_SELECT}
 };
 
 const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_beta_cnt = {
     .id = MPIDI_Reduce_intra_composition_beta_id,
     .params.ch4_reduce_params.ch4_reduce_beta = {
-                                                 .roots_reduce = MPIDI_COLL_AUTO_SELECT,
-                                                 .node_reduce = MPIDI_COLL_AUTO_SELECT}
+                                                 .node_reduce = MPIDI_COLL_AUTO_SELECT,
+                                                 .roots_reduce = MPIDI_COLL_AUTO_SELECT}
 };
 
 const MPIDI_coll_algo_container_t MPIDI_Reduce_intra_composition_gamma_cnt = {


### PR DESCRIPTION
## Pull Request Description

The default `-shared` flag:
    `sunf77 -shared -olibxxx.so [objs]`
does not work. It need use `-G`
    `sunf77 -G -olibxxx.so [objs]`

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This PR fixes the build issues for Oracle Developer Studio 12.5.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
