### PR TITLE
init: simplify away MPII_Wait_for_debugger and MPII_debugger_set_aborting

### DIFF
--- a/src/include/mpir_debugger.h
+++ b/src/include/mpir_debugger.h
@@ -12,11 +12,11 @@
    selected.  As there is extra overhead for this, we only do this
    when specifically requested
 */
-#ifdef HAVE_DEBUGGER_SUPPORT
-void MPIR_Debugger_set_aborting(const char *);
 
-/* internal functions */
+#ifdef HAVE_DEBUGGER_SUPPORT
 void MPII_Wait_for_debugger(void);
+void MPIR_Debugger_set_aborting(const char *);
+/* internal functions */
 void MPII_Sendq_remember(MPIR_Request *, int, int, int);
 void MPII_Sendq_forget(MPIR_Request *);
 void MPII_CommL_remember(MPIR_Comm *);
@@ -28,6 +28,14 @@ void MPII_CommL_forget(MPIR_Comm *);
 #define MPII_COMML_FORGET(_a) MPII_CommL_forget(_a)
 #define MPII_REQUEST_CLEAR_DBG(_r) ((_r)->u.send.dbg_next = NULL)
 #else
+static inline void MPII_Wait_for_debugger(void)
+{
+}
+
+static inline void MPIR_Debugger_set_aborting(const char *dummy)
+{
+}
+
 #define MPII_SENDQ_REMEMBER(a,b,c,d)
 #define MPII_SENDQ_FORGET(a)
 #define MPII_COMML_REMEMBER(_a)

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -138,7 +138,8 @@ int MPI_Finalize(void)
     /* Call the high-priority callbacks */
     MPIR_Call_finalize_callbacks(MPIR_FINALIZE_CALLBACK_PRIO + 1, MPIR_FINALIZE_CALLBACK_MAX_PRIO);
 
-    MPII_debugger_set_aborting();
+    /* Signal the debugger that we are about to exit. */
+    MPIR_Debugger_set_aborting(NULL);
 
     mpi_errno = MPID_Finalize();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -138,7 +138,10 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
     MPII_post_init_memory_tracing();
     MPII_init_dbg_logging();
-    MPII_wait_for_debugger();
+    /* if --enable-debuginfo is configured, prepare for debug info data.
+     * if MPIEXEC_DEBUG is set in environment, wait for debugger until MPIR_debug_gate is set to 1.
+     */
+    MPII_Wait_for_debugger();
 
     /* dup comm_self and creates progress thread (if needed) */
     mpi_errno = MPII_init_async(thread_provided);

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -111,25 +111,6 @@ static inline void MPII_debugger_hold(void)
     }
 }
 
-static inline void MPII_wait_for_debugger(void)
-{
-    /* FIXME: Does this need to come before the call to MPID_InitComplete?
-     * For some debugger support, MPII_Wait_for_debugger may want to use
-     * MPI communication routines to collect information for the debugger */
-#ifdef HAVE_DEBUGGER_SUPPORT
-    MPII_Wait_for_debugger();
-#endif
-}
-
-static inline void MPII_debugger_set_aborting(void)
-{
-    /* Signal the debugger that we are about to exit. */
-    /* FIXME: Should this also be a finalize callback? */
-#ifdef HAVE_DEBUGGER_SUPPORT
-    MPIR_Debugger_set_aborting((char *) 0);
-#endif
-}
-
 static inline void MPII_final_coverage_delay(int rank)
 {
 #if defined(HAVE_USLEEP) && defined(USE_COVERAGE)


### PR DESCRIPTION
## Pull Request Description

Previous initthread refactor parked some of the code in `mpi_init.h` that meant to be further refactored. This PR further refactors the init and finalize of debugger support.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Cleaner code.
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
    See comment in issue #4128
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
