### PR TITLE
Cleanup CH4 AM implementation

### DIFF
--- a/src/mpid/ch4/generic/mpidig_globals.c
+++ b/src/mpid/ch4/generic/mpidig_globals.c
@@ -24,6 +24,7 @@ int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code)
     int size = 0;
     MPIR_Request *sreq = NULL;
     MPIDIG_hdr_t am_hdr;
+    MPIDI_av_entry_t *av;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_COMM_ABORT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_COMM_ABORT);
@@ -46,8 +47,9 @@ int MPIDIG_comm_abort(MPIR_Comm * comm, int exit_code)
         sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2);
         MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-        mpi_errno = MPIDI_NM_am_isend(dest, comm, MPIDIG_COMM_ABORT, &am_hdr,
-                                      sizeof(am_hdr), NULL, 0, MPI_INT, sreq);
+        av = MPIDIU_comm_rank_to_av(comm, dest);
+        mpi_errno = MPIDI_NM_am_isend(dest, comm, MPIDIG_COMM_ABORT, &am_hdr, sizeof(am_hdr), NULL,
+                                      0, MPI_INT, sreq, av);
         if (mpi_errno)
             continue;
         else

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -66,7 +66,8 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
     }
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_av_is_local(addr)) {
-        mpi_errno = MPIDI_SHM_am_isend(rank, comm, type, hdr, hdr_sz, buf, count, datatype, sreq);
+        mpi_errno = MPIDI_SHM_am_isend(rank, comm, type, hdr, hdr_sz, buf, count, datatype, sreq,
+                                       addr);
     } else
 #endif
     {

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -14,6 +14,9 @@
 
 #include "ch4_impl.h"
 
+#define MPIDI_NONBLOCKING 0
+#define MPIDI_BLOCKING    1
+
 static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                     int rank, int tag, MPIR_Comm * comm, int context_offset,
                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
@@ -67,7 +70,8 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
     } else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend(rank, comm, type, hdr, hdr_sz, buf, count, datatype, sreq);
+        mpi_errno = MPIDI_NM_am_isend(rank, comm, type, hdr, hdr_sz, buf, count, datatype, sreq,
+                                      addr);
     }
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -538,6 +538,10 @@ typedef struct MPIDI_av_entry {
 #ifdef MPIDI_BUILD_CH4_LOCALITY_INFO
     MPIDI_locality_t is_local;
 #endif
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    union {
+    MPIDI_SHM_ADDR_DECL} shm;
+#endif
 } MPIDI_av_entry_t;
 
 typedef struct {

--- a/src/mpid/ch4/include/shmpre.h
+++ b/src/mpid/ch4/include/shmpre.h
@@ -34,6 +34,8 @@
 #define MPIDI_SHM_WIN_DECL           MPIDI_POSIX_win_t posix;   \
                                      MPIDI_SHM_XPMEM_WIN_DECL
 
+#define MPIDI_SHM_ADDR_DECL          MPIDI_POSIX_addr_t posix;
+
 #define MPIDI_SHM_REQUEST(req, field)  ((req)->dev.ch4.am.shm_am.field)
 
 #endif /* SHMPRE_H_INCLUDED */

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -30,19 +30,22 @@ typedef int (*MPIDI_NM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_NM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info, int root,
                                            MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_NM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                       const void *am_hdr, size_t am_hdr_sz);
+                                       const void *am_hdr, size_t am_hdr_sz, MPIDI_av_entry_t * av);
 typedef int (*MPIDI_NM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
                                     size_t am_hdr_sz, const void *data, MPI_Count count,
-                                    MPI_Datatype datatype, MPIR_Request * sreq);
+                                    MPI_Datatype datatype, MPIR_Request * sreq,
+                                    MPIDI_av_entry_t * av);
 typedef int (*MPIDI_NM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
                                      struct iovec * am_hdrs, size_t iov_len, const void *data,
-                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq);
-typedef int (*MPIDI_NM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz);
-typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
+                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq,
+                                     MPIDI_av_entry_t * av);
+typedef int (*MPIDI_NM_am_send_hdr_reply_t) (int src_rank, MPIR_Comm * comm, int handler_id,
+                                             const void *am_hdr, size_t am_hdr_sz,
+                                             MPIDI_av_entry_t * av);
+typedef int (*MPIDI_NM_am_isend_reply_t) (int src_rank, MPIR_Comm * comm,
                                           int handler_id, const void *am_hdr, size_t am_hdr_sz,
                                           const void *data, MPI_Count count, MPI_Datatype datatype,
-                                          MPIR_Request * sreq);
+                                          MPIR_Request * sreq, MPIDI_av_entry_t * av);
 typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
 typedef int (*MPIDI_NM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx, int *lpid_ptr,
                                          bool is_remote);
@@ -652,25 +655,31 @@ int MPIDI_NM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root, 
                              MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
                                                   const void *am_hdr,
-                                                  size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                  size_t am_hdr_sz,
+                                                  MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
                                                MPI_Datatype datatype,
-                                               MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIR_Request * sreq,
+                                               MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
                                                 MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
+                                                MPIR_Request * sreq,
+                                                MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
                                                         int handler_id, const void *am_hdr,
-                                                        size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+                                                        size_t am_hdr_sz, MPIDI_av_entry_t * av)
+    MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(int src_rank, MPIR_Comm * comm,
                                                      int handler_id, const void *am_hdr,
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                     MPIR_Request * sreq,
+                                                     MPIDI_av_entry_t *
+                                                     av) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr,

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -17,14 +17,15 @@
 #ifndef NETMOD_DISABLE_INLINES
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                  const void *am_hdr, size_t am_hdr_sz)
+                                                  const void *am_hdr, size_t am_hdr_sz,
+                                                  MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
 
-    ret = MPIDI_NM_func->am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_NM_func->am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     return ret;
@@ -33,7 +34,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, in
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                const void *am_hdr, size_t am_hdr_sz,
                                                const void *data, MPI_Count count,
-                                               MPI_Datatype datatype, MPIR_Request * sreq)
+                                               MPI_Datatype datatype, MPIR_Request * sreq,
+                                               MPIDI_av_entry_t * av)
 {
     int ret;
 
@@ -41,7 +43,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
     ret = MPIDI_NM_func->am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count, datatype,
-                                  sreq);
+                                  sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
     return ret;
@@ -50,7 +52,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int h
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                 struct iovec *am_hdrs, size_t iov_len,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                MPIDI_av_entry_t * av)
 {
     int ret;
 
@@ -58,40 +61,40 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
 
     ret = MPIDI_NM_func->am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count, datatype,
-                                   sreq);
+                                   sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISENDV);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                        int src_rank, int handler_id,
-                                                        const void *am_hdr, size_t am_hdr_sz)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
+                                                        int handler_id, const void *am_hdr,
+                                                        size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
 
-    ret = MPIDI_NM_func->am_send_hdr_reply(context_id, src_rank, handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_NM_func->am_send_hdr_reply(src_rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(int src_rank, MPIR_Comm * comm,
                                                      int handler_id, const void *am_hdr,
                                                      size_t am_hdr_sz, const void *data,
                                                      MPI_Count count, MPI_Datatype datatype,
-                                                     MPIR_Request * sreq)
+                                                     MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
-    ret = MPIDI_NM_func->am_isend_reply(context_id, src_rank, handler_id, am_hdr, am_hdr_sz, data,
-                                        count, datatype, sreq);
+    ret = MPIDI_NM_func->am_isend_reply(src_rank, comm, handler_id, am_hdr, am_hdr_sz, data,
+                                        count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     return ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -26,32 +26,26 @@ static inline void MPIDI_NM_am_request_finalize(MPIR_Request * req)
     MPIDI_OFI_am_clear_request(req);
 }
 
-static inline int MPIDI_NM_am_isend(int rank,
-                                    MPIR_Comm * comm,
-                                    int handler_id,
-                                    const void *am_hdr,
-                                    size_t am_hdr_sz,
-                                    const void *data,
-                                    MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
+                                    size_t am_hdr_sz, const void *data, MPI_Count count,
+                                    MPI_Datatype datatype, MPIR_Request * sreq,
+                                    MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_AM_ISEND);
 
-    mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id,
-                                      am_hdr, am_hdr_sz, data, count, datatype, sreq);
+    mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count,
+                                      datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND);
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_am_isendv(int rank,
-                                     MPIR_Comm * comm,
-                                     int handler_id,
-                                     struct iovec *am_hdr,
-                                     size_t iov_len,
-                                     const void *data,
-                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                     struct iovec *am_hdr, size_t iov_len, const void *data,
+                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq,
+                                     MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS, is_allocated;
     size_t am_hdr_sz = 0, i;
@@ -80,8 +74,8 @@ static inline int MPIDI_NM_am_isendv(int rank,
         am_hdr_sz += am_hdr[i].iov_len;
     }
 
-    mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id, am_hdr_buf, am_hdr_sz,
-                                      data, count, datatype, sreq);
+    mpi_errno = MPIDI_OFI_do_am_isend(rank, comm, handler_id, am_hdr_buf, am_hdr_sz, data, count,
+                                      datatype, sreq, av);
 
     if (is_allocated)
         MPL_free(am_hdr_buf);
@@ -92,21 +86,17 @@ static inline int MPIDI_NM_am_isendv(int rank,
     return mpi_errno;
 }
 
-static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id,
-                                          int src_rank,
-                                          int handler_id,
-                                          const void *am_hdr,
-                                          size_t am_hdr_sz,
-                                          const void *data,
-                                          MPI_Count count,
-                                          MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend_reply(int src_rank, MPIR_Comm * comm,
+                                          int handler_id, const void *am_hdr, size_t am_hdr_sz,
+                                          const void *data, MPI_Count count, MPI_Datatype datatype,
+                                          MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_AM_ISEND_REPLY);
 
-    mpi_errno = MPIDI_OFI_do_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id),
-                                      handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
+    mpi_errno = MPIDI_OFI_do_am_isend(src_rank, comm, handler_id, am_hdr, am_hdr_sz, data, count,
+                                      datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_NETMOD_AM_ISEND_REPLY);
     return mpi_errno;
@@ -123,14 +113,13 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
     return MPL_MIN(max_shortsend, max_representable);
 }
 
-static inline int MPIDI_NM_am_send_hdr(int rank,
-                                       MPIR_Comm * comm,
-                                       int handler_id, const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
+                                       const void *am_hdr, size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR);
-    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz);
+    mpi_errno = MPIDI_OFI_do_inject(rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -141,17 +130,16 @@ static inline int MPIDI_NM_am_send_hdr(int rank,
     goto fn_exit;
 }
 
-static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                             int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm, int handler_id,
+                                             const void *am_hdr, size_t am_hdr_sz,
+                                             MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_NETMOD_OFI_AM_SEND_HDR_REPLY);
 
-    mpi_errno = MPIDI_OFI_do_inject(src_rank, MPIDIG_context_id_to_comm(context_id), handler_id,
-                                    am_hdr, am_hdr_sz);
+    mpi_errno = MPIDI_OFI_do_inject(src_rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_control.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_control.h
@@ -16,7 +16,8 @@
 static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
                                             char *send_buf,
                                             size_t msgsize,
-                                            int rank, MPIR_Comm * comm_ptr, MPIR_Request * ackreq)
+                                            int rank, MPIR_Comm * comm_ptr, MPIR_Request * ackreq,
+                                            MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
@@ -26,12 +27,11 @@ static inline int MPIDI_OFI_do_control_send(MPIDI_OFI_send_control_t * control,
     control->send_buf = (uintptr_t) send_buf;
     control->msgsize = msgsize;
     control->comm_id = comm_ptr->context_id;
-    control->endpoint_id = MPIDI_OFI_comm_to_ep(comm_ptr, comm_ptr->rank);
+    control->endpoint_id = MPIDI_OFI_av_to_ep(&MPIDI_OFI_AV(av));
     control->ackreq = ackreq;
 
-    mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr,
-                                    MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                    (void *) control, sizeof(*control));
+    mpi_errno = MPIDI_OFI_do_inject(rank, comm_ptr, MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
+                                    (void *) control, sizeof(*control), av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_CONTROL_SEND);
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -408,6 +408,7 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_huge_recv_t *recv_elem = (MPIDI_OFI_huge_recv_t *) req;
     uint64_t remote_key;
+    MPIDI_av_entry_t *av;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_GETHUGE_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_GETHUGE_EVENT);
 
@@ -430,9 +431,10 @@ int MPIDI_OFI_get_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
             recv_elem->wc.len = recv_elem->cur_offset;
             recv_elem->done_fn(&recv_elem->wc, recv_elem->localreq, recv_elem->event_id);
             ctrl.type = MPIDI_OFI_CTRL_HUGEACK;
+            av = MPIDIU_comm_rank_to_av(recv_elem->comm_ptr, recv_elem->remote_info.origin_rank);
             mpi_errno =
                 MPIDI_OFI_do_control_send(&ctrl, NULL, 0, recv_elem->remote_info.origin_rank,
-                                          recv_elem->comm_ptr, recv_elem->remote_info.ackreq);
+                                          recv_elem->comm_ptr, recv_elem->remote_info.ackreq, av);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPIDIU_map_erase(MPIDI_OFI_COMM(recv_elem->comm_ptr).huge_recv_counters, key_to_erase);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ctrl.tag = tag;
 
         /* Send information about the memory region here to get the lmt going. */
-        mpi_errno = MPIDI_OFI_do_control_send(&ctrl, send_buf, data_sz, dst_rank, comm, sreq);
+        mpi_errno = MPIDI_OFI_do_control_send(&ctrl, send_buf, data_sz, dst_rank, comm, sreq, addr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -13,37 +13,28 @@
 
 #include "stubnm_impl.h"
 
-static inline int MPIDI_NM_am_isend(int rank,
-                                    MPIR_Comm * comm,
-                                    int handler_id,
-                                    const void *am_hdr,
-                                    size_t am_hdr_sz,
-                                    const void *data,
-                                    MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend(int rank, MPIR_Comm * comm, int handler_id, const void *am_hdr,
+                                    size_t am_hdr_sz, const void *data, MPI_Count count,
+                                    MPI_Datatype datatype, MPIR_Request * sreq,
+                                    MPIDI_av_entry_t * av)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_NM_am_isendv(int rank,
-                                     MPIR_Comm * comm,
-                                     int handler_id,
-                                     struct iovec *am_hdr,
-                                     size_t iov_len,
-                                     const void *data,
-                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
+                                     struct iovec *am_hdr, size_t iov_len, const void *data,
+                                     MPI_Count count, MPI_Datatype datatype, MPIR_Request * sreq,
+                                     MPIDI_av_entry_t * av)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
-                                          int handler_id,
-                                          const void *am_hdr,
-                                          size_t am_hdr_sz,
-                                          const void *data,
-                                          MPI_Count count,
-                                          MPI_Datatype datatype, MPIR_Request * sreq)
+static inline int MPIDI_NM_am_isend_reply(int src_rank, MPIR_Comm * comm, int handler_id,
+                                          const void *am_hdr, size_t am_hdr_sz, const void *data,
+                                          MPI_Count count, MPI_Datatype datatype,
+                                          MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
@@ -55,16 +46,16 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
     return 0;
 }
 
-static inline int MPIDI_NM_am_send_hdr(int rank,
-                                       MPIR_Comm * comm,
-                                       int handler_id, const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
+                                       const void *am_hdr, size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;
 }
 
-static inline int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
-                                             int handler_id, const void *am_hdr, size_t am_hdr_sz)
+static inline int MPIDI_NM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm, int handler_id,
+                                             const void *am_hdr, size_t am_hdr_sz,
+                                             MPIDI_av_entry_t * av)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -31,22 +31,25 @@ typedef int (*MPIDI_SHM_mpi_close_port_t) (const char *port_name);
 typedef int (*MPIDI_SHM_mpi_comm_accept_t) (const char *port_name, MPIR_Info * info,
                                             int root, MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr);
 typedef int (*MPIDI_SHM_am_send_hdr_t) (int rank, MPIR_Comm * comm, int handler_id,
-                                        const void *am_hdr, size_t am_hdr_sz);
+                                        const void *am_hdr, size_t am_hdr_sz,
+                                        MPIDI_av_entry_t * av);
 typedef int (*MPIDI_SHM_am_isend_t) (int rank, MPIR_Comm * comm, int handler_id,
                                      const void *am_hdr, size_t am_hdr_sz,
                                      const void *data, MPI_Count count,
-                                     MPI_Datatype datatype, MPIR_Request * sreq);
+                                     MPI_Datatype datatype, MPIR_Request * sreq,
+                                     MPIDI_av_entry_t * av);
 typedef int (*MPIDI_SHM_am_isendv_t) (int rank, MPIR_Comm * comm, int handler_id,
                                       struct iovec * am_hdrs, size_t iov_len,
                                       const void *data, MPI_Count count,
-                                      MPI_Datatype datatype, MPIR_Request * sreq);
-typedef int (*MPIDI_SHM_am_send_hdr_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                              int handler_id, const void *am_hdr, size_t am_hdr_sz);
-typedef int (*MPIDI_SHM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_rank,
-                                           int handler_id, const void *am_hdr,
-                                           size_t am_hdr_sz, const void *data,
+                                      MPI_Datatype datatype, MPIR_Request * sreq,
+                                      MPIDI_av_entry_t * av);
+typedef int (*MPIDI_SHM_am_send_hdr_reply_t) (int src_rank, MPIR_Comm * comm, int handler_id,
+                                              const void *am_hdr, size_t am_hdr_sz,
+                                              MPIDI_av_entry_t * av);
+typedef int (*MPIDI_SHM_am_isend_reply_t) (int src_rank, MPIR_Comm * comm, int handler_id,
+                                           const void *am_hdr, size_t am_hdr_sz, const void *data,
                                            MPI_Count count, MPI_Datatype datatype,
-                                           MPIR_Request * sreq);
+                                           MPIR_Request * sreq, MPIDI_av_entry_t * av);
 typedef size_t(*MPIDI_SHM_am_hdr_max_sz_t) (void);
 typedef int (*MPIDI_SHM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx,
                                           int *lpid_ptr, bool is_remote);
@@ -580,26 +583,28 @@ int MPIDI_SHM_mpi_close_port(const char *port_name);
 int MPIDI_SHM_mpi_comm_accept(const char *port_name, MPIR_Info * info, int root, MPIR_Comm * comm,
                               MPIR_Comm ** newcomm_ptr);
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr,
-                                                   size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
+                                                   const void *am_hdr, size_t am_hdr_sz,
+                                                   MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype,
-                                                MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype,
-                                                 MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id, int src_rank,
+                                                 MPI_Datatype datatype, MPIR_Request * sreq,
+                                                 MPIDI_av_entry_t * av) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
                                                          int handler_id, const void *am_hdr,
-                                                         size_t am_hdr_sz) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+                                                         size_t am_hdr_sz, MPIDI_av_entry_t * av)
+    MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(int src_rank, MPIR_Comm * comm,
                                                       int handler_id, const void *am_hdr,
                                                       size_t am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
-                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
+                                                      MPIR_Request * sreq, MPIDI_av_entry_t * av)
+    MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr,

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -81,15 +81,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_request(const void *am_hdr, 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
-                                                  MPIR_Comm * comm,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank, MPIR_Comm * comm,
                                                   MPIDI_POSIX_am_header_kind_t kind,
-                                                  int handler_id,
-                                                  const void *am_hdr,
-                                                  size_t am_hdr_sz,
-                                                  const void *data,
-                                                  MPI_Count count,
-                                                  MPI_Datatype datatype, MPIR_Request * sreq)
+                                                  int handler_id, const void *am_hdr,
+                                                  size_t am_hdr_sz, const void *data,
+                                                  MPI_Count count, MPI_Datatype datatype,
+                                                  MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     int result = MPIDI_POSIX_OK;
@@ -101,7 +98,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     uint8_t *send_buf = NULL;
     MPIDI_POSIX_am_header_t *msg_hdr_p = &msg_hdr;
     MPIDI_POSIX_am_request_header_t *curr_sreq_hdr = NULL;
-    const int grank = MPIDIU_rank_to_lpid(rank, comm);
+    const int grank = MPIDI_POSIX_AV_TO_GRANK(av);
     struct iovec iov_left[2];
     struct iovec *iov_left_ptr;
     size_t iov_num_left;
@@ -219,15 +216,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
-                                                   MPIR_Comm * comm,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank, MPIR_Comm * comm,
                                                    MPIDI_POSIX_am_header_kind_t kind,
-                                                   int handler_id,
-                                                   struct iovec *am_hdr,
-                                                   size_t iov_len,
-                                                   const void *data,
-                                                   MPI_Count count,
-                                                   MPI_Datatype datatype, MPIR_Request * sreq)
+                                                   int handler_id, struct iovec *am_hdr,
+                                                   size_t iov_len, const void *data,
+                                                   MPI_Count count, MPI_Datatype datatype,
+                                                   MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_allocated;
@@ -259,7 +253,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
     }
 
     mpi_errno = MPIDI_POSIX_am_isend(rank, comm, kind, handler_id, am_hdr_buf, am_hdr_sz,
-                                     data, count, datatype, sreq);
+                                     data, count, datatype, sreq, av);
 
     if (is_allocated)
         MPL_free(am_hdr_buf);
@@ -271,22 +265,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isendv(int rank,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend_reply(int src_rank, MPIR_Comm * comm,
                                                         MPIDI_POSIX_am_header_kind_t kind,
-                                                        int handler_id,
-                                                        const void *am_hdr,
-                                                        size_t am_hdr_sz,
-                                                        const void *data,
-                                                        MPI_Count count,
-                                                        MPI_Datatype datatype, MPIR_Request * sreq)
+                                                        int handler_id, const void *am_hdr,
+                                                        size_t am_hdr_sz, const void *data,
+                                                        MPI_Count count, MPI_Datatype datatype,
+                                                        MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_POSIX_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_POSIX_AM_ISEND_REPLY);
 
-    mpi_errno = MPIDI_POSIX_am_isend(src_rank, MPIDIG_context_id_to_comm(context_id), kind,
-                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
+    mpi_errno = MPIDI_POSIX_am_isend(src_rank, comm, kind, handler_id, am_hdr, am_hdr_sz, data,
+                                     count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POSIX_AM_ISEND_REPLY);
 
@@ -346,11 +338,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
-                                                     MPIR_Comm * comm,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank, MPIR_Comm * comm,
                                                      MPIDI_POSIX_am_header_kind_t kind,
-                                                     int handler_id,
-                                                     const void *am_hdr, size_t am_hdr_sz)
+                                                     int handler_id, const void *am_hdr,
+                                                     size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
     int result = MPIDI_POSIX_OK;
@@ -359,7 +350,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
     struct iovec iov_left[1];
     struct iovec *iov_left_ptr = iov_left;
     size_t iov_num_left = 1;
-    const int grank = MPIDIU_rank_to_lpid(rank, comm);
+    const int grank = MPIDI_POSIX_AV_TO_GRANK(av);
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_POSIX_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_POSIX_AM_SEND_HDR);
@@ -403,20 +394,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                           int src_rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
                                                            MPIDI_POSIX_am_header_kind_t kind,
                                                            int handler_id, const void *am_hdr,
-                                                           size_t am_hdr_sz)
+                                                           size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_POSIX_SEND_AM_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_POSIX_SEND_AM_HDR_REPLY);
 
-    mpi_errno = MPIDI_POSIX_am_send_hdr(src_rank,
-                                        MPIDIG_context_id_to_comm(context_id),
-                                        kind, handler_id, am_hdr, am_hdr_sz);
+    mpi_errno = MPIDI_POSIX_am_send_hdr(src_rank, comm, kind, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POSIX_SEND_AM_HDR_REPLY);
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -118,6 +118,10 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *n_vcis_provided, int *tag
         MPIDI_POSIX_global.active_rreq[i] = NULL;
     }
 
+    for (i = 0; i < MPIR_Process.size; ++i) {
+        MPIDI_POSIX_AV(&MPIDIU_get_av(0, i)) = i;
+    }
+
     choose_posix_eager();
 
     mpi_errno = MPIDI_POSIX_eager_init(rank, size);

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -138,6 +138,8 @@ typedef struct {
     MPL_proc_mutex_t *shm_mutex_ptr;    /* interprocess mutex for shm atomic RMA */
 } MPIDI_POSIX_win_t;
 
+typedef int MPIDI_POSIX_addr_t;
+
 /*
  * Wrapper routines of process mutex for shared memory RMA.
  * Called by both POSIX RMA and fallback AM handlers through CS hooks.

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -29,6 +29,10 @@ enum {
 #define MPIDI_POSIX_AMREQUEST_HDR_PTR(req)    ((req)->dev.ch4.am.shm_am.posix.req_hdr)
 #define MPIDI_POSIX_REQUEST(req, field)       ((req)->dev.ch4.shm.posix.field)
 #define MPIDI_POSIX_COMM(comm)                (&(comm)->dev.ch4.shm.posix)
+#define MPIDI_POSIX_AV(av)                    ((av)->shm.posix)
+
+#define MPIDI_POSIX_AV_TO_GRANK(av) (MPIDI_POSIX_AV((av)))
+
 
 typedef struct {
     MPIDIU_buf_pool_t *am_buf_pool;

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -20,17 +20,18 @@
 #include "../xpmem/shm_inline.h"
 #endif
 
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
                                                    int handler_id, const void *am_hdr,
-                                                   size_t am_hdr_sz)
+                                                   size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
 
-    ret = MPIDI_POSIX_am_send_hdr(rank, comm, MPIDI_POSIX_AM_HDR_CH4,
-                                  handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_POSIX_am_send_hdr(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr,
+                                  am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
     return ret;
@@ -39,15 +40,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND);
 
-    ret = MPIDI_POSIX_am_isend(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr,
-                               am_hdr_sz, data, count, datatype, sreq);
+    ret = MPIDI_POSIX_am_isend(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr, am_hdr_sz,
+                               data, count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND);
     return ret;
@@ -56,49 +58,50 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq)
+                                                 MPI_Datatype datatype, MPIR_Request * sreq,
+                                                 MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISENDV);
 
-    ret = MPIDI_POSIX_am_isendv(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdrs,
-                                iov_len, data, count, datatype, sreq);
+    ret = MPIDI_POSIX_am_isendv(rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdrs, iov_len,
+                                data, count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISENDV);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                         int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
+                                                         int handler_id, const void *am_hdr,
+                                                         size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
 
-    ret = MPIDI_POSIX_am_send_hdr_reply(context_id, src_rank, MPIDI_POSIX_AM_HDR_CH4,
-                                        handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_POSIX_am_send_hdr_reply(src_rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr,
+                                        am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id,
-                                                      int src_rank, int handler_id,
-                                                      const void *am_hdr, size_t am_hdr_sz,
-                                                      const void *data, MPI_Count count,
-                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(int src_rank, MPIR_Comm * comm,
+                                                      int handler_id, const void *am_hdr,
+                                                      size_t am_hdr_sz, const void *data,
+                                                      MPI_Count count, MPI_Datatype datatype,
+                                                      MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
 
-    ret = MPIDI_POSIX_am_isend_reply(context_id, src_rank, MPIDI_POSIX_AM_HDR_CH4,
-                                     handler_id, am_hdr, am_hdr_sz, data, count, datatype, sreq);
+    ret = MPIDI_POSIX_am_isend_reply(src_rank, comm, MPIDI_POSIX_AM_HDR_CH4, handler_id, am_hdr,
+                                     am_hdr_sz, data, count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_control.h
+++ b/src/mpid/ch4/shm/src/shm_control.h
@@ -14,12 +14,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_do_ctrl_send(int rank, MPIR_Comm * comm,
                                                     int ctrl_id, void *ctrl_hdr)
 {
     int ret;
+    MPIDI_av_entry_t *av;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
 
-    ret = MPIDI_POSIX_am_send_hdr(rank, comm, MPIDI_POSIX_AM_HDR_SHM,
-                                  ctrl_id, ctrl_hdr, sizeof(MPIDI_SHM_ctrl_hdr_t));
+    av = MPIDIU_comm_rank_to_av(comm, rank);
+
+    ret = MPIDI_POSIX_am_send_hdr(rank, comm, MPIDI_POSIX_AM_HDR_SHM, ctrl_id, ctrl_hdr,
+                                  sizeof(MPIDI_SHM_ctrl_hdr_t), av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_DO_CTRL_SEND);
     return ret;

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -20,14 +20,15 @@
 #ifndef SHM_DISABLE_INLINES
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, int handler_id,
-                                                   const void *am_hdr, size_t am_hdr_sz)
+                                                   const void *am_hdr, size_t am_hdr_sz,
+                                                   MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
 
-    ret = MPIDI_SHM_src_funcs.am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_SHM_src_funcs.am_send_hdr(rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_SEND_HDR);
     return ret;
@@ -36,16 +37,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr(int rank, MPIR_Comm * comm, i
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int handler_id,
                                                 const void *am_hdr, size_t am_hdr_sz,
                                                 const void *data, MPI_Count count,
-                                                MPI_Datatype datatype, MPIR_Request * sreq)
+                                                MPI_Datatype datatype, MPIR_Request * sreq,
+                                                MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND);
 
-    ret =
-        MPIDI_SHM_src_funcs.am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count,
-                                     datatype, sreq);
+    ret = MPIDI_SHM_src_funcs.am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, data, count,
+                                       datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND);
     return ret;
@@ -54,51 +55,49 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend(int rank, MPIR_Comm * comm, int 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isendv(int rank, MPIR_Comm * comm, int handler_id,
                                                  struct iovec *am_hdrs, size_t iov_len,
                                                  const void *data, MPI_Count count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq)
+                                                 MPI_Datatype datatype, MPIR_Request * sreq,
+                                                 MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISENDV);
 
-    ret =
-        MPIDI_SHM_src_funcs.am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count,
-                                      datatype, sreq);
+    ret = MPIDI_SHM_src_funcs.am_isendv(rank, comm, handler_id, am_hdrs, iov_len, data, count,
+                                        datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISENDV);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(MPIR_Context_id_t context_id,
-                                                         int src_rank, int handler_id,
-                                                         const void *am_hdr, size_t am_hdr_sz)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_send_hdr_reply(int src_rank, MPIR_Comm * comm,
+                                                         int handler_id, const void *am_hdr,
+                                                         size_t am_hdr_sz, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
 
-    ret =
-        MPIDI_SHM_src_funcs.am_send_hdr_reply(context_id, src_rank, handler_id, am_hdr, am_hdr_sz);
+    ret = MPIDI_SHM_src_funcs.am_send_hdr_reply(src_rank, comm, handler_id, am_hdr, am_hdr_sz, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_SEND_HDR_REPLY);
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_id, int src_rank,
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(int src_rank, MPIR_Comm * comm,
                                                       int handler_id, const void *am_hdr,
                                                       size_t am_hdr_sz, const void *data,
                                                       MPI_Count count, MPI_Datatype datatype,
-                                                      MPIR_Request * sreq)
+                                                      MPIR_Request * sreq, MPIDI_av_entry_t * av)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
 
-    ret =
-        MPIDI_SHM_src_funcs.am_isend_reply(context_id, src_rank, handler_id, am_hdr, am_hdr_sz,
-                                           data, count, datatype, sreq);
+    ret = MPIDI_SHM_src_funcs.am_isend_reply(src_rank, comm, handler_id, am_hdr, am_hdr_sz,
+                                             data, count, datatype, sreq, av);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SHM_AM_ISEND_REPLY);
     return ret;

--- a/src/mpid/ch4/src/ch4_impl.c
+++ b/src/mpid/ch4/src/ch4_impl.c
@@ -12,7 +12,7 @@
 #include "mpidimpl.h"
 #include "ch4_impl.h"
 
-int MPIDIG_get_context_index(uint64_t context_id)
+int MPIDIG_get_context_index(MPIR_Context_id_t context_id)
 {
     int raw_prefix, idx, bitpos, gen_id;
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -16,7 +16,7 @@
 #include "mpidu_shm.h"
 
 int MPIDI_Progress_test(int flags);
-int MPIDIG_get_context_index(uint64_t context_id);
+int MPIDIG_get_context_index(MPIR_Context_id_t context_id);
 uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);
 
 /* Static inlines */
@@ -40,7 +40,7 @@ static inline int MPIDI_prequest_get_context_offset(MPIR_Request * preq)
     return context_offset;
 }
 
-static inline MPIR_Comm *MPIDIG_context_id_to_comm(uint64_t context_id)
+static inline MPIR_Comm *MPIDIG_context_id_to_comm(MPIR_Context_id_t context_id)
 {
     int comm_idx = MPIDIG_get_context_index(context_id);
     int subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, context_id);
@@ -58,7 +58,7 @@ static inline MPIR_Comm *MPIDIG_context_id_to_comm(uint64_t context_id)
     return ret;
 }
 
-static inline MPIDIG_rreq_t **MPIDIG_context_id_to_uelist(uint64_t context_id)
+static inline MPIDIG_rreq_t **MPIDIG_context_id_to_uelist(MPIR_Context_id_t context_id)
 {
     int comm_idx = MPIDIG_get_context_index(context_id);
     int subcomm_type = MPIR_CONTEXT_READ_FIELD(SUBCOMM, context_id);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -299,6 +299,9 @@ static int init_builtin_comms(void)
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
     MPIR_ERR_CHECK(mpi_errno);
 
+    MPIDI_global.my_av = MPIDIU_comm_rank_to_av(MPIR_Process.comm_world,
+                                                MPIR_Process.comm_world->rank);
+
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -322,6 +322,9 @@ typedef struct MPIDI_CH4_Global_t {
     MPIDI_workq_t workqueue;
 #endif
     MPIDI_CH4_configurations_t settings;
+
+    /* cache source av */
+    MPIDI_av_entry_t *my_av;
 } MPIDI_CH4_Global_t;
 extern MPIDI_CH4_Global_t MPIDI_global;
 #ifdef MPL_USE_DBG_LOGGING

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -33,11 +33,11 @@ int MPIDIG_do_long_ack(MPIR_Request * rreq)
     MPIR_Comm *comm = MPIDIG_context_id_to_comm(MPIDIG_REQUEST(rreq, context_id));
     av = MPIDIU_comm_rank_to_av(comm, rank);
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr));
+    mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr), av);
 #else
     if (MPIDI_REQUEST(rreq, is_local)) {
-        mpi_errno = MPIDI_SHM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK,
-                                          &am_hdr, sizeof(am_hdr));
+        mpi_errno = MPIDI_SHM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr),
+                                          av);
     } else {
         mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_ACK, &am_hdr, sizeof(am_hdr),
                                          av);
@@ -791,12 +791,11 @@ int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void **data
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(sreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(context_id,
-                                     MPIDIG_REQUEST(sreq, rank), MPIDIG_SEND_LONG_LMT,
+            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(sreq, rank), comm, MPIDIG_SEND_LONG_LMT,
                                      &send_hdr, sizeof(send_hdr),
                                      MPIDIG_REQUEST(sreq, req->lreq).src_buf,
                                      MPIDIG_REQUEST(sreq, req->lreq).count,
-                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq);
+                                     MPIDIG_REQUEST(sreq, req->lreq).datatype, sreq, av);
     else
 #endif
     {

--- a/src/mpid/ch4/src/ch4r_proc.h
+++ b/src/mpid/ch4/src/ch4r_proc.h
@@ -31,6 +31,11 @@ int MPIDIU_get_max_node_id(MPIR_Comm * comm, int *max_id_p);
 int MPIDIU_build_nodemap(int myrank, MPIR_Comm * comm, int sz, int *out_nodemap, int *sz_out);
 int MPIDIU_build_nodemap_avtid(int myrank, MPIR_Comm * comm, int sz, int avtid);
 
+MPL_STATIC_INLINE_PREFIX MPIDI_av_entry_t *MPIDIU_get_my_av()
+{
+    return MPIDI_global.my_av;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank, int *idx,
                                                      int *avtid)
 {

--- a/src/mpid/ch4/src/ch4r_recv.h
+++ b/src/mpid/ch4/src/ch4r_recv.h
@@ -33,9 +33,8 @@ static inline int MPIDIG_reply_ssend(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(rreq, context_id),
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_SSEND_ACK, &ack_msg,
-                                     sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq);
+            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_SSEND_ACK, &ack_msg,
+                                     sizeof(ack_msg), NULL, 0, MPI_DATATYPE_NULL, rreq, av);
     else
 #endif
     {

--- a/src/mpid/ch4/src/ch4r_rma.h
+++ b/src/mpid/ch4/src/ch4r_rma.h
@@ -90,9 +90,9 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
-                                           &am_hdr, sizeof(am_hdr), origin_addr,
-                                           origin_count, origin_datatype, sreq);
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_REQ, &am_hdr,
+                                           sizeof(am_hdr), origin_addr, origin_count,
+                                           origin_datatype, sreq, av);
         else
 #endif
         {
@@ -137,9 +137,8 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
     if ((am_iov[0].iov_len + am_iov[1].iov_len) <= am_hdr_max_size) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_PUT_REQ,
-                                            am_iov, 2, origin_addr, origin_count,
-                                            origin_datatype, sreq);
+            mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_PUT_REQ, am_iov, 2,
+                                            origin_addr, origin_count, origin_datatype, sreq, av);
         else
 #endif
         {
@@ -154,9 +153,9 @@ static inline int MPIDIG_do_put(const void *origin_addr, int origin_count,
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_IOV_REQ,
-                                           &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_IOV_REQ, &am_hdr,
+                                           sizeof(am_hdr), am_iov[1].iov_base, am_iov[1].iov_len,
+                                           MPI_BYTE, sreq, av);
         else
 #endif
         {
@@ -252,9 +251,8 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr,
-                                           MPIDIG_GET_REQ, &am_hdr, sizeof(am_hdr),
-                                           NULL, 0, MPI_DATATYPE_NULL, sreq);
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ, &am_hdr,
+                                           sizeof(am_hdr), NULL, 0, MPI_DATATYPE_NULL, sreq, av);
         else
 #endif
         {
@@ -286,9 +284,9 @@ static inline int MPIDIG_do_get(void *origin_addr, int origin_count, MPI_Datatyp
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (av->is_local)
-        mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ,
-                                       &am_hdr, sizeof(am_hdr), dt_iov,
-                                       sizeof(struct iovec) * am_hdr.n_iov, MPI_BYTE, sreq);
+        mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ, &am_hdr,
+                                       sizeof(am_hdr), dt_iov, sizeof(struct iovec) * am_hdr.n_iov,
+                                       MPI_BYTE, sreq, av);
     else
 #endif
     {
@@ -391,10 +389,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
-                                           &am_hdr, sizeof(am_hdr), origin_addr,
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_REQ, &am_hdr,
+                                           sizeof(am_hdr), origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, av);
         else
 #endif
         {
@@ -443,10 +441,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
     if ((am_iov[0].iov_len + am_iov[1].iov_len) <= am_hdr_max_sz) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_ACC_REQ,
-                                            am_iov, 2, origin_addr,
+            mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_ACC_REQ, am_iov, 2,
+                                            origin_addr,
                                             (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                            sreq);
+                                            sreq, av);
         else
 #endif
         {
@@ -463,9 +461,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, int o
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_IOV_REQ,
-                                           &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_IOV_REQ, &am_hdr,
+                                           sizeof(am_hdr), am_iov[1].iov_base, am_iov[1].iov_len,
+                                           MPI_BYTE, sreq, av);
         else
 #endif
         {
@@ -583,10 +581,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
-                                           &am_hdr, sizeof(am_hdr), origin_addr,
+            mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ, &am_hdr,
+                                           sizeof(am_hdr), origin_addr,
                                            (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                           sreq);
+                                           sreq, av);
         else
 #endif
         {
@@ -638,7 +636,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
             mpi_errno = MPIDI_SHM_am_isendv(target_rank, win->comm_ptr, MPIDIG_GET_ACC_REQ,
                                             am_iov, 2, origin_addr,
                                             (op == MPI_NO_OP) ? 0 : origin_count, origin_datatype,
-                                            sreq);
+                                            sreq, av);
         else
 #endif
         {
@@ -657,7 +655,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
         if (av->is_local)
             mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_IOV_REQ,
                                            &am_hdr, sizeof(am_hdr), am_iov[1].iov_base,
-                                           am_iov[1].iov_len, MPI_BYTE, sreq);
+                                           am_iov[1].iov_len, MPI_BYTE, sreq, av);
         else
 #endif
         {
@@ -928,8 +926,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (av->is_local)
-        mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_CSWAP_REQ,
-                                       &am_hdr, sizeof(am_hdr), (char *) p_data, 2, datatype, sreq);
+        mpi_errno = MPIDI_SHM_am_isend(target_rank, win->comm_ptr, MPIDIG_CSWAP_REQ, &am_hdr,
+                                       sizeof(am_hdr), (char *) p_data, 2, datatype, sreq, av);
     else
 #endif
     {

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -243,10 +243,8 @@ static int ack_put(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_PUT_ACK, &ack_msg,
+                                        sizeof(ack_msg), av);
     else
 #endif
     {
@@ -289,10 +287,9 @@ static int ack_cswap(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(context_id,
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_CSWAP_ACK, &ack_msg,
+            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_CSWAP_ACK, &ack_msg,
                                      sizeof(ack_msg), result_addr, 1,
-                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq);
+                                     MPIDIG_REQUEST(rreq, req->creq.datatype), rreq, av);
     else
 #endif
     {
@@ -328,10 +325,8 @@ static int ack_acc(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_ACC_ACK, &ack_msg,
+                                        sizeof(ack_msg), av);
     else
 #endif
     {
@@ -369,11 +364,10 @@ static int ack_get_acc(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_isend_reply(context_id,
-                                     MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_ACK,
+            MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_GET_ACC_ACK,
                                      &ack_msg, sizeof(ack_msg),
                                      MPIDIG_REQUEST(rreq, req->areq.data),
-                                     MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq);
+                                     MPIDIG_REQUEST(rreq, req->areq.data_sz), MPI_BYTE, rreq, av);
     else
 #endif
     {
@@ -429,8 +423,8 @@ static int win_lock_advance(MPIR_Win * win)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
-                                                    lock->rank, handler_id, &msg, sizeof(msg));
+            mpi_errno = MPIDI_SHM_am_send_hdr_reply(lock->rank, win->comm_ptr, handler_id, &msg,
+                                                    sizeof(msg), av);
         else
 #endif
         {
@@ -522,9 +516,8 @@ static void win_unlock_proc(const MPIDIG_win_cntrl_msg_t * info, int is_local, M
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context(win),
-                                                info->origin_rank,
-                                                MPIDIG_WIN_UNLOCK_ACK, &msg, sizeof(msg));
+        mpi_errno = MPIDI_SHM_am_send_hdr_reply(info->origin_rank, win->comm_ptr,
+                                                MPIDIG_WIN_UNLOCK_ACK, &msg, sizeof(msg), av);
     else
 #endif
     {
@@ -839,11 +832,11 @@ static int get_target_cmpl_cb(MPIR_Request * req)
     if (MPIDIG_REQUEST(req, req->greq.n_iov) == 0) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (MPIDI_REQUEST(req, is_local))
-            mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
-                                                 MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
+            mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(req, rank), comm, MPIDIG_GET_ACK,
+                                                 &get_ack, sizeof(get_ack),
                                                  (void *) MPIDIG_REQUEST(req, req->greq.addr),
                                                  MPIDIG_REQUEST(req, req->greq.count),
-                                                 MPIDIG_REQUEST(req, req->greq.datatype), req);
+                                                 MPIDIG_REQUEST(req, req->greq.datatype), req, av);
         else
 #endif
         {
@@ -882,9 +875,9 @@ static int get_target_cmpl_cb(MPIR_Request * req)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(req, is_local))
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
-                                             MPIDIG_GET_ACK, &get_ack, sizeof(get_ack), p_data,
-                                             data_sz, MPI_BYTE, req);
+        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(req, rank), comm, MPIDIG_GET_ACK,
+                                             &get_ack, sizeof(get_ack), p_data, data_sz, MPI_BYTE,
+                                             req, av);
     else
 #endif
     {
@@ -946,10 +939,8 @@ static int put_iov_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->preq.win_ptr)),
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_PUT_IOV_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_PUT_IOV_ACK,
+                                        &ack_msg, sizeof(ack_msg), av);
     else
 #endif
     {
@@ -986,10 +977,8 @@ static int acc_iov_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_ACC_IOV_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_ACC_IOV_ACK,
+                                        &ack_msg, sizeof(ack_msg), av);
     else
 #endif
     {
@@ -1026,10 +1015,8 @@ static int get_acc_iov_target_cmpl_cb(MPIR_Request * rreq)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (MPIDI_REQUEST(rreq, is_local))
         mpi_errno =
-            MPIDI_SHM_am_send_hdr_reply(MPIDIG_win_to_context
-                                        (MPIDIG_REQUEST(rreq, req->areq.win_ptr)),
-                                        MPIDIG_REQUEST(rreq, rank), MPIDIG_GET_ACC_IOV_ACK,
-                                        &ack_msg, sizeof(ack_msg));
+            MPIDI_SHM_am_send_hdr_reply(MPIDIG_REQUEST(rreq, rank), comm, MPIDIG_GET_ACC_IOV_ACK,
+                                        &ack_msg, sizeof(ack_msg), av);
     else
 #endif
     {
@@ -1593,13 +1580,12 @@ int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id,
-                                             MPIDIG_REQUEST(origin_req, rank),
+        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(origin_req, rank), comm,
                                              MPIDIG_PUT_DAT_REQ, &dat_msg, sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->preq.origin_datatype),
-                                             rreq);
+                                             rreq, av);
     else
 #endif
     {
@@ -1654,14 +1640,12 @@ int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id,
-                                             MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_ACC_DAT_REQ,
-                                             &dat_msg, sizeof(dat_msg),
+        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(origin_req, rank), comm,
+                                             MPIDIG_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
+                                             rreq, av);
     else
 #endif
     {
@@ -1717,14 +1701,12 @@ int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **da
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (is_local)
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id,
-                                             MPIDIG_REQUEST(origin_req, rank),
-                                             MPIDIG_GET_ACC_DAT_REQ,
-                                             &dat_msg, sizeof(dat_msg),
+        mpi_errno = MPIDI_SHM_am_isend_reply(MPIDIG_REQUEST(origin_req, rank), comm,
+                                             MPIDIG_GET_ACC_DAT_REQ, &dat_msg, sizeof(dat_msg),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_addr),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_count),
                                              MPIDIG_REQUEST(origin_req, req->areq.origin_datatype),
-                                             rreq);
+                                             rreq, av);
     else
 #endif
     {

--- a/src/mpid/ch4/src/ch4r_win.h
+++ b/src/mpid/ch4/src/ch4r_win.h
@@ -168,8 +168,8 @@ static inline int MPIDIG_mpi_win_complete(MPIR_Win * win)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_COMPLETE, &msg, sizeof(msg));
+            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr, MPIDIG_WIN_COMPLETE, &msg,
+                                              sizeof(msg), av);
         else
 #endif
         {
@@ -236,8 +236,8 @@ static inline int MPIDIG_mpi_win_post(MPIR_Group * group, int assert, MPIR_Win *
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr,
-                                              MPIDIG_WIN_POST, &msg, sizeof(msg));
+            mpi_errno = MPIDI_SHM_am_send_hdr(peer, win->comm_ptr, MPIDIG_WIN_POST, &msg,
+                                              sizeof(msg), av);
         else
 #endif
         {
@@ -347,7 +347,8 @@ static inline int MPIDIG_mpi_win_lock(int lock_type, int rank, int assert, MPIR_
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (av->is_local)
-        mpi_errno = MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_LOCK, &msg, sizeof(msg));
+        mpi_errno = MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_LOCK, &msg, sizeof(msg),
+                                          av);
     else
 #endif
     {
@@ -426,7 +427,7 @@ static inline int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     if (av->is_local)
         mpi_errno =
-            MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_UNLOCK, &msg, sizeof(msg));
+            MPIDI_SHM_am_send_hdr(rank, win->comm_ptr, MPIDIG_WIN_UNLOCK, &msg, sizeof(msg), av);
     else
 #endif
     {
@@ -684,8 +685,8 @@ static inline int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_UNLOCKALL, &msg, sizeof(msg));
+            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr, MPIDIG_WIN_UNLOCKALL, &msg,
+                                              sizeof(msg), av);
         else
 #endif
         {
@@ -836,8 +837,8 @@ static inline int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
         if (av->is_local)
-            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr,
-                                              MPIDIG_WIN_LOCKALL, &msg, sizeof(msg));
+            mpi_errno = MPIDI_SHM_am_send_hdr(i, win->comm_ptr, MPIDIG_WIN_LOCKALL, &msg,
+                                              sizeof(msg), av);
         else
 #endif
         {


### PR DESCRIPTION
This PR cleans up how the `comm` and `av` are passed in AM code path. The following are the guidelines.

1. `(comm, rank) -> av` translation should always happen at CH4 level (not at netmod, shmmod, or MPIDIG level), therefore, an `av` or `addr` should always be passed along. This is roughly true for the netmod native path and shmmod. The problem is MPIDIG does not take an addr (or av) which this PR aims to fix.

2. Preferring passing `comm` rather than passing `context_id` when possible. Most of our functions take `comm` while only a small fraction of them take `context_id`. This PR makes all of them to take `comm`.

3. For shm, we need to store the "addr" of SHM in AV. For POSIX it is just a global rank. This PR adds that. This avoids the double translation in the SHM AM code.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
