### PR TITLE
config: add AC_PROG_CC_C99 in mpich/configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -613,6 +613,7 @@ AC_CANONICAL_TARGET
 # We also need to do this before the F77 and FC test to ensure that we
 # find the C preprocessor reliably.
 AC_PROG_CC
+AC_PROG_CC_C99
 AM_PROG_CC_C_O dnl needed for automake "silent-rules"
 PAC_PUSH_FLAG([CFLAGS])
 AC_PROG_CPP


### PR DESCRIPTION
## Pull Request Description
I am surprised that we have added AC_PROG_CC_C99 is all the submodules
but neglected in the main configure.ac. For modern C99 default
compilers, this macro does nothing. For other compilers, this macros will
add necessary options to enable C99. Without it, the compilation may
fail due to C99 usage in our code. In particular, both ICC and gcc 4.x
will fail.

The problem hasn't shown up because currently, we pull the HWLOC
configure directly into the main configure, which calls AC_PROG_CC_C99
inside. Once we refactored HWLOC configure or uses external hwloc, the problem will show up.

This commit fixes it.



<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
