### PR TITLE
pmi: fix a wrong condition checking return of MPL_get_sockaddr

### DIFF
--- a/src/mpl/include/mpl_sockaddr.h
+++ b/src/mpl/include/mpl_sockaddr.h
@@ -21,6 +21,9 @@
 
 typedef struct sockaddr_storage MPL_sockaddr_t;
 
+/* The following functions when return an int, it returns 0 on success,
+ * non-zero indicates error. It is consistent with posix socket functions.
+ */
 void MPL_sockaddr_set_aftype(int type);
 int MPL_get_sockaddr(const char *s_hostname, MPL_sockaddr_t * p_addr);
 int MPL_get_sockaddr_direct(int type, MPL_sockaddr_t * p_addr);

--- a/src/pmi/simple/simple_pmi.c
+++ b/src/pmi/simple/simple_pmi.c
@@ -891,7 +891,7 @@ static int PMII_Connect_to_pm(char *hostname, int portnum)
     int q_wait = 1;
 
     ret = MPL_get_sockaddr(hostname, &addr);
-    if (!ret) {
+    if (ret) {
         PMIU_printf(1, "Unable to get host entry for %s\n", hostname);
         return PMI_FAIL;
     }


### PR DESCRIPTION
## Pull Request Description

Fix an error in `simple_pmi.c` assuming the opposite of error condition for `MPL_get_sockaddr`.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
     Fixes #4278
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
