### PR TITLE
romio: let romio have its own thread-safety

### DIFF
--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -69,9 +69,10 @@ extern int MPIR_Ext_dbg_romio_terse_enabled;
 extern int MPIR_Ext_dbg_romio_typical_enabled;
 extern int MPIR_Ext_dbg_romio_verbose_enabled;
 
-/* to be called early by ROMIO's initialization process in order to setup init-time
+/* to be called early by MPIR_Init_thread when ROMIO is included in order to setup init-time
  * glue code that cannot be initialized statically */
 int MPIR_Ext_init(void);
+int MPIR_Ext_finalize(void);
 
 void MPIR_Ext_cs_enter(void);
 void MPIR_Ext_cs_exit(void);

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -182,6 +182,11 @@ int MPI_Finalize(void)
     MPII_thread_mutex_destroy();
     MPL_atomic_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__POST_FINALIZED);
 
+#if defined(ROMIO_VERSION)
+    mpi_errno = MPIR_Ext_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
     /* ... end of body of routine ... */
   fn_exit:
     MPIR_FUNC_TERSE_FINALIZE_EXIT(MPID_STATE_MPI_FINALIZE);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -206,6 +206,11 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     MPIR_ThreadInfo.isThreaded = (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
 #endif
 
+#if defined(ROMIO_VERSION)
+    mpi_errno = MPIR_Ext_init();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
     mpi_errno = MPII_init_async();
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/romio/adio/common/ad_init.c
+++ b/src/mpi/romio/adio/common/ad_init.c
@@ -56,10 +56,6 @@ void ADIO_Init(int *argc, char ***argv, int *error_code)
     MPL_UNREFERENCED_ARG(argc);
     MPL_UNREFERENCED_ARG(argv);
 
-#ifdef ROMIO_INSIDE_MPICH
-    MPIR_Ext_init();
-#endif
-
 #if defined(ROMIO_XFS) || defined(ROMIO_LUSTRE)
     c = getenv("MPIO_DIRECT_READ");
     if (c && (!strcmp(c, "true") || !strcmp(c, "TRUE")))


### PR DESCRIPTION


## Pull Request Description

Because romio and the main mpich do not share resources, romio's thread
safety should be independent of that in mpich other than sharing the
same thread package via MPL. Letting ROMIO's granular mutex separate
from the MPICH's, it frees MPICH to implement new thread model
without affecting ROMIO's thread safety.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
