### PR TITLE
ch4/ofi: Update name for fi_getinfo errors

### DIFF
--- a/src/mpid/ch4/netmod/ofi/catalog.c
+++ b/src/mpid/ch4/netmod/ofi/catalog.c
@@ -5,7 +5,7 @@ static inline void MPIDI_OFI_unused_gen_catalog()
     char *a;
     int b, e;
     MPIR_ERR_SET2(e, MPI_ERR_OTHER, "**ofid_pmi", "**ofid_pmi %s %d %s %s", a, b, a, a);
-    MPIR_ERR_SET2(e, MPI_ERR_OTHER, "**ofid_addrinfo", "**ofid_addrinfo %s %d %s %s", a, b, a, a);
+    MPIR_ERR_SET2(e, MPI_ERR_OTHER, "**ofid_getinfo", "**ofid_getinfo %s %d %s %s", a, b, a, a);
     MPIR_ERR_SET2(e, MPI_ERR_OTHER, "**ofid_opendomain", "**ofid_opendomain %s %d %s %s", a, b, a,
                   a);
     MPIR_ERR_SET2(e, MPI_ERR_OTHER, "**ofid_bind", "**ofid_bind %s %d %s %s", a, b, a, a);

--- a/src/mpid/ch4/netmod/ofi/errnames.txt
+++ b/src/mpid/ch4/netmod/ofi/errnames.txt
@@ -1,8 +1,8 @@
 **ofid_pmi:PMI_Init() failure
 **ofid_pmi %s %d %s %s:pmi failed (%s:%d:%s:%s)
-**ofid_addrinfo:OFI addrinfo() failure
-**ofid_addrinfo %s %d %s %s:OFI addrinfo() failed (%s:%d:%s:%s)
-**ofid_addrinfo %s:Addrinfo failure ('%s')
+**ofid_getinfo:OFI fi_getinfo() failure
+**ofid_getinfo %s %d %s %s:OFI fi_getinfo() failed (%s:%d:%s:%s)
+**ofid_getinfo %s:fi_getinfo failure ('%s')
 **ofid_opendomain:OFI fi_open domain failure
 **ofid_opendomain %s %d %s %s:OFI fi_open domain failed (%s:%d:%s:%s)
 **ofid_fabric:OFI fi_fabric failure

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -562,7 +562,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
          * Currently, this needs to fit into a uint64_t and we take 4 bits for protocol. */
         MPIR_Assert(MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS <= 60);
 
-        MPIDI_OFI_CALL(fi_getinfo(ofi_version, NULL, NULL, 0ULL, NULL, &prov), addrinfo);
+        MPIDI_OFI_CALL(fi_getinfo(ofi_version, NULL, NULL, 0ULL, NULL, &prov), getinfo);
 
         /* We'll try to pick the best provider three times.
          * 1 - Check to see if any provider matches an existing capability set (e.g. sockets)
@@ -599,7 +599,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         }
 
         /* If we did not find a provider, return an error */
-        MPIR_ERR_CHKANDJUMP(prov_use == NULL, mpi_errno, MPI_ERR_OTHER, "**ofid_addrinfo");
+        MPIR_ERR_CHKANDJUMP(prov_use == NULL, mpi_errno, MPI_ERR_OTHER, "**ofid_getinfo");
 
         fi_freeinfo(prov);
     } else {
@@ -613,8 +613,8 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                             mpi_errno, MPI_ERR_OTHER, "**ofi_provider_mismatch");
     }
 
-    MPIDI_OFI_CALL(fi_getinfo(ofi_version, NULL, NULL, 0ULL, hints, &prov), addrinfo);
-    MPIR_ERR_CHKANDJUMP(prov == NULL, mpi_errno, MPI_ERR_OTHER, "**ofid_addrinfo");
+    MPIDI_OFI_CALL(fi_getinfo(ofi_version, NULL, NULL, 0ULL, hints, &prov), getinfo);
+    MPIR_ERR_CHKANDJUMP(prov == NULL, mpi_errno, MPI_ERR_OTHER, "**ofid_getinfo");
     /* When a specific provider is specified at configure time,
      * make sure it is the one selected by fi_getinfo */
     MPIR_ERR_CHKANDJUMP(!MPIDI_OFI_ENABLE_RUNTIME_CHECKS &&


### PR DESCRIPTION
## Pull Request Description

If errors are encountered during fi_getinfo, "addrinfo" error message
were displayed. Rename to getinfo to avoid misleading the reader.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Better error messages.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
