### PR TITLE
Revert: "Merge pull request #4218 from hzhou/1912_vci_netmod"

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -70,8 +70,7 @@ typedef void (*MPIDI_NM_am_request_init_t) (MPIR_Request * req);
 typedef void (*MPIDI_NM_am_request_finalize_t) (MPIR_Request * req);
 typedef int (*MPIDI_NM_mpi_send_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                     int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                    MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                    int src_vci, int dst_vci);
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_send_coll_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                      int rank, int tag, MPIR_Comm * comm, int context_offset,
                                      MPIDI_av_entry_t * addr, MPIR_Request ** request,
@@ -81,8 +80,7 @@ typedef int (*MPIDI_NM_mpi_ssend_t) (const void *buf, MPI_Aint count, MPI_Dataty
                                      MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_isend_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                      int rank, int tag, MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                     int src_vci, int dst_vci);
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_isend_coll_t) (const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       int rank, int tag, MPIR_Comm * comm, int context_offset,
                                       MPIDI_av_entry_t * addr, MPIR_Request ** request,
@@ -94,11 +92,10 @@ typedef int (*MPIDI_NM_mpi_cancel_send_t) (MPIR_Request * sreq);
 typedef int (*MPIDI_NM_mpi_recv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                     int tag, MPIR_Comm * comm, int context_offset,
                                     MPIDI_av_entry_t * addr, MPI_Status * status,
-                                    MPIR_Request ** request, int src_vci, int dst_vci);
+                                    MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_irecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype, int rank,
                                      int tag, MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                     int src_vci, int dst_vci);
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request);
 typedef int (*MPIDI_NM_mpi_imrecv_t) (void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       MPIR_Request * message);
 typedef int (*MPIDI_NM_mpi_cancel_recv_t) (MPIR_Request * rreq);
@@ -709,8 +706,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPI_Datatype datatype, int rank, int tag,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr,
-                                               MPIR_Request ** request,
-                                               int src_vci, int dst_vci) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_send_coll(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
@@ -725,8 +721,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
                                                 MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request,
-                                                int src_vci, int dst_vci) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_isend_coll(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int context_offset,
@@ -742,13 +737,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Da
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t * addr,
                                                MPI_Status * status,
-                                               MPIR_Request ** request,
-                                               int src_vci, int dst_vci) MPL_STATIC_INLINE_SUFFIX;
+                                               MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request,
-                                                int src_vci, int dst_vci) MPL_STATIC_INLINE_SUFFIX;
+                                                MPIR_Request ** request) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  MPIR_Request * message) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -212,16 +212,16 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPI_Datatype datatype, int rank, int tag,
                                                MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_SEND);
 
-    ret = MPIDI_NM_native_func->mpi_send(buf, count, datatype, rank, tag, comm, context_offset,
-                                         addr, request, src_vci, dst_vci);
+    ret =
+        MPIDI_NM_native_func->mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                       request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
     return ret;
@@ -266,16 +266,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_ISEND);
 
-    ret = MPIDI_NM_native_func->mpi_isend(buf, count, datatype, rank, tag, comm, context_offset,
-                                          addr, request, src_vci, dst_vci);
+    ret =
+        MPIDI_NM_native_func->mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                        request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISEND);
     return ret;
@@ -334,16 +334,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_send(MPIR_Request * sreq)
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                int rank, int tag, MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPI_Status * status, MPIR_Request ** request)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_RECV);
 
-    ret = MPIDI_NM_native_func->mpi_recv(buf, count, datatype, rank, tag, comm, context_offset,
-                                         addr, status, request, src_vci, dst_vci);
+    ret =
+        MPIDI_NM_native_func->mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                       status, request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_RECV);
     return ret;
@@ -352,15 +352,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf, MPI_Aint count, MPI_Da
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                 int rank, int tag, MPIR_Comm * comm,
                                                 int context_offset, MPIDI_av_entry_t * addr,
-                                                MPIR_Request ** request, int src_vci, int dst_vci)
+                                                MPIR_Request ** request)
 {
     int ret;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IRECV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_MPI_IRECV);
 
-    ret = MPIDI_NM_native_func->mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
-                                          addr, request, src_vci, dst_vci);
+    ret =
+        MPIDI_NM_native_func->mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, addr,
+                                        request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_IRECV);
     return ret;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -301,8 +301,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                int tag,
                                                MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPI_Status * status, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_RECV);
@@ -357,8 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_IRECV);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -473,8 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_coll(const void *buf, MPI_Aint count
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
                                                MPI_Datatype datatype, int rank, int tag,
                                                MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_SEND);
@@ -564,8 +563,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
                                                 MPI_Datatype datatype, int rank, int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_MPI_ISEND);

--- a/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_recv.h
@@ -21,8 +21,7 @@ static inline int MPIDI_NM_mpi_recv(void *buf,
                                     MPIR_Comm * comm,
                                     int context_offset,
                                     MPIDI_av_entry_t * addr,
-                                    MPI_Status * status, MPIR_Request ** request,
-                                    int src_vci, int dst_vci)
+                                    MPI_Status * status, MPIR_Request ** request)
 {
     int err = MPI_SUCCESS;
     MPIR_Assert(0);
@@ -42,8 +41,7 @@ static inline int MPIDI_NM_mpi_irecv(void *buf,
                                      int rank,
                                      int tag,
                                      MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                     int src_vci, int dst_vci)
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int err = MPI_SUCCESS;
     MPIR_Assert(0);

--- a/src/mpid/ch4/netmod/stubnm/stubnm_send.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_send.h
@@ -19,8 +19,7 @@ static inline int MPIDI_NM_mpi_send(const void *buf,
                                     int rank,
                                     int tag,
                                     MPIR_Comm * comm, int context_offset,
-                                    MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                    int src_vci, int dst_vci)
+                                    MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }
@@ -51,8 +50,7 @@ static inline int MPIDI_NM_mpi_isend(const void *buf,
                                      int rank,
                                      int tag,
                                      MPIR_Comm * comm, int context_offset,
-                                     MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                     int src_vci, int dst_vci)
+                                     MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_am_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_recv.h
@@ -20,8 +20,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                int tag,
                                                MPIR_Comm * comm,
                                                int context_offset, MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPI_Status * status, MPIR_Request ** request)
 {
     int ret;
 
@@ -55,8 +54,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     int ret;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_am_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am_send.h
@@ -19,8 +19,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
                                                int rank,
                                                int tag,
                                                MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }
@@ -42,8 +41,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -220,8 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_recv(void *buf,
                                                MPIR_Comm * comm,
                                                int context_offset,
                                                MPIDI_av_entry_t * addr,
-                                               MPI_Status * status, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPI_Status * status, MPIR_Request ** request)
 {
     return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }
@@ -232,8 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, request);
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -141,8 +141,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf,
                                                int rank,
                                                int tag,
                                                MPIR_Comm * comm, int context_offset,
-                                               MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                               int src_vci, int dst_vci)
+                                               MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
                           addr, request, 0, 0);
@@ -195,8 +194,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int context_offset,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                int src_vci, int dst_vci)
+                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
 {
     return MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
                           addr, request, 1, 0);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno =
         MPIDI_NM_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, av, status,
-                          request, 0, 0);
+                          request);
 #else
     if (unlikely(rank == MPI_ANY_SOURCE)) {
         mpi_errno =
@@ -41,7 +41,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
 
         if (!MPIR_Request_is_complete(*request) && !MPIDIG_REQUEST_IN_PROGRESS(*request)) {
             mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
-                                           av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)), 0, 0);
+                                           av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)));
 
             MPIR_ERR_CHECK(mpi_errno);
 
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_unsafe(void *buf,
         else
             mpi_errno =
                 MPIDI_NM_mpi_recv(buf, count, datatype, rank, tag, comm, context_offset, av, status,
-                                  request, 0, 0);
+                                  request);
         if (mpi_errno == MPI_SUCCESS && *request) {
             MPIDI_REQUEST(*request, is_local) = r;
             MPIDI_REQUEST_ANYSOURCE_PARTNER(*request) = NULL;
@@ -99,8 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno =
-        MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, av, request, 0,
-                           0);
+        MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 #else
     if (unlikely(rank == MPI_ANY_SOURCE)) {
         mpi_errno =
@@ -111,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
         MPIR_Assert(*request);
         if (!MPIR_Request_is_complete(*request) && !MPIDIG_REQUEST_IN_PROGRESS(*request)) {
             mpi_errno = MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
-                                           av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)), 0, 0);
+                                           av, &(MPIDI_REQUEST_ANYSOURCE_PARTNER(*request)));
 
             MPIR_ERR_CHECK(mpi_errno);
 
@@ -138,7 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_unsafe(void *buf,
         else
             mpi_errno =
                 MPIDI_NM_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, av,
-                                   request, 0, 0);
+                                   request);
         if (mpi_errno == MPI_SUCCESS) {
             MPIR_Assert(*request);
             MPIDI_REQUEST(*request, is_local) = r;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -28,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *buf,
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno =
-        MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request, 0, 0);
+        MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
@@ -36,8 +36,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *buf,
             MPIDI_SHM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
     else
         mpi_errno =
-            MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request, 0,
-                              0);
+            MPIDI_NM_mpi_send(buf, count, datatype, rank, tag, comm, context_offset, av, request);
     if (mpi_errno == MPI_SUCCESS && *request)
         MPIDI_REQUEST(*request, is_local) = r;
 #endif
@@ -107,8 +106,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_unsafe(const void *buf,
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno =
-        MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request, 0,
-                           0);
+        MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
@@ -116,8 +114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_unsafe(const void *buf,
             MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
     else
         mpi_errno =
-            MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request,
-                               0, 0);
+            MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, av, request);
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*request, is_local) = r;
 #endif


### PR DESCRIPTION
This reverts commit 412d54a67c654bc600177f9a4f91e61eefc912ec, reversing
changes made to f05e7bc6e773e41091b374dadb994b756c61c6a7.

## Pull Request Description

Descision has been made to do vci hashing at the netmod/shmmod layer,
which made the passing down vci parameters unnecessary.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
