### PR TITLE
Add heterogeneous memory support for win_allocate and win_allocate_shared

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -29,6 +29,7 @@
 #include "uthash.h"
 #include "ch4_coll_params.h"
 #include "ch4i_workq_types.h"
+#include "mpir_hwtopo.h"
 
 #ifdef MPIDI_CH4_USE_MT_DIRECT
 #define MPIDI_CH4_MT_MODEL MPIDI_CH4_MT_DIRECT
@@ -306,6 +307,7 @@ typedef struct MPIDIG_win_info_args_t {
     MPI_Aint accumulate_max_bytes;      /* Non-negative integer, -1 (unlimited) by default.
                                          * TODO: can be set to win_size.*/
     bool disable_shm_accumulate;        /* false by default. */
+    MPIR_hwtopo_type_e bind_memory;
 
     /* alloc_shm: MPICH specific hint (same in CH3).
      * If true, MPICH will try to use shared memory routines for the window.
@@ -393,8 +395,9 @@ typedef struct MPIDIG_win_target {
 
 typedef struct MPIDIG_win_t {
     uint64_t win_id;
-    void *mmap_addr;
-    int64_t mmap_sz;
+    void **mmap_addr;
+    int64_t *mmap_sz;
+    int num_seg;
 
     /* per-window OP completion for fence */
     MPIR_cc_t local_cmpl_cnts;  /* increase at OP issuing, decrease at local completion */


### PR DESCRIPTION
## Pull Request Description

`MPI_Win_allocate/allocate_shared` both use on-node shared memory when allocating memory for intra-node communication. Currently it is not possible placing such memory on devices other than standard DDR memory. This PR adds support for this. 

There are, however, some limitations. One of such limitations is that for symmetric memory allocation in `MPI_Win_allocate` MPICH tries multiple round of collective communication among processes, both on the same as well as remote nodes, in order to reach an agreement on the value of the base address shared by all processes (optimization). If the segment is split to consider NUMA awareness, i.e., multiple NUMA domains on the node (see https://github.com/pmodels/mpich/pull/3916) there will be multiple rounds of collective communication (one for each segment) among processes, which might make `MPI_Win_allocate` unacceptably slow. 

Moreover, nodes might not have the same number of processes or even have different memory topology (e.g., some node might be UMA and some other have different number of NUMAs). In this case the communication among the nodes would be asymmetric, with some of the processes requesting different number of segments. Considering these cases would add unnecessary complexity and probably be of little benefit.

For these reasons in this PR memory binding is enabled in the following cases:
1. Memory binding information is provided by user (either in the form of CVARs or as hints to the `win_alloc` function) and all processes are bound to the same NUMA (equivalent to the case in which NUMA awareness is not available as there is only one shared memory segment required);
2. Memory binding information is provided by user (either in the form of CVARs or as hints to the `win_alloc` function) and processes are bound to different NUMAs. In this case we prioritize memory locality over symmetric memory optimizations (disabling symmetric allocation) and allocate multiple shared memory segments, binding each of them to the corresponding NUMA (since symmetric memory is disabled, shared memory is allocated independently in each node).

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact
Improved intranode communication performance, especially for put operations

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
