### PR TITLE
Use single object kind for MPICH internal objects

### DIFF
--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -129,14 +129,9 @@
   MPI handle represents.  It is an enum because only this applies only the
   the MPI and internal MPICH objects.
 
-  The 'MPIR_PROCGROUP' kind is used to manage process groups (different
-  from MPI Groups) that are used to keep track of collections of
-  processes (each 'MPIR_PROCGROUP' corresponds to a group of processes
-  that define an 'MPI_COMM_WORLD'.  This becomes important only
-  when MPI-2 dynamic process features are supported.  'MPIR_VCONN' is
-  a virtual connection; while this is not part of the overall ADI3
-  design, an object that manages connections to other processes is
-  a common need, and 'MPIR_VCONN' may be used for that.
+  'MPIR_VCONN' is a virtual connection; while this is not part of the
+  overall ADI3 design, an object that manages connections to other processes
+  is a common need, and 'MPIR_VCONN' may be used for that.
 
   Module:
   Attribute-DS
@@ -153,11 +148,10 @@ typedef enum MPII_Object_kind {
     MPIR_KEYVAL = 0x9,
     MPIR_ATTR = 0xa,
     MPIR_REQUEST = 0xb,
-    MPIR_PROCGROUP = 0xc,       /* These are internal device objects */
-    MPIR_VCONN = 0xd,
-    MPIR_WORKQ_ELEM = 0xe,      /* Work queue element, currently only meaningful in CH4 */
-    MPIR_GREQ_CLASS = 0xf,
-    MPIR_XPMEM_SEG = 0x10,      /* XPMEM segment, only meaningful in CH4
+    MPIR_VCONN = 0xc,
+    MPIR_WORKQ_ELEM = 0xd,      /* Work queue element, currently only meaningful in CH4 */
+    MPIR_GREQ_CLASS = 0xe,
+    MPIR_XPMEM_SEG = 0xf,       /* XPMEM segment, only meaningful in CH4
                                  * when XPMEM shmmod is enabled */
 } MPII_Object_kind;
 

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -149,10 +149,9 @@ typedef enum MPII_Object_kind {
     MPIR_ATTR = 0xa,
     MPIR_REQUEST = 0xb,
     MPIR_VCONN = 0xc,
-    MPIR_WORKQ_ELEM = 0xd,      /* Work queue element, currently only meaningful in CH4 */
-    MPIR_GREQ_CLASS = 0xe,
-    MPIR_XPMEM_SEG = 0xf,       /* XPMEM segment, only meaningful in CH4
-                                 * when XPMEM shmmod is enabled */
+    MPIR_GREQ_CLASS = 0xd,
+    MPIR_INTERNAL = 0xe,        /* used for various MPICH internal objects that
+                                 * do not require a handle */
 } MPII_Object_kind;
 
 

--- a/src/mpid/ch4/shm/xpmem/globals.c
+++ b/src/mpid/ch4/shm/xpmem/globals.c
@@ -18,7 +18,7 @@ MPL_dbg_class MPIDI_CH4_SHM_XPMEM_GENERAL;
 MPIDI_XPMEM_seg_t MPIDI_XPMEM_seg_mem_direct[MPIDI_XPMEM_SEG_PREALLOC] = { {0}
 };
 
-MPIR_Object_alloc_t MPIDI_XPMEM_seg_mem = { 0, 0, 0, 0, MPIR_XPMEM_SEG,
+MPIR_Object_alloc_t MPIDI_XPMEM_seg_mem = { 0, 0, 0, 0, MPIR_INTERNAL,
     sizeof(MPIDI_XPMEM_seg_t), MPIDI_XPMEM_seg_mem_direct,
     MPIDI_XPMEM_SEG_PREALLOC
 };

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -26,7 +26,7 @@ MPIDI_NM_native_funcs_t *MPIDI_NM_native_func;
 struct MPIDI_workq_elemt MPIDI_workq_elemt_direct[MPIDI_WORKQ_ELEMT_PREALLOC];
 
 MPIR_Object_alloc_t MPIDI_workq_elemt_mem = {
-    0, 0, 0, 0, MPIR_WORKQ_ELEM, sizeof(struct MPIDI_workq_elemt), MPIDI_workq_elemt_direct,
+    0, 0, 0, 0, MPIR_INTERNAL, sizeof(struct MPIDI_workq_elemt), MPIDI_workq_elemt_direct,
     MPIDI_WORKQ_ELEMT_PREALLOC
 };
 #endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -162,8 +162,8 @@ const char *MPIR_Handle_get_kind_str(int kind)
             mpiu_name_case_(ATTR);
             mpiu_name_case_(REQUEST);
             mpiu_name_case_(VCONN);
-            mpiu_name_case_(WORKQ_ELEM);
             mpiu_name_case_(GREQ_CLASS);
+            mpiu_name_case_(INTERNAL);
         default:
             return "unknown";
     }

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -161,7 +161,6 @@ const char *MPIR_Handle_get_kind_str(int kind)
             mpiu_name_case_(KEYVAL);
             mpiu_name_case_(ATTR);
             mpiu_name_case_(REQUEST);
-            mpiu_name_case_(PROCGROUP);
             mpiu_name_case_(VCONN);
             mpiu_name_case_(WORKQ_ELEM);
             mpiu_name_case_(GREQ_CLASS);


### PR DESCRIPTION
## Pull Request Description
The object kind attribute embedded in the object handle (`MPII_Object_kind`) has a 4-bit limit which allows value up to 15. We need define two internal object pools for XPMEM and reuse the object allocator routines. The new object kinds will exceed the bit limit. 

This PR defines an `MPI_INTERNAL` kind to replace all existing internal kinds. Thus, all kinds can fit in 4 bits. An internal object needs separate kind only for debugging purpose, thus the side effect is very small.

**Original object handle structure**
```
Direct object:
---------------------------------------------------------
handle_kind (2bits) | obj_kind(4bits) | handle index
---------------------------------------------------------
Indirect object:
---------------------------------------------------------------------------------
handle_kind (2bits) | obj_kind(4bits) | block num (14bits) | handle index (12bits)
---------------------------------------------------------------------------------
```

## Expected Impact

It is a prereq of PR #4095.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
