### PR TITLE
Assert when passing invalid pointer to MPIDU_Init_shm_free

### DIFF
--- a/src/mpid/common/shm/mpidu_init_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_init_shm_alloc.c
@@ -173,6 +173,8 @@ int MPIDU_Init_shm_free(void *ptr)
         }
     }
 
+    MPIR_Assert(memory != NULL);
+
     if (MPIR_Process.local_size == 1)
         MPL_free(memory->base_addr);
     else {


### PR DESCRIPTION
## Pull Request Description

`MPIDU_Init_shm_free` looks up the passed pointer into a linked list to find the corresponding memory handle, created when memory was allocated with `MPIDU_Init_shm_alloc`. If the pointer does not have any entry in the linked list (e.g., because the user passes a buffer that was allocated using another allocation mechanism, such as `malloc`) we assert.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
