### PR TITLE
bindings/fortran: move fortran code to libmpifort.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,25 +65,6 @@ pmpi_convenience_libs = @mpllib@ @zmlib@ @hwloclib@ @jsonlib@ @yaksalib@
 DIST_SUBDIRS = ${external_subdirs}
 SUBDIRS = ${external_subdirs}
 
-## Automake attempts to guess the correct linker among the various compilers
-## for each language (see "How the Linker is Chosen" in the AM manual).
-## However, this process is static and doesn't assume that you will "disable"
-## Fortran support for a library and still actually build that library.
-## lib@MPILIBNAME@.la contains both C and F77 source, so AM picks "F77LD" as the
-## linker.  Instead we manually override automake's choice based on the value of
-## enable_f77.
-if BUILD_F77_BINDING
-# link with libtool+F77LD
-lib_lib@MPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=F77 \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(F77LD) \
-	$(AM_FFLAGS) $(FFLAGS) $(lib_lib@MPILIBNAME@_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-lib_lib@PMPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=F77 \
-	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(F77LD) \
-	$(AM_FFLAGS) $(FFLAGS) $(lib_lib@PMPILIBNAME@_la_LDFLAGS) \
-	$(LDFLAGS) -o $@
-else !BUILD_F77_BINDING
-# link with libtool+CCLD
 lib_lib@MPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(lib_lib@MPILIBNAME@_la_CFLAGS) $(CFLAGS) \
@@ -92,7 +73,6 @@ lib_lib@PMPILIBNAME@_la_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC \
 	$(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=link $(CCLD) \
 	$(lib_lib@PMPILIBNAME@_la_CFLAGS) $(CFLAGS) \
 	$(lib_lib@PMPILIBNAME@_la_LDFLAGS) $(LDFLAGS) -o $@
-endif !BUILD_F77_BINDING
 
 if BUILD_F77_BINDING
 if BUILD_FC_BINDING

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -4118,12 +4118,6 @@ sub build_specials {
     # Gcc only allows attributes on the prototypes, not the function
     # definitions
     print $OUTFD "{\n";
-    print $OUTFD "#ifndef F77_RUNTIME_VALUES
-    /* any compile/link time values go here */
-#else
-#   error \"Fortran values must be determined at configure time\"
-#endif
-";
     # See the discussion on MPIR_F_NeedInit at the head of this file
     print $OUTFD "    mpirinitf_(); MPIR_F_NeedInit = 0;\n";
     print $OUTFD "    *ierr = MPI_Init( 0, 0 );\n";

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -1044,7 +1044,7 @@ EOT
 
     # The definitions for the Fortran wrappers are special
     print MAKEFD <<EOT;
-mpi_core_sources += src/binding/fortran/mpif_h/fdebug.c \\
+mpi_f77_sources += src/binding/fortran/mpif_h/fdebug.c \\
 		src/binding/fortran/mpif_h/setbot.c \\
 		src/binding/fortran/mpif_h/setbotf.f
 mpi_sources += src/binding/fortran/mpif_h/statusf2c.c src/binding/fortran/mpif_h/statusc2f.c

--- a/src/binding/fortran/mpif_h/setbot.c.in
+++ b/src/binding/fortran/mpif_h/setbot.c.in
@@ -26,24 +26,6 @@ FORT_DLL_SPEC void FORT_CALL mpirinitc_(void *si, void *ssi,
 FORT_DLL_SPEC void FORT_CALL mpirinitc2_(char *FORT_MIXED_LEN_DECL FORT_END_LEN_DECL);
 
 /*
-    # These are here rather than in initf.c to solve some link order
-    # problems for Windows when separate libraries are used for the C and
-    # Fortran routines.
-    # Note that the global variables have values.  This is to work around
-    # a bug in some C environments (e.g., Mac OS/X) that don't load
-    # external symbols that don't have a value assigned at compile time
-    # (so called common symbols)
-*/
-#ifndef F77_USE_BOOLEAN_LITERALS
-#if defined(F77_RUNTIME_VALUES) || !defined(F77_TRUE_VALUE_SET)
-MPI_Fint MPII_F_TRUE = 1, MPII_F_FALSE = 0;
-#else
-const MPI_Fint MPII_F_TRUE = F77_TRUE_VALUE;
-const MPI_Fint MPII_F_FALSE = F77_FALSE_VALUE;
-#endif
-#endif
-
-/*
     # MPI-2, section 4.12.5, on the declaration of MPI_F_STATUS_IGNORE
     # MPI_F_STATUSES_IGNORE as global variables in mpi.h (!)
 */

--- a/src/include/mpii_fortlogical.h
+++ b/src/include/mpii_fortlogical.h
@@ -8,16 +8,8 @@
 
 /* Fortran logical values */
 #ifndef _CRAY
-#ifdef F77_USE_BOOLEAN_LITERALS
-#define MPII_F_TRUE  F77_TRUE_VALUE
-#define MPII_F_FALSE F77_FALSE_VALUE
-#else
-#if !defined(F77_RUNTIME_VALUES) && defined(F77_TRUE_VALUE_SET)
 MPICH_API_PUBLIC extern const MPI_Fint MPII_F_TRUE, MPII_F_FALSE;
-#else
-MPICH_API_PUBLIC extern MPI_Fint MPII_F_TRUE, MPII_F_FALSE;
-#endif
-#endif
+
 #define MPII_TO_FLOG(a) ((a) ? MPII_F_TRUE : MPII_F_FALSE)
 /*
    Note on true and false.  This code is only an approximation.

--- a/src/include/mpii_fortlogical.h
+++ b/src/include/mpii_fortlogical.h
@@ -6,9 +6,24 @@
 #ifndef MPII_FORTLOGICAL_H_INCLUDED
 #define MPII_FORTLOGICAL_H_INCLUDED
 
+#if !defined(F77_TRUE_VALUE_SET)
+#define F77_TRUE_VALUE 1
+#define F77_FALSE_VALUE 0
+#define F77_TRUE_VALUE_SET
+#endif
+
+/* We originally support F77_RUNTIME_VALUES, which I believe it is the
+ * reason we require MPII_F_TRUE/FALSE to be global variables.
+ * Now that F77_RUNTIME_VALUES support has disappeared, let's remove the
+ * global variables and redefine them as boolearn literal. This will remove
+ * the complication of resolving symbols between libmpi.so and libmpifort.so.
+ */
+
+#define MPII_F_TRUE F77_TRUE_VALUE
+#define MPII_F_FALSE F77_FALSE_VALUE
+
 /* Fortran logical values */
 #ifndef _CRAY
-MPICH_API_PUBLIC extern const MPI_Fint MPII_F_TRUE, MPII_F_FALSE;
 
 #define MPII_TO_FLOG(a) ((a) ? MPII_F_TRUE : MPII_F_FALSE)
 /*

--- a/src/mpi/init/init.c
+++ b/src/mpi/init/init.c
@@ -48,9 +48,6 @@ int MPI_Init(int *argc, char ***argv) __attribute__ ((weak, alias("PMPI_Init")))
 #undef MPI_Init
 #define MPI_Init PMPI_Init
 
-/* Fortran logical values. extern'd in mpiimpl.h */
-/* MPI_Fint MPII_F_TRUE, MPII_F_FALSE; */
-
 /* Any internal routines can go here.  Make them static if possible */
 
 #endif

--- a/src/mpi/init/init_bindings.c
+++ b/src/mpi/init/init_bindings.c
@@ -6,28 +6,6 @@
 #include "mpiimpl.h"
 #include "mpi_init.h"
 
-/* ** FORTRAN binding **************/
-
-#ifdef HAVE_FORTRAN_BINDING
-/* Fortran logical values. extern'd in mpiimpl.h */
-/* MPI_Fint MPII_F_TRUE, MPII_F_FALSE; */
-/*
-    # Note that the global variables have values.  This is to work around
-    # a bug in some C environments (e.g., Mac OS/X) that don't load
-    # external symbols that don't have a value assigned at compile time
-    # (so called common symbols)
-*/
-#if !defined(F77_TRUE_VALUE_SET)
-#define F77_TRUE_VALUE 1
-#define F77_FALSE_VALUE 0
-#define F77_TRUE_VALUE_SET
-#endif
-
-const MPI_Fint MPII_F_TRUE = F77_TRUE_VALUE;
-const MPI_Fint MPII_F_FALSE = F77_FALSE_VALUE;
-
-#endif /* HAVE_FORTRAN_BINDING */
-
 /* ** CXX binding **************/
 void MPII_init_binding_cxx(void)
 {

--- a/src/mpi/init/init_bindings.c
+++ b/src/mpi/init/init_bindings.c
@@ -17,14 +17,14 @@
     # external symbols that don't have a value assigned at compile time
     # (so called common symbols)
 */
-#ifndef F77_USE_BOOLEAN_LITERALS
-#if defined(F77_RUNTIME_VALUES) || !defined(F77_TRUE_VALUE_SET)
-MPI_Fint MPII_F_TRUE = 1, MPII_F_FALSE = 0;
-#else
+#if !defined(F77_TRUE_VALUE_SET)
+#define F77_TRUE_VALUE 1
+#define F77_FALSE_VALUE 0
+#define F77_TRUE_VALUE_SET
+#endif
+
 const MPI_Fint MPII_F_TRUE = F77_TRUE_VALUE;
 const MPI_Fint MPII_F_FALSE = F77_FALSE_VALUE;
-#endif
-#endif
 
 #endif /* HAVE_FORTRAN_BINDING */
 

--- a/src/mpi/init/init_bindings.c
+++ b/src/mpi/init/init_bindings.c
@@ -6,6 +6,28 @@
 #include "mpiimpl.h"
 #include "mpi_init.h"
 
+/* ** FORTRAN binding **************/
+
+#ifdef HAVE_FORTRAN_BINDING
+/* Fortran logical values. extern'd in mpiimpl.h */
+/* MPI_Fint MPII_F_TRUE, MPII_F_FALSE; */
+/*
+    # Note that the global variables have values.  This is to work around
+    # a bug in some C environments (e.g., Mac OS/X) that don't load
+    # external symbols that don't have a value assigned at compile time
+    # (so called common symbols)
+*/
+#ifndef F77_USE_BOOLEAN_LITERALS
+#if defined(F77_RUNTIME_VALUES) || !defined(F77_TRUE_VALUE_SET)
+MPI_Fint MPII_F_TRUE = 1, MPII_F_FALSE = 0;
+#else
+const MPI_Fint MPII_F_TRUE = F77_TRUE_VALUE;
+const MPI_Fint MPII_F_FALSE = F77_FALSE_VALUE;
+#endif
+#endif
+
+#endif /* HAVE_FORTRAN_BINDING */
+
 /* ** CXX binding **************/
 void MPII_init_binding_cxx(void)
 {

--- a/src/mpi/init/init_bindings.c
+++ b/src/mpi/init/init_bindings.c
@@ -6,36 +6,6 @@
 #include "mpiimpl.h"
 #include "mpi_init.h"
 
-/* ** FORTRAN binding **************/
-#if defined(HAVE_FORTRAN_BINDING) && defined(HAVE_MPI_F_INIT_WORKS_WITH_C)
-#ifdef F77_NAME_UPPER
-#define mpirinitf_ MPIRINITF
-#elif defined(F77_NAME_LOWER) || defined(F77_NAME_MIXED)
-#define mpirinitf_ mpirinitf
-#endif
-void mpirinitf_(void);
-
-void MPII_init_binding_fortran(void)
-{
-    /* Initialize the C versions of the Fortran link-time constants.
-     *
-     * We now initialize the Fortran symbols from within the Fortran
-     * interface in the routine that first needs the symbols.
-     * This fixes a problem with symbols added by a Fortran compiler that
-     * are not part of the C runtime environment (the Portland group
-     * compilers would do this)
-     */
-    mpirinitf_();
-}
-
-#else
-
-void MPII_init_binding_fortran(void)
-{
-}
-
-#endif /* HAVE_FORTRAN_BINDING && HAVE_MPI_F_INIT_WORKS_WITH_C */
-
 /* ** CXX binding **************/
 void MPII_init_binding_cxx(void)
 {

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -106,7 +106,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     MPII_hwtopo_init();
     MPII_nettopo_init();
     MPII_init_windows();
-    MPII_init_binding_fortran();
     MPII_init_binding_cxx();
     MPII_init_binding_f08();
 

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -49,7 +49,6 @@ int MPII_init_local_proc_attrs(int *p_thread_required);
 int MPII_finalize_local_proc_attrs(void);
 
 void MPII_init_windows(void);
-void MPII_init_binding_fortran(void);
 void MPII_init_binding_cxx(void);
 void MPII_init_binding_f08(void);
 void MPII_pre_init_dbg_logging(int *argc, char ***argv);


### PR DESCRIPTION
## Pull Request Description

Continuing the investigation of issue #4130 and PR #4140, see if we can move the fortran code into `libmpifort.so` entirely.
[skip warnings]
## Issue
This PR is originally a response to issue #4130 -- users want to run C app by only linking to `libmpi.so`  without every gfortran dependency. This PR  achieves it by ensure `libmpi.so` is linked by `CC` instead of `FC`.

However, this PR gets renewed attention as a potential fix for a separate issue from mpich-discuss mailing list:

    On Wed, May 27, 2020 at 10:25 AM Patrick McNally <rpmcnally at gmail.com>
    wrote:

    > Our application consists primarily of a Python head calling into Fortran
    > routines to do the heavy lifting.  We have never been able to successfully
    > use MPI_IN_PLACE in Fortran but weren't sure why.  Recently, we discovered
    > that it works fine in standalone Fortran code and is only broken when the
    > Fortran code is run through our Python modules.
    >
    > The issue appears to be related to having code that only links to the C
    > libmpi library loaded first and with RTLD_LOCAL, as happens when we load
    > mpi4py.  It works if you load something linked to libmpifort first or load
    > everything with RTLD_GLOBAL.  I'm assuming this has something to do with
    > how MPICH tests the address of MPIR_F08_MPI_IN_PLACE but I don't understand
    > SO loading well enough to fully grasp the issue.  Below is some standalone
    > code to show the issue.  I'd appreciate any insight you can provide into
    > why this is happening.
    >
    > Relevant system details:
    > RHEL 7.8
    > Python 2.7
    > GCC 7.3.0
    > MPICH 3.3.2 (and 3.2)
    >
    > The below files are also available towards the end of the bug report at
    > the following link:
    >
    > https://bitbucket.org/mpi4py/mpi4py/issues/162/mpi4py-initialization-breaks-fortran

If I understand correctly, `mpi4py` may only load a `libmpi.so`. Since `libmpifort.so` is not loaded, `libmpi.so` will have its own common block for variables such as `MPI_BOTTOM`, `MPI_IN_PLACE`. These are constants in C API, but because fortran can't use constants for address, it need actual variables. When `mpi4py` later run into fortran code, it will dynamically load `libmpifort.so`, which will load a **separate** common block -- not linked to the common block in `libmpi.so`, resulting special address for `MPI_BOTTOM` etc. unrecognized by C (since it was initialized by a different set of addresses).

This PR removes the fortran initialization from `MPI_Init`, and only runs the initialization lazily when fortran code runs. Thus the only common block in `libmpifort.so` will get used. So it may fix the above mentioned issue.

Recently, a ticket filed to PetSc raises the seriousness of this issue. The bug maybe the same `mpi4py` issue, but user would have no clue (who would) and files the issue against the application `firedrake`, then `petsc`, then `mumps` -- leaving a trail of confusion -- and eventually leads back to here.


## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
