### PR TITLE
config: remove the check for invalid prototype

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -55,36 +55,6 @@ AC_MSG_RESULT([$pac_result])
 dnl Delete the conftest created by AC_LANG_CONFTEST.
 rm -f conftest.$ac_ext
 
-# gcc 4.2.4 on 32-bit does not complain about the -Wno-type-limits option 
-# even though it doesn't support it.  However, when another warning is 
-# triggered, it gives an error that the option is not recognized.  So we 
-# need to test with a conftest file that will generate warnings.
-# 
-# add an extra switch, pac_c_check_compiler_option_prototest, to
-# disable this test just in case some new compiler does not like it.
-#
-# Linking with a program with an invalid prototype to ensure a compiler warning.
-
-if test "$pac_result" = "yes" \
-     -a "$pac_c_check_compiler_option_prototest" != "no" ; then
-    AC_MSG_CHECKING([whether C compiler option $1 works with an invalid prototype program])
-    AC_LINK_IFELSE([
-        dnl We want a warning, but we don't want to inadvertently disable
-        dnl special warnings like -Werror-implicit-function-declaration (e.g.,
-        dnl in PAC_CC_STRICT) by compiling something that might actually be
-        dnl treated as an error by the compiler.  So we try to elicit an
-        dnl "unused variable" warning and/or an "uninitialized" warning with the
-        dnl test program below.
-        dnl
-        dnl The old sanity program was:
-        dnl   void main() {return 0;}
-        dnl which clang (but not GCC) would treat as an *error*, invalidating
-        dnl the test for any given parameter.
-        AC_LANG_SOURCE([int main(int argc, char **argv){ int foo, bar = 0; foo += 1; return foo; }])
-    ],[pac_result=yes],[pac_result=no])
-    AC_MSG_RESULT([$pac_result])
-fi
-#
 if test "$pac_result" = "yes" ; then
     AC_MSG_CHECKING([whether routines compiled with $pac_opt can be linked with ones compiled without $pac_opt])
     pac_result=unknown


### PR DESCRIPTION


## Pull Request Description

In PAC_C_CHECK_COMPILER_OPTION, after we check for whether a cflag works
with a trivial program, we also check if it works with a program that
contains a warning. First, the check won't work if the presumed warning
is not triggered. In our choses code, the use of uninitialized variable
warning does not trigger in icc by default. Second, if it gives warning,
then it won't work with -Werror or its like. Sometime we want to check
and add -Werror, and its supposed behavior is very unclear with this
check. Third, the original issue seems to be a particular odd behavior
of a very old gcc (gcc 4.2). Therefore, we are removing this check.

## Background

This issue arises during the troubleshooting on why `icc` didn't pick a warning-free version of mpl_atomics despite we checked with -Werror. It become clear that the mentioned check gives more confusion than its worth.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
