### PR TITLE
test/mpi/rma: fix racc_local_comp test

### DIFF
--- a/test/mpi/rma/racc_local_comp.c
+++ b/test/mpi/rma/racc_local_comp.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
             int val = -1;
 
             buf[0] = rank * i;
-            MPI_Raccumulate(&buf[0], 1, MPI_INT, 0, 0, 1, MPI_INT, MPI_MAX, window, &acc_req);
+            MPI_Raccumulate(&buf[0], 1, MPI_INT, 0, 0, 1, MPI_INT, MPI_REPLACE, window, &acc_req);
             MPI_Wait(&acc_req, MPI_STATUS_IGNORE);
 
             /* reset local buffer to check local completion */


### PR DESCRIPTION
MPI_Alloc_mem() does not make any guarantees regarding the content of
the returned memory region. Therefore, Rank 1 needs to use the
MPI_REPLACE reduce operation to ensure that the following MPI_Get()
actually returns the original content of buf[0] located at Rank 1.

## Pull Request Description

Rank 1 is performing an `MPI_MAX` operation on potentially uninitialized data. Therefore, the test `val != rank * i` might fail if the value in `winbuf` at offset 0 of Rank 0 is actually larger than `rank * i`.

If my assumptions are correct, I would simply propose to switch the reduce operation to `MPI_REPLACE` ensuring that `rank * i` is actually written to the window.


## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
