### PR TITLE
test/mpi/rma: fix racc_local_comp test (3.3.x)

### DIFF
--- a/test/mpi/rma/racc_local_comp.c
+++ b/test/mpi/rma/racc_local_comp.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
             int val = -1;
 
             buf[0] = rank * i;
-            MPI_Raccumulate(&buf[0], 1, MPI_INT, 0, 0, 1, MPI_INT, MPI_MAX, window, &acc_req);
+            MPI_Raccumulate(&buf[0], 1, MPI_INT, 0, 0, 1, MPI_INT, MPI_REPLACE, window, &acc_req);
             MPI_Wait(&acc_req, MPI_STATUS_IGNORE);
 
             /* reset local buffer to check local completion */


### PR DESCRIPTION
## Pull Request Description

MPI_Alloc_mem() does not make any guarantees regarding the content of
the returned memory region. Therefore, Rank 1 needs to use the
MPI_REPLACE reduce operation to ensure that the following MPI_Get()
actually returns the original content of buf[0] located at Rank 1.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
