### PR TITLE
warnings: fix missing returns

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_coll_select.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_select.h
@@ -409,6 +409,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Reduce_scatter_select(const void 
             return &MPIDI_POSIX_Reduce_scatter_intra_recursive_doubling_cnt;
         }
     }
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX const
@@ -467,6 +468,7 @@ MPIDI_POSIX_coll_algo_container_t *MPIDI_POSIX_Reduce_scatter_block_select(const
             return &MPIDI_POSIX_Reduce_scatter_block_intra_recursive_doubling_cnt;
         }
     }
+    return NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX const


### PR DESCRIPTION

## Pull Request Description
Certain compiler (sun) will complain for extra return that is
unreachable. However, last patch (98da430) was over zealous and removed
a couple return that should not be removed. This commit fixes that.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
