### PR TITLE
ch4/ofi: Use FI_ORDER_ATOMIC_ instead of FI_ORDER_

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -14,6 +14,15 @@
 #define MPIDI_OFI_OFF     0
 #define MPIDI_OFI_ON      1
 
+/* Check to see if the OFI library supports FI_ORDER_ATOMIC_* flags. */
+#if defined(FI_ORDER_ATOMIC_RAR) && defined(FI_ORDER_ATOMIC_RAW) && defined(FI_ORDER_ATOMIC_WAR) && defined(FI_ORDER_ATOMIC_WAW)
+/* Support for atomic flags was added in OFI 1.8. */
+#define MPIDI_OFI_ATOMIC_ORDER_FLAGS (FI_ORDER_ATOMIC_RAR | FI_ORDER_ATOMIC_RAW | FI_ORDER_ATOMIC_WAR | FI_ORDER_ATOMIC_WAW)
+#else
+/* Earlier versions of OFI will use the more generic flags that will do more locking. */
+#define MPIDI_OFI_ATOMIC_ORDER_FLAGS (FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW)
+#endif
+
 enum {
     MPIDI_OFI_SET_NUMBER_DEFAULT = 0,
     MPIDI_OFI_SET_NUMBER_MINIMAL,

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -636,7 +636,7 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
         /* A shared transmit context’s attributes must be a union of all associated
          * endpoints' transmit capabilities. */
         tx_attr.caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;
-        tx_attr.msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+        tx_attr.msg_order = MPIDI_OFI_ATOMIC_ORDER_FLAGS;
         tx_attr.op_flags = FI_DELIVERY_COMPLETE | FI_COMPLETION;
         MPIDI_OFI_CALL_RETURN(fi_stx_context(MPIDI_OFI_global.domain,
                                              &tx_attr,
@@ -1430,7 +1430,7 @@ bool match_global_settings(struct fi_info * prov)
 
     CHECK_CAP(MPIDI_OFI_ENABLE_RMA, !(prov->caps & FI_RMA));
 
-    uint64_t msg_order = FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+    uint64_t msg_order = MPIDI_OFI_ATOMIC_ORDER_FLAGS;
     CHECK_CAP(MPIDI_OFI_ENABLE_ATOMICS,
               !(prov->caps & FI_ATOMICS) || (prov->tx_attr->msg_order & msg_order) != msg_order);
 
@@ -1647,7 +1647,7 @@ static void init_hints(struct fi_info *hints)
         hints->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
         /* Apply most restricted msg order in hints for RMA ATOMICS. */
         if (MPIDI_OFI_ENABLE_ATOMICS)
-            hints->tx_attr->msg_order |= FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_WAR | FI_ORDER_WAW;
+            hints->tx_attr->msg_order |= MPIDI_OFI_ATOMIC_ORDER_FLAGS;
     }
     hints->tx_attr->comp_order = FI_ORDER_NONE;
     hints->rx_attr->op_flags = FI_COMPLETION;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -150,16 +150,32 @@ static void set_rma_fi_info(MPIR_Win * win, struct fi_info *finfo)
     finfo->tx_attr->msg_order = FI_ORDER_NONE;  /* FI_ORDER_NONE is an alias for the value 0 */
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_RAR) ==
         MPIDIG_ACCU_ORDER_RAR)
+#ifdef FI_ORDER_ATOMIC_RAR
+        finfo->tx_attr->msg_order |= FI_ORDER_ATOMIC_RAR;
+#else
         finfo->tx_attr->msg_order |= FI_ORDER_RAR;
+#endif
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_RAW) ==
         MPIDIG_ACCU_ORDER_RAW)
+#ifdef FI_ORDER_ATOMIC_RAW
+        finfo->tx_attr->msg_order |= FI_ORDER_ATOMIC_RAW;
+#else
         finfo->tx_attr->msg_order |= FI_ORDER_RAW;
+#endif
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAR) ==
         MPIDIG_ACCU_ORDER_WAR)
+#ifdef FI_ORDER_ATOMIC_WAR
+        finfo->tx_attr->msg_order |= FI_ORDER_ATOMIC_WAR;
+#else
         finfo->tx_attr->msg_order |= FI_ORDER_WAR;
+#endif
     if ((MPIDIG_WIN(win, info_args).accumulate_ordering & MPIDIG_ACCU_ORDER_WAW) ==
         MPIDIG_ACCU_ORDER_WAW)
+#ifdef FI_ORDER_ATOMIC_WAW
+        finfo->tx_attr->msg_order |= FI_ORDER_ATOMIC_WAW;
+#else
         finfo->tx_attr->msg_order |= FI_ORDER_WAW;
+#endif
 }
 
 static int win_allgather(MPIR_Win * win, void *base, int disp_unit)


### PR DESCRIPTION
## Pull Request Description

In OFI 1.8, more relaxed ordering requirements were introduced to allow
a provider to only guarantee a specific ordering level for atomics,
rather than for all messages. As most hardware-offloaded networks are
likely to use these flags, and MPICH doesn't require the ordering for
non-atomic operations, this commit changes all uses of `FI_ORDER_*` to
be `FI_ORDER_ATOMIC_*`.

Because these new flags didn't exist before OFI 1.8, there is a compile
time check to look for the correct version of these flags to be used.
For older versions of libfabric, the older `FI_ORDER_*` flags will be
used instead. Of course, this means that compiling with an older version
of libfabric will not work when running with a newer version of
libfabric (or at least will result in unexpected behavior).

## Expected Impact

Could have better performance as the ordering requirement is less strict.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
