### PR TITLE
mpl/atomic: suppress warnings with icc 19.0.4

### DIFF
--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -7,6 +7,16 @@
 #ifndef MPL_ATOMIC_C11_H_INCLUDED
 #define MPL_ATOMIC_C11_H_INCLUDED
 
+#ifdef __INTEL_COMPILER
+/*
+ * Function prototypes of C11 atomic functions in ICC 19.0.4 are different from
+ * the C11 standard, causing countless "dropping qualifiers" warnings.
+ * The following pragmas are to suppress these warnings.
+ */
+#pragma warning(push)
+#pragma warning(disable: 2330)
+#endif
+
 #include <stdint.h>
 #include <stdatomic.h>
 
@@ -114,5 +124,9 @@ static inline void MPL_atomic_compiler_barrier(void)
     /* atomic_signal_fence performs a compiler barrier without any overhead */
     atomic_signal_fence(memory_order_acq_rel);
 }
+
+#ifdef __INTEL_COMPILER
+#pragma warning(pop)
+#endif
 
 #endif /* MPL_ATOMIC_C11_H_INCLUDED */


### PR DESCRIPTION
Intel C Compiler has non-standard prototypes of C11 atomic functions, causing many "dropping qualifiers" warnings in `mpl_atomic_c11.h`.  This patch fixes this issue by locally suppressing this warning as suggested in #3997.

This commit will allow ICC (19.0.4 and so on) to choose C11 atomics for MPL/atomic (without warnings), while previously ICC chooses GCC `__atomic` builtins (see #3999).

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

No performance difference.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
