### PR TITLE
runtests: append load information when tests fail in timout

### DIFF
--- a/test/mpi/runtests.in
+++ b/test/mpi/runtests.in
@@ -891,12 +891,6 @@ sub RunMPIProgram {
         $rc = close ( MPIOUT );
         my $end_time = gettimeofday();  # seconds in floating point
         $runtime = $end_time - $start_time;
-        # count # of timeout when tests are configured with sufficient timeLimit
-        if ($test_opt->{_timeout} > 60) {
-            if ($runtime - $test_opt->{_timeout} >= -10) {
-                $g_num_timeout++;
-            }
-        }
         print STDOUT "Runtime: $runtime\n" if $verbose;
         if ($rc == 0) {
             # Only generate a message if we think that the program
@@ -1285,6 +1279,15 @@ sub RunTestFailed {
     my $progArgs = join(' ', @{$test_opt->{args}});
     my $progEnv = join(' ', @{$test_opt->{envs}});
 
+    # count # of timeout when tests are configured with sufficient timeLimit
+    if ($test_opt->{_timeout} > 60) {
+        if ($runtime - $test_opt->{_timeout} >= -10) {
+            $g_num_timeout++;
+            # append load information to output
+            my $uptime = `uptime`;
+            $output .= "\n  uptime:\n$uptime";
+        }
+    }
     if ($xmloutput) {
         my $xout = $output;
         # basic escapes that wreck the XML output


### PR DESCRIPTION
## Pull Request Description

Sometime tests fail in timeout due to stress situations such as zombie processes eating up the cpu resources. Append uptime info to help identify the situations.

This is response for this comment: https://github.com/pmodels/mpich/pull/4141#issuecomment-549949147
<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
