### PR TITLE
ch4: Convert sequence number type to MPL atomic

### DIFF
--- a/src/mpid/ch4/generic/mpidig_init.c
+++ b/src/mpid/ch4/generic/mpidig_init.c
@@ -44,8 +44,8 @@ int MPIDIG_init(void)
 #endif
 
     MPIDI_global.cmpl_list = NULL;
-    OPA_store_int(&MPIDI_global.exp_seq_no, 0);
-    OPA_store_int(&MPIDI_global.nxt_seq_no, 0);
+    MPL_atomic_store_uint64(&MPIDI_global.exp_seq_no, 0);
+    MPL_atomic_store_uint64(&MPIDI_global.nxt_seq_no, 0);
 
     MPIDI_global.buf_pool = MPIDIU_create_buf_pool(MPIDIU_BUF_POOL_NUM, MPIDIU_BUF_POOL_SZ);
     MPIR_Assert(MPIDI_global.buf_pool);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -314,8 +314,8 @@ typedef struct MPIDI_CH4_Global_t {
     MPIDIG_rreq_t *unexp_list;
 #endif
     MPIDIG_req_ext_t *cmpl_list;
-    OPA_int_t exp_seq_no;
-    OPA_int_t nxt_seq_no;
+    MPL_atomic_uint64_t exp_seq_no;
+    MPL_atomic_uint64_t nxt_seq_no;
     MPIDIU_buf_pool_t *buf_pool;
 #ifdef HAVE_SIGNAL
     void (*prev_sighandler) (int);

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -27,8 +27,8 @@ int MPIDIG_check_cmpl_order(MPIR_Request * req, MPIDIG_am_target_cmpl_cb target_
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CHECK_CMPL_ORDER);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_CHECK_CMPL_ORDER);
 
-    if (MPIDIG_REQUEST(req, req->seq_no) == (uint64_t) OPA_load_int(&MPIDI_global.exp_seq_no)) {
-        OPA_incr_int(&MPIDI_global.exp_seq_no);
+    if (MPIDIG_REQUEST(req, req->seq_no) == MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)) {
+        MPL_atomic_fetch_add_uint64(&MPIDI_global.exp_seq_no, 1);
         ret = 1;
         goto fn_exit;
     }
@@ -56,7 +56,7 @@ void MPIDIG_progress_compl_list(void)
     /* MPIDI_CS_ENTER(); */
   do_check_again:
     DL_FOREACH_SAFE(MPIDI_global.cmpl_list, curr, tmp) {
-        if (curr->seq_no == (uint64_t) OPA_load_int(&MPIDI_global.exp_seq_no)) {
+        if (curr->seq_no == MPL_atomic_load_uint64(&MPIDI_global.exp_seq_no)) {
             DL_DELETE(MPIDI_global.cmpl_list, curr);
             req = (MPIR_Request *) curr->request;
             target_cmpl_cb = (MPIDIG_am_target_cmpl_cb) curr->target_cmpl_cb;
@@ -263,7 +263,7 @@ static int do_send_target(void **data, size_t * p_data_sz, int *is_contig,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_DO_SEND_TARGET);
 
     *target_cmpl_cb = recv_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
 
     if (p_data_sz == NULL || 0 == MPIDIG_REQUEST(rreq, count))
         return MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -1820,7 +1820,7 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     *req = rreq;
 
     *target_cmpl_cb = cswap_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -1884,7 +1884,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     }
 
     *target_cmpl_cb = acc_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
@@ -2009,7 +2009,7 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     *data = (void *) dt_iov;
 
     *target_cmpl_cb = acc_iov_target_cmpl_cb;
-    MPIDIG_REQUEST(rreq, req->seq_no) = OPA_fetch_and_add_int(&MPIDI_global.nxt_seq_no, 1);
+    MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif

--- a/src/mpl/include/mpl_atomic.h
+++ b/src/mpl/include/mpl_atomic.h
@@ -22,15 +22,15 @@ typedef struct MPL_atomic_ptr_t MPL_atomic_ptr_t;
  */
 #define MPL_atomic_load_int MPL_atomic_acquire_load_int
 #define MPL_atomic_load_int32 MPL_atomic_acquire_load_int32
-#define MPL_atomic_load_int32 MPL_atomic_acquire_load_int32
+#define MPL_atomic_load_uint32 MPL_atomic_acquire_load_uint32
 #define MPL_atomic_load_int64 MPL_atomic_acquire_load_int64
-#define MPL_atomic_load_int64 MPL_atomic_acquire_load_int64
+#define MPL_atomic_load_uint64 MPL_atomic_acquire_load_uint64
 #define MPL_atomic_load_ptr MPL_atomic_acquire_load_ptr
 #define MPL_atomic_store_int MPL_atomic_release_store_int
 #define MPL_atomic_store_int32 MPL_atomic_release_store_int32
-#define MPL_atomic_store_int32 MPL_atomic_release_store_int32
+#define MPL_atomic_store_uint32 MPL_atomic_release_store_uint32
 #define MPL_atomic_store_int64 MPL_atomic_release_store_int64
-#define MPL_atomic_store_int64 MPL_atomic_release_store_int64
+#define MPL_atomic_store_uint64 MPL_atomic_release_store_uint64
 #define MPL_atomic_store_ptr MPL_atomic_release_store_ptr
 
 /* Forward declarations of atomic functions */


### PR DESCRIPTION
## Pull Request Description

At the packet level, sequence number is defined as a uint64_t. Convert
ch4 global variables tracking sequence numbers to MPL_atomic_uint64_t
to match the underlying value.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
