### PR TITLE
autogen: Flang support

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -973,6 +973,7 @@ if [ "$do_build_configure" = "yes" ] ; then
                 # There is no need to patch if we're not going to use Fortran.
                 ifort_patch_requires_rebuild=no
                 oracle_patch_requires_rebuild=no
+                flang_patch_requires_rebuild=no
                 arm_patch_requires_rebuild=no
                 ibm_patch_requires_rebuild=no
                 sys_lib_dlsearch_path_patch_requires_rebuild=no
@@ -1007,6 +1008,16 @@ if [ "$do_build_configure" = "yes" ] ; then
                     else
                         echo "failed"
                     fi
+                    echo_n "Patching libtool.m4 for compatibility with Flang..."
+                    patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/flang.patch
+                    if [ $? -eq 0 ] ; then
+                        flang_patch_requires_rebuild=yes
+                        # Remove possible leftovers, which don't imply a failure
+                        rm -f $amdir/confdb/libtool.m4.orig
+                        echo "done"
+                    else
+                        echo "failed"
+                    fi
                     echo_n "Patching libtool.m4 for compatibility with Arm LLVM compilers..."
                     patch -N -s -l $amdir/confdb/libtool.m4 maint/patches/optional/confdb/arm-compiler.patch
                     if [ $? -eq 0 ] ; then
@@ -1031,7 +1042,7 @@ if [ "$do_build_configure" = "yes" ] ; then
 
                 if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ] \
                     || [ $arm_patch_requires_rebuild = "yes" ] || [ $ibm_patch_requires_rebuild = "yes" ] \
-                    || [ $sys_lib_dlsearch_path_patch_requires_rebuild = "yes" ]; then
+                    || [ $sys_lib_dlsearch_path_patch_requires_rebuild = "yes" ] || [ $flang_patch_requires_rebuild = "yes" ]; then
                     # Rebuild configure
                     (cd $amdir && $autoconf -f) || exit 1
                     # Reset libtool.m4 timestamps to avoid confusing make

--- a/autogen.sh
+++ b/autogen.sh
@@ -1031,7 +1031,7 @@ if [ "$do_build_configure" = "yes" ] ; then
 
                 if [ $ifort_patch_requires_rebuild = "yes" ] || [ $oracle_patch_requires_rebuild = "yes" ] \
                     || [ $arm_patch_requires_rebuild = "yes" ] || [ $ibm_patch_requires_rebuild = "yes" ] \
-                    [ $sys_lib_dlsearch_path_patch_requires_rebuild = "yes" ]; then
+                    || [ $sys_lib_dlsearch_path_patch_requires_rebuild = "yes" ]; then
                     # Rebuild configure
                     (cd $amdir && $autoconf -f) || exit 1
                     # Reset libtool.m4 timestamps to avoid confusing make

--- a/maint/patches/optional/confdb/flang.patch
+++ b/maint/patches/optional/confdb/flang.patch
@@ -1,0 +1,15 @@
+--- libtool.m4~	2019-11-08 13:59:39.000000000 -0600
++++ libtool.m4	2019-11-11 15:34:57.000000000 -0600
+@@ -4736,6 +4736,12 @@
+ 	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
+ 	_LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
+         ;;
++      # flang / f18
++      flang* | f18*)
++       _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++       _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++       _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++        ;;
+       # icc used to be incompatible with GCC.
+       # ICC 10 doesn't accept -KPIC any more.
+       icc* | ifort*)

--- a/test/mpi/Makefile_cxx.mtest
+++ b/test/mpi/Makefile_cxx.mtest
@@ -16,7 +16,7 @@ LDADD = $(top_builddir)/util/mtest_cxx.$(OBJEXT) $(top_builddir)/util/mtest_comm
 
 # Add libdtpools support
 AM_CPPFLAGS += -I$(top_srcdir)/dtpools/include
-LDADD += $(top_builddir)/dtpools/src/.libs/libdtpools.a
+LDADD += $(top_builddir)/dtpools/src/.libs/libdtpools.la
 
 $(top_builddir)/util/mtest_cxx.$(OBJEXT): $(top_srcdir)/util/mtest_cxx.cxx
 	(cd $(top_builddir)/util && $(MAKE) mtest_cxx.$(OBJEXT))
@@ -24,7 +24,7 @@ $(top_builddir)/util/mtest_cxx.$(OBJEXT): $(top_srcdir)/util/mtest_cxx.cxx
 $(top_builddir)/util/mtest_common.$(OBJEXT): $(top_srcdir)/util/mtest_common.c
 	(cd $(top_builddir)/util && $(MAKE) mtest_common.$(OBJEXT))
 
-$(top_builddir)/dtpools/src/.libs/libdtpools.a: $(top_srcdir)/dtpools/src/*.c
+$(top_builddir)/dtpools/src/.libs/libdtpools.la:
 	(cd $(top_builddir)/dtpools && $(MAKE))
 
 testing:


### PR DESCRIPTION
## Pull Request Description

Patch libtool to support Flang compiler. Based on patch in Debian Bullseye version of libtool.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
