### PR TITLE
testsuite: missing return in test io/i_darray_read

### DIFF
--- a/test/mpi/io/i_darray_read.c
+++ b/test/mpi/io/i_darray_read.c
@@ -128,5 +128,5 @@ int main(int argc, char *argv[])
     MPI_Type_free(&darray);
     MTest_Finalize(nerrors);
 
-    MTestReturnValue(total_errors);
+    return MTestReturnValue(total_errors);
 }


### PR DESCRIPTION
## Pull Request Description

The nightly test on `ch3-centos` has been failing for `pgi - debug` configuration:
```
 summary_junit_xml. - ./io/i_darray_read 4
 Error Details

not ok  - ./io/i_darray_read 4
  ...
## Test output (expected 'No Errors'):
##  No Errors
```    

Turns out we were missing the `return` statement.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
