### PR TITLE
mpir/netloc: bug fix in network topology parsing

### DIFF
--- a/src/include/mpir_netloc.h
+++ b/src/include/mpir_netloc.h
@@ -9,6 +9,7 @@
 #define MPIR_NETLOC_H_INCLUDED
 
 #include "netloc.h"
+#include "hwloc.h"
 #include "mpir_hw_topo.h"
 
 typedef struct {
@@ -32,7 +33,7 @@ typedef struct {
     netloc_node_t *network_endpoint;
 } MPIR_Netloc_network_attributes;
 
-int MPIR_Netloc_parse_topology(netloc_topology_t topology,
+int MPIR_Netloc_parse_topology(hwloc_topology_t hwloc_topology, netloc_topology_t topology,
                                MPIR_Netloc_network_attributes * network_attr);
 
 int MPIR_Netloc_get_network_end_point(MPIR_Netloc_network_attributes,

--- a/src/util/mpir_hw_topo.c
+++ b/src/util/mpir_hw_topo.c
@@ -267,7 +267,8 @@ int MPII_hw_topo_init(void)
     if (strlen(MPIR_CVAR_NETLOC_NODE_FILE)) {
         mpi_errno = netloc_parse_topology(&hw_topo.netloc_topology, MPIR_CVAR_NETLOC_NODE_FILE);
         if (mpi_errno == NETLOC_SUCCESS)
-            MPIR_Netloc_parse_topology(hw_topo.netloc_topology, &hw_topo.network_attr);
+            MPIR_Netloc_parse_topology(hw_topo.hwloc_topology, hw_topo.netloc_topology,
+                                       &hw_topo.network_attr);
     }
 #endif
 

--- a/src/util/mpir_netloc.c
+++ b/src/util/mpir_netloc.c
@@ -26,7 +26,7 @@ typedef struct tree {
     int num_edges;
 } tree;
 
-static int get_tree_attributes(netloc_topology_t topology,
+static int get_tree_attributes(hwloc_topology_t hwloc_topology, netloc_topology_t topology,
                                MPIR_Netloc_network_attributes * network_attr)
 {
     int i, j, k, l;
@@ -293,7 +293,7 @@ static int get_tree_attributes(netloc_topology_t topology,
                 }
 
                 errno = MPIR_Netloc_get_network_end_point(network_attr,
-                                                          netloc_topology,
+                                                          topology,
                                                           hwloc_topology,
                                                           &network_attr->network_endpoint);
                 if (errno != MPI_SUCCESS) {
@@ -841,7 +841,7 @@ static void find_maximum_matching(netloc_topology_t topology, netloc_node_t *** 
     return;
 }
 
-static int get_torus_attributes(netloc_topology_t topology,
+static int get_torus_attributes(hwloc_topology_t hwloc_topology, netloc_topology_t topology,
                                 MPIR_Netloc_network_attributes * network_attr)
 {
     netloc_dt_lookup_table_t *nodes;
@@ -1414,7 +1414,7 @@ static int get_torus_attributes(netloc_topology_t topology,
 
             /* Identify the network node corresponding to the current rank's node */
             errno = MPIR_Netloc_get_network_end_point(network_attr,
-                                                      netloc_topology,
+                                                      topology,
                                                       hwloc_topology,
                                                       &network_attr->network_endpoint);
             if (errno != MPI_SUCCESS) {
@@ -1452,15 +1452,15 @@ static int get_torus_attributes(netloc_topology_t topology,
     goto fn_exit;
 }
 
-int MPIR_Netloc_parse_topology(netloc_topology_t netloc_topology,
+int MPIR_Netloc_parse_topology(hwloc_topology_t hwloc_topology, netloc_topology_t netloc_topology,
                                MPIR_Netloc_network_attributes * network_attr)
 {
     int mpi_errno = MPI_SUCCESS;
-    mpi_errno = get_tree_attributes(netloc_topology, network_attr);
+    mpi_errno = get_tree_attributes(hwloc_topology, netloc_topology, network_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (network_attr->type == MPIR_NETWORK_TOPOLOGY_TYPE__INVALID) {
-        mpi_errno = get_torus_attributes(netloc_topology, network_attr);
+        mpi_errno = get_torus_attributes(hwloc_topology, netloc_topology, network_attr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/util/mpir_netloc.c
+++ b/src/util/mpir_netloc.c
@@ -292,11 +292,10 @@ static int get_tree_attributes(netloc_topology_t topology,
                     network_attr->type = MPIR_NETWORK_TOPOLOGY_TYPE__FAT_TREE;
                 }
 
-                errno = MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
-                                                          MPIR_Process.netloc_topology,
-                                                          MPIR_Process.hwloc_topology,
-                                                          &MPIR_Process.
-                                                          network_attr.network_endpoint);
+                errno = MPIR_Netloc_get_network_end_point(network_attr,
+                                                          netloc_topology,
+                                                          hwloc_topology,
+                                                          &network_attr->network_endpoint);
                 if (errno != MPI_SUCCESS) {
                     network_attr->type = MPIR_NETWORK_TOPOLOGY_TYPE__INVALID;
                 }
@@ -1414,16 +1413,15 @@ static int get_torus_attributes(netloc_topology_t topology,
             }
 
             /* Identify the network node corresponding to the current rank's node */
-            errno = MPIR_Netloc_get_network_end_point(MPIR_Process.network_attr,
-                                                      MPIR_Process.netloc_topology,
-                                                      MPIR_Process.hwloc_topology,
-                                                      &MPIR_Process.network_attr.network_endpoint);
+            errno = MPIR_Netloc_get_network_end_point(network_attr,
+                                                      netloc_topology,
+                                                      hwloc_topology,
+                                                      &network_attr->network_endpoint);
             if (errno != MPI_SUCCESS) {
                 network_attr->type = MPIR_NETWORK_TOPOLOGY_TYPE__INVALID;
             } else {
                 /* Flatten computed coordinates into a long value for the current node */
-                coordinates =
-                    temp_coordinate_map[MPIR_Process.network_attr.network_endpoint->__uid__];
+                coordinates = temp_coordinate_map[network_attr->network_endpoint->__uid__];
                 node_index = coordinates[0];
                 for (j = 1; j < path_graph_insert; j++) {
                     node_index = (node_index * network_attr->u.torus.geometry[j]) + coordinates[j];
@@ -1458,11 +1456,11 @@ int MPIR_Netloc_parse_topology(netloc_topology_t netloc_topology,
                                MPIR_Netloc_network_attributes * network_attr)
 {
     int mpi_errno = MPI_SUCCESS;
-    mpi_errno = get_tree_attributes(MPIR_Process.netloc_topology, network_attr);
+    mpi_errno = get_tree_attributes(netloc_topology, network_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (network_attr->type == MPIR_NETWORK_TOPOLOGY_TYPE__INVALID) {
-        mpi_errno = get_torus_attributes(MPIR_Process.netloc_topology, network_attr);
+        mpi_errno = get_torus_attributes(netloc_topology, network_attr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 


### PR DESCRIPTION
## Pull Request Description

Strangely the old parsing code was taking netloc topology and network
attributes as function arguments but was still using direct references
to the `MPIR_Process` counterparts. Remove such references.

These bugs were introduced by https://github.com/pmodels/mpich/pull/3594
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
