### PR TITLE
test/mpi/io: Check status after zero-byte read

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1073,6 +1073,7 @@
 /io/testfile*
 /io/testlist
 /io/userioerr
+/io/zero_count
 /maint/conftimestamp
 /maint/testmerge
 /manual/dimsbalanced

--- a/test/mpi/io/Makefile.am
+++ b/test/mpi/io/Makefile.am
@@ -28,7 +28,8 @@ noinst_PROGRAMS = \
     hindexed_io   \
     simple_collective \
     external32_derived_dtype \
-    tst_fileview
+    tst_fileview \
+    zero_count
 
 
 if BUILD_MPIX_TESTS

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -12,6 +12,7 @@ resized2 1
 bigtype 1 mem=6.5
 hindexed_io 1
 tst_fileview 1
+zero_count 4
 simple_collective 1 arg=simple_collective.testfile
 external32_derived_dtype 1
 i_bigtype 1 mpiversion=3.1 mem=6.5

--- a/test/mpi/io/zero_count.c
+++ b/test/mpi/io/zero_count.c
@@ -1,0 +1,50 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+/*
+static char MTEST_Descrip[] = "Test count for zero length reads";
+*/
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    int len, rank, get_size;
+    char buf[10], *filename = __FILE__;
+    MPI_File fh;
+    MPI_Status status;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
+
+    if (rank == 0)
+        len = 10;
+    else
+        len = 0;
+
+    /* mimic the case status object may not be initialized to 0 */
+    memset(&status, 1, sizeof(status));
+
+    MPI_File_read_all(fh, buf, len, MPI_BYTE, &status);
+    MPI_Get_count(&status, MPI_BYTE, &get_size);
+
+    if (len != get_size) {
+        printf("Error: expecting get_size to be %d but got %d\n", len, get_size);
+        errs++;
+    }
+
+    MPI_File_close(&fh);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}


### PR DESCRIPTION
## Pull Request Description

Until [4b7d553b4cbc], ROMIO was failing to fill in the status object
for zero-byte operations. See pmodels/mpich#2332.

Co-authored-by: Jeff Hammond <jeff.r.hammond@intel.com>

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
