### PR TITLE
ch3: fix improper error handling from MPL_get_sockaddr

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
@@ -305,8 +305,8 @@ static int GetSockInterfaceAddr(int myRank, char *ifname, int maxIfname, MPL_soc
     if (MPIR_CVAR_NEMESIS_TCP_NETWORK_IFACE) {
         char s[100];
         int len;
-        mpi_errno = MPL_get_sockaddr_iface(MPIR_CVAR_NEMESIS_TCP_NETWORK_IFACE, p_addr);
-        MPIR_ERR_CHKANDJUMP1(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**iface_notfound",
+        int ret = MPL_get_sockaddr_iface(MPIR_CVAR_NEMESIS_TCP_NETWORK_IFACE, p_addr);
+        MPIR_ERR_CHKANDJUMP1(ret != 0, mpi_errno, MPI_ERR_OTHER, "**iface_notfound",
                              "**iface_notfound %s", MPIR_CVAR_NEMESIS_TCP_NETWORK_IFACE);
 
         MPL_sockaddr_to_str(p_addr, s, 100);
@@ -351,9 +351,9 @@ static int GetSockInterfaceAddr(int myRank, char *ifname, int maxIfname, MPL_soc
          * directly from the available interfaces, if that is supported on
          * this platform.  Otherwise, we'll drop into the next step that uses
          * the ifname */
-        mpi_errno = MPL_get_sockaddr_iface(NULL, p_addr);
-        if (mpi_errno)
-            MPIR_ERR_POP(mpi_errno);
+        int ret = MPL_get_sockaddr_iface(NULL, p_addr);
+        MPIR_ERR_CHKANDJUMP1(ret != 0, mpi_errno, MPI_ERR_OTHER, "**iface_notfound",
+                             "**iface_notfound %s", NULL);
         ifaddrFound = 1;
     } else {
         /* Copy this name into the output name */
@@ -362,8 +362,8 @@ static int GetSockInterfaceAddr(int myRank, char *ifname, int maxIfname, MPL_soc
 
     /* If we don't have an IP address, try to get it from the name */
     if (!ifaddrFound) {
-        mpi_errno = MPL_get_sockaddr(ifname_string, p_addr);
-        MPIR_ERR_CHKANDJUMP2(mpi_errno, mpi_errno, MPI_ERR_OTHER, "**gethostbyname",
+        int ret = MPL_get_sockaddr(ifname_string, p_addr);
+        MPIR_ERR_CHKANDJUMP2(ret != 0, mpi_errno, MPI_ERR_OTHER, "**gethostbyname",
                              "**gethostbyname %s %d", ifname_string, h_errno);
     }
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -104,6 +104,7 @@ int
 MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 {
     int    mpi_errno       = MPI_SUCCESS;
+    int    tmp_mpi_errno;
     int    num_procs       = pg_p->size;
     int    ret;
     int    num_local       = -1;
@@ -413,7 +414,9 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     MPIR_CHKPMEM_COMMIT();
  fn_exit:
-    mpi_errno = MPIDU_Init_shm_finalize();
+    /* we do not want to lose a potential failed errno */
+    tmp_mpi_errno = MPIDU_Init_shm_finalize();
+    MPIR_ERR_ADD(mpi_errno, tmp_mpi_errno);
     return mpi_errno;
  fn_fail:
     /* --BEGIN ERROR HANDLING-- */


### PR DESCRIPTION
## Pull Request Description
MPL layer does not directly return mpi_errno. Need use
MPIR_ERR_CHKANDJUMP macro instead of MPIR_ERR_POP.

At fn_exit, we need be careful not to overwrite the mpi_errno.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       On hosts with bad configured hostname, we will not be able to resolve ip address. Previously we miss handled the error return, resulting mysterious error message. This patch fixes it.
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
