### PR TITLE
pm/hydra2: Restrict linkage of some variables

### DIFF
--- a/src/pm/hydra2/mpiexec/mpiexec.c
+++ b/src/pm/hydra2/mpiexec/mpiexec.c
@@ -73,10 +73,10 @@ struct mpiexec_params_s mpiexec_params = {
 
 struct mpiexec_pg *mpiexec_pg_hash = NULL;
 
-int *contig_pids;
-int **exitcodes;
-int **exitcode_node_ids;
-int *n_proxy_exitcodes;
+static int *contig_pids;
+static int **exitcodes;
+static int **exitcode_node_ids;
+static int *n_proxy_exitcodes;
 
 static void signal_cb(int signum)
 {

--- a/src/pm/hydra2/mpiexec/mpiexec.h
+++ b/src/pm/hydra2/mpiexec/mpiexec.h
@@ -114,7 +114,6 @@ struct mpiexec_pg {
 
 extern struct mpiexec_pg *mpiexec_pg_hash;
 extern struct mpiexec_params_s mpiexec_params;
-extern int *contig_pids;
 
 HYD_status mpiexec_get_parameters(char **t_argv);
 HYD_status mpiexec_pmi_barrier(struct mpiexec_pg *pg);


### PR DESCRIPTION
## Pull Request Description

These file scope variables are not used outside of mpiexec.c, so make
their declarations static to prevent accidental or erroneous usage.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

work in progress...

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
