### PR TITLE
maint: Fix release script secondary configure

### DIFF
--- a/maint/release.pl
+++ b/maint/release.pl
@@ -256,7 +256,7 @@ print("done\n");
 print("===> Creating secondary codebase for the docs... ");
 run_cmd("mkdir ${expdir}-build");
 chdir("${expdir}-build");
-run_cmd("${expdir}/configure --disable-fortran --disable-cxx");
+run_cmd("${expdir}/configure --with-device=ch4:stubnm --disable-fortran --disable-cxx");
 run_cmd("(make mandoc && make htmldoc && make latexdoc)");
 print("done\n");
 


### PR DESCRIPTION
## Pull Request Description

release.pl needs to specify a device configuration in order to build
the documentation. Use ch4:stubnm as a simple default.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

release script will work again.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
