### PR TITLE
ch4/ofi: Remove unnecessary struct member

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -299,7 +299,6 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
 
     MPIDI_OFI_AMREQUEST_HDR(rreq, msg_hdr) = *msg_hdr;
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info) = *lmt_msg;
-    MPIDI_OFI_AMREQUEST_HDR(rreq, rreq_ptr) = (void *) rreq;
 
     if (is_contig) {
         if (in_data_sz > data_sz) {

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -597,6 +597,7 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
     MPIDI_OFI_am_request_t *ofi_req;
+    MPIDI_OFI_lmt_msg_payload_t *lmt_info;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_AM_READ_EVENT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_AM_READ_EVENT);
@@ -607,10 +608,10 @@ static int am_read_event(struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_
     if (ofi_req->req_hdr->lmt_cntr)
         goto fn_exit;
 
-    rreq = (MPIR_Request *) ofi_req->req_hdr->rreq_ptr;
-    mpi_errno = MPIDI_OFI_dispatch_ack(MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).src_rank,
-                                       MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).context_id,
-                                       MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info).sreq_ptr,
+    lmt_info = &ofi_req->req_hdr->lmt_info;
+    mpi_errno = MPIDI_OFI_dispatch_ack(lmt_info->src_rank,
+                                       lmt_info->context_id,
+                                       lmt_info->sreq_ptr,
                                        MPIDI_AMTYPE_LMT_ACK);
 
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -107,7 +107,6 @@ typedef struct {
     uint64_t lmt_cntr;
     struct fid_mr *lmt_mr;
     void *pack_buffer;
-    MPIR_Request *rreq_ptr;
     void *am_hdr;
     int (*target_cmpl_cb) (struct MPIR_Request * req);
     uint16_t am_hdr_sz;


### PR DESCRIPTION
## Pull Request Description

lmt_info is part of the am request header struct. There is no need to
derive that from a top-level request pointer (which can also be
derived using container_of).

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
