### PR TITLE
mpl/atomic: fix acquire-load and release-store in gcc_sync.h

### DIFF
--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -39,9 +39,9 @@ static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
                                 (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
-    volatile int i = 0;                                                        \
     TYPE val = ptr->v;                                                         \
-    __sync_lock_test_and_set(&i, 1); /* guarantees acquire semantics */        \
+    /* Need a full barrier (see https://github.com/pmodels/mpich/pull/4222) */ \
+    __sync_synchronize();                                                      \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
@@ -52,8 +52,8 @@ static inline void MPL_atomic_relaxed_store_ ## NAME                           \
 static inline void MPL_atomic_release_store_ ## NAME                           \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
-    volatile int i = 1;                                                        \
-    __sync_lock_release(&i); /* guarantees release semantics */                \
+    /* Need a full barrier (see https://github.com/pmodels/mpich/pull/4222) */ \
+    __sync_synchronize();                                                      \
     ptr->v = val;                                                              \
 }                                                                              \
 static inline TYPE MPL_atomic_cas_ ## NAME                                     \


### PR DESCRIPTION
## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

This PR addresses #4228.

As discussed in #4222, `__sync_lock_test_and_set()` and `__sync_lock_release()` are not enough to implement a acquire-release memory model with `__sync` builtins. OpenPA code was discussed in #4222, but the same bug exists in MPL/atomic as well. This PR fixes GCC's `__sync` in MPL/atomic by replacing `__sync_lock_test_and_set()` and `__sync_lock_release()` with a full memory barrier (`__sync_synchronize()`).

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

We note that MPL/atomic implements write-barrier as release-barrier and read-barrier as acquire-barrier, so this PR does not change this part.

## Expected Impact

Modern compilers that support `__atomic` are not affected by this PR. With old compilers that only support `__sync`, the performance can get potentially worse, but this change is necessary for correctness.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
