### PR TITLE
Change to preferred capitialization for Slurm.

### DIFF
--- a/README.vin
+++ b/README.vin
@@ -535,15 +535,15 @@ is only meant for single-node systems.
 
 slurm
 -----
-SLURM is an external process manager not distributed with
+Slurm is an external process manager not distributed with
 MPICH. MPICH's default process manager, hydra, has native support
-for slurm and you can directly use it in slurm environments (it will
-automatically detect slurm and use slurm capabilities). However, if
-you want to use the slurm provided "srun" process manager, you can use
+for Slurm and you can directly use it in Slurm environments (it will
+automatically detect Slurm and use Slurm capabilities). However, if
+you want to use the Slurm-provided "srun" process manager, you can use
 the "--with-pmi=slurm --with-pm=no" option with configure. Note that
-the "srun" process manager that comes with slurm uses an older PMI
+the "srun" process manager that comes with Slurm uses an older PMI
 standard which does not have some of the performance enhancements that
-hydra provides in slurm environments.
+hydra provides in Slurm environments.
 
 -------------------------------------------------------------------------
 

--- a/doc/userguide/user.tex.vin
+++ b/doc/userguide/user.tex.vin
@@ -391,18 +391,18 @@ machines listed to satisfy the requested number of processes; you can list the
 same machine name multiple times if necessary.  
 
 
-\subsection{Using MPICH with SLURM and PBS}
+\subsection{Using MPICH with Slurm and PBS}
 \label{sec:external_pm}
 
-There are multiple ways of using MPICH with SLURM or PBS. Hydra
-provides native support for both SLURM and PBS, and is likely the
+There are multiple ways of using MPICH with Slurm or PBS. Hydra
+provides native support for both Slurm and PBS, and is likely the
 easiest way to use MPICH on these systems (see the Hydra
 documentation above for more details).
 
-Alternatively, SLURM also provides compatibility with MPICH's
+Alternatively, Slurm also provides compatibility with MPICH's
 internal process management interface. To use this, you need to
-configure MPICH with SLURM support, and then use the {\texttt srun}
-job launching utility provided by SLURM.
+configure MPICH with Slurm support, and then use the {\texttt srun}
+job launching utility provided by Slurm.
 
 For PBS, MPICH jobs can be launched in two ways: (i) use Hydra's
 mpiexec with the appropriate options corresponding to PBS, or (ii)

--- a/src/pm/hydra/tools/bootstrap/external/slurm_query_proxy_id.c
+++ b/src/pm/hydra/tools/bootstrap/external/slurm_query_proxy_id.c
@@ -17,7 +17,7 @@ HYD_status HYDT_bscd_slurm_query_proxy_id(int *proxy_id)
 
     if (MPL_env2int("SLURM_NODEID", proxy_id) == 0) {
         *proxy_id = -1;
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "cannot find slurm proxy ID\n");
+        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "cannot find Slurm proxy ID\n");
     }
 
   fn_exit:

--- a/src/pm/hydra/tools/bootstrap/include/bsci.h
+++ b/src/pm/hydra/tools/bootstrap/include/bsci.h
@@ -112,7 +112,7 @@ HYD_status HYDT_bsci_init(const char *rmk, const char *launcher,
  * Background of use_rmk: RMK is used to allocate nodes on a system
  * before launching a job.  If it is not specified in the user
  * arguments for the UI process (e.g., mpiexec), it is set to the same
- * as a job launcher (e.g., SLURM or PBS).  This works fine for
+ * as a job launcher (e.g., Slurm or PBS).  This works fine for
  * launching processes on nodes for the first time, but it has
  * a problem when a process dynamically creates other processes at run
  * time, e.g., by calling MPI_Comm_spawn(), because the job launcher

--- a/src/pm/hydra2/libhydra/bstrap/slurm/slurm_launch.c
+++ b/src/pm/hydra2/libhydra/bstrap/slurm/slurm_launch.c
@@ -51,7 +51,7 @@ HYD_status HYDI_bstrap_slurm_launch(const char *hostname, const char *launch_exe
 
     /* Fill in the remaining arguments */
     /* We do not need to create a quoted version of the string for
-     * SLURM. It seems to be internally quoting it anyway. */
+     * Slurm. It seems to be internally quoting it anyway. */
     for (i = 0; args[i]; i++)
         targs[idx++] = MPL_strdup(args[i]);
 

--- a/src/pmi/slurm/subconfigure.m4
+++ b/src/pmi/slurm/subconfigure.m4
@@ -15,7 +15,7 @@ AC_CHECK_HEADER([slurm/pmi.h], [], [AC_MSG_ERROR([could not find slurm/pmi.h.  C
 AC_CHECK_LIB([pmi], [PMI_Init],
              [PAC_PREPEND_FLAG([-lpmi],[LIBS])
               PAC_PREPEND_FLAG([-lpmi], [WRAPPER_LIBS])],
-             [AC_MSG_ERROR([could not find the slurm libpmi.  Configure aborted])])
+             [AC_MSG_ERROR([could not find the Slurm libpmi.  Configure aborted])])
 
 ])dnl end COND_IF
 


### PR DESCRIPTION
Signed-off-by: Tim Wickberg <tim@schedmd.com>

Fixes inconsistent and incorrect capitialization for Slurm.