### PR TITLE
ch4/ofi: Look for FI_ENOENT when cancelling

### DIFF
--- a/src/mpid/ch4/netmod/ofi/errnames.txt
+++ b/src/mpid/ch4/netmod/ofi/errnames.txt
@@ -99,3 +99,5 @@
 **ofid_stx_ctx_close %s %d %s %s:OFI stx context close failed (%s:%d:%s:%s)
 **ofi_provider_mismatch:OFI Provider name does not match configure-time provider name
 **ofi_provider_mismatch %s %d %s %s:OFI Provider name does not match configure-time provider name (%s:%d:%s:%s)
+**ofid_cancel:OFI cancel failed
+**ofid_cancel %s %d %s %s:OFI cancel failed (%s:%d:%s:%s)

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -43,8 +43,6 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 # xfail known failures of OFI build for Hackathon
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
-# the below tests timeout with the ofi/sockets provider
-* * * ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 # am-only failures
 * * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
 * * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist
@@ -56,6 +54,7 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 * * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
 * * am-only ch4:ofi * sed -i "s+\(^pingping .* arg=-sendcnt=65530 .*\)+\1 xfail=issue3886+g" test/mpi/pt2pt/testlist.dtp
+* * am-only ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 ################################################################################
 #ch3:ofi
 ofi * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist

--- a/test/mpi/pt2pt/many_isend.c
+++ b/test/mpi/pt2pt/many_isend.c
@@ -10,16 +10,17 @@
 #include "mpitest.h"
 
 #define ITER 5
-#define BUF_COUNT (16*1024)
+#define BUF_COUNT (16*1024/sizeof(int))
 
 int rank, nprocs;
-char recvbuf[BUF_COUNT], sendbuf[BUF_COUNT];
+int recvbuf[BUF_COUNT], sendbuf[BUF_COUNT];
 
 int main(int argc, char *argv[])
 {
-    int x, i;
+    int x, i, j, errs = 0;
     MPI_Status *sendstats = NULL;
     MPI_Request *sendreqs = NULL;
+    MPI_Status recvstatus;
 
     MTest_Init(&argc, &argv);
 
@@ -32,15 +33,29 @@ int main(int argc, char *argv[])
     for (x = 0; x < ITER; x++) {
         MPI_Barrier(MPI_COMM_WORLD);
 
+        for (i = 0; i < BUF_COUNT; i++) {
+            sendbuf[i] = rank;
+            recvbuf[i] = -1;
+        }
+
         /* all to all send */
         for (i = 0; i < nprocs; i++) {
-            MPI_Isend(sendbuf, BUF_COUNT, MPI_CHAR, i, 0, MPI_COMM_WORLD, &sendreqs[i]);
+            MPI_Isend(sendbuf, BUF_COUNT, MPI_INT, i, 0, MPI_COMM_WORLD, &sendreqs[i]);
         }
 
         /* receive one by one */
         for (i = 0; i < nprocs; i++) {
-            MPI_Recv(recvbuf, BUF_COUNT, MPI_CHAR, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD,
-                     MPI_STATUS_IGNORE);
+            MPI_Recv(recvbuf, BUF_COUNT, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD,
+                     &recvstatus);
+
+            for (j = 0; j < BUF_COUNT; j++) {
+                if (recvbuf[j] != recvstatus.MPI_SOURCE) {
+                    if (++errs < 10) {
+                        fprintf(stderr, "recvbuf[%d] (%d) != %d\n", j, recvbuf[j],
+                                recvstatus.MPI_SOURCE);
+                    }
+                }
+            }
         }
 
         /* ensure all send request completed */
@@ -52,7 +67,7 @@ int main(int argc, char *argv[])
     free(sendreqs);
     free(sendstats);
 
-    MTest_Finalize(0);
+    MTest_Finalize(errs);
 
     return 0;
 }


### PR DESCRIPTION
## Pull Request Description

If fi_cancel returns FI_ENOENT, the problem is probably that the requested context was already completed, not an error. Check for that case checking the return value of fi_cancel.

## Expected Impact

Fixes a problem for some providers (PSM2 in particular).

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
