### PR TITLE
pmi: fix bugs for handling long business card strings

### DIFF
--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -201,6 +201,16 @@ int PMI_Init(int *spawned)
 #endif
 
     PMII_getmaxes(&PMI_kvsname_max, &PMI_keylen_max, &PMI_vallen_max);
+    /* we need construct a cmd like "cmd=put kvsname=%s key=%s value=%s\n",
+     * make sure it fits in PMIU_MAXLINE.
+     */
+    if (PMI_kvsname_max + PMI_keylen_max + PMI_vallen_max + 30 > PMIU_MAXLINE) {
+        if (PMI_keylen_max > 256) {
+            PMI_keylen_max = 256;
+        }
+        PMI_vallen_max = PMIU_MAXLINE - PMI_kvsname_max - PMI_keylen_max - 30;
+        assert(PMI_vallen_max > 256);
+    }
 
     /* FIXME: This is something that the PM should tell the process,
      * rather than deliver it through the environment */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -297,8 +297,7 @@ int MPIR_pmi_barrier_local(void)
     int pmi_errno;
     int local_size = MPIR_Process.local_size;
     pmix_proc_t *procs = MPL_malloc(local_size * sizeof(pmix_proc_t), MPL_MEM_OTHER);
-    int i;
-    for (i = 0; i < local_size; i++) {
+    for (int i = 0; i < local_size; i++) {
         PMIX_PROC_CONSTRUCT(&procs[i]);
         strncpy(procs[i].nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
         procs[i].rank = MPIR_Process.node_local_map[i];
@@ -411,8 +410,7 @@ static int put_ex(const char *key, const void *buf, int bufsize, int is_local)
         MPL_snprintf(val, pmi_max_val_size, "segments=%d", num_segs);
         mpi_errno = MPIR_pmi_kvs_put(key, val);
         MPIR_ERR_CHECK(mpi_errno);
-        int i;
-        for (i = 0; i < num_segs; i++) {
+        for (int i = 0; i < num_segs; i++) {
             char seg_key[50];
             sprintf(seg_key, "%s-seg-%d/%d", key, i + 1, num_segs);
             int n = segsize;
@@ -453,9 +451,8 @@ static int get_ex(int src, const char *key, void *buf, int *p_size, int is_local
     MPIR_ERR_CHECK(mpi_errno);
     if (strncmp(val, "segments=", 9) == 0) {
         int num_segs = atoi(val + 9);
-        int i;
         got_size = 0;
-        for (i = 0; i < num_segs; i++) {
+        for (int i = 0; i < num_segs; i++) {
             char seg_key[50];
             sprintf(seg_key, "%s-seg-%d/%d", key, i + 1, num_segs);
             mpi_errno = optimized_get(src, seg_key, val, pmi_max_val_size, is_local);
@@ -626,8 +623,7 @@ int MPIR_pmi_allgather(const void *sendbuf, int sendsize, void *recvbuf, int rec
         if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS) {
             domain_size = MPIR_Process.num_nodes;
         }
-        int i;
-        for (i = 0; i < domain_size; i++) {
+        for (int i = 0; i < domain_size; i++) {
             int rank = i;
             if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS) {
                 rank = MPIR_Process.node_root_map[i];
@@ -655,7 +651,6 @@ int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int
                            MPIR_PMI_DOMAIN domain)
 {
     int mpi_errno = MPI_SUCCESS;
-    int i;
 
     MPIR_Assert(domain != MPIR_PMI_DOMAIN_LOCAL);
 
@@ -695,7 +690,7 @@ int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int
     if (end > size) {
         end = size;
     }
-    for (i = start; i < end; i++) {
+    for (int i = start; i < end; i++) {
         int src = i;
         if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS) {
             src = MPIR_Process.node_root_map[i];
@@ -810,14 +805,12 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
     MPIR_ERR_CHKANDJUMP(!info_keyval_vectors, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
     if (!info_ptrs) {
-        int i;
-        for (i = 0; i < count; i++) {
+        for (int i = 0; i < count; i++) {
             info_keyval_vectors[i] = 0;
             info_keyval_sizes[i] = 0;
         }
     } else {
-        int i;
-        for (i = 0; i < count; i++) {
+        for (int i = 0; i < count; i++) {
             mpi_errno = mpi_to_pmi_keyvals(info_ptrs[i], &info_keyval_vectors[i],
                                            &info_keyval_sizes[i]);
             MPIR_ERR_CHECK(mpi_errno);
@@ -934,8 +927,7 @@ static int get_option_num_cliques(void)
 /* one process per node */
 int build_nodemap_nolocal(int *nodemap, int sz, int *p_max_node_id)
 {
-    int i;
-    for (i = 0; i < sz; ++i) {
+    for (int i = 0; i < sz; ++i) {
         nodemap[i] = i;
     }
     *p_max_node_id = sz - 1;
@@ -945,8 +937,7 @@ int build_nodemap_nolocal(int *nodemap, int sz, int *p_max_node_id)
 /* assign processes to num_cliques nodes in a round-robin fashion */
 static int build_nodemap_roundrobin(int num_cliques, int *nodemap, int sz, int *p_max_node_id)
 {
-    int i;
-    for (i = 0; i < sz; ++i) {
+    for (int i = 0; i < sz; ++i) {
         nodemap[i] = i % num_cliques;
     }
     *p_max_node_id = num_cliques - 1;
@@ -1028,7 +1019,6 @@ int build_nodemap_pmix(int *nodemap, int sz, int *p_max_node_id)
     char *nodelist = NULL, *node = NULL;
     pmix_proc_t *procs = NULL;
     size_t nprocs, node_id = 0;
-    int i;
 
     pmi_errno = PMIx_Resolve_nodes(pmix_proc.nspace, &nodelist);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -1040,7 +1030,7 @@ int build_nodemap_pmix(int *nodemap, int sz, int *p_max_node_id)
         pmi_errno = PMIx_Resolve_peers(node, pmix_proc.nspace, &procs, &nprocs);
         MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                              "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
-        for (i = 0; i < nprocs; i++) {
+        for (int i = 0; i < nprocs; i++) {
             nodemap[procs[i].rank] = node_id;
         }
         node_id++;
@@ -1062,7 +1052,6 @@ int build_nodemap_pmix(int *nodemap, int sz, int *p_max_node_id)
 /* allocate and populate MPIR_Process.node_local_map and MPIR_Process.node_root_map */
 static int build_locality(void)
 {
-    int i;
     int local_rank = -1;
     int local_size = 0;
     int *node_root_map, *node_local_map;
@@ -1074,11 +1063,11 @@ static int build_locality(void)
     int local_node_id = node_map[rank];
 
     node_root_map = MPL_malloc(num_nodes * sizeof(int), MPL_MEM_ADDRESS);
-    for (i = 0; i < num_nodes; i++) {
+    for (int i = 0; i < num_nodes; i++) {
         node_root_map[i] = -1;
     }
 
-    for (i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
         int node_id = node_map[i];
         if (node_root_map[node_id] < 0) {
             node_root_map[node_id] = i;
@@ -1090,7 +1079,7 @@ static int build_locality(void)
 
     node_local_map = MPL_malloc(local_size * sizeof(int), MPL_MEM_ADDRESS);
     int j = 0;
-    for (i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
         int node_id = node_map[i];
         if (node_id == local_node_id) {
             node_local_map[j] = i;
@@ -1126,8 +1115,7 @@ static int hex(unsigned char c)
 
 static void encode(int size, const char *src, char *dest)
 {
-    int i;
-    for (i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
         MPL_snprintf(dest, 3, "%02X", (unsigned char) *src);
         src++;
         dest += 2;
@@ -1136,8 +1124,7 @@ static void encode(int size, const char *src, char *dest)
 
 static void decode(int size, const char *src, char *dest)
 {
-    int i;
-    for (i = 0; i < size; i++) {
+    for (int i = 0; i < size; i++) {
         *dest = (char) (hex(src[0]) << 4) + hex(src[1]);
         src += 2;
         dest++;
@@ -1150,7 +1137,7 @@ static int mpi_to_pmi_keyvals(MPIR_Info * info_ptr, PMI_keyval_t ** kv_ptr, int 
 {
     char key[MPI_MAX_INFO_KEY];
     PMI_keyval_t *kv = 0;
-    int i, nkeys = 0, vallen, flag, mpi_errno = MPI_SUCCESS;
+    int nkeys = 0, vallen, flag, mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_MPI_TO_PMI_KEYVALS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_MPI_TO_PMI_KEYVALS);
@@ -1165,7 +1152,7 @@ static int mpi_to_pmi_keyvals(MPIR_Info * info_ptr, PMI_keyval_t ** kv_ptr, int 
 
     kv = (PMI_keyval_t *) MPL_malloc(nkeys * sizeof(PMI_keyval_t), MPL_MEM_BUFFER);
 
-    for (i = 0; i < nkeys; i++) {
+    for (int i = 0; i < nkeys; i++) {
         mpi_errno = MPIR_Info_get_nthkey_impl(info_ptr, i, key);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Info_get_valuelen_impl(info_ptr, key, &vallen, &flag);
@@ -1186,13 +1173,11 @@ static int mpi_to_pmi_keyvals(MPIR_Info * info_ptr, PMI_keyval_t ** kv_ptr, int 
 
 static void free_pmi_keyvals(PMI_keyval_t ** kv, int size, int *counts)
 {
-    int i, j;
-
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_FREE_PMI_KEYVALS);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_FREE_PMI_KEYVALS);
 
-    for (i = 0; i < size; i++) {
-        for (j = 0; j < counts[i]; j++) {
+    for (int i = 0; i < size; i++) {
+        for (int j = 0; j < counts[i]; j++) {
             MPL_free((char *) kv[i][j].key);
             MPL_free(kv[i][j].val);
         }


### PR DESCRIPTION
## Pull Request Description
In making segments, neglected to use segment_key.

Our simple PMI code may not actually handling the maximum value size
properly. Add comment to note this.

ToDo:
 * [x] Check simple pmi code to make sure it handles maximum value size properly, or patch it.
 * [x] Test by manually setting value limit to 100 and test with ucx (~170 BC on our jenkins)
 * [x] Inflate the business card to very long and test
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       We added code to handle arbitrary size of PMI values, but it was never tested. When user apply to summit where its ucx produces super long business card string, it embarassingly fails due to trivial bugs. Let's fix it and test it this time.
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
