### PR TITLE
Refactor request creation to add MPIR_Request_create_unsafe

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -239,7 +239,10 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
 {
     MPIR_Request *req;
 
-    req = MPIR_Handle_obj_alloc(&MPIR_Request_mem);
+    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
+    req = MPIR_Handle_obj_alloc_unsafe(&MPIR_Request_mem);
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
+
     if (req != NULL) {
         MPL_DBG_MSG_P(MPIR_DBG_REQUEST, VERBOSE, "allocated request, handle=0x%08x", req->handle);
 #ifdef MPICH_DBG_OUTPUT

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -73,6 +73,10 @@ typedef enum MPIR_Request_kind_t {
 #endif
 } MPIR_Request_kind_t;
 
+typedef enum MPII_Reqalloc_use_lock {
+    LOCK, NOLOCK
+} MPII_Reqalloc_use_lock_t;
+
 /* This currently defines a single structure type for all requests.
    Eventually, we may want a union type, as used in MPICH-1 */
 /* Typedefs for Fortran generalized requests */
@@ -235,13 +239,16 @@ static inline int MPIR_Request_is_active(MPIR_Request * req_ptr)
                                          | MPIR_REQUESTS_PROPERTY__NO_GREQUESTS   \
                                          | MPIR_REQUESTS_PROPERTY__SEND_RECV_ONLY)
 
-static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
+static inline MPIR_Request *MPIR_Request_create_impl(MPIR_Request_kind_t kind,
+                                                     MPII_Reqalloc_use_lock_t use_lock)
 {
     MPIR_Request *req;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
+    if (use_lock == LOCK)
+        MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
     req = MPIR_Handle_obj_alloc_unsafe(&MPIR_Request_mem);
-    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
+    if (use_lock == LOCK)
+        MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_POBJ_HANDLE_MUTEX);
 
     if (req != NULL) {
         MPL_DBG_MSG_P(MPIR_DBG_REQUEST, VERBOSE, "allocated request, handle=0x%08x", req->handle);
@@ -294,6 +301,22 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
         MPL_DBG_MSG(MPIR_DBG_REQUEST, TYPICAL, "unable to allocate a request");
     }
 
+    return req;
+}
+
+/* Thread-safe version for request creation */
+static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind)
+{
+    MPIR_Request *req;
+    req = MPIR_Request_create_impl(kind, LOCK);
+    return req;
+}
+
+/* Thread-unsafe version for request creation */
+static inline MPIR_Request *MPIR_Request_create_unsafe(MPIR_Request_kind_t kind)
+{
+    MPIR_Request *req;
+    req = MPIR_Request_create_impl(kind, NOLOCK);
     return req;
 }
 


### PR DESCRIPTION
## Pull Request Description

The unsafe version will be helpful to avoid unnecessary locking. E.g,
if we have already acquired a global lock before creating request, we
don't need to acquire any new lock. Creation of light-weight request
objects during the init phase is one scenario where this can be
useful.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
