### PR TITLE
Revamp of hardware topology node APIs

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -72,7 +72,8 @@ noinst_HEADERS +=                   \
     src/include/rlog.h              \
     src/include/rlog_macros.h       \
     src/include/mpir_op_util.h      \
-    src/include/mpir_hw_topo.h
+    src/include/mpir_hw_topo.h      \
+    src/include/mpir_hwtopo.h
 
 src/include/mpir_cvars.h:
 	$(top_srcdir)/maint/extractcvars --dirs="`cat $(top_srcdir)/maint/cvardirs`"

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -246,6 +246,7 @@ typedef struct MPIR_Topology MPIR_Topology;
 #include "mpit.h"
 #include "mpir_handlemem.h"
 #include "mpir_hw_topo.h"
+#include "mpir_hwtopo.h"
 
 /*****************************************************************************/
 /******************** PART 6: DEVICE "POST" FUNCTIONALITY ********************/

--- a/src/include/mpir_hwtopo.h
+++ b/src/include/mpir_hwtopo.h
@@ -1,0 +1,128 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#ifndef MPIR_HWTOPO_H_INCLUDED
+#define MPIR_HWTOPO_H_INCLUDED
+
+/* hwtopo types */
+typedef enum {
+    MPIR_HWTOPO_TYPE__NONE = -1,
+    MPIR_HWTOPO_TYPE__NODE,
+    MPIR_HWTOPO_TYPE__PACKAGE,
+    MPIR_HWTOPO_TYPE__SOCKET,
+    MPIR_HWTOPO_TYPE__CPU,
+    MPIR_HWTOPO_TYPE__CORE,
+    MPIR_HWTOPO_TYPE__HWTHREAD,
+    MPIR_HWTOPO_TYPE__L1CACHE,
+    MPIR_HWTOPO_TYPE__L2CACHE,
+    MPIR_HWTOPO_TYPE__L3CACHE,
+    MPIR_HWTOPO_TYPE__L4CACHE,
+    MPIR_HWTOPO_TYPE__L5CACHE,
+    MPIR_HWTOPO_TYPE__DDR,
+    MPIR_HWTOPO_TYPE__HBM,
+    MPIR_HWTOPO_TYPE__PCI_DEVICE,
+    MPIR_HWTOPO_TYPE__MAX
+} MPIR_hwtopo_type_e;
+
+#define MPIR_HWTOPO_GID_INVALID (-1)
+
+typedef int MPIR_hwtopo_gid_t;
+
+/* Topology managing APIs start here. These allow for the
+ * users to to init/finalize and query the status of the
+ * topology layer during runtime */
+
+int MPII_hwtopo_init(void);
+
+int MPII_hwtopo_finalize(void);
+
+bool MPIR_hwtopo_is_initialized(void);
+
+
+/* Topology tree APIs start here. These allow for users to
+ * get an entry point in the topology tree, usually this is
+ * the lowest object in the tree that has matching cpuset
+ * with the current process */
+
+/*
+ * Return the global id of the leaf object for this process. The leaf
+ * is the lowest object in the topology tree such that the cpuset of
+ * the process invoking the function is equal to the cpuset of the leaf
+ * or a subset of it, that is, the leaf contains the cpuset of the
+ * calling process or it matches it.
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_leaf(void);
+
+/*
+ * Return the depth in the topology tree for the given gid. A gid
+ * returned by the topology layer can be passed to this function to
+ * query the level of the object in the topology tree. For Normal
+ * class objects (e.g., cores, hwthreads, caches, etc) this is a
+ * positive integer. For non-Normal objects (e.g., Numa nodes) this
+ * is a negative integer (-3 for Numa nodes).
+ */
+int MPIR_hwtopo_get_depth(MPIR_hwtopo_gid_t gid);
+
+/*
+ * Return the global id of the ancestor object located at level depth.
+ * This function allows users to traverse the topology tree from a
+ * leaf up to the root. The following example walks from leaf to root:
+ *
+ *   MPIR_hwtopo_gid_t gid = MPIR_hwtopo_get_leaf();
+ *   int depth = MPIR_hwtopo_get_depth(gid);
+ *   while (depth > 0) {
+ *      gid = MPIR_hwtopo_get_ancestor(gid, --depth);
+ *   }
+ *
+ * NOTE: as already mentioned, non-Normal objects are not part of the
+ *       main tree and thus MPIR_hwtopo_get_leaf() will never return
+ *       the gid of a non-Normal object with negative depth.
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_ancestor(MPIR_hwtopo_gid_t gid, int depth);
+
+
+/* Topology flat APIs start here. These allow for users to
+ * get any object in the topology tree based on the process
+ * locality and the type of the requested object */
+
+/*
+ * Return the enum type corresponding to the requested name. For example,
+ * MPIR_hwtopo_get_type_id("ddr") returns MPIR_HWTOPO_TYPE__DDR.
+ */
+MPIR_hwtopo_type_e MPIR_hwtopo_get_type_id(const char *name);
+
+/*
+ * Return the gid of the object affine to the querying process by type.
+ * Similar to MPIR_hwtopo_get_leaf() but will also return non-Normal
+ * objects (with negative depth).
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_type(MPIR_hwtopo_type_e type);
+
+/*
+ * Similar to MPIR_hwtopo_get_obj_by_type but takes a name instead.
+ * MPIR_hwtopo_get_obj_by_type(MPIR_HWTOPO_TYPE__DDR) is equivalent to
+ * MPIR_hwtopo_get_obj_by_name("ddr").
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_name(const char *name);
+
+/*
+ * Bind the buffer starting at 'baseaddr' and with length 'len' to the
+ * memory object identified by gid.
+ */
+int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid);
+
+
+/* Topology miscellaneous APIs start here. These allow for the
+ * user to query general properties of the system like total amount
+ * of memory in the node, for example */
+
+/*
+ * Return the total amount of system memory (includes HBM)
+ */
+uint64_t MPIR_hwtopo_get_node_mem(void);
+
+#endif /* MPIR_HWTOPO_H_INCLUDED */

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -156,7 +156,8 @@ int MPI_Finalize(void)
     /* Call the low-priority (post Finalize) callbacks */
     MPIR_Call_finalize_callbacks(0, MPIR_FINALIZE_CALLBACK_PRIO - 1);
 
-    MPII_hw_topo_finalize();
+    MPII_hw_topo_finalize();    /* to be eventually replaced by MPII_hwtopo_finalize() */
+    MPII_hwtopo_finalize();
 
     /* Users did not call MPI_T_init_thread(), so we free memories allocated to
      * MPIR_T during MPI_Init here. Otherwise, free them in MPI_T_finalize() */

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -91,7 +91,8 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPII_init_global(&required);
     MPIR_ERR_CHECK(mpi_errno);  /* out-of-mem */
 
-    MPII_hw_topo_init();
+    MPII_hw_topo_init();        /* to be eventually replaced by MPII_hwtopo_init() */
+    MPII_hwtopo_init();
     MPII_init_windows();
     MPII_init_binding_fortran();
     MPII_init_binding_cxx();

--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -16,7 +16,8 @@ mpi_core_sources +=   \
     src/util/mpir_strerror.c   \
     src/util/mpir_localproc.c  \
     src/util/mpir_netloc.c     \
-    src/util/mpir_hw_topo.c
+    src/util/mpir_hw_topo.c    \
+    src/util/mpir_hwtopo.c
 
 noinst_HEADERS +=   \
     src/util/mpir_nodemap.h

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -1,0 +1,59 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ */
+
+#include "mpiimpl.h"
+
+#ifdef HAVE_HWLOC
+#include "hwloc.h"
+#endif
+
+int MPII_hwtopo_init(void)
+{
+}
+
+int MPII_hwtopo_finalize(void)
+{
+}
+
+bool MPIR_hwtopo_is_initialized(void)
+{
+}
+
+
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_leaf(void)
+{
+}
+
+int MPIR_hwtopo_get_depth(MPIR_hwtopo_gid_t gid)
+{
+}
+
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_ancestor(MPIR_hwtopo_gid_t gid, int depth)
+{
+}
+
+
+MPIR_hwtopo_type_e MPIR_hwtopo_get_type_id(const char *name)
+{
+}
+
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_type(MPIR_hwtopo_type_e type)
+{
+}
+
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_name(const char *name)
+{
+}
+
+int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
+{
+}
+
+
+uint64_t MPIR_hwtopo_get_node_mem(void)
+{
+}

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -11,49 +11,514 @@
 #include "hwloc.h"
 #endif
 
+/*********************************************************************************************
+ * hwtopo unique global id
+ *********************************************************************************************
+ | 1 sign bit | unused (13) | class (2 bits) | tree depth (6 bits) | logical index (10 bits) |
+ |            |             | obj class      | [-63 -- 63]         | [0 -- 1023]             |
+ *********************************************************************************************/
+#define HWTOPO_GID_BITS        (31)
+#define HWTOPO_GID_CLASS_BITS  (2)
+#define HWTOPO_GID_DEPTH_BITS  (6)
+#define HWTOPO_GID_INDEX_BITS  (10)
+#define HWTOPO_GID_CLASS_SHIFT (HWTOPO_GID_DEPTH_BITS + HWTOPO_GID_INDEX_BITS)
+#define HWTOPO_GID_DEPTH_SHIFT (HWTOPO_GID_INDEX_BITS)
+#define HWTOPO_GID_INDEX_SHIFT (0)
+#define HWTOPO_GID_CLASS_MASK  (0x00030000)
+#define HWTOPO_GID_DEPTH_MASK  (0x0000FC00)
+#define HWTOPO_GID_INDEX_MASK  (0x000003FF)
+#define HWTOPO_GID_CLASS_MAX   ((1 << HWTOPO_GID_CLASS_BITS) - 1)
+#define HWTOPO_GID_DEPTH_MAX   ((1 << HWTOPO_GID_DEPTH_BITS) - 1)
+#define HWTOPO_GID_INDEX_MAX   ((1 << HWTOPO_GID_INDEX_BITS) - 1)
+
+/* hwloc has 4 classes of objects: Memory, I/O, Misc and Normal. Numa nodes
+ * (i.e., HWLOC_OBJ_NUMANODE) are a memory class object and are attached as
+ * child to the object in the topology tree grouping cores (e.g., package).
+ * This means that Numa nodes are not part of the main topology tree (a walk
+ * from a leaf to the root will not traverse any Numa node) and thus, like
+ * other non-Normal objects, have a special negative depth value (-3 for Numa
+ * nodes). For this reason, as we need to be able to perform different actions
+ * for different classes of objects, we also encode the object class in the
+ * gid. */
+typedef enum {
+    MPIR_HWTOPO_CLASS__INVALID = -1,
+    MPIR_HWTOPO_CLASS__MEMORY,
+    MPIR_HWTOPO_CLASS__IO,
+    MPIR_HWTOPO_CLASS__MISC,
+    MPIR_HWTOPO_CLASS__NORMAL
+} MPIR_hwtopo_class_e;
+
+/* When calculating the gid for non-Normal objects we remove the sign of
+ * the depth field. This is done as valid gids are positive and the depth
+ * is not directly available outside the topology layer anyway (it has to
+ * be queried using get_depth). In this case, when we calculate the depth
+ * from the gid we do the opposite operation, restoring the sign. */
+#define HWTOPO_GET_GID(class, depth, idx) ({              \
+    MPIR_Assert(class != MPIR_HWTOPO_CLASS__INVALID);     \
+    MPIR_hwtopo_gid_t gid_;                               \
+    int depth_ = (class != MPIR_HWTOPO_CLASS__NORMAL) ?   \
+                 -depth : depth;                          \
+    do {                                                  \
+        MPIR_Assert(depth <= HWTOPO_GID_DEPTH_MAX);       \
+        MPIR_Assert(idx   <= HWTOPO_GID_INDEX_MAX);       \
+        gid_  = (class  << HWTOPO_GID_CLASS_SHIFT);       \
+        gid_ |= (depth_ << HWTOPO_GID_DEPTH_SHIFT);       \
+        gid_ |= (idx    << HWTOPO_GID_INDEX_SHIFT);       \
+    } while (0);                                          \
+    gid_;                                                 \
+})
+
+#define HWTOPO_GET_CLASS(gid) ({                          \
+    int class_;                                           \
+    do {                                                  \
+        class_ = (gid & HWTOPO_GID_CLASS_MASK);           \
+        class_ = (class_ >> HWTOPO_GID_CLASS_SHIFT);      \
+    } while (0);                                          \
+    class_;                                               \
+})
+
+#define HWTOPO_GET_DEPTH(gid) ({                          \
+    int depth_;                                           \
+    do {                                                  \
+        depth_ = (gid & HWTOPO_GID_DEPTH_MASK);           \
+        depth_ = (depth_ >> HWTOPO_GID_DEPTH_SHIFT);      \
+        if (HWTOPO_GET_CLASS(gid) != MPIR_HWTOPO_CLASS__NORMAL) \
+            depth_ = -depth_;                             \
+    } while (0);                                          \
+    depth_;                                               \
+})
+
+#define HWTOPO_GET_INDEX(gid) ({                          \
+    int index_;                                           \
+    do {                                                  \
+        index_ = (gid & HWTOPO_GID_INDEX_MASK);           \
+        index_ = (index_ >> HWTOPO_GID_INDEX_SHIFT);      \
+    } while (0);                                          \
+    index_;                                               \
+})
+
+#ifdef HAVE_HWLOC
+static hwloc_obj_type_t get_hwloc_obj_type(MPIR_hwtopo_type_e type)
+{
+    hwloc_obj_type_t hwloc_obj_type;
+
+    switch (type) {
+        case MPIR_HWTOPO_TYPE__NODE:
+            hwloc_obj_type = HWLOC_OBJ_MACHINE;
+            break;
+        case MPIR_HWTOPO_TYPE__PACKAGE:
+        case MPIR_HWTOPO_TYPE__SOCKET:
+        case MPIR_HWTOPO_TYPE__CPU:
+            hwloc_obj_type = HWLOC_OBJ_PACKAGE;
+            break;
+        case MPIR_HWTOPO_TYPE__CORE:
+            hwloc_obj_type = HWLOC_OBJ_CORE;
+            break;
+        case MPIR_HWTOPO_TYPE__HWTHREAD:
+            hwloc_obj_type = HWLOC_OBJ_PU;
+            break;
+        case MPIR_HWTOPO_TYPE__L1CACHE:
+            hwloc_obj_type = HWLOC_OBJ_L1CACHE;
+            break;
+        case MPIR_HWTOPO_TYPE__L2CACHE:
+            hwloc_obj_type = HWLOC_OBJ_L2CACHE;
+            break;
+        case MPIR_HWTOPO_TYPE__L3CACHE:
+            hwloc_obj_type = HWLOC_OBJ_L3CACHE;
+            break;
+        case MPIR_HWTOPO_TYPE__L4CACHE:
+            hwloc_obj_type = HWLOC_OBJ_L4CACHE;
+            break;
+        case MPIR_HWTOPO_TYPE__L5CACHE:
+            hwloc_obj_type = HWLOC_OBJ_L5CACHE;
+            break;
+        case MPIR_HWTOPO_TYPE__DDR:
+        case MPIR_HWTOPO_TYPE__HBM:
+            hwloc_obj_type = HWLOC_OBJ_NUMANODE;
+            break;
+        case MPIR_HWTOPO_TYPE__PCI_DEVICE:
+            hwloc_obj_type = HWLOC_OBJ_PCI_DEVICE;
+            break;
+        default:
+            hwloc_obj_type = -1;
+    }
+
+    return hwloc_obj_type;
+}
+
+/* Get object type class in hwloc: Memory, I/O, Misc or Normal */
+static MPIR_hwtopo_class_e get_type_class(hwloc_obj_type_t type)
+{
+    MPIR_hwtopo_class_e class;
+
+    switch (type) {
+        case HWLOC_OBJ_NUMANODE:
+            class = MPIR_HWTOPO_CLASS__MEMORY;
+            break;
+        case HWLOC_OBJ_BRIDGE:
+        case HWLOC_OBJ_PCI_DEVICE:
+        case HWLOC_OBJ_OS_DEVICE:
+            class = MPIR_HWTOPO_CLASS__IO;
+            break;
+        case HWLOC_OBJ_MISC:
+            class = MPIR_HWTOPO_CLASS__MISC;
+            break;
+        case HWLOC_OBJ_MACHINE:
+        case HWLOC_OBJ_PACKAGE:
+        case HWLOC_OBJ_CORE:
+        case HWLOC_OBJ_PU:
+        case HWLOC_OBJ_L1CACHE:
+        case HWLOC_OBJ_L2CACHE:
+        case HWLOC_OBJ_L3CACHE:
+        case HWLOC_OBJ_L4CACHE:
+        case HWLOC_OBJ_L5CACHE:
+        case HWLOC_OBJ_L1ICACHE:
+        case HWLOC_OBJ_L2ICACHE:
+        case HWLOC_OBJ_L3ICACHE:
+        case HWLOC_OBJ_GROUP:
+            class = MPIR_HWTOPO_CLASS__NORMAL;
+            break;
+        default:
+            class = MPIR_HWTOPO_CLASS__INVALID;
+    }
+
+    return class;
+}
+#endif
+
+/*
+ * Hardware topology
+ */
+#ifdef HAVE_HWLOC
+static hwloc_topology_t hwloc_topology;
+static hwloc_cpuset_t bindset;
+#endif
+static int bindset_is_valid;
+
+
 int MPII_hwtopo_init(void)
 {
+    int mpi_errno = MPI_SUCCESS;
+
+    bindset_is_valid = 0;
+
+#ifdef HAVE_HWLOC
+    bindset = hwloc_bitmap_alloc();
+    hwloc_topology_init(&hwloc_topology);
+    hwloc_topology_set_io_types_filter(hwloc_topology, HWLOC_TYPE_FILTER_KEEP_ALL);
+    if (!hwloc_topology_load(hwloc_topology))
+        bindset_is_valid =
+            !hwloc_get_proc_cpubind(hwloc_topology, getpid(), bindset, HWLOC_CPUBIND_PROCESS);
+#endif
+
+    return mpi_errno;
 }
 
 int MPII_hwtopo_finalize(void)
 {
+    int mpi_errno = MPI_SUCCESS;
+
+#ifdef HAVE_HWLOC
+    hwloc_topology_destroy(hwloc_topology);
+    hwloc_bitmap_free(bindset);
+#endif
+
+    bindset_is_valid = 0;
+
+    return mpi_errno;
 }
 
 bool MPIR_hwtopo_is_initialized(void)
 {
+    return (bindset_is_valid == 1);
 }
 
 
 MPIR_hwtopo_gid_t MPIR_hwtopo_get_leaf(void)
 {
+    MPIR_hwtopo_gid_t gid = MPIR_HWTOPO_GID_INVALID;
+
+    if (!bindset_is_valid)
+        return gid;
+
+#ifdef HAVE_HWLOC
+    hwloc_obj_t leaf = hwloc_get_obj_covering_cpuset(hwloc_topology, bindset);
+    MPIR_hwtopo_class_e class = get_type_class(leaf->type);
+    gid = HWTOPO_GET_GID(class, leaf->depth, leaf->logical_index);
+#endif
+
+    return gid;
 }
 
 int MPIR_hwtopo_get_depth(MPIR_hwtopo_gid_t gid)
 {
+    if (gid < 0)
+        return gid;
+
+    return HWTOPO_GET_DEPTH(gid);
 }
 
 MPIR_hwtopo_gid_t MPIR_hwtopo_get_ancestor(MPIR_hwtopo_gid_t gid, int depth)
 {
+    MPIR_hwtopo_gid_t ancestor_gid = MPIR_HWTOPO_GID_INVALID;
+    int obj_depth = HWTOPO_GET_DEPTH(gid);
+
+    /* Sanity check on global id and depth */
+    if (gid < 0 || depth >= obj_depth || depth < 0)
+        return gid;
+
+#ifdef HAVE_HWLOC
+    int obj_index = HWTOPO_GET_INDEX(gid);
+    hwloc_obj_t obj = hwloc_get_obj_by_depth(hwloc_topology, obj_depth, obj_index);
+
+    while (obj && obj->depth != depth)
+        obj = obj->parent;
+
+    MPIR_hwtopo_class_e class = get_type_class(obj->type);
+    ancestor_gid = HWTOPO_GET_GID(class, obj->depth, obj->logical_index);
+#endif
+
+    return ancestor_gid;
 }
 
 
 MPIR_hwtopo_type_e MPIR_hwtopo_get_type_id(const char *name)
 {
+    MPIR_hwtopo_type_e query_type = MPIR_HWTOPO_TYPE__MAX;
+
+    struct node_info_table {
+        const char *val;
+        MPIR_hwtopo_type_e type;
+    };
+
+    /* hwtopo node object table */
+    struct node_info_table node_info[] = {
+        {"node", MPIR_HWTOPO_TYPE__NODE},
+        {"machine", MPIR_HWTOPO_TYPE__NODE},
+        {"socket", MPIR_HWTOPO_TYPE__SOCKET},
+        {"package", MPIR_HWTOPO_TYPE__PACKAGE},
+        {"cpu", MPIR_HWTOPO_TYPE__CPU},
+        {"core", MPIR_HWTOPO_TYPE__CORE},
+        {"hwthread", MPIR_HWTOPO_TYPE__HWTHREAD},
+        {"pu", MPIR_HWTOPO_TYPE__HWTHREAD},
+        {"l1dcache", MPIR_HWTOPO_TYPE__L1CACHE},
+        {"l1ucache", MPIR_HWTOPO_TYPE__L1CACHE},
+        {"l1cache", MPIR_HWTOPO_TYPE__L1CACHE},
+        {"l2dcache", MPIR_HWTOPO_TYPE__L2CACHE},
+        {"l2ucache", MPIR_HWTOPO_TYPE__L2CACHE},
+        {"l2cache", MPIR_HWTOPO_TYPE__L2CACHE},
+        {"l3dcache", MPIR_HWTOPO_TYPE__L3CACHE},
+        {"l3ucache", MPIR_HWTOPO_TYPE__L3CACHE},
+        {"l3cache", MPIR_HWTOPO_TYPE__L3CACHE},
+        {"l4dcache", MPIR_HWTOPO_TYPE__L4CACHE},
+        {"l4ucache", MPIR_HWTOPO_TYPE__L4CACHE},
+        {"l4cache", MPIR_HWTOPO_TYPE__L4CACHE},
+        {"l5dcache", MPIR_HWTOPO_TYPE__L5CACHE},
+        {"l5ucache", MPIR_HWTOPO_TYPE__L5CACHE},
+        {"l5cache", MPIR_HWTOPO_TYPE__L5CACHE},
+        {"numanode", MPIR_HWTOPO_TYPE__DDR},
+        {"ddr", MPIR_HWTOPO_TYPE__DDR},
+        {"hbm", MPIR_HWTOPO_TYPE__HBM},
+        {NULL, MPIR_HWTOPO_TYPE__MAX}
+    };
+
+    for (int i = 0; node_info[i].val; i++) {
+        if (!strcmp(node_info[i].val, name)) {
+            query_type = node_info[i].type;
+            break;
+        }
+    }
+
+    return query_type;
 }
 
 MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_type(MPIR_hwtopo_type_e type)
 {
+    MPIR_hwtopo_gid_t gid = MPIR_HWTOPO_GID_INVALID;
+
+    if (!bindset_is_valid || type <= MPIR_HWTOPO_TYPE__NONE || type >= MPIR_HWTOPO_TYPE__MAX)
+        return gid;
+
+#ifdef HAVE_HWLOC
+    hwloc_obj_type_t hw_obj_type = get_hwloc_obj_type(type);
+
+    hwloc_obj_t tmp = NULL;
+    while ((tmp = hwloc_get_next_obj_by_type(hwloc_topology, hw_obj_type, tmp)) != NULL) {
+        if (hwloc_bitmap_isincluded(bindset, tmp->cpuset) ||
+            hwloc_bitmap_isequal(bindset, tmp->cpuset)) {
+            MPIR_hwtopo_class_e class = get_type_class(tmp->type);
+            if (type == MPIR_HWTOPO_TYPE__DDR) {
+                if (!tmp->subtype)
+                    gid = HWTOPO_GET_GID(class, tmp->depth, tmp->logical_index);
+                else
+                    continue;
+            } else if (type == MPIR_HWTOPO_TYPE__HBM) {
+                if (tmp->subtype)
+                    gid = HWTOPO_GET_GID(class, tmp->depth, tmp->logical_index);
+                else
+                    continue;
+            } else {
+                gid = HWTOPO_GET_GID(class, tmp->depth, tmp->logical_index);
+            }
+            break;
+        }
+    }
+#endif
+
+    return gid;
 }
+
+#ifdef HAVE_HWLOC
+static int io_device_found(const char *resource, const char *devname, hwloc_obj_t io_device,
+                           hwloc_obj_osdev_type_t obj_type)
+{
+    if (!strncmp(resource, devname, strlen(devname))) {
+        /* device type does not match */
+        if (io_device->attr->osdev.type != obj_type)
+            return 0;
+
+        /* device prefix does not match */
+        if (strncmp(io_device->name, devname, strlen(devname)))
+            return 0;
+
+        /* specific device is supplied, but does not match */
+        if (strlen(resource) != strlen(devname) && strcmp(io_device->name, resource))
+            return 0;
+    }
+
+    return 1;
+}
+#endif
 
 MPIR_hwtopo_gid_t MPIR_hwtopo_get_obj_by_name(const char *name)
 {
+    MPIR_hwtopo_gid_t gid = MPIR_HWTOPO_GID_INVALID;
+
+    if (!name || !bindset_is_valid)
+        return gid;
+
+#ifdef HAVE_HWLOC
+    hwloc_obj_t io_device = NULL;
+    hwloc_obj_t non_io_ancestor = NULL;
+
+    if (!strncmp(name, "pci:", strlen("pci:"))) {
+        io_device = hwloc_get_pcidev_by_busidstring(hwloc_topology, name + strlen("pci:"));
+        if (io_device) {
+            non_io_ancestor = hwloc_get_non_io_ancestor_obj(hwloc_topology, io_device);
+            MPIR_hwtopo_class_e class = get_type_class(non_io_ancestor->type);
+            gid = HWTOPO_GET_GID(class, non_io_ancestor->depth, non_io_ancestor->logical_index);
+        }
+        return gid;
+    }
+
+    if (!strncmp(name, "hfi", strlen("hfi")) || !strncmp(name, "ib", strlen("ib")) ||
+        !strncmp(name, "eth", strlen("eth")) || !strncmp(name, "en", strlen("en")) ||
+        !strncmp(name, "gpu", strlen("gpu"))) {
+
+        hwloc_obj_t obj_containing_cpuset = hwloc_get_obj_covering_cpuset(hwloc_topology, bindset);
+
+        while ((io_device = hwloc_get_next_osdev(hwloc_topology, io_device))) {
+            if (!io_device_found(name, "hfi", io_device, HWLOC_OBJ_OSDEV_OPENFABRICS))
+                continue;
+            if (!io_device_found(name, "ib", io_device, HWLOC_OBJ_OSDEV_NETWORK))
+                continue;
+            if (!io_device_found(name, "eth", io_device, HWLOC_OBJ_OSDEV_NETWORK) &&
+                !io_device_found(name, "en", io_device, HWLOC_OBJ_OSDEV_NETWORK))
+                continue;
+
+            if (!strncmp(name, "gpu", strlen("gpu"))) {
+                if (io_device->attr->osdev.type == HWLOC_OBJ_OSDEV_GPU) {
+                    if ((*(name + strlen("gpu")) != '\0') &&
+                        atoi(name + strlen("gpu")) != io_device->logical_index) {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+
+            non_io_ancestor = hwloc_get_non_io_ancestor_obj(hwloc_topology, io_device);
+            while (!hwloc_obj_type_is_normal(non_io_ancestor->type))
+                non_io_ancestor = non_io_ancestor->parent;
+            MPIR_Assert(non_io_ancestor && non_io_ancestor->depth >= 0);
+
+            if (!hwloc_obj_is_in_subtree(hwloc_topology, obj_containing_cpuset, non_io_ancestor))
+                continue;
+
+            break;
+        }
+
+        if (non_io_ancestor) {
+            MPIR_hwtopo_class_e class = get_type_class(non_io_ancestor->type);
+            gid = HWTOPO_GET_GID(class, non_io_ancestor->depth, non_io_ancestor->logical_index);
+        }
+
+        return gid;
+    }
+#endif
+
+    MPIR_hwtopo_type_e type = MPIR_hwtopo_get_type_id(name);
+    if (type != MPIR_HWTOPO_TYPE__MAX)
+        gid = MPIR_hwtopo_get_obj_by_type(type);
+    else
+        MPID_Get_node_id(MPIR_Process.comm_world, MPIR_Process.comm_world->rank, &gid);
+
+    return gid;
 }
 
 int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
 {
+    int ret = MPI_SUCCESS;
+
+#ifdef HAVE_HWLOC
+    const struct hwloc_topology_support *support = hwloc_topology_get_support(hwloc_topology);
+    if (!support->membind->set_area_membind) {
+        fprintf(stderr,
+                "%s: hwloc_set_area_membind() is not supported, skipping memory binding\n",
+                __func__);
+        return MPI_ERR_OTHER;
+    }
+
+    hwloc_membind_policy_t policy = HWLOC_MEMBIND_BIND;
+    hwloc_membind_flags_t flags = HWLOC_MEMBIND_STRICT;
+
+    int hwloc_obj_index = HWTOPO_GET_INDEX(gid);
+    int hwloc_obj_depth = HWTOPO_GET_DEPTH(gid);
+
+    hwloc_obj_t hwloc_obj =
+        hwloc_get_obj_by_depth(hwloc_topology, hwloc_obj_depth, hwloc_obj_index);
+
+    hwloc_bitmap_t bitmap = hwloc_bitmap_alloc();
+    hwloc_bitmap_or(bitmap, bitmap, hwloc_obj->nodeset);
+
+    if (hwloc_obj->type == HWLOC_OBJ_NUMANODE) {
+        flags |= HWLOC_MEMBIND_BYNODESET;
+    } else {
+        fprintf(stderr, "%s: object type not valid, skipping memory binding\n", __func__);
+        return MPI_ERR_OTHER;
+    }
+
+    ret = hwloc_set_area_membind(hwloc_topology, baseaddr, len, bitmap, policy, flags);
+
+    hwloc_bitmap_free(bitmap);
+#endif
+
+    return ret;
 }
 
 
 uint64_t MPIR_hwtopo_get_node_mem(void)
 {
+    uint64_t size = 0;
+
+    if (!bindset_is_valid)
+        return size;
+
+#ifdef HAVE_HWLOC
+    hwloc_obj_t tmp = NULL;
+    while ((tmp = hwloc_get_next_obj_by_type(hwloc_topology, HWLOC_OBJ_NUMANODE, tmp)))
+        size += tmp->total_memory;
+#endif
+
+    return size;
 }


### PR DESCRIPTION
## Pull Request Description

This PR condenses existing hardware topology API for node functionality. The new APIs make little assumptions about the structure of topology tree managed by underlying hardware topology library (i.e., hwloc) and replaces opaque object handles, as returned by current APIs, with global identifiers. Global identifiers are 32 bits signed integers partitioned as following: 10 least significant bits for logical index of objects in the topology tree (which gives a maximum of 1024 objects per level), next 6 bits for depth of the object in the topology tree (which gives a maximum depth of 64 levels), next 2 bits for object class (hwloc provides 4 classes: `memory`, `i/o`, `misc` and `normal`) that contains information on the sign of the depth field, the next 13 bits for future use, and the most significant bit for sign. Such integers are unique by construction accross all the objects in the topology tree as they contain both depth and logical index information of the object.

The APIs are grouped into four categories: `topology layer managing` APIs (initialize/finalize and get status of the topology), `topology tree` APIs (provide minimal functionality to get a tree entry point and traverse it), `flat topology` APIs (provide means for users to query objects of the topology tree by their types) and `miscellaneous topology` APIs that can be used to query specific properties of the node (e.g., total amount of system memory).

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
