### PR TITLE
pm/hydra: Free temporary buf to avoid leak

### DIFF
--- a/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
+++ b/src/pm/hydra/pm/pmiserv/pmiserv_cb.c
@@ -320,12 +320,12 @@ static HYD_status control_cb(int fd, HYD_event_t events, void *userp)
                                      HYDU_SOCK_COMM_MSGWAIT);
             HYDU_ERR_POP(status, "error writing to control socket\n");
             HYDU_ASSERT(!closed, status);
-
-            MPL_free(buf);
         } else {
             status = HYDT_dmx_deregister_fd(STDIN_FILENO);
             HYDU_ERR_POP(status, "unable to deregister STDIN\n");
         }
+
+        MPL_free(buf);
     } else if (hdr.cmd == PROCESS_TERMINATED) {
         if (HYD_server_info.user_global.auto_cleanup == 0) {
             /* Update the map of the alive processes */


### PR DESCRIPTION
## Pull Request Description

Temporary space is always allocated in this callback branch, but may
not be freed. Move the free out of a conditional to ensure we do not
leak. Found with LeakSanitizer.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
