### PR TITLE
openpa: create a header for GCC's __atomic.

### DIFF
--- a/src/openpa/README
+++ b/src/openpa/README
@@ -46,6 +46,9 @@ opa_gcc_intel_32_64.h - GCC (and some GCC-like compilers) on x86 and
 opa_gcc_sync.h        - GCC on many other platforms.  These use GCC's __sync
                         intrinsics which are not always implemented on
                         every platform
+opa_gcc_atomic.h      - GCC on many other platforms.  These use GCC's __atomic
+                        intrinsics which are not always implemented on
+                        every platform
 opa_gcc_ppc.h         - GCC and IBM's XLC on PowerPC 4xx and 970 systems.
                         Specifically, this supports the modified-PPC440
                         processor in IBM's Blue Gene/P supercomputers and most

--- a/src/openpa/README
+++ b/src/openpa/README
@@ -43,7 +43,7 @@ listed platforms:
 opa_gcc_ia64.h        - GCC on Intel's IA64 (Itanium) architecture
 opa_gcc_intel_32_64.h - GCC (and some GCC-like compilers) on x86 and
                         x86_64 architectures
-opa_gcc_intrinsics.h  - GCC on many other platforms.  These use compiler
+opa_gcc_sync.h        - GCC on many other platforms.  These use GCC's __sync
                         intrinsics which are not always implemented on
                         every platform
 opa_gcc_ppc.h         - GCC and IBM's XLC on PowerPC 4xx and 970 systems.

--- a/src/openpa/configure.ac
+++ b/src/openpa/configure.ac
@@ -344,6 +344,7 @@ dnl without AC_TRY_RUN().
         OPA_TRY_PRIMITIVE_HEADER([opa_gcc_sicortex.h], [GCC_AND_SICORTEX_ASM], [gcc SiCortex atomics])
     fi
 
+    OPA_TRY_PRIMITIVE_HEADER([opa_gcc_atomic.h], [GCC_ATOMIC_INTRINSICS], [gcc __atomic intrinsics])
     OPA_TRY_PRIMITIVE_HEADER([opa_gcc_sync.h], [GCC_SYNC_INTRINSICS], [gcc __sync intrinsics])
     OPA_TRY_PRIMITIVE_HEADER([opa_nt_intrinsics.h], [NT_INTRINSICS], [Windows NT atomic intrinsics])
     OPA_TRY_PRIMITIVE_HEADER([opa_sun_atomic_ops.h], [SUN_ATOMIC_OPS], [Sun atomic operations library])

--- a/src/openpa/configure.ac
+++ b/src/openpa/configure.ac
@@ -344,7 +344,7 @@ dnl without AC_TRY_RUN().
         OPA_TRY_PRIMITIVE_HEADER([opa_gcc_sicortex.h], [GCC_AND_SICORTEX_ASM], [gcc SiCortex atomics])
     fi
 
-    OPA_TRY_PRIMITIVE_HEADER([opa_gcc_intrinsics.h], [GCC_INTRINSIC_ATOMICS], [gcc atomic intrinsics])
+    OPA_TRY_PRIMITIVE_HEADER([opa_gcc_sync.h], [GCC_SYNC_INTRINSICS], [gcc __sync intrinsics])
     OPA_TRY_PRIMITIVE_HEADER([opa_nt_intrinsics.h], [NT_INTRINSICS], [Windows NT atomic intrinsics])
     OPA_TRY_PRIMITIVE_HEADER([opa_sun_atomic_ops.h], [SUN_ATOMIC_OPS], [Sun atomic operations library])
 

--- a/src/openpa/src/Makefile.am
+++ b/src/openpa/src/Makefile.am
@@ -20,7 +20,7 @@ nobase_include_HEADERS = primitives/opa_by_lock.h                   \
                          primitives/opa_gcc_intel_32_64_ops.h       \
                          primitives/opa_gcc_intel_32_64_p3.h        \
                          primitives/opa_gcc_intel_32_64_p3barrier.h \
-                         primitives/opa_gcc_intrinsics.h            \
+                         primitives/opa_gcc_sync.h                  \
                          primitives/opa_gcc_ppc.h                   \
                          primitives/opa_gcc_sicortex.h              \
                          primitives/opa_nt_intrinsics.h             \

--- a/src/openpa/src/Makefile.am
+++ b/src/openpa/src/Makefile.am
@@ -14,6 +14,7 @@ nodist_include_HEADERS = opa_config.h
 # "nobase_" causes the primitives directory to be preserved when installed
 nobase_include_HEADERS = primitives/opa_by_lock.h                   \
                          primitives/opa_emulated.h                  \
+                         primitives/opa_gcc_atomic.h                \
                          primitives/opa_gcc_ia64.h                  \
                          primitives/opa_gcc_intel_32_64.h           \
                          primitives/opa_gcc_intel_32_64_barrier.h   \

--- a/src/openpa/src/opa_primitives.h
+++ b/src/openpa/src/opa_primitives.h
@@ -95,6 +95,8 @@
 #include "primitives/opa_gcc_ia64.h"
 #elif defined(OPA_HAVE_GCC_AND_SICORTEX_ASM)
 #include "primitives/opa_gcc_sicortex.h"
+#elif defined(OPA_HAVE_GCC_ATOMIC_INTRINSICS)
+#include "primitives/opa_gcc_atomic.h"
 #elif defined(OPA_HAVE_GCC_SYNC_INTRINSICS)
 #include "primitives/opa_gcc_sync.h"
 #elif defined(OPA_HAVE_SUN_ATOMIC_OPS)

--- a/src/openpa/src/opa_primitives.h
+++ b/src/openpa/src/opa_primitives.h
@@ -95,8 +95,8 @@
 #include "primitives/opa_gcc_ia64.h"
 #elif defined(OPA_HAVE_GCC_AND_SICORTEX_ASM)
 #include "primitives/opa_gcc_sicortex.h"
-#elif defined(OPA_HAVE_GCC_INTRINSIC_ATOMICS)
-#include "primitives/opa_gcc_intrinsics.h"
+#elif defined(OPA_HAVE_GCC_SYNC_INTRINSICS)
+#include "primitives/opa_gcc_sync.h"
 #elif defined(OPA_HAVE_SUN_ATOMIC_OPS)
 #include "primitives/opa_sun_atomic_ops.h"
 #elif defined(OPA_HAVE_NT_INTRINSICS)

--- a/src/openpa/src/primitives/opa_gcc_atomic.h
+++ b/src/openpa/src/primitives/opa_gcc_atomic.h
@@ -1,12 +1,12 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
 /*
- *  (C) 2008 by Argonne National Laboratory.
+ *  (C) 2019 by Argonne National Laboratory.
  *      See COPYRIGHT in top-level directory.
  */
 
 /* FIXME needs to be converted to new style functions with OPA_int_t/OPA_ptr_t-types */
-#ifndef OPA_GCC_SYNC_H_INCLUDED
-#define OPA_GCC_SYNC_H_INCLUDED
+#ifndef OPA_GCC_ATOMIC_H_INCLUDED
+#define OPA_GCC_ATOMIC_H_INCLUDED
 
 /* FIXME do we need to align these? */
 typedef struct {
@@ -34,58 +34,42 @@ typedef struct {
    may not be true at all. */
 static inline int OPA_load_int(const OPA_int_t * ptr)
 {
-    return ptr->v;
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
 }
 
 static inline void OPA_store_int(OPA_int_t * ptr, int val)
 {
-    ptr->v = val;
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
 }
 
 static inline void *OPA_load_ptr(const OPA_ptr_t * ptr)
 {
-    return ptr->v;
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
 }
 
 static inline void OPA_store_ptr(OPA_ptr_t * ptr, void *val)
 {
-    ptr->v = val;
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
 }
 
 static inline int OPA_load_acquire_int(const OPA_int_t * ptr)
 {
-    int tmp = ptr->v;
-    /* __sync does not have a true load-acquire barrier builtin,
-     * so the best that can be done is use a normal barrier to
-     * ensure the read of ptr->v happens before the ensuing block
-     * of memory references we are ordering.
-     */
-    __sync_synchronize();
-    return tmp;
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
 }
 
 static inline void OPA_store_release_int(OPA_int_t * ptr, int val)
 {
-    /* __sync does not a true store-release barrier builtin,
-     * so the best that can be done is to use a normal barrier
-     * to ensure previous memory operations are ordered-before
-     * the following store.
-     */
-    __sync_synchronize();
-    ptr->v = val;
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
 }
 
 static inline void *OPA_load_acquire_ptr(const OPA_ptr_t * ptr)
 {
-    void *tmp = ptr->v;
-    __sync_synchronize();
-    return tmp;
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
 }
 
 static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 {
-    __sync_synchronize();
-    ptr->v = val;
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
 }
 
 
@@ -95,12 +79,12 @@ static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 
 static inline int OPA_fetch_and_add_int(OPA_int_t * ptr, int val)
 {
-    return __sync_fetch_and_add(&ptr->v, val, /* protected variables: */ &ptr->v);
+    return __atomic_fetch_add(&ptr->v, val, __ATOMIC_SEQ_CST);
 }
 
 static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 {
-    return __sync_sub_and_fetch(&ptr->v, 1, /* protected variables: */ &ptr->v) == 0;
+    return __atomic_sub_fetch(&ptr->v, 1, __ATOMIC_SEQ_CST) == 0;
 }
 
 #define OPA_fetch_and_incr_int_by_faa OPA_fetch_and_incr_int
@@ -112,32 +96,31 @@ static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 
 static inline void *OPA_cas_ptr(OPA_ptr_t * ptr, void *oldv, void *newv)
 {
-    return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+    void *expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
 }
 
 static inline int OPA_cas_int(OPA_int_t * ptr, int oldv, int newv)
 {
-    return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+    int expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
 }
 
-#ifdef SYNC_LOCK_TEST_AND_SET_IS_SWAP
 static inline void *OPA_swap_ptr(OPA_ptr_t * ptr, void *val)
 {
-    return __sync_lock_test_and_set(&ptr->v, val, /* protected variables: */ &ptr->v);
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
 }
 
 static inline int OPA_swap_int(OPA_int_t * ptr, int val)
 {
-    return __sync_lock_test_and_set(&ptr->v, val, /* protected variables: */ &ptr->v);
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
 }
-#else
-#define OPA_swap_ptr_by_cas OPA_swap_ptr
-#define OPA_swap_int_by_cas OPA_swap_int
-#endif /* SYNC_LOCK_TEST_AND_SET_IS_SWAP */
 
-#define OPA_write_barrier()      __sync_synchronize()
-#define OPA_read_barrier()       __sync_synchronize()
-#define OPA_read_write_barrier() __sync_synchronize()
+#define OPA_write_barrier()      __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_barrier()       __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_write_barrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""  ::: "memory")
 
@@ -150,4 +133,4 @@ static inline int OPA_swap_int(OPA_int_t * ptr, int val)
 
 #include"opa_emulated.h"
 
-#endif /* OPA_GCC_SYNC_H_INCLUDED */
+#endif /* OPA_GCC_ATOMIC_H_INCLUDED */

--- a/src/openpa/src/primitives/opa_gcc_intrinsics.h
+++ b/src/openpa/src/primitives/opa_gcc_intrinsics.h
@@ -19,6 +19,14 @@ typedef struct {
 #define OPA_INT_T_INITIALIZER(val_) { (val_) }
 #define OPA_PTR_T_INITIALIZER(val_) { (val_) }
 
+/* Use __atomic builtins if GCC >= 4.7.4 */
+#if __GNUC__ > 4 || \
+    (__GNUC__ == 4 && (__GNUC_MINOR__ > 7 || \
+                       (__GNUC_MINOR__ == 7 && \
+                        __GNUC_PATCHLEVEL__ >= 4)))
+#define USE_GCC_ATOMIC
+#endif
+
 /* Oracle Developer Studio (suncc) supports gcc sync intrinsics, but it is very noisy.
  * Suppress the error_messages here and reset at the end of this file.
  */
@@ -34,54 +42,90 @@ typedef struct {
    may not be true at all. */
 static inline int OPA_load_int(const OPA_int_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
+#else
     return ptr->v;
+#endif
 }
 
 static inline void OPA_store_int(OPA_int_t * ptr, int val)
 {
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
+#else
     ptr->v = val;
+#endif
 }
 
 static inline void *OPA_load_ptr(const OPA_ptr_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_RELAXED);
+#else
     return ptr->v;
+#endif
 }
 
 static inline void OPA_store_ptr(OPA_ptr_t * ptr, void *val)
 {
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELAXED);
+#else
     ptr->v = val;
+#endif
 }
 
 static inline int OPA_load_acquire_int(const OPA_int_t * ptr)
 {
-    volatile int i = 0;
-    int tmp;
-    tmp = ptr->v;
-    __sync_lock_test_and_set(&i, 1);    /* guarantees acquire semantics */
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
+#else
+    int tmp = ptr->v;
+    /* __sync does not have a true load-acquire barrier builtin,
+     * so the best that can be done is use a normal barrier to
+     * ensure the read of ptr->v happens before the ensuing block
+     * of memory references we are ordering.
+     */
+    __sync_synchronize();
     return tmp;
+#endif
 }
 
 static inline void OPA_store_release_int(OPA_int_t * ptr, int val)
 {
-    volatile int i = 1;
-    __sync_lock_release(&i);    /* guarantees release semantics */
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
+#else
+    /* __sync does not a true store-release barrier builtin,
+     * so the best that can be done is to use a normal barrier
+     * to ensure previous memory operations are ordered-before
+     * the following store.
+     */
+    __sync_synchronize();
     ptr->v = val;
+#endif
 }
 
 static inline void *OPA_load_acquire_ptr(const OPA_ptr_t * ptr)
 {
-    volatile int i = 0;
-    void *tmp;
-    tmp = ptr->v;
-    __sync_lock_test_and_set(&i, 1);    /* guarantees acquire semantics */
+#ifdef USE_GCC_ATOMIC
+    return __atomic_load_n(&ptr->v, __ATOMIC_ACQUIRE);
+#else
+    void *tmp = ptr->v;
+    __sync_synchronize();
     return tmp;
+#endif
 }
 
 static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 {
-    volatile int i = 1;
-    __sync_lock_release(&i);    /* guarantees release semantics */
+#ifdef USE_GCC_ATOMIC
+    __atomic_store_n(&ptr->v, val, __ATOMIC_RELEASE);
+#else
+    __sync_synchronize();
     ptr->v = val;
+#endif
 }
 
 
@@ -91,12 +135,20 @@ static inline void OPA_store_release_ptr(OPA_ptr_t * ptr, void *val)
 
 static inline int OPA_fetch_and_add_int(OPA_int_t * ptr, int val)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_fetch_add(&ptr->v, val, __ATOMIC_SEQ_CST);
+#else
     return __sync_fetch_and_add(&ptr->v, val, /* protected variables: */ &ptr->v);
+#endif
 }
 
 static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 {
+#ifdef USE_GCC_ATOMIC
+    return __atomic_sub_fetch(&ptr->v, 1, __ATOMIC_SEQ_CST) == 0;
+#else
     return __sync_sub_and_fetch(&ptr->v, 1, /* protected variables: */ &ptr->v) == 0;
+#endif
 }
 
 #define OPA_fetch_and_incr_int_by_faa OPA_fetch_and_incr_int
@@ -108,14 +160,41 @@ static inline int OPA_decr_and_test_int(OPA_int_t * ptr)
 
 static inline void *OPA_cas_ptr(OPA_ptr_t * ptr, void *oldv, void *newv)
 {
+
+#ifdef USE_GCC_ATOMIC
+    void *expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
+#else
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+#endif
 }
 
 static inline int OPA_cas_int(OPA_int_t * ptr, int oldv, int newv)
 {
+
+#ifdef USE_GCC_ATOMIC
+    int expected = oldv;
+    __atomic_compare_exchange_n(&ptr->v, &expected, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    return expected;
+#else
     return __sync_val_compare_and_swap(&ptr->v, oldv, newv, /* protected variables: */ &ptr->v);
+#endif
 }
 
+
+
+#ifdef USE_GCC_ATOMIC
+static inline void *OPA_swap_ptr(OPA_ptr_t * ptr, void *val)
+{
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
+}
+
+static inline int OPA_swap_int(OPA_int_t * ptr, int val)
+{
+    return __atomic_exchange_n(&ptr->v, val, __ATOMIC_SEQ_CST);
+}
+#else
 #ifdef SYNC_LOCK_TEST_AND_SET_IS_SWAP
 static inline void *OPA_swap_ptr(OPA_ptr_t * ptr, void *val)
 {
@@ -126,15 +205,22 @@ static inline int OPA_swap_int(OPA_int_t * ptr, int val)
 {
     return __sync_lock_test_and_set(&ptr->v, val, /* protected variables: */ &ptr->v);
 }
-
 #else
 #define OPA_swap_ptr_by_cas OPA_swap_ptr
 #define OPA_swap_int_by_cas OPA_swap_int
-#endif
+#endif /* SYNC_LOCK_TEST_AND_SET_IS_SWAP */
+#endif /* USE_GCC_ATOMIC */
 
+#ifdef USE_GCC_ATOMIC
+#define OPA_write_barrier()      __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_barrier()       __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#define OPA_read_write_barrier() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#else
 #define OPA_write_barrier()      __sync_synchronize()
 #define OPA_read_barrier()       __sync_synchronize()
 #define OPA_read_write_barrier() __sync_synchronize()
+#endif
+
 #define OPA_compiler_barrier()   __asm__ __volatile__  (""  ::: "memory")
 
 #ifdef __SUNPRO_C

--- a/src/openpa/src/primitives/opa_gcc_sync.h
+++ b/src/openpa/src/primitives/opa_gcc_sync.h
@@ -5,8 +5,8 @@
  */
 
 /* FIXME needs to be converted to new style functions with OPA_int_t/OPA_ptr_t-types */
-#ifndef OPA_GCC_INTRINSICS_H_INCLUDED
-#define OPA_GCC_INTRINSICS_H_INCLUDED
+#ifndef OPA_GCC_SYNC_H_INCLUDED
+#define OPA_GCC_SYNC_H_INCLUDED
 
 /* FIXME do we need to align these? */
 typedef struct {
@@ -232,4 +232,4 @@ static inline int OPA_swap_int(OPA_int_t * ptr, int val)
 
 #include"opa_emulated.h"
 
-#endif /* OPA_GCC_INTRINSICS_H_INCLUDED */
+#endif /* OPA_GCC_SYNC_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

This PR creates and implements a header for GCC's `__atomic` (`openpa/src/primitives/opa_gcc_atomic.h`) with some bug fixes in #4222.

~This PR creates a stub for GCC's `__atomic` in OpenPA (as OpenPA is still used in MPICH).
It might be used in #4222, might be merged before #4222, or it can be introduced after #4222 is merged.~

~Now `opa_gcc_atomic.h` causes an error by `#error`, so this option won't be chosen; implementation is needed.~

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

`__atomic` is preferred to `__sync`, which should perform better. However, this change does not affect the  architectures that have assembly-based atomics (e.g., Power and Intel x86/64) since the priority of assembly-based implementations is higher.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
