### PR TITLE
init: automatically insert component init code

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -931,6 +931,11 @@ echo "## Generating configure files"
 echo "###########################################################"
 echo
 
+# autogen init/finalize placeholders
+echo_n "Extracting component init/finalize (autogen.h) ... "
+perl ./maint/gen_init.pl
+echo "done"
+
 ########################################################################
 ## Running autotools on non-simplemake directories
 ########################################################################

--- a/maint/gen_init.pl
+++ b/maint/gen_init.pl
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+#
+# (C) 2019 by Argonne National Laboratory.
+#     See COPYRIGHT in top-level directory.
+#
+
+# Scan C source files to search for component init functions and
+# and aggregate into src/include/autogen.h
+
+use strict;
+use warnings;
+
+my $srcdir = ".";
+
+# read in template
+my @lines;
+my $template_file = "$srcdir/src/include/autogen.h.in";
+open In, $template_file or die "Failed to open template $template_file\n";
+while (<In>) {
+    push @lines, $_;
+}
+close In;
+
+# collect source file list
+my $t = `find $srcdir -name '*.c' |xargs grep -l 'AUTOGEN-'`;
+my @all_files = split /\n/, $t;
+
+my %placeholders;
+$placeholders{DECLARE} = [];
+foreach my $f (@all_files) {
+    my %func_hash;
+    open In, $f or die "Failed to open source file $f\n";
+    while (<In>) {
+        if (/^\/\*\s*AUTOGEN-(\w+)/) {
+            if(!$placeholders{$1}) {
+                $placeholders{$1} = [];
+            }
+            my $place = $placeholders{$1};
+
+            # prototype next line
+            my $t = <In>;
+            if ($t =~ /^(void|int)\s+(\w+)\(void\)/) {
+                push @{$placeholders{DECLARE}}, "$1 $2(void);";
+                if ($1 eq "void") {
+                    push @{$place}, "$2();"
+                }
+                else {
+                    push @{$place}, "mpi_errno = $2();";
+                    push @{$place}, "MPIR_ERR_CHECK(mpi_errno);";
+                }
+            }
+        }
+    }
+    close In;
+}
+
+# generate autogen.h
+
+my $autogen_file = "$srcdir/src/include/autogen.h";
+open Out, ">$autogen_file" or die "Can't write $autogen_file\n";
+foreach my $l (@lines) {
+    if ($l=~/^\/\*\s* DISCLAIMER/){
+        print Out "/* Automatically generated. Do not edit. */\n";
+    }
+    elsif ($l=~/^(\s*)\/\*\s*PLACEHOLDER-(\w+)/) {
+        my ($sp, $name) = ($1, $2);
+        my $place = $placeholders{$name};
+        if ($place) {
+            foreach $t (@$place) {
+                print Out "$sp$t\n";
+            }
+        }
+    }
+    else {
+        print Out $l;
+    }
+}
+close Out;

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -13,6 +13,7 @@ nodist_include_HEADERS += src/include/mpi.h
 ## important because they contain lots of info that is computed by configure.
 nodist_noinst_HEADERS +=     \
     src/include/mpichinfo.h \
+    src/include/autogen.h   \
     src/include/mpichconf.h
 
 ## listed here in BUILT_SOURCES to ensure that if mpir_ext.h is out of date

--- a/src/include/autogen.h.in
+++ b/src/include/autogen.h.in
@@ -1,0 +1,49 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+/* This file will be processed by `maint/gen_init.pl` into autogen.h.
+ * The script will scan through all source file and extracting snippets
+ * into variouls placeholders.
+ *
+ * The main purpose is to gather component init/finalize code so that
+ * a component development do not need to touch code outside its component
+ * tree.
+ *
+ * Potentially, features can be extended.
+ */
+
+/* DISCLAIMER */
+
+#ifndef AUTOGEN_H_INCLUDED
+#define AUTOGEN_H_INCLUDED
+
+/* PLACEHOLDER-DECLARE */
+
+static inline int MPIR_init_components(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* PLACEHOLDER-MPIR_INIT */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static inline int MPID_ch4_init_components(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* PLACEHOLDER-MPID_CH4_INIT */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#endif

--- a/src/include/autogen.h.in
+++ b/src/include/autogen.h.in
@@ -46,4 +46,15 @@ static inline int MPID_ch4_init_components(void)
     goto fn_exit;
 }
 
+static inline int MPID_ch3_init_components(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* PLACEHOLDER-MPID_CH3_INIT */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
 #endif

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -17,6 +17,7 @@
 #include "mpir_info.h"
 #include "datatype.h"
 #include "mpi_init.h"
+#include "autogen.h"
 #ifdef HAVE_CRTDBG_H
 #include <crtdbg.h>
 #endif
@@ -146,6 +147,10 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
 
     /* dup comm_self and creates progress thread (if needed) */
     mpi_errno = MPII_init_async(thread_provided);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* run components init, which are aggregated in autogen.h by script */
+    mpi_errno = MPIR_init_components();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create fine-grained mutexes */

--- a/src/mpid/ch3/src/Makefile.mk
+++ b/src/mpid/ch3/src/Makefile.mk
@@ -37,6 +37,7 @@ mpi_core_sources +=                          \
     src/mpid/ch3/src/mpid_comm_failure_ack.c               \
     src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c      \
     src/mpid/ch3/src/mpid_comm_revoke.c                    \
+    src/mpid/ch3/src/mpid_comm_hints.c                     \
     src/mpid/ch3/src/mpid_finalize.c                       \
     src/mpid/ch3/src/mpid_get_universe_size.c              \
     src/mpid/ch3/src/mpid_getpname.c                       \

--- a/src/mpid/ch3/src/mpid_comm_hints.c
+++ b/src/mpid/ch3/src/mpid_comm_hints.c
@@ -1,0 +1,47 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2020 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "mpidimpl.h"
+
+static int set_eager_threshold(MPIR_Comm *comm_ptr, MPIR_Info *info, void *state);
+
+static int set_eager_threshold(MPIR_Comm *comm_ptr, MPIR_Info *info, void *state)
+{
+    int mpi_errno = MPI_SUCCESS;
+    char *endptr;
+    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
+
+    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
+
+    comm_ptr->dev.eager_max_msg_sz = strtol(info->value, &endptr, 0);
+
+    MPIR_ERR_CHKANDJUMP1(*endptr, mpi_errno, MPI_ERR_ARG,
+                         "**infohintparse", "**infohintparse %s",
+                         info->key);
+
+ fn_exit:
+    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
+    return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}
+
+/* AUTOGEN-MPID_CH3_INIT */
+int init_ch3_comm_hints(void);
+int init_ch3_comm_hints(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Comm_register_hint("eager_rendezvous_threshold",
+                                        set_eager_threshold,
+                                        NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+
+ fn_exit:
+    return mpi_errno;
+ fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -34,7 +34,6 @@ char *MPIDI_DBG_parent_str = "?";
 static int init_pg(int *argc, char ***argv, int *has_parent, int *pg_rank_p, MPIDI_PG_t **pg_p);
 static int pg_compare_ids(void * id1, void * id2);
 static int pg_destroy(MPIDI_PG_t * pg );
-static int set_eager_threshold(MPIR_Comm *comm_ptr, MPIR_Info *info, void *state);
 
 MPIDI_Process_t MPIDI_Process = { NULL };
 MPIDI_CH3U_SRBuf_element_t * MPIDI_CH3U_SRBuf_pool = NULL;
@@ -64,28 +63,6 @@ static int finalize_failed_procs_group(void *param)
  fn_fail:
     return mpi_errno;
 }
-
-static int set_eager_threshold(MPIR_Comm *comm_ptr, MPIR_Info *info, void *state)
-{
-    int mpi_errno = MPI_SUCCESS;
-    char *endptr;
-    MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
-
-    MPIR_FUNC_TERSE_ENTER(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
-
-    comm_ptr->dev.eager_max_msg_sz = strtol(info->value, &endptr, 0);
-
-    MPIR_ERR_CHKANDJUMP1(*endptr, mpi_errno, MPI_ERR_ARG,
-                         "**infohintparse", "**infohintparse %s",
-                         info->key);
-
- fn_exit:
-    MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIDI_CH3_SET_EAGER_THRESHOLD);
-    return mpi_errno;
- fn_fail:
-    goto fn_exit;
-}
-
 
 int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 {
@@ -267,11 +244,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
 	*provided = (MPICH_THREAD_LEVEL < requested) ? 
 	    MPICH_THREAD_LEVEL : requested;
     }
-
-    mpi_errno = MPIR_Comm_register_hint("eager_rendezvous_threshold",
-                                        set_eager_threshold,
-                                        NULL);
-    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_RMA_init();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -5,6 +5,7 @@
  */
 
 #include "mpidimpl.h"
+#include "autogen.h"
 
 #define MAX_JOBID_LEN 1024
 
@@ -273,6 +274,10 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_RMA_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* run components init, which are aggregated in autogen.h by script */
+    mpi_errno = MPID_ch3_init_components();
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -13,6 +13,7 @@
 #include "mpidch4r.h"
 #include "datatype.h"
 #include "mpidu_init_shm.h"
+#include "autogen.h"
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -471,6 +472,10 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     MPIDI_global.is_initialized = 0;
 
     mpi_errno = MPIDU_Init_shm_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* run components init, which are aggregated in autogen.h by script */
+    mpi_errno = MPID_ch4_init_components();
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -394,12 +394,6 @@ int MPID_Init(int *argc, char ***argv, int requested, int *provided)
     size = MPIR_Process.size;
     appnum = MPIR_Process.appnum;
 
-    MPIR_Add_mutex(&MPIDIU_THREAD_PROGRESS_MUTEX);
-    MPIR_Add_mutex(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
-    MPIR_Add_mutex(&MPIDIU_THREAD_UTIL_MUTEX);
-    MPIR_Add_mutex(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
-    MPIR_Add_mutex(&MPIDI_global.vci_lock);
-
 #if defined(MPIDI_CH4_USE_WORK_QUEUES)
     MPIDI_workq_init(&MPIDI_global.workqueue);
 #endif /* #if defined(MPIDI_CH4_USE_WORK_QUEUES) */
@@ -819,4 +813,17 @@ int MPID_Op_free_hook(MPIR_Op * op)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
+}
+
+/* components init */
+
+/* AUTOGEN-MPID_CH4_INIT */
+void init_ch4_mutexes(void);
+void init_ch4_mutexes(void)
+{
+    MPIR_Add_mutex(&MPIDIU_THREAD_PROGRESS_MUTEX);
+    MPIR_Add_mutex(&MPIDIU_THREAD_PROGRESS_HOOK_MUTEX);
+    MPIR_Add_mutex(&MPIDIU_THREAD_UTIL_MUTEX);
+    MPIR_Add_mutex(&MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
+    MPIR_Add_mutex(&MPIDI_global.vci_lock);
 }

--- a/src/util/mpir_thread.c
+++ b/src/util/mpir_thread.c
@@ -27,8 +27,10 @@ void MPIR_Add_mutex(MPID_Thread_mutex_t * p_mutex)
  * all mutexes
  */
 
-/* These routine handle any thread initialization that may be required */
-void MPIR_Thread_CS_Init(void)
+/* AUTOGEN-MPIR_INIT */
+void MPIR_thread_add_mutexes(void);
+
+void MPIR_thread_add_mutexes(void)
 {
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__GLOBAL
     /* Use the single MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX for all MPI calls */
@@ -55,7 +57,11 @@ void MPIR_Thread_CS_Init(void)
 #else
 #error Unrecognized thread granularity
 #endif
+}
 
+/* These routine handle any thread initialization that may be required */
+void MPIR_Thread_CS_Init(void)
+{
     int err;
     for (int i = 0; i < mutex_count; i++) {
         MPID_Thread_mutex_create(mutex_list[i], &err);


### PR DESCRIPTION
## Pull Request Description
    Each component often need init/finalize code that requires inserting
    code into other places where initialization and finalization gets run.
    Not only this makes component maintenence a hassle, it adds extra
    complexity for init since it needs to worry about dependency and
    execution order, or even necessity.

    Having a infrastructure to automatically aggregate the init code allows
    the component code to be self-contained and potentially opaque, which
    provides better maintainability.


## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
