### PR TITLE
init: add MPICH_IS_THREADED guard in init_globals.c

### DIFF
--- a/src/mpi/init/init_global.c
+++ b/src/mpi/init/init_global.c
@@ -146,7 +146,10 @@ int MPII_post_init_global(int thread_provided)
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_ThreadInfo.thread_provided = thread_provided;
+
+#if defined MPICH_IS_THREADED
     MPIR_ThreadInfo.isThreaded = (thread_provided == MPI_THREAD_MULTIPLE);
+#endif
 
     /* Set tag_ub as function of tag_bits set by the device */
     MPIR_Process.attrs.tag_ub = MPIR_TAG_USABLE_BITS;


### PR DESCRIPTION
## Pull Request Description

It is currently broken with `--enable-threads=single`, which removes the `isThreaded` filed in `MPIR_ThreadInfo`, and it should be guarded for its usage in `init_globals`.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
