### PR TITLE
dtpools: Fix memory leaks

### DIFF
--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -66,6 +66,10 @@ int DTP_pool_free(DTP_pool_s dtp)
     if (dtpi->base_type_is_struct) {
         rc = MPI_Type_free(&dtp.DTP_base_type);
         DTPI_ERR_CHK_MPI_RC(rc);
+
+        DTPI_FREE(dtpi->base_type_attrs.array_of_blklens);
+        DTPI_FREE(dtpi->base_type_attrs.array_of_displs);
+        DTPI_FREE(dtpi->base_type_attrs.array_of_types);
     }
     DTPI_FREE(dtpi);
 

--- a/test/mpi/dtpools/src/dtpools_attr.c
+++ b/test/mpi/dtpools/src/dtpools_attr.c
@@ -1429,7 +1429,6 @@ static int attr_tree_free(DTPI_Attr_s * attr)
         rc = attr_tree_free(attr->child);
         DTPI_ERR_CHK_RC(rc);
     }
-    DTPI_FREE(attr->child);
 
     switch (attr->kind) {
         case DTPI_DATATYPE_KIND__BLKINDX:
@@ -1464,6 +1463,8 @@ static int attr_tree_free(DTPI_Attr_s * attr)
         default:
             break;
     }
+
+    DTPI_FREE(attr);
 
   fn_exit:
     return rc;


### PR DESCRIPTION
## Pull Request Description

Fix issues found with LeakSanitizer.
 1. Free root of the type attribute tree.
 2. Free arrays associated with struct type.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
