### PR TITLE
config: Make ch4 the default device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -475,6 +475,32 @@ AC_ARG_WITH(device,
 	AC_HELP_STRING([--with-device=name], [Specify the communication device for MPICH]),,
 	with_device=default)
 
+if test $with_device = "default" -o $with_device = "ch4" ; then
+  dnl default linux builds must choose a netmod.
+  AC_MSG_ERROR([no ch4 netmod selected
+
+  The default ch4 device requires users to choose a netmod. Supported
+  options are ofi (libfabric) and ucx:
+
+    --with-device=ch4:ofi or --with-device=ch4:ucx
+
+  Configure will attempt to discover external libfabric or ucx
+  libraries to link with. Users may also specify an installation by
+  adding
+
+    --with-libfabric=<path/to/install> or --with-ucx=<path/to/install>
+
+  to the configuration. If no installation is specified or found, an
+  embedded library will be built and used.
+
+  The previous MPICH default device (ch3) is also available and
+  supported with option:
+
+    --with-device=ch3
+  ])
+fi
+
+
 AC_ARG_WITH(pmi,
 	AC_HELP_STRING([--with-pmi=name], [Specify the pmi interface for MPICH]),,
 	with_pmi=default)
@@ -827,10 +853,7 @@ export OPALIBNAME
 export MPLLIBNAME
 # ----------------------------------------------------------------------------
 # with-device
-if test "$with_device" = "default" ; then
-    # Pick the device.  For now, always choose ch3
-    with_device=ch3
-fi
+#
 # Extract the device name from any options
 # Allow the device to specify a directory; if no directory, use the
 # included directories

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -44,19 +44,8 @@ MPID_MAX_ERROR_STRING=512
 
 # $device_args - contains the netmods
 if test -z "${device_args}" ; then
-    # need pick a netmod
-    if test $have_libfabric = yes ; then
-        ch4_netmods="ofi"
-    elif test $have_ucx = yes ; then
-        ch4_netmods="ucx"
-    elif test -n $with_libfabric ; then
-        ch4_netmods="ofi"
-    elif test -n $with_ucx ; then
-        ch4_netmods="ucx"
-    else
-        ch4_netmods="ofi"
-        with_libfabric=embedded
-    fi
+    AC_MSG_ERROR([Netmod configuration not specified. To build ch4, you must select a netmod:
+    --with-device=ch4:ofi or --with-device=ch4:ucx])
 else
     changequote(<<,>>)
     netmod_args=`echo ${device_args} | sed -e 's/^[^:]*//' -e 's/^://' -e 's/,/ /g'`


### PR DESCRIPTION
## Pull Request Description

Take ch4 out from behind the opt-in barrier. Require users to select a netmod to avoid complex default selection logic.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Increased usage and feedback of ch4 device.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
