### PR TITLE
warnings: misc warning squash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5011,18 +5011,10 @@ dnl PAC_SUBDIR_CACHE_CLEANUP
 # FIXME does the makefile actually need this?
 subsystems="$devsubsystems $subsystems $bindingsubsystems"
 
-# Find the size of OPA_ptr_t. This step needs to come after the OPA
-# configure above in order to get the size OPA_ptr_t evaluated for
-# this platform.
-AC_CHECK_SIZEOF(OPA_ptr_t,0,[
-#include "${master_top_srcdir}/src/openpa/src/opa_primitives.h"
-pthread_mutex_t *OPA_emulation_lock;
-])
-
-# Find the size of MPL_atomic_ptr_t. This step needs to come after the MPL
-# configuration in order to get the size MPL_atomic_ptr_t evaluated for this
-# platform.
+# SIZEOF_MPL_ATOMIC_PTR_T is needed by ch3:nemesis. Only works after the MPL
+# configuration is done.
 AC_CHECK_SIZEOF(MPL_atomic_ptr_t,0,[
+#include <pthread.h>
 #include "${master_top_srcdir}/src/mpl/include/mpl_atomic.h"
 pthread_mutex_t *MPL_atomic_emulation_lock;
 ])

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -51,19 +51,19 @@ struct MPIR_HINT {
 static struct MPIR_HINT MPIR_comm_hint_list[MPIR_COMM_HINT_MAX];
 static int next_comm_hint_index = MPIR_COMM_HINT_PREDEFINED_COUNT;
 
-int MPIR_Comm_register_hint(int index, const char *hint_key, MPIR_Comm_hint_fn_t fn,
+int MPIR_Comm_register_hint(int idx, const char *hint_key, MPIR_Comm_hint_fn_t fn,
                             int type, int attr)
 {
-    if (index == 0) {
-        index = next_comm_hint_index;
+    if (idx == 0) {
+        idx = next_comm_hint_index;
         next_comm_hint_index++;
-        MPIR_Assert(index < MPIR_COMM_HINT_MAX);
+        MPIR_Assert(idx < MPIR_COMM_HINT_MAX);
     } else {
-        MPIR_Assert(index > 0 && index < MPIR_COMM_HINT_PREDEFINED_COUNT);
+        MPIR_Assert(idx > 0 && idx < MPIR_COMM_HINT_PREDEFINED_COUNT);
     }
-    MPIR_comm_hint_list[index] = (struct MPIR_HINT) {
+    MPIR_comm_hint_list[idx] = (struct MPIR_HINT) {
     hint_key, fn, type, attr};
-    return index;
+    return idx;
 }
 
 static int parse_string_value(const char *s, int type, int *val)

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -130,14 +130,21 @@ int MPII_Comm_set_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)
 
 int MPII_Comm_get_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     char hint_val_str[MPI_MAX_INFO_VAL];
     for (int i = 0; i < next_comm_hint_index; i++) {
         if (MPIR_comm_hint_list[i].key) {
             get_string_value(hint_val_str, MPIR_comm_hint_list[i].type, comm_ptr->hints[i]);
-            MPIR_Info_set_impl(info, MPIR_comm_hint_list[i].key, hint_val_str);
+            mpi_errno = MPIR_Info_set_impl(info, MPIR_comm_hint_list[i].key, hint_val_str);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
-    return MPI_SUCCESS;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPII_Comm_check_hints(MPIR_Comm * comm)

--- a/src/mpi/info/info_set.c
+++ b/src/mpi/info/info_set.c
@@ -102,7 +102,8 @@ int MPI_Info_set(MPI_Info info, const char *key, const char *value)
 #endif /* HAVE_ERROR_CHECKING */
 
     /* ... body of routine ...  */
-    MPIR_Info_set_impl(info_ptr, key, value);
+    mpi_errno = MPIR_Info_set_impl(info_ptr, key, value);
+    MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
 
 #ifdef HAVE_ERROR_CHECKING

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -116,13 +116,13 @@
    
 */
 
-#if (SIZEOF_MPL_ATOMIC_PTR_T > 8)
-#  if (SIZEOF_MPL_ATOMIC_PTR_T > 16)
-#    error unexpected size for MPL_atomic_ptr_t
-#  endif
-#  define MPID_NEM_CELL_HEAD_LEN  16 /* We use this to keep elements 64-bit aligned */
+/* define MPID_NEM_CELL_HEAD_LEN to keep elements 64-bit aligned */
+#if (SIZEOF_MPL_ATOMIC_PTR_T == 0 || SIZEOF_MPL_ATOMIC_PTR_T > 16)
+#error "Unexpected size for MPL_atomic_ptr_t."
+#elif (SIZEOF_MPL_ATOMIC_PTR_T > 8)
+#  define MPID_NEM_CELL_HEAD_LEN  16
 #else /* (SIZEOF_MPL_ATOMIC_PTR_T <= 8) */
-#  define MPID_NEM_CELL_HEAD_LEN  8 /* We use this to keep elements 64-bit aligned */
+#  define MPID_NEM_CELL_HEAD_LEN  8
 #endif
 
 #define MPID_NEM_CELL_PAYLOAD_LEN (MPID_NEM_CELL_LEN - MPID_NEM_CELL_HEAD_LEN)

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -430,7 +430,7 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
                 c += snprintf(buf + c, BUFSIZE - c, "%swaw", (c > 0) ? "," : "");
         }
 
-        MPIR_Info_set_impl(*info_used, "accumulate_ordering", buf);
+        mpi_errno = MPIR_Info_set_impl(*info_used, "accumulate_ordering", buf);
         MPIR_ERR_CHECK(mpi_errno);
 #undef BUFSIZE
     }


### PR DESCRIPTION
## Pull Request Description
* Coverity warns that we throw away the error return on MPIR_Info_set_impl
* `index` -> `idx`
* configure glitch for `SIZEOF_MPL_ATOMIC_PTR_T`

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Background
![image](https://user-images.githubusercontent.com/1496702/72209363-e4eee900-3472-11ea-9210-53231471828a.png)

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
