### PR TITLE
ch4: Fixes for intermittent pt2pt test failures

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -116,8 +116,11 @@ static int peek_empty_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 
     switch (MPIDI_OFI_REQUEST(rreq, event_id)) {
         case MPIDI_OFI_EVENT_PEEK:
-            MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_NOT_FOUND;
             rreq->status.MPI_ERROR = MPI_SUCCESS;
+            /* util_id should be the last thing to change in rreq. Reason is
+             * we use util_id to indicate peek_event has completed and all the
+             * relevant values have been copied to rreq. */
+            MPIDI_OFI_REQUEST(rreq, util_id) = MPIDI_OFI_PEEK_NOT_FOUND;
             break;
 
         case MPIDI_OFI_EVENT_ACCEPT_PROBE:

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -140,7 +140,7 @@ typedef struct {
 typedef struct {
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
-    int util_id;
+    MPL_atomic_int_t util_id;
     MPI_Datatype datatype;
     union {
         struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -63,7 +63,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
         rreq->comm = comm;
         MPIR_Comm_add_ref(comm);
     }
-    MPIDI_OFI_REQUEST(rreq, util_id) = context_id;
+    /* Read ordering unnecessary for context_id, so use relaxed load */
+    MPL_atomic_relaxed_store_int(&MPIDI_OFI_REQUEST(rreq, util_id), context_id);
+
     MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_NOPACK;
 
     msg.msg_iov = originv;
@@ -185,7 +187,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         rreq->comm = comm;
         MPIR_Comm_add_ref(comm);
     }
-    MPIDI_OFI_REQUEST(rreq, util_id) = context_id;
+    /* Read ordering unnecessary for context_id, so use relaxed load */
+    MPL_atomic_relaxed_store_int(&MPIDI_OFI_REQUEST(rreq, util_id), context_id);
 
     if (unlikely(data_sz > MPIDI_OFI_global.max_msg_size)) {
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_HUGE;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -265,7 +265,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
          * MPIDI_OFI_global.max_msg_size */
         sreq->comm = comm;
         MPIR_Comm_add_ref(comm);
-        MPIDI_OFI_REQUEST(sreq, util_id) = dst_rank;
+        /* Store ordering unnecessary for dst_rank, so use relaxed store */
+        MPL_atomic_relaxed_store_int(&MPIDI_OFI_REQUEST(sreq, util_id), dst_rank);
         match_bits |= MPIDI_OFI_HUGE_SEND;      /* Add the bit for a huge message */
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[0].tx,
                                           send_buf, MPIDI_OFI_global.max_msg_size, NULL /* desc */ ,

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -147,7 +147,8 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
                  * important information and remove the element from the list. */
                 if (recv_elem->peek) {
                     MPIR_STATUS_SET_COUNT(recv_elem->localreq->status, info->msgsize);
-                    MPIDI_OFI_REQUEST(recv_elem->localreq, util_id) = MPIDI_OFI_PEEK_FOUND;
+                    MPL_atomic_release_store_int(&(MPIDI_OFI_REQUEST(recv_elem->localreq, util_id)),
+                                                 MPIDI_OFI_PEEK_FOUND);
                     MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters,
                                      recv_elem->localreq->handle);
                     MPL_free(recv_elem);


### PR DESCRIPTION
## Pull Request Description
This PR includes two patches that fix intermittent failures of pt2pt tests including multi threaded Probe.

1. Provide error buffer in fi_cq_err_entry
This way, the error buffer is private to each thread. If we
don't pass the buffer when calling fi_cq_readerr, OFI will copy
its internal buffer address and return it to the threads. As a
result, the threads can share the error buffer.

2. Avoid a race condition for MT probe with single vci 
Changes are introduced to ensure that a thread waiting during
a probe call will unblock only after all the related data have
been copied to the request object during progress. 
This fixes an intermittent race condition that can occur under
multi-threaded probe when the threads are sharing a vci. Race can
occur if an OFI peek request submitted by a thread is processed
by a different thread during progress, which is possible when
the threads share a vci.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
