### PR TITLE
dtpools: Remove references to basictypelist.txt

### DIFF
--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1421,7 +1421,6 @@
 /pt2pt/testlist
 /cxx/attr/testlist
 /cxx/datatype/testlist
-/dtpools/basictypelist.txt
 /dtpools/aclocal.m4
 /dtpools/ar-lib
 /dtpools/compile

--- a/test/mpi/dtpools/Makefile.am
+++ b/test/mpi/dtpools/Makefile.am
@@ -4,4 +4,3 @@
 #     See COPYRIGHT in top-level directory.
 #
 SUBDIRS = src include
-EXTRA_DIST = basictypelist.txt

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -11,7 +11,7 @@
 #
 # The autogen.sh script generates a single binary for every line. Each binary will appear in
 # the testlist file multiple times, corresponding to different combinations of basic datatypes
-# (a list of which is defined in basictypelist.txt) and counts.
+# and counts.
 #
 # NOTE: the second (ssv args), fourth (timeLimit) and seventh (maxtestsize) fields are optional.
 


### PR DESCRIPTION
## Pull Request Description

This file is no longer used by dtpools for test generation. Remove all
references to it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
