### PR TITLE
openpa: Fix barrier implementation

### DIFF
--- a/src/openpa/src/primitives/opa_gcc_intrinsics.h
+++ b/src/openpa/src/primitives/opa_gcc_intrinsics.h
@@ -19,6 +19,14 @@ typedef struct {
 #define OPA_INT_T_INITIALIZER(val_) { (val_) }
 #define OPA_PTR_T_INITIALIZER(val_) { (val_) }
 
+/* Use __atomic builtins if GCC >= 4.7.4 */
+#if __GNUC__ > 4 || \
+    (__GNUC__ == 4 && (__GNUC_MINOR__ > 7 || \
+                       (__GNUC_MINOR__ == 7 && \
+                        __GNUC_PATCHLEVEL__ >= 4)))
+#define USE_GCC_ATOMIC
+#endif
+
 /* Oracle Developer Studio (suncc) supports gcc sync intrinsics, but it is very noisy.
  * Suppress the error_messages here and reset at the end of this file.
  */
@@ -34,54 +42,90 @@ typedef struct {
    may not be true at all. */
 static inline int OPA_load_int(const OPA_int_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
+#else
     return ptr->v;
+#endif
 }
 
 static inline void OPA_store_int(OPA_int_t * ptr, int val)
 {
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
+#else
     ptr->v = val;
+#endif
 }
 
 static inline void *OPA_load_ptr(const OPA_ptr_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
+#else
     return ptr->v;
+#endif
 }
 
 static inline void OPA_store_ptr(OPA_ptr_t * ptr, void *val)
 {
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
+#else
     ptr->v = val;
+#endif
 }
 
 static inline int OPA_load_acquire_int(const OPA_int_t * ptr)
 {
-    volatile int i = 0;
-    int tmp;
-    tmp = ptr->v;
-    __sync_lock_test_and_set(&i, 1);    /* guarantees acquire semantics */
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
+#else
+    int tmp = ptr->v;
+    /* __sync does not have a true load-acquire barrier builtin,
+     * so the best that can be done is use a normal barrier to
+     * ensure the read of ptr->v happens before the ensuing block
+     * of memory references we are ordering.
+     */
+    __sync_synchronize();
     return tmp;
+#endif
 }
 
 static inline void OPA_store_release_int(OPA_int_t * ptr, int val)
 {
-    volatile int i = 1;
-    __sync_lock_release(&i);    /* guarantees release semantics */
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
+#else
+    /* __sync does not a true store-release barrier builtin,
+     * so the best that can be done is to use a normal barrier
+     * to ensure previous memory operations are ordered-before
+     * the following store.
+     */
+    __sync_synchronize();
     ptr->v = val;
+#endif
 }
 
 static inline void *OPA_load_acquire_ptr(const OPA_ptr_t * ptr)
 {
-    volatile int i = 0;
-    void *tmp;
-    tmp = ptr->v;
-    __sync_lock_test_and_set(&i, 1);    /* guarantees acquire semantics */
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
+#else
+    void *tmp = ptr->v;
+    __sync_synchronize();
     return tmp;
+#endif
 }
 
 static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 {
-    volatile int i = 1;
-    __sync_lock_release(&i);    /* guarantees release semantics */
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
     ptr->v = val;
+#endif
 }
 
 
@@ -91,12 +135,20 @@ static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 
 static inline int OPA_fetch_and_add_int(OPA_int_t * ptr, int val)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_fetch_add(&ptr->v, val, __ATOMIC_SEQ_CST);
+#else
     return __sync_fetch_and_add(&ptr->v, val, /* protected variables: */ &ptr->v);
+#endif
 }
 
 static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_sub_fetch(&ptr->v, 1, __ATOMIC_SEQ_CST) == 0;
+#else
     return __sync_sub_and_fetch(&ptr->v, 1, /* protected variables: */ &ptr->v) == 0;
+#endif
 }
 
 #define OPA_fetch_and_incr_int_by_faa OPA_fetch_and_incr_int
@@ -108,14 +160,41 @@ static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 
 static inline void *OPA_cas_ptr(OPA_ptr_t * ptr, void *oldv, void *newv)
 {
+
+#ifdef USE_GCC_ATOMIC
+    void *expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
+#else
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+#endif
 }
 
 static inline int OPA_cas_int(OPA_int_t * ptr, int oldv, int newv)
 {
+
+#ifdef USE_GCC_ATOMIC
+    int expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
+#else
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+#endif
 }
 
+
+
+#ifdef USE_GCC_ATOMIC
+static inline void *OPA_swap_ptr(OPA_ptr_t * ptr, void *val)
+{
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
+}
+
+static inline int OPA_swap_int(OPA_int_t * ptr, int val)
+{
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
+}
+#else
 #ifdef SYNC_LOCK_TEST_AND_SET_IS_SWAP
 static inline void *OPA_swap_ptr(OPA_ptr_t * ptr, void *val)
 {
@@ -126,15 +205,22 @@ static inline int OPA_swap_int(OPA_int_t * ptr, int val)
 {
     return __sync_lock_test_and_set(&ptr->v, val, /* protected variables: */ &ptr->v);
 }
-
 #else
 #define OPA_swap_ptr_by_cas OPA_swap_ptr
 #define OPA_swap_int_by_cas OPA_swap_int
-#endif
+#endif /* SYNC_LOCK_TEST_AND_SET_IS_SWAP */
+#endif /* USE_GCC_ATOMIC */
 
+#ifdef USE_GCC_ATOMIC
+#define OPA_write_barrier()      __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_barrier()       __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_write_barrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#else
 #define OPA_write_barrier()      __sync_synchronize()
 #define OPA_read_barrier()       __sync_synchronize()
 #define OPA_read_write_barrier() __sync_synchronize()
+#endif
+
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""  ::: "memory")
 
 #ifdef __SUNPRO_C


### PR DESCRIPTION
Port openpa gcc intrinsic primitives to use __atomic gcc builtins when GCC >=4.7.4.

## Pull Request Description

The barrier implementation of openpa is incorrect for aggressively re-ordering architectures such as AWS M6g instances using Arm Neoverse N1 cores.  Race conditions happen that break the nemesis queues.  This patch fixes the barrier implementation and also modernizes it for newer GCC compilers. 

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
