### PR TITLE
handlemem: cleaner indirect type declaration

### DIFF
--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -423,7 +423,7 @@ typedef struct MPIR_Handle_common {
 typedef struct MPIR_Object_alloc_t {
     MPIR_Handle_common *avail;  /* Next available object */
     int initialized;            /* */
-    void *(*indirect)[];        /* Pointer to indirect object blocks */
+    void **indirect;            /* Pointer to indirect object blocks */
     int indirect_size;          /* Number of allocated indirect blocks */
     MPII_Object_kind kind;      /* Kind of object this is for */
     int size;                   /* Size of an individual object */


### PR DESCRIPTION

## Pull Request Description
The existing code declares the indirect pointer of type
`*(*indirect)[]`. This is difficult to read and some compiler complains
about it, such as Oracle Developer Studion (suncc).

Indirect is a dynamically allocated array of void pointers, each points
to a block of objects. Therefore, the type should simply be void **.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
