### PR TITLE
Fix mutex initialization

### DIFF
--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -85,6 +85,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     MPID_Wtime_init();
     MPII_pre_init_dbg_logging(argc, argv);
 
+    /* create fine-grained mutexes */
+    MPIR_Thread_CS_Init();
+
     mpi_errno = MPIR_T_env_init();
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -147,9 +150,6 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* dup comm_self and creates progress thread (if needed) */
     mpi_errno = MPII_init_async(thread_provided);
     MPIR_ERR_CHECK(mpi_errno);
-
-    /* create fine-grained mutexes */
-    MPIR_Thread_CS_Init();
 
     /* connect to remote processes is has parent */
     if (MPIR_Process.has_parent) {

--- a/src/util/mpir_thread.c
+++ b/src/util/mpir_thread.c
@@ -16,8 +16,12 @@ static int mutex_count = 0;
 
 void MPIR_Add_mutex(MPID_Thread_mutex_t * p_mutex)
 {
+    int err;
     MPIR_Assert(mutex_count < MAX_MUTEX_COUNT);
-    mutex_list[mutex_count++] = p_mutex;
+    mutex_list[mutex_count] = p_mutex;
+    MPID_Thread_mutex_create(mutex_list[mutex_count], &err);
+    MPIR_Assert(err == 0);
+    mutex_count++;
 }
 
 /* All the other mutexes that depend on the configured thread granularity */
@@ -55,12 +59,6 @@ void MPIR_Thread_CS_Init(void)
 #else
 #error Unrecognized thread granularity
 #endif
-
-    int err;
-    for (int i = 0; i < mutex_count; i++) {
-        MPID_Thread_mutex_create(mutex_list[i], &err);
-        MPIR_Assert(err == 0);
-    }
 
     MPID_THREADPRIV_KEY_CREATE;
 


### PR DESCRIPTION
## Pull Request Description

This commit fixes an order of mutex initialization. Previously, uninitialized mutexes are used in `MPIR_Init_thread()` (for example, in `MPII_init_global()`) before the initialization (`MPIR_Thread_CS_Init()`), which is a potential bug. This PR fixes the initialization order by executing `MPIR_Thread_CS_Init()` at the beginning of `MPIR_Init_thread()`.

To do so, we need to change the behavior of `MPIR_Add_mutex()` so that mutex is initialized in `MPIR_Add_mutex()`, not in `MPIR_Init_thread()`. It is because some mutexes are added (e.g., `MPID_Init()` in `ch4_init.c` even after execution of `MPIR_Init_thread()`.

### Why this bug was not found previously

It is not a problem with certain Pthreads implementations because major implementations of `pthread_mutex lock()` seem to ignore `NULL`, though it is really implementation dependent.

For example, on Ubuntu 16.04 (x86/64),
```c
// gcc 5.4.0
#include <pthread.h>
#include <stdio.h>
pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
int main() {
    int err1 = pthread_mutex_lock(&mutex);
    int err2 = pthread_mutex_unlock(&mutex);
    int err3 = pthread_mutex_lock(NULL);
    int err4 = pthread_mutex_unlock(NULL);
    printf("err = %d, %d, %d, %d\n", err1, err2, err3, err4);
}
```
the code above shows warnings:
```
warning: null argument where non-null required (argument 1) [-Wnonnull]
int err3 = pthread_mutex_lock(NULL);
...
```
while they succeed:
```
$ ./a.out
err = 0, 0, 0, 0
```
I believe this mutex behavior is implementation dependent. The Argobots mutex does not allow a NULL mutex pointer, causing an error reported in #4192.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

No performance issue.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
