### PR TITLE
test/mpi/io: Fix memory leak

### DIFF
--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -325,6 +325,8 @@ int main(int argc, char **argv)
     if (mynod)
         free(filename);
     free(cb_config_string);
+    for (i = 0; i < array->namect; i++)
+        free(array->names[i]);
     free(array->names);
     free(array);
     MTest_Finalize(errs);


### PR DESCRIPTION
## Pull Request Description

[7ecba09a1e3c] missed one issue in i_noncontig_coll2.c. It neglected
to free the individually allocated names in array->names. This commit
fixes it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
