### PR TITLE
config: use LDCC to link libmpi.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,25 +66,6 @@ pmpi_convenience_libs = @opalib@ @mpllib@ @zmlib@ @hwloclib@
 DIST_SUBDIRS = ${external_subdirs}
 SUBDIRS = ${external_subdirs}
 
-## Automake attempts to guess the correct linker among the various compilers
-## for each language (see "How the Linker is Chosen" in the AM manual).
-## However, this process is static and doesn't assume that you will "disable"
-## Fortran support for a library and still actually build that library.
-## lib@MPILIBNAME@.la contains both C and F77 source, so AM picks "F77LD" as the
-## linker.  Instead we manually override automake's choice based on the value of
-## enable_f77.
-if BUILD_F77_BINDING
-# link with libtool+F77LD
-lib_lib@MPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=F77 \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(F77LD) \
-	$(AM_FFLAGS) $(FFLAGS) $(lib_lib@MPILIBNAME@_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-lib_lib@PMPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=F77 \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(F77LD) \
-	$(AM_FFLAGS) $(FFLAGS) $(lib_lib@PMPILIBNAME@_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-else !BUILD_F77_BINDING
-# link with libtool+CCLD
 lib_lib@MPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(lib_lib@MPILIBNAME@_la_CFLAGS) $(CFLAGS) \
@@ -93,7 +74,6 @@ lib_lib@PMPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(lib_lib@PMPILIBNAME@_la_CFLAGS) $(CFLAGS) \
 	$(lib_lib@PMPILIBNAME@_la_LDFLAGS) $(LDFLAGS) -o $@
-endif !BUILD_F77_BINDING
 
 if BUILD_F77_BINDING
 if BUILD_FC_BINDING


### PR DESCRIPTION


## Pull Request Description
It removes the link dependency on fortran libraries when compile c
programs.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
      Fixes #4130
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
