### PR TITLE
ch4: always use handoff when workq is configured

### DIFF
--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -244,29 +244,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
                                              MPIR_Comm * comm, int context_offset,
                                              MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
-                                  rank, tag, comm, context_offset, av,
-                                  NULL /*status */ , *req, NULL /*flag */ ,
-                                  NULL /*message */ , NULL /*processed */);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    /* NOTE: When WORKQ is enabled, we always enqueue. However, it probably makes sense
+     *       to directly do lightweight send for small message. It is tricky since the
+     *       threshold for lightweight send is controlled by lower layer. It'll be nice
+     *       if the lower layer expose the threshold.
+     */
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
+                              rank, tag, comm, context_offset, av,
+                              NULL /*status */ , *req, NULL /*flag */ ,
+                              NULL /*message */ , NULL /*processed */);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_send_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_SAFE);
     return mpi_errno;
 
@@ -283,29 +285,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
                                                   MPIDI_av_entry_t * av, MPIR_Request ** req,
                                                   MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SEND_COLL_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm, context_offset, av,
-                                  *req, errflag);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req,
-                                   errflag);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
+                              context_offset, av, *req, errflag);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_send_coll_unsafe(buf, count, datatype, rank, tag, comm,
+                                       context_offset, av, req, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SEND_COLL_SAFE);
     return mpi_errno;
 
@@ -321,29 +320,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
                                               MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
-                                  rank, tag, comm, context_offset, av,
-                                  NULL /*status */ , *req, NULL /*flag */ ,
-                                  NULL /*message */ , NULL /*processed */);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_isend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
+                              rank, tag, comm, context_offset, av,
+                              NULL /*status */ , *req, NULL /*flag */ ,
+                              NULL /*message */ , NULL /*processed */);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_isend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_SAFE);
     return mpi_errno;
 
@@ -360,29 +356,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
                                                    MPIDI_av_entry_t * av, MPIR_Request ** req,
                                                    MPIR_Errflag_t * errflag)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm, context_offset, av,
-                                  *req, errflag);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_isend_coll_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                    req, errflag);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
+                              context_offset, av, *req, errflag);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_isend_coll_unsafe(buf, count, datatype, rank, tag, comm,
+                                        context_offset, av, req, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
     return mpi_errno;
 
@@ -398,29 +391,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
                                               MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SSEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                                  rank, tag, comm, context_offset, av,
-                                  NULL /*status */ , *req, NULL /*flag */ ,
-                                  NULL /*message */ , NULL /*processed */);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
+                              rank, tag, comm, context_offset, av,
+                              NULL /*status */ , *req, NULL /*flag */ ,
+                              NULL /*message */ , NULL /*processed */);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_ssend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_SSEND_SAFE);
     return mpi_errno;
 
@@ -436,29 +426,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * av, MPIR_Request ** req)
 {
-    int mpi_errno = MPI_SUCCESS, cs_acq = 0;
+    int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_ISSEND_SAFE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
-    MPID_THREAD_SAFE_BEGIN(VCI, MPIDI_global.vci_lock, cs_acq);
-
-    if (!cs_acq) {
-        *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
-                                  rank, tag, comm, context_offset, av,
-                                  NULL /*status */ , *req, NULL /*flag */ ,
-                                  NULL /*message */ , NULL /*processed */);
-    } else {
-        *(req) = NULL;
-        MPIDI_workq_vci_progress_unsafe();
-        mpi_errno =
-            MPIDI_issend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
-    }
+#ifdef MPIDI_CH4_USE_WORK_QUEUES
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_Datatype_add_ref_if_not_builtin(datatype);
+    MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
+                              rank, tag, comm, context_offset, av,
+                              NULL /*status */ , *req, NULL /*flag */ ,
+                              NULL /*message */ , NULL /*processed */);
+#else
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);
+    *(req) = NULL;
+    mpi_errno = MPIDI_issend_unsafe(buf, count, datatype, rank, tag, comm, context_offset, av, req);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);
+#endif
 
   fn_exit:
-    MPID_THREAD_SAFE_END(VCI, MPIDI_global.vci_lock, cs_acq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_ISSEND_SAFE);
     return mpi_errno;
 


### PR DESCRIPTION
## Pull Request Description

This commit decouples the thread-safety of workq from that of regular
communications. The decoupling allows refactoring of per-vci thread
safety to proceed. One of change we are considering is to move
thread-safety of send/recv operation down to netmod/shmmod layer.
Without the decoupling, the workq code need to be moved down too,
making things complicated.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
