### PR TITLE
ch4/ofi: Fix MR mode bit usage

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1554,6 +1554,11 @@ static void update_global_settings(struct fi_info *prov_use, struct fi_info *hin
                                prov_use->domain_attr->mr_mode != FI_MR_SCALABLE);
         UPDATE_SETTING_BY_INFO(enable_mr_prov_key,
                                prov_use->domain_attr->mr_mode != FI_MR_SCALABLE);
+    } else {
+        UPDATE_SETTING_BY_INFO(enable_mr_virt_address,
+                               prov_use->domain_attr->mr_mode == FI_MR_VIRT_ADDR);
+        UPDATE_SETTING_BY_INFO(enable_mr_prov_key,
+                               prov_use->domain_attr->mr_mode == FI_MR_PROV_KEY);
     }
     UPDATE_SETTING_BY_INFO(enable_tagged,
                            (prov_use->caps & FI_TAGGED) &&


### PR DESCRIPTION
## Pull Request Description

When one of the MR mode bits is intended to be set, the bits need to be set after the capability set is selected. This was missing in 5cd8f83ffbde, but is added here.

## Expected Impact

Fixes #4253 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
