### PR TITLE
init: split MPID_Pre_init from MPID_init

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@
 
 # Fix several static analysis and compiler warnings.
 
+# Add MPID_Pre_init to ADI, and change the signature of MPID_Init.
+
 ===============================================================================
                                Changes in 3.3.2
 ===============================================================================

--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -184,7 +184,7 @@ int MPIR_Finalize_async_thread(void)
 }
 
 /* called inside MPIR_Init_thread */
-int MPII_init_async(int thread_provided)
+int MPII_init_async(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -193,7 +193,7 @@ int MPII_init_async(int thread_provided)
         printf("WARNING: Asynchronous progress is not supported with Argobots\n");
         goto fn_fail;
 #else
-        if (thread_provided == MPI_THREAD_MULTIPLE) {
+        if (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE) {
             mpi_errno = MPID_Init_async_thread();
             if (mpi_errno)
                 goto fn_fail;
@@ -235,7 +235,7 @@ int MPIR_Init_async_thread(void)
     return MPI_SUCCESS;
 }
 
-int MPII_init_async(int thread_provided ATTRIBUTE((unused)))
+int MPII_init_async(void)
 {
     return MPI_SUCCESS;
 }

--- a/src/mpi/init/init_global.c
+++ b/src/mpi/init/init_global.c
@@ -141,14 +141,12 @@ int MPII_init_global(int *p_thread_required)
     goto fn_exit;
 }
 
-int MPII_post_init_global(int thread_provided)
+int MPII_post_init_global()
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_ThreadInfo.thread_provided = thread_provided;
-
 #if defined MPICH_IS_THREADED
-    MPIR_ThreadInfo.isThreaded = (thread_provided == MPI_THREAD_MULTIPLE);
+    MPIR_ThreadInfo.isThreaded = (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
 #endif
 
     /* Set tag_ub as function of tag_bits set by the device */

--- a/src/mpi/init/init_thread_cs.c
+++ b/src/mpi/init/init_thread_cs.c
@@ -38,7 +38,7 @@ void MPII_init_thread_and_enter_cs(int thread_required)
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
 }
 
-void MPII_init_thread_and_exit_cs(int thread_provided)
+void MPII_init_thread_and_exit_cs(void)
 {
     /* need to ensure consistency here */
     int save_is_threaded = MPIR_ThreadInfo.isThreaded;
@@ -89,7 +89,7 @@ void MPII_init_thread_and_enter_cs(int thread_required)
 {
 }
 
-void MPII_init_thread_and_exit_cs(int thread_provided)
+void MPII_init_thread_and_exit_cs(void)
 {
 }
 

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -44,14 +44,14 @@ cvars:
 int MPIR_Init_thread(int *, char ***, int, int *);
 
 void MPII_init_thread_and_enter_cs(int thread_required);
-void MPII_init_thread_and_exit_cs(int thread_provided);
+void MPII_init_thread_and_exit_cs(void);
 void MPII_init_thread_failed_exit_cs(void);
 void MPII_finalize_thread_and_enter_cs(void);
 void MPII_finalize_thread_and_exit_cs(void);
 void MPII_finalize_thread_failed_exit_cs(void);
 
 int MPII_init_global(int *p_thread_required);
-int MPII_post_init_global(int thread_provided);
+int MPII_post_init_global(void);
 int MPII_finalize_global(void);
 
 void MPII_init_windows(void);
@@ -61,7 +61,7 @@ void MPII_init_binding_f08(void);
 void MPII_pre_init_dbg_logging(int *argc, char ***argv);
 void MPII_init_dbg_logging(void);
 
-int MPII_init_async(int thread_provided);
+int MPII_init_async(void);
 int MPII_finalize_async(void);
 
 static inline void MPII_pre_init_memory_tracing(void)

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -515,13 +515,13 @@ int MPIDI_VCRT_Add_ref(struct MPIDI_VCRT *vcrt);
 int MPIDI_VCRT_Release(struct MPIDI_VCRT *vcrt, int isDisconnect);
 int MPIDI_VCR_Dup(MPIDI_VCR orig_vcr, MPIDI_VCR * new_vcr);
 
-int MPIDI_PG_Init( int *, char ***, 
-		   MPIDI_PG_Compare_ids_fn_t, MPIDI_PG_Destroy_fn_t);
+int MPIDI_PG_Init(MPIDI_PG_Compare_ids_fn_t, MPIDI_PG_Destroy_fn_t);
 int MPIDI_PG_Finalize(void);
 int MPIDI_PG_Create(int vct_sz, void * pg_id, MPIDI_PG_t ** ppg);
 int MPIDI_PG_Destroy(MPIDI_PG_t * pg);
 int MPIDI_PG_Find(void * id, MPIDI_PG_t ** pgp);
 int MPIDI_PG_Id_compare(void *id1, void *id2);
+void MPIDI_PG_set_verbose(int level);
 
 /* Always use the MPIDI_PG_iterator type, never its expansion.  Otherwise it
    will be difficult to make any changes later. */

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -537,7 +537,9 @@ typedef struct {
 /* Tell initthread to prepare a private comm_world */
 #define MPID_NEEDS_ICOMM_WORLD
 
-int MPID_Init(int *argc_p, char ***argv_p, int requested, int *provided);
+int MPID_Pre_init(int *argc_p, char ***argv_p, int requested, int *provided);
+
+int MPID_Init(void);
 
 int MPID_Init_spawn(void);
 

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -30,38 +30,17 @@ static MPIDI_PG_t *pg_world = NULL;
 
 #define MPIDI_MAX_KVS_KEY_LEN      256
 
-int MPIDI_PG_Init(int *argc_p, char ***argv_p, 
-		  MPIDI_PG_Compare_ids_fn_t compare_ids_fn, 
+void MPIDI_PG_set_verbose(int level) {
+    verbose = level;
+}
+
+int MPIDI_PG_Init(MPIDI_PG_Compare_ids_fn_t compare_ids_fn, 
 		  MPIDI_PG_Destroy_fn_t destroy_fn)
 {
     int mpi_errno = MPI_SUCCESS;
-    char *p;
     
     MPIDI_PG_Compare_ids_fn = compare_ids_fn;
     MPIDI_PG_Destroy_fn     = destroy_fn;
-
-    /* Check for debugging options.  We use MPICHD_DBG and -mpichd-dbg 
-       to avoid confusion with the code in src/util/dbg/dbg_printf.c */
-    p = getenv( "MPICHD_DBG_PG" );
-    if (p && ( strcmp( p, "YES" ) == 0 || strcmp( p, "yes" ) == 0) )
-	verbose = 1;
-    if (argc_p && argv_p) {
-	int argc = *argc_p, i;
-	char **argv = *argv_p;
-        /* applied patch from Juha Jeronen, req #3920 */
-	for (i=1; i<argc && argv[i]; i++) {
-	    if (strcmp( "-mpichd-dbg-pg", argv[i] ) == 0) {
-		int j;
-		verbose = 1;
-		for (j=i; j<argc-1; j++) {
-		    argv[j] = argv[j+1];
-		}
-		argv[argc-1] = NULL;
-		*argc_p = argc - 1;
-		break;
-	    }
-	}
-    }
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -21,7 +21,8 @@
 #define MPIDI_CH4I_API_NOINLINE(rc,fcnname,...)            \
   rc MPID_##fcnname(__VA_ARGS__)
 
-MPIDI_CH4I_API_NOINLINE(int, Init, int *, char ***, int, int *);
+MPIDI_CH4I_API_NOINLINE(int, Pre_init, int *, char ***, int, int *);
+MPIDI_CH4I_API_NOINLINE(int, Init, void);
 MPIDI_CH4I_API_NOINLINE(int, Init_spawn, void);
 MPIDI_CH4I_API_NOINLINE(int, InitCompleted, void);
 MPIDI_CH4I_API(int, Cancel_recv, MPIR_Request *);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -350,7 +350,23 @@ static int init_av_table(void)
     return avtid;
 }
 
-int MPID_Init(int *argc, char ***argv, int requested, int *provided)
+int MPID_Pre_init(int *argc, char ***argv, int requested, int *provided)
+{
+    switch (requested) {
+        case MPI_THREAD_SINGLE:
+        case MPI_THREAD_SERIALIZED:
+        case MPI_THREAD_FUNNELED:
+            *provided = requested;
+            break;
+
+        case MPI_THREAD_MULTIPLE:
+            *provided = MAX_THREAD_MODE;
+            break;
+    }
+    return MPI_SUCCESS;
+}
+
+int MPID_Init(void)
 {
     int mpi_errno = MPI_SUCCESS, rank, size, appnum;
     MPIR_Comm *init_comm = NULL;
@@ -452,21 +468,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     destroy_init_comm(&init_comm);
     mpi_errno = init_builtin_comms();
     MPIR_ERR_CHECK(mpi_errno);
-
-    /* -------------------------------- */
-    /* Return MPICH Parameters          */
-    /* -------------------------------- */
-    switch (requested) {
-        case MPI_THREAD_SINGLE:
-        case MPI_THREAD_SERIALIZED:
-        case MPI_THREAD_FUNNELED:
-            *provided = requested;
-            break;
-
-        case MPI_THREAD_MULTIPLE:
-            *provided = MAX_THREAD_MODE;
-            break;
-    }
 
     MPIDI_global.is_initialized = 0;
 


### PR DESCRIPTION
## Pull Request Description
MPID layer will make final decisions on provided thread levels and
potentially provide capabilities. These descisions need be made at the
earlies stage since multiple components' initializations may depend on
thread level (and potentially other capabilites). On the other hand,
MPID_Init itself depends on certain MPIR-layer initializations, creating
complex dependency graph and potentially circular situations.

To simplify the dependency, we split the command line parsing and thread
level setting part from MPID_Init into MPID_Pre_init.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact
New abstract device interface.
 
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
This pr is picked from PR #4199
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand

