### PR TITLE
pm/hydra: Remove references to non-C compilers

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -114,21 +114,6 @@ if test "$CC" != "" ; then
 else
    AC_DEFINE_UNQUOTED(HYDRA_CC,"",[C compiler])
 fi
-if test "$CXX" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_CXX,"$CXX $CPPFLAGS $CXXFLAGS $LDFLAGS $LIBS",[C++ compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_CXX,"",[C++ compiler])
-fi
-if test "$F77" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_F77,"$F77 $FFLAGS $LDFLAGS $LIBS",[Fortran 77 compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_F77,"",[Fortran 77 compiler])
-fi
-if test "$FC" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_F90,"$FC $FCFLAGS $LDFLAGS $LIBS",[Fortran 90 compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_F90,"",[Fortran 90 compiler])
-fi
 PAC_POP_ALL_FLAGS
 
 AC_DEFINE_UNQUOTED(HYDRA_CONFIGURE_ARGS_CLEAN,"`echo $ac_configure_args`",[Configure arguments])

--- a/src/pm/hydra/ui/mpich/utils.c
+++ b/src/pm/hydra/ui/mpich/utils.c
@@ -1239,9 +1239,6 @@ static HYD_status info_fn(char *arg, char ***argv)
     HYDU_dump_noprefix(stdout,
                        "    Release Date:                            %s\n", HYDRA_RELEASE_DATE);
     HYDU_dump_noprefix(stdout, "    CC:                              %s\n", HYDRA_CC);
-    HYDU_dump_noprefix(stdout, "    CXX:                             %s\n", HYDRA_CXX);
-    HYDU_dump_noprefix(stdout, "    F77:                             %s\n", HYDRA_F77);
-    HYDU_dump_noprefix(stdout, "    F90:                             %s\n", HYDRA_F90);
     HYDU_dump_noprefix(stdout,
                        "    Configure options:                       %s\n",
                        HYDRA_CONFIGURE_ARGS_CLEAN);

--- a/src/pm/hydra2/configure.ac
+++ b/src/pm/hydra2/configure.ac
@@ -116,21 +116,6 @@ if test "$CC" != "" ; then
 else
    AC_DEFINE_UNQUOTED(HYDRA_CC,"",[C compiler])
 fi
-if test "$CXX" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_CXX,"$CXX $CPPFLAGS $CXXFLAGS $LDFLAGS $LIBS",[C++ compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_CXX,"",[C++ compiler])
-fi
-if test "$F77" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_F77,"$F77 $FFLAGS $LDFLAGS $LIBS",[Fortran 77 compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_F77,"",[Fortran 77 compiler])
-fi
-if test "$FC" != "" ; then
-   AC_DEFINE_UNQUOTED(HYDRA_F90,"$FC $FCFLAGS $LDFLAGS $LIBS",[Fortran 90 compiler])
-else
-   AC_DEFINE_UNQUOTED(HYDRA_F90,"",[Fortran 90 compiler])
-fi
 PAC_POP_ALL_FLAGS
 
 AC_DEFINE_UNQUOTED(HYDRA_CONFIGURE_ARGS_CLEAN,"`echo $ac_configure_args`",[Configure arguments])

--- a/src/pm/hydra2/mpiexec/mpiexec_params.c
+++ b/src/pm/hydra2/mpiexec/mpiexec_params.c
@@ -683,9 +683,6 @@ static HYD_status info_fn(char *arg, char ***argv)
     HYD_PRINT_NOPREFIX(stdout, "    Release Date:                            %s\n",
                        HYDRA_RELEASE_DATE);
     HYD_PRINT_NOPREFIX(stdout, "    CC:                              %s\n", HYDRA_CC);
-    HYD_PRINT_NOPREFIX(stdout, "    CXX:                             %s\n", HYDRA_CXX);
-    HYD_PRINT_NOPREFIX(stdout, "    F77:                             %s\n", HYDRA_F77);
-    HYD_PRINT_NOPREFIX(stdout, "    F90:                             %s\n", HYDRA_F90);
     HYD_PRINT_NOPREFIX(stdout, "    Configure options:                       %s\n",
                        HYDRA_CONFIGURE_ARGS_CLEAN);
     HYD_PRINT_NOPREFIX(stdout, "    Process Manager:                         pmi\n");


### PR DESCRIPTION
## Pull Request Description

Hydra is C-only. Delete references to C++ and Fortran compilers.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
