### PR TITLE
mpl: define MPL_CACHELINE_SIZE in configure

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -991,6 +991,12 @@ if test "$ac_cv_func_posix_memalign" = "yes" -o "$ac_cv_func_aligned_alloc" = "y
    AC_DEFINE([DEFINE_ALIGNED_ALLOC],[1],[Define to 1 if MPL enables MPL_aligned_alloc.])
 fi
 
+# Define some configurabel constants
+AC_ARG_WITH([cacheline],
+[AS_HELP_STRING([--with-cacheline=SIZE], [Define cacheline size (default is 64)])],
+[],[with_cacheline=64])
+AC_DEFINE([CACHELINE_SIZE],[$with_cacheline], [Define cacheline size.])
+
 # Check for execinfo backtrace support
 AX_EXECINFO
 


### PR DESCRIPTION
Many parts of the code currently defines macros for cache line
size. This commit adds a configure option, --with-cacheline=size, to MPL
configure and provide macro MPL_CACHELINE_SIZE for consistency and
potential architecture dependent detections.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
