### PR TITLE
Add memory binding for MPI_Alloc_mem

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -217,6 +217,11 @@ MPI_TYPECLASS_INTEGER, or MPI_TYPECLASS_COMPLEX
 Reconfigure mpich with --enable-izem=atomic --with-zm-prefix=yes
 **sockaddrfailed: MPL_get_sockaddr failed
 
+**nomembind: hwloc_set_area_membind() is not available
+**invalidmembind: Invalid bind object identifier.
+**invalidmembind %d: cannot bind memory to object (%d). \
+A memory object id was expected but a non-memory object id was passed instead
+
 # -- FIXME: Some (but not all) of the messages below this line have been used
 #---- The messages below this line haven't been used yet.
 #

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -797,18 +797,12 @@ int MPIDI_OFI_get_vci_attr(int vci)
 
 void *MPIDI_OFI_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
 {
-
-    void *ap;
-    ap = MPL_malloc(size, MPL_MEM_USER);
-    return ap;
+    return MPIDIG_mpi_alloc_mem(size, info_ptr);
 }
 
 int MPIDI_OFI_mpi_free_mem(void *ptr)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPL_free(ptr);
-
-    return mpi_errno;
+    return MPIDIG_mpi_free_mem(ptr);
 }
 
 int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, size_t ** local_upid_size, char **local_upids)

--- a/src/mpid/ch4/src/ch4r_init.c
+++ b/src/mpid/ch4/src/ch4r_init.c
@@ -94,12 +94,72 @@ int MPIDIG_destroy_comm(MPIR_Comm * comm)
     return mpi_errno;
 }
 
+/* Linked list internally used to keep track of
+ * allocated memory for which memory binding is
+ * requested by the user. */
+typedef struct mem_node {
+    void *ptr;
+    size_t size;
+    struct mem_node *next;
+} mem_node_t;
+
+static mem_node_t *mem_list_head = NULL;
+static mem_node_t *mem_list_tail = NULL;
+
 void *MPIDIG_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);
     void *p;
-    p = MPL_malloc(size, MPL_MEM_USER);
+    MPIR_hwtopo_type_e mem_type = MPIR_HWTOPO_TYPE__DDR;
+    MPIR_hwtopo_gid_t mem_gid = MPIR_HWTOPO_GID_ROOT;
+    int flag = 0;
+    char hint_str[MPI_MAX_INFO_VAL + 1];
+
+    /* retrieve requested memory type for allocation */
+    if (info_ptr) {
+        MPIR_Info_get_impl(info_ptr, "bind_memory", MPI_MAX_INFO_VAL, hint_str, &flag);
+    }
+
+    if (flag) {
+        if (!strcmp(hint_str, "ddr"))
+            mem_type = MPIR_HWTOPO_TYPE__DDR;
+        else if (!strcmp(hint_str, "hbm")) {
+            mem_type = MPIR_HWTOPO_TYPE__HBM;
+        } else {
+            mem_type = MPIR_HWTOPO_TYPE__DDR;
+        }
+        mem_gid = MPIR_hwtopo_get_obj_by_type(mem_type);
+    }
+
+    if (mem_gid != MPIR_HWTOPO_GID_ROOT) {
+        /* requested memory type is available in the system and process is bound
+         * to the corresponding device; allocate memory and bind it to device. */
+        p = MPL_mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0,
+                     MPL_MEM_USER);
+        MPIR_hwtopo_mem_bind(p, size, mem_gid);
+
+        /* keep track of bound memory for freeing it later */
+        mem_node_t *el = MPL_malloc(sizeof(*el), MPL_MEM_OTHER);
+        el->ptr = p;
+        el->size = size;
+        LL_APPEND(mem_list_head, mem_list_tail, el);
+    } else if (mem_type != MPIR_HWTOPO_TYPE__DDR) {
+        /* if mem_gid = MPIR_HWTOPO_GID_ROOT and mem_type is non-default (DDR)
+         * it can mean either that the requested memory type is not available
+         * in the system or the requested memory type is available but there
+         * are many devices of such type and the process requesting memory is
+         * not bound to any of them. Regardless the reason we do not fall back
+         * to the default allocation and return a NULL pointer to the upper layer
+         * instead. */
+        p = NULL;
+    } else {
+        /* if mem_gid = MPIR_HWTOPO_GID_ROOT and mem_type is default (DDR) it
+         * means that we cannot bind memory to a single device explicitly. In
+         * this case we still allocate memory and leave the binding to the OS
+         * (first touch policy in Linux). */
+        p = MPL_malloc(size, MPL_MEM_USER);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_ALLOC_MEM);
     return p;
 }
@@ -109,7 +169,22 @@ int MPIDIG_mpi_free_mem(void *ptr)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_MPI_FREE_MEM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_MPI_FREE_MEM);
-    MPL_free(ptr);
+    mem_node_t *el = NULL;
+
+    /* scan memory list for allocations */
+    LL_FOREACH(mem_list_head, el) {
+        if (el->ptr == ptr) {
+            LL_DELETE(mem_list_head, mem_list_tail, el);
+            break;
+        }
+    }
+
+    if (el) {
+        MPL_munmap(el->ptr, el->size, MPL_MEM_USER);
+        MPL_free(el);
+    } else {
+        MPL_free(ptr);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_MPI_FREE_MEM);
     return mpi_errno;
 }

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -504,6 +504,7 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
         flags |= HWLOC_MEMBIND_BYNODESET;
     } else {
         fprintf(stderr, "%s: object type not valid, skipping memory binding\n", __func__);
+        hwloc_bitmap_free(bitmap);
         return MPI_ERR_OTHER;
     }
 

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -482,10 +482,12 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
 #ifdef HAVE_HWLOC
     const struct hwloc_topology_support *support = hwloc_topology_get_support(hwloc_topology);
     if (!support->membind->set_area_membind) {
-        fprintf(stderr,
-                "%s: hwloc_set_area_membind() is not supported, skipping memory binding\n",
-                __func__);
-        return MPI_ERR_OTHER;
+#ifdef HAVE_ERROR_CHECKING
+        ret =
+            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**nomembind", 0);
+#endif /* HAVE_ERROR_CHECKING */
+        return ret;
     }
 
     hwloc_membind_policy_t policy = HWLOC_MEMBIND_BIND;
@@ -503,9 +505,13 @@ int MPIR_hwtopo_mem_bind(void *baseaddr, size_t len, MPIR_hwtopo_gid_t gid)
     if (hwloc_obj->type == HWLOC_OBJ_NUMANODE) {
         flags |= HWLOC_MEMBIND_BYNODESET;
     } else {
-        fprintf(stderr, "%s: object type not valid, skipping memory binding\n", __func__);
+#ifdef HAVE_ERROR_CHECKING
+        ret =
+            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                 MPI_ERR_OTHER, "**invalidmembind", "**invalidmembind %d", gid);
+#endif /* HAVE_ERROR_CHECKING */
         hwloc_bitmap_free(bitmap);
-        return MPI_ERR_OTHER;
+        return ret;
     }
 
     ret = hwloc_set_area_membind(hwloc_topology, baseaddr, len, bitmap, policy, flags);

--- a/test/mpi/rma/allocmem.c
+++ b/test/mpi/rma/allocmem.c
@@ -20,10 +20,18 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
+    MPI_Info mem_hints;
+    MPI_Info hints;
+    MPI_Info_create(&mem_hints);
+    hints = mem_hints;
+
+    /* try allocating ddr memory first (default) */
+    MPI_Info_set(mem_hints, "bind_memory", "ddr");
+
     MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
     for (count = 1; count < 128000; count *= 2) {
 
-        err = MPI_Alloc_mem(count, MPI_INFO_NULL, &ap);
+        err = MPI_Alloc_mem(count, hints, &ap);
         if (err) {
             int errclass;
             /* An error of  MPI_ERR_NO_MEM is allowed */
@@ -31,6 +39,11 @@ int main(int argc, char *argv[])
             if (errclass != MPI_ERR_NO_MEM) {
                 errs++;
                 MTestPrintError(err);
+            } else {
+                /* if MPI_ERR_NO_MEM memory cannot be allocated
+                 * to the requested type. Fall back to system
+                 * default and try again. */
+                hints = MPI_INFO_NULL;
             }
 
         } else {
@@ -41,6 +54,39 @@ int main(int argc, char *argv[])
             MPI_Free_mem(ap);
         }
     }
+
+    hints = mem_hints;
+
+    /* try allocating hbm memory second (non-default) */
+    MPI_Info_set(mem_hints, "bind_memory", "hbm");
+
+    for (count = 1; count < 128000; count *= 2) {
+
+        err = MPI_Alloc_mem(count, hints, &ap);
+        if (err) {
+            int errclass;
+            /* An error of  MPI_ERR_NO_MEM is allowed */
+            MPI_Error_class(err, &errclass);
+            if (errclass != MPI_ERR_NO_MEM) {
+                errs++;
+                MTestPrintError(err);
+            } else {
+                /* if MPI_ERR_NO_MEM memory cannot be allocated
+                 * to the requested type. Fall back to system
+                 * default and try again. */
+                hints = MPI_INFO_NULL;
+            }
+
+        } else {
+            /* Access all of this memory */
+            for (j = 0; j < count; j++) {
+                ap[j] = (char) (j & 0x7f);
+            }
+            MPI_Free_mem(ap);
+        }
+    }
+
+    MPI_Info_free(&mem_hints);
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);


### PR DESCRIPTION
## Pull Request Description

Users can set "bind_memory" info hint to "ddr" or "hbm" and pass it to
`MPI_Alloc_mem` which allocates memory and binds it to the requested
memory type.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
