### PR TITLE
Adding new device interface for post comm creation op

### DIFF
--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -139,6 +139,9 @@ int MPIR_Coll_comm_init(MPIR_Comm * comm)
     mpi_errno = MPII_Gentran_comm_init(comm);
     MPIR_ERR_CHECK(mpi_errno);
 
+    mpi_errno = MPID_Coll_comm_init_hook(comm);
+    MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -310,10 +310,6 @@ static int MPIR_Comm_commit_internal(MPIR_Comm * comm)
     mpi_errno = MPID_Comm_create_hook(comm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Create collectives-specific infrastructure */
-    mpi_errno = MPIR_Coll_comm_init(comm);
-    MPIR_ERR_CHECK(mpi_errno);
-
     MPIR_Comm_map_free(comm);
 
   fn_exit:
@@ -461,6 +457,20 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
 
     if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !MPIR_CONTEXT_READ_FIELD(SUBCOMM, comm->context_id)) {  /*make sure this is not a subcomm */
         mpi_errno = MPIR_Comm_create_subcomms(comm);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    /* Create collectives-specific infrastructure */
+    mpi_errno = MPIR_Coll_comm_init(comm);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (comm->node_comm) {
+        mpi_errno = MPIR_Coll_comm_init(comm->node_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    if (comm->node_roots_comm) {
+        mpi_errno = MPIR_Coll_comm_init(comm->node_roots_comm);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -214,6 +214,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request * request_pt
 /* communicator hooks */
 int MPIDI_CH3I_Comm_create_hook(struct MPIR_Comm *);
 int MPIDI_CH3I_Comm_destroy_hook(struct MPIR_Comm *);
+int MPIDI_CH3I_Coll_comm_init_hook(struct MPIR_Comm *);
 
 int MPIDI_CH3I_Progress_register_hook(int (*progress_fn)(int*), int *id);
 int MPIDI_CH3I_Progress_deregister_hook(int id);

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -169,6 +169,7 @@ typedef union {
  */
 
 #define MPID_Comm_create_hook(comm_) MPIDI_CH3I_Comm_create_hook(comm_)
+#define MPID_Coll_comm_init_hook(comm_) MPIDI_CH3I_Coll_comm_init_hook(comm_)
 #define MPID_Comm_free_hook(comm_) MPIDI_CH3I_Comm_destroy_hook(comm_)
 
 #ifndef HAVE_MPIDI_VCRT

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -304,6 +304,19 @@ int MPIDI_CH3I_Comm_create_hook(MPIR_Comm *comm)
     goto fn_exit;
 }
 
+int MPIDI_CH3I_Coll_comm_init_hook(MPIR_Comm *comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_CH3U_COLL_COMM_INIT_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_CH3U_COLL_COMM_INIT_HOOK);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_CH3U_COLL_COMM_INIT_HOOK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIDI_CH3I_Comm_destroy_hook(MPIR_Comm *comm)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -158,6 +158,7 @@ MPIDI_CH4I_API_NOINLINE(int, Intercomm_exchange_map, MPIR_Comm *, int, MPIR_Comm
 MPIDI_CH4I_API_NOINLINE(int, Create_intercomm_from_lpids, MPIR_Comm *, int, const int[]);
 MPIDI_CH4I_API_NOINLINE(int, Comm_create_hook, MPIR_Comm *);
 MPIDI_CH4I_API_NOINLINE(int, Comm_free_hook, MPIR_Comm *);
+MPIDI_CH4I_API_NOINLINE(int, Coll_comm_init_hook, MPIR_Comm *);
 MPIDI_CH4I_API(int, Barrier, MPIR_Comm *, MPIR_Errflag_t *);
 MPIDI_CH4I_API(int, Bcast, void *, int, MPI_Datatype, int, MPIR_Comm *, MPIR_Errflag_t *);
 MPIDI_CH4I_API(int, Allreduce, const void *, void *, int, MPI_Datatype, MPI_Op, MPIR_Comm *,

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -208,6 +208,19 @@ int MPID_Comm_create_hook(MPIR_Comm * comm)
     goto fn_exit;
 }
 
+int MPID_Coll_comm_init_hook(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_COLL_COMM_INIT_HOOK);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_COLL_COMM_INIT_HOOK);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPID_COLL_COMM_INIT_HOOK);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPID_Comm_free_hook(MPIR_Comm * comm)
 {
     int mpi_errno;


### PR DESCRIPTION
## Pull Request Description

Some collective related init code for the comm need to be called at the end of comm creation. Adding this interface enables that without requiring refactoring the CH4 comm creation hook and separating current rankmap code. As I mentioned in the call this morning, the refactoring breaks CH3 and would require implementing the av table related stuff in CH3 to replace VCs.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
