### PR TITLE
mpi/test: fix incorrect code in a few io tests

### DIFF
--- a/test/mpi/io/i_coll_test.c
+++ b/test/mpi/io/i_coll_test.c
@@ -51,15 +51,13 @@ int main(int argc, char **argv)
 
     /* process 0 broadcasts the file name to other processes */
     if (!mynod) {
-        filename = "testfile";
+        filename = strdup("testfile");
         len = strlen(filename);
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
-    } else {
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        filename = (char *) malloc(len + 1);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
+    MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (mynod)
+        filename = (char *) malloc(len + 1);
+    MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
 
 
     /* create the distributed array filetype */
@@ -189,8 +187,7 @@ int main(int argc, char **argv)
     MPI_Type_free(&newtype);
     free(readbuf);
     free(writebuf);
-    if (mynod)
-        free(filename);
+    free(filename);
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);

--- a/test/mpi/io/i_noncontig_coll.c
+++ b/test/mpi/io/i_noncontig_coll.c
@@ -47,15 +47,13 @@ int main(int argc, char **argv)
 
     /* process 0 broadcasts the file name to other processes */
     if (!mynod) {
-        filename = "testfile";
+        filename = strdup("testfile");
         len = strlen(filename);
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
-    } else {
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        filename = (char *) malloc(len + 1);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
+    MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (mynod)
+        filename = (char *) malloc(len + 1);
+    MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
 
     buf = (int *) malloc(SIZE * sizeof(int));
 
@@ -248,8 +246,7 @@ int main(int argc, char **argv)
 
     MPI_Type_free(&newtype);
     free(buf);
-    if (mynod)
-        free(filename);
+    free(filename);
     MTest_Finalize(errs);
     return MTestReturnValue(errs);
 }

--- a/test/mpi/io/i_noncontig_coll2.c
+++ b/test/mpi/io/i_noncontig_coll2.c
@@ -264,15 +264,13 @@ int main(int argc, char **argv)
     /* process 0 takes the file name as a command-line argument and
      * broadcasts it to other processes */
     if (!mynod) {
-        filename = "testfile";
+        filename = strdup("testfile");
         len = strlen(filename);
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
-    } else {
-        MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
-        filename = (char *) malloc(len + 1);
-        MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
     }
+    MPI_Bcast(&len, 1, MPI_INT, 0, MPI_COMM_WORLD);
+    if (mynod)
+        filename = (char *) malloc(len + 1);
+    MPI_Bcast(filename, len + 1, MPI_CHAR, 0, MPI_COMM_WORLD);
 
     /* want to hint the cb_config_list, but do so in a non-sequential way */
     cb_gather_name_array(MPI_COMM_WORLD, &array);
@@ -322,8 +320,7 @@ int main(int argc, char **argv)
     errs += test_file(filename, mynod, nprocs, cb_config_string,
                       "collective w/ hinting: permutation2", verbose);
 
-    if (mynod)
-        free(filename);
+    free(filename);
     free(cb_config_string);
     for (i = 0; i < array->namect; i++)
         free(array->names[i]);


### PR DESCRIPTION
The bcast root buffer (filename) can not be a pointer pointing to a
constant, its buffer can also be used for receiving.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
