### PR TITLE
request: implement multiple request pool

### DIFF
--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -483,7 +483,7 @@ static inline void *MPIR_Handle_get_ptr_indirect(int, MPIR_Object_alloc_t *);
 #define MPIR_Op_get_ptr(a,ptr)         MPIR_Getb_ptr(Op,OP,a,0x000000ff,ptr)
 #define MPIR_Info_get_ptr(a,ptr)       MPIR_Getb_ptr(Info,INFO,a,0x03ffffff,ptr)
 #define MPIR_Win_get_ptr(a,ptr)        MPIR_Get_ptr(Win,a,ptr)
-#define MPIR_Request_get_ptr(a,ptr)    MPIR_Get_ptr(Request,a,ptr)
+/* Request objects are handled differently. See mpir_request.h */
 #define MPIR_Grequest_class_get_ptr(a,ptr) MPIR_Get_ptr(Grequest_class,a,ptr)
 /* Keyvals have a special format. This is roughly MPIR_Get_ptrb, but
    the handle index is in a smaller bit field.  In addition,

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -365,7 +365,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIR_Request_create_complete(MPIR_Request
     MPIR_Request *req;
 
 #ifdef HAVE_DEBUGGER_SUPPORT
-    req = MPIR_Request_create(kind);
+    req = MPIR_Request_create(kind, 0);
     MPIR_cc_set(&req->cc, 0);
 #else
     req = MPIR_Process.lw_req;

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -228,7 +228,7 @@ struct MPIR_Request {
 #define MPIR_REQUEST_PREALLOC 8
 
 extern MPIR_Object_alloc_t MPIR_Request_mem[MPIR_REQUEST_NUM_POOLS];
-extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_NUM_POOLS][MPIR_REQUEST_PREALLOC];
+extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
 
 #define MPIR_Request_get_ptr(a, ptr) \
     do { \
@@ -236,7 +236,8 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_NUM_POOLS][MPIR_REQUEST_PRE
         pool = ((a) & REQUEST_POOL_MASK) >> REQUEST_POOL_SHIFT; \
         switch (HANDLE_GET_KIND(a)) { \
         case HANDLE_KIND_DIRECT: \
-            ptr = MPIR_Request_direct[pool] + HANDLE_INDEX(a); \
+            MPIR_Assert(pool == 0); \
+            ptr = MPIR_Request_direct + HANDLE_INDEX(a); \
             break; \
         case HANDLE_KIND_INDIRECT: \
             blk = ((a) & REQUEST_BLOCK_MASK) >> REQUEST_BLOCK_SHIFT; \
@@ -252,8 +253,9 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_NUM_POOLS][MPIR_REQUEST_PRE
 static inline void MPII_init_request(void)
 {
     /* *INDENT-OFF* */
-    for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
-        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct[i], MPIR_REQUEST_PREALLOC };
+    MPIR_Request_mem[0] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct, MPIR_REQUEST_PREALLOC };
+    for (int i = 1; i < MPIR_REQUEST_NUM_POOLS; i++) {
+        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), NULL, 0 };
     }
     /* *INDENT-ON* */
 }

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -409,7 +409,7 @@ int MPII_Genutil_sched_start(MPII_Genutil_sched_t * sched, MPIR_Comm * comm, MPI
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPII_GENUTIL_SCHED_START);
 
     /* Create a request */
-    reqp = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
+    reqp = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
     if (!reqp)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     *req = reqp;

--- a/src/mpi/init/init_global.c
+++ b/src/mpi/init/init_global.c
@@ -130,7 +130,7 @@ int MPII_init_global(int *p_thread_required)
 
     /* Create complete request to return in the event of immediately complete
      * operations. Use a SEND request to cover all possible use-cases. */
-    MPIR_Process.lw_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    MPIR_Process.lw_req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT(MPIR_Process.lw_req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                         "**nomemreq");
     MPIR_cc_set(&MPIR_Process.lw_req->cc, 0);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -89,6 +89,8 @@ int MPIR_Init_thread(int *argc, char ***argv, int required, int *provided)
     mpi_errno = MPIR_T_env_init();
     MPIR_ERR_CHECK(mpi_errno);
 
+    MPII_init_request();
+
     /* Certain features may potentially change required thread-level */
     mpi_errno = MPII_init_global(&required);
     MPIR_ERR_CHECK(mpi_errno);  /* out-of-mem */

--- a/src/mpi/request/greq_start.c
+++ b/src/mpi/request/greq_start.c
@@ -81,7 +81,7 @@ int MPIR_Grequest_start(MPI_Grequest_query_function * query_fn,
 
     /* MT FIXME this routine is not thread-safe in the non-global case */
 
-    *request_ptr = MPIR_Request_create(MPIR_REQUEST_KIND__GREQUEST);
+    *request_ptr = MPIR_Request_create(MPIR_REQUEST_KIND__GREQUEST, 0);
     MPIR_ERR_CHKANDJUMP1(*request_ptr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
                          "generalized request");
 

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -9,12 +9,8 @@
 
 /* style:PMPIuse:PMPI_Status_f2c:2 sig:0 */
 
-MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
-
-MPIR_Object_alloc_t MPIR_Request_mem = {
-    0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct,
-    MPIR_REQUEST_PREALLOC
-};
+MPIR_Request MPIR_Request_direct[MPIR_REQUEST_NUM_POOLS][MPIR_REQUEST_PREALLOC];
+MPIR_Object_alloc_t MPIR_Request_mem[MPIR_REQUEST_NUM_POOLS];
 
 /* Complete a request, saving the status data if necessary.
    If debugger information is being provided for pending (user-initiated)

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -9,7 +9,7 @@
 
 /* style:PMPIuse:PMPI_Status_f2c:2 sig:0 */
 
-MPIR_Request MPIR_Request_direct[MPIR_REQUEST_NUM_POOLS][MPIR_REQUEST_PREALLOC];
+MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
 MPIR_Object_alloc_t MPIR_Request_mem[MPIR_REQUEST_NUM_POOLS];
 
 /* Complete a request, saving the status data if necessary.

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -231,7 +231,7 @@ static inline int MPID_nem_ofi_create_req(MPIR_Request ** request, int refcnt)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req;
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_Assert(req);
     MPIR_Object_set_ref(req, refcnt);
     MPID_nem_ofi_init_req(req);

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -354,7 +354,7 @@ int MPID_nem_tcp_iStartContigMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, vo
     MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "enqueuing");
 
     /* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_Assert(sreq != NULL);
     MPIR_Object_set_ref(sreq, 2);
 
@@ -437,7 +437,7 @@ int MPID_nem_tcp_iStartContigMsg_paused(MPIDI_VC_t * vc, void *hdr, intptr_t hdr
     MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "enqueuing");
 
     /* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_Assert(sreq != NULL);
     MPIR_Object_set_ref(sreq, 2);
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsg.c
@@ -85,7 +85,7 @@ int MPIDI_CH3_iStartMsg (MPIDI_VC_t *vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, TERSE, "enqueuing");
 
 	/* create a request */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
 	MPIR_Assert (sreq != NULL);
 	MPIR_Object_set_ref (sreq, 2);
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_istartmsgv.c
@@ -112,7 +112,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, MPL_IOV *iov, int n_iov, MPIR_Request 
 	{
             /* Create a new request and save remaining portions of the
 	     * iov in it. */
-            sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+            sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
 	    MPIR_Assert(sreq != NULL);
 	    MPIR_Object_set_ref(sreq, 2);
 	    sreq->kind = MPIR_REQUEST_KIND__SEND;
@@ -143,7 +143,7 @@ int MPIDI_CH3_iStartMsgv (MPIDI_VC_t *vc, MPL_IOV *iov, int n_iov, MPIR_Request 
 	
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, TERSE, "request enqueued");
 	/* create a request */
-	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
 	MPIR_Assert(sreq != NULL);
 	MPIR_Object_set_ref(sreq, 2);
 	sreq->kind = MPIR_REQUEST_KIND__SEND;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -88,7 +88,7 @@ int MPID_nem_send_iov(MPIDI_VC_t *vc, MPIR_Request **sreq_ptr, MPL_IOV *iov, int
     if (*sreq_ptr == NULL)
     {
 	/* create a request */
-	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+	sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
 	MPIR_Assert(sreq != NULL);
 	MPIR_Object_set_ref(sreq, 2);
 	sreq->kind = MPIR_REQUEST_KIND__SEND;

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsg.c
@@ -13,7 +13,7 @@ static MPIR_Request *create_request(void *hdr, intptr_t hdr_sz, size_t nb)
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_REQUEST);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     /* --BEGIN ERROR HANDLING-- */
     if (sreq == NULL)
         return NULL;
@@ -111,7 +111,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
             else {
                 MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, TYPICAL,
                               "ERROR - MPIDI_CH3I_Sock_write failed, rc=%d", rc);
-                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
                 if (!sreq) {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
                 }
@@ -168,7 +168,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void *hdr, intptr_t hdr_sz, MPIR_Reques
     else {
         /* Connection failed, so allocate a request and return an error. */
         MPL_DBG_VCUSE(vc, "ERROR - connection failed");
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         if (!sreq) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         }

--- a/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_istartmsgv.c
@@ -14,7 +14,7 @@ static MPIR_Request *create_request(MPL_IOV * iov, int iov_count, int iov_offset
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_CREATE_REQUEST);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     /* --BEGIN ERROR HANDLING-- */
     if (sreq == NULL)
         return NULL;
@@ -139,7 +139,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, MPL_IOV * iov, int n_iov, MPIR_Request
             else {
                 MPL_DBG_MSG_D(MPIDI_CH3_DBG_CHANNEL, TYPICAL,
                               "ERROR - MPIDI_CH3I_Sock_writev failed, rc=%d", rc);
-                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+                sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
                 if (sreq == NULL) {
                     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
                 }
@@ -195,7 +195,7 @@ int MPIDI_CH3_iStartMsgv(MPIDI_VC_t * vc, MPL_IOV * iov, int n_iov, MPIR_Request
     else {
         /* Connection failed, so allocate a request and return an error. */
         MPL_DBG_VCUSE(vc, "ERROR - connection failed");
-        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+        sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
         if (sreq == NULL) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
         }

--- a/src/mpid/ch3/include/mpid_rma_issue.h
+++ b/src/mpid/ch3/include/mpid_rma_issue.h
@@ -223,7 +223,7 @@ static int issue_from_origin_buffer(MPIDI_RMA_Op_t * rma_op, MPIDI_VC_t * vc,
      * always need a request to be passed in. */
 
     /* create a new request */
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDJUMP(req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     MPIR_Object_set_ref(req, 2);
@@ -565,7 +565,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         /* Create a request for the GACC response.  Store the response buf, count, and
          * datatype in it, and pass the request's handle in the GACC packet. When the
          * response comes from the target, it will contain the request handle. */
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
         MPIR_Object_set_ref(resp_req, 2);
@@ -660,7 +660,7 @@ static int issue_get_acc_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
         /* Create a request for the GACC response.  Store the response buf, count, and
          * datatype in it, and pass the request's handle in the GACC packet. When the
          * response comes from the target, it will contain the request handle. */
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
         MPIR_Object_set_ref(resp_req, 2);
@@ -786,7 +786,7 @@ static int issue_get_op(MPIDI_RMA_Op_t * rma_op, MPIR_Win * win_ptr,
      * and pass a handle to it in the get packet. When the get
      * response comes from the target, it will contain the request
      * handle. */
-    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     if (curr_req == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -901,7 +901,7 @@ static int issue_cas_op(MPIDI_RMA_Op_t * rma_op,
     /* Create a request for the RMW response.  Store the origin buf, count, and
      * datatype in it, and pass the request's handle RMW packet. When the
      * response comes from the target, it will contain the request handle. */
-    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    curr_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_ERR_CHKANDJUMP(curr_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* Set refs on the request to 2: one for the response message, and one for
@@ -960,7 +960,7 @@ static int issue_fop_op(MPIDI_RMA_Op_t * rma_op,
     /* Create a request for the GACC response.  Store the response buf, count, and
      * datatype in it, and pass the request's handle in the GACC packet. When the
      * response comes from the target, it will contain the request handle. */
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     MPIR_Object_set_ref(resp_req, 2);

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -277,7 +277,7 @@ extern MPIDI_Process_t MPIDI_Process;
 */
 #define MPIDI_Request_create_sreq(sreq_, mpi_errno_, FAIL_)	\
 {								\
-    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);     \
+    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);     \
     MPIR_Object_set_ref((sreq_), 2);				\
     (sreq_)->comm = comm;					\
     (sreq_)->dev.partner_request   = NULL;                         \
@@ -294,7 +294,7 @@ extern MPIDI_Process_t MPIDI_Process;
 /* This is the receive request version of MPIDI_Request_create_sreq */
 #define MPIDI_Request_create_rreq(rreq_, mpi_errno_, FAIL_)	\
 {								\
-    (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);           \
+    (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);           \
     MPIR_Object_set_ref((rreq_), 2);				\
     (rreq_)->dev.partner_request   = NULL;                         \
 }
@@ -303,7 +303,7 @@ extern MPIDI_Process_t MPIDI_Process;
  * returning when a user passed MPI_PROC_NULL */
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)           \
     do {                                                                   \
-        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);               \
+        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);               \
         if ((rreq_) != NULL) {                                             \
             MPIR_Object_set_ref((rreq_), 1);                               \
             /* MT FIXME should these be handled by MPIR_Request_create? */ \

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -418,7 +418,7 @@ static inline int enqueue_lock_origin(MPIR_Win * win_ptr, MPIDI_VC_t * vc,
         }
 
         /* create request to receive upcoming requests */
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_Object_set_ref(req, 1);
 
         /* fill in area in req that will be used in Receive_data_found() */

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -289,7 +289,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     MPIR_Datatype_is_contig(rreq->dev.datatype, &is_contig);
     MPIR_Datatype_get_true_lb(rreq->dev.datatype, &dt_true_lb);
 
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     MPIR_Object_set_ref(resp_req, 1);
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_GET_ACCUM_RESP);
@@ -411,7 +411,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     MPIR_Datatype_is_contig(rreq->dev.datatype, &is_contig);
 
     /* Create response request */
-    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_ERR_CHKANDJUMP(resp_req == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_FOP_RESP);
     MPIR_Object_set_ref(resp_req, 1);
@@ -784,7 +784,7 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
     MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
 
     /* create request for sending data */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     MPIR_ERR_CHKANDJUMP(sreq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     sreq->kind = MPIR_REQUEST_KIND__SEND;
@@ -1009,7 +1009,7 @@ static inline int perform_get_in_lock_queue(MPIR_Win * win_ptr,
     /* Make sure that all data is received for this op. */
     MPIR_Assert(target_lock_entry->all_data_recved == 1);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     if (sreq == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -1182,7 +1182,7 @@ static inline int perform_get_acc_in_lock_queue(MPIR_Win * win_ptr,
     /* Make sure that all data is received for this op. */
     MPIR_Assert(target_lock_entry->all_data_recved == 1);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     if (sreq == NULL) {
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
     }
@@ -1390,7 +1390,7 @@ static inline int perform_fop_in_lock_queue(MPIR_Win * win_ptr,
         fop_resp_pkt->pkt_flags |= MPIDI_CH3_PKT_FLAG_RMA_ACK;
 
     if (fop_pkt->type == MPIDI_CH3_PKT_FOP) {
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         if (resp_req == NULL) {
             MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomemreq");
         }

--- a/src/mpid/ch3/src/ch3u_rma_pkthandler.c
+++ b/src/mpid/ch3/src/ch3u_rma_pkthandler.c
@@ -280,7 +280,7 @@ int MPIDI_CH3_PktHandler_Put(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         data_len = *buflen;
         data_buf = (char *) data;
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_Object_set_ref(req, 1);
 
         req->dev.user_buf = put_pkt->addr;
@@ -412,7 +412,7 @@ int MPIDI_CH3_PktHandler_Get(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         goto fn_exit;
     }
 
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
     req->dev.target_win_handle = get_pkt->target_win_handle;
     req->dev.pkt_flags = get_pkt->pkt_flags;
 
@@ -634,7 +634,7 @@ int MPIDI_CH3_PktHandler_Accumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void
     else {
         MPIR_Assert(pkt->type == MPIDI_CH3_PKT_ACCUMULATE);
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_Object_set_ref(req, 1);
         *rreqp = req;
 
@@ -833,7 +833,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
         /* Immed packet type is used when target datatype is predefined datatype. */
         MPIR_Assert(MPIR_DATATYPE_IS_PREDEFINED(get_accum_pkt->datatype));
 
-        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        resp_req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         resp_req->dev.target_win_handle = get_accum_pkt->target_win_handle;
         resp_req->dev.pkt_flags = get_accum_pkt->pkt_flags;
 
@@ -908,7 +908,7 @@ int MPIDI_CH3_PktHandler_GetAccumulate(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, v
 
         MPIR_Assert(pkt->type == MPIDI_CH3_PKT_GET_ACCUM);
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_Object_set_ref(req, 1);
         *rreqp = req;
 
@@ -1353,7 +1353,7 @@ int MPIDI_CH3_PktHandler_FOP(MPIDI_VC_t * vc, MPIDI_CH3_Pkt_t * pkt, void *data,
         if (fop_pkt->op == MPI_NO_OP)
             is_empty_origin = TRUE;
 
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED, 0);
         MPIR_Object_set_ref(req, 1);
         MPIDI_Request_set_type(req, MPIDI_REQUEST_TYPE_FOP_RECV);
         *rreqp = req;

--- a/src/mpid/ch3/src/ch3u_rma_reqops.c
+++ b/src/mpid/ch3/src/ch3u_rma_reqops.c
@@ -33,7 +33,7 @@ int MPID_Rput(const void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -87,7 +87,7 @@ int MPID_Rget(void *origin_addr, int origin_count,
     MPIDI_Datatype_get_info(origin_count, origin_datatype, dt_contig, data_sz, dtp, dt_true_lb);
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -139,7 +139,7 @@ int MPID_Raccumulate(const void *origin_addr, int origin_count,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */
@@ -194,7 +194,7 @@ int MPID_Rget_accumulate(const void *origin_addr, int origin_count,
                         mpi_errno, MPI_ERR_RMA_SYNC, "**rmasync");
 
     /* Create user request, initially cc=1, ref=1 */
-    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    ureq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDJUMP(ureq == NULL, mpi_errno, MPI_ERR_OTHER, "**nomemreq");
 
     /* This request is referenced by user and ch3 by default. */

--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -22,7 +22,7 @@
 /* This macro initializes all of the fields in a persistent request */
 #define MPIDI_Request_create_psreq(sreq_, mpi_errno_, FAIL_)		\
 {									\
-    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);                  \
+    (sreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND, 0);                  \
     if ((sreq_) == NULL)						\
     {									\
 	MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"send request allocation failed");\
@@ -278,7 +278,7 @@ int MPID_Recv_init(void * buf, int count, MPI_Datatype datatype, int rank, int t
 
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
     
-    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
+    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV, 0);
     if (rreq == NULL)
     {
 	/* --BEGIN ERROR HANDLING-- */

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -166,3 +166,7 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
      .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
 };
+
+/* MPIDI_OFI_win_request_t objects */
+MPIR_Object_alloc_t MPIDI_OFI_win_request_mem =
+    { 0, 0, 0, 0, MPIR_INTERNAL, sizeof(MPIDI_OFI_win_request_t), NULL, 0 };

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -466,7 +466,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
     char *ibuf;
     size_t len;
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     len = am_hdr_sz + sizeof(*msg_hdrp);
     ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -278,14 +278,26 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_check_acc_order_size(MPIR_Win * win, s
     return max_size;
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * req)
+extern MPIR_Object_alloc_t MPIDI_OFI_win_request_mem;
+
+MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_create(void)
+{
+    MPIDI_OFI_win_request_t *winreq;
+    winreq = MPIR_Handle_obj_alloc(&MPIDI_OFI_win_request_mem);
+    if (winreq) {
+        MPIR_Object_set_ref(winreq, 1);
+    }
+    return winreq;
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * winreq)
 {
     int in_use;
-    MPIR_Assert(HANDLE_GET_MPI_KIND(req->handle) == MPIR_REQUEST);
-    MPIR_Object_release_ref(req, &in_use);
+    MPIR_Assert(HANDLE_GET_MPI_KIND(winreq->handle) == MPIR_INTERNAL);
+    MPIR_Object_release_ref(winreq, &in_use);
     if (!in_use) {
-        MPL_free(req->noncontig);
-        MPIR_Handle_obj_free(&MPIR_Request_mem, (req));
+        MPL_free(winreq->noncontig);
+        MPIR_Handle_obj_free(&MPIDI_OFI_win_request_mem, (winreq));
     }
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -129,7 +129,7 @@ int MPIDI_OFI_progress(int vci, int blocking);
 
 #define MPIDI_OFI_REQUEST_CREATE(req, kind)                 \
     do {                                                      \
-        (req) = MPIR_Request_create(kind);  \
+        (req) = MPIR_Request_create(kind, 0);  \
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq"); \
         MPIR_Request_add_ref((req));                                \
     } while (0)
@@ -174,7 +174,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_lw_request_cc_val(void)
           if (MPIDI_OFI_need_request_creation(req)) {                   \
               MPIR_Assert(MPIDI_CH4_MT_MODEL == MPIDI_CH4_MT_DIRECT ||  \
                           (req) == NULL);                               \
-              (req) = MPIR_Request_create(kind);                        \
+              (req) = MPIR_Request_create(kind, 0);                        \
               MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, \
                                   "**nomemreq");                        \
           }                                                             \
@@ -190,7 +190,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_lw_request_cc_val(void)
         } else {                                                        \
             if (MPIDI_OFI_need_request_creation(req)) {                 \
                 MPIR_Assert((req) == NULL);                             \
-                (req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);   \
+                (req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);   \
                 MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, \
                                     "**nomemreq");                      \
             }                                                           \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -524,12 +524,9 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
                             offsetof(MPIDI_OFI_ssendack_request_t, context));
     MPL_COMPILE_TIME_ASSERT(offsetof(struct MPIR_Request, dev.ch4.netmod) ==
                             offsetof(MPIDI_OFI_dynamic_process_request_t, context));
-    MPL_COMPILE_TIME_ASSERT(offsetof(struct MPIR_Request, dev.ch4.netmod) ==
-                            offsetof(MPIDI_OFI_win_request_t, context));
     MPL_COMPILE_TIME_ASSERT(offsetof(struct MPIR_Request, dev.ch4.am.netmod_am.ofi.context) ==
                             offsetof(struct MPIR_Request, dev.ch4.netmod.ofi.context));
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_Devreq_t) >= sizeof(MPIDI_OFI_request_t));
-    MPL_COMPILE_TIME_ASSERT(sizeof(MPIR_Request) >= sizeof(MPIDI_OFI_win_request_t));
 
     MPIR_Add_mutex(&MPIDI_OFI_THREAD_UTIL_MUTEX);
     MPIR_Add_mutex(&MPIDI_OFI_THREAD_PROGRESS_MUTEX);

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -38,7 +38,7 @@ static inline int MPIDI_OFI_do_iprobe(int source,
         remote_proc = MPIDI_OFI_av_to_phys(addr);
 
     if (message) {
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
+        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE, 0);
         MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         rreq = &r;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -217,7 +217,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),
@@ -280,7 +280,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),
@@ -351,7 +351,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
         + MPIDI_OFI_align_iov_len(alloc_iovs * r_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),
@@ -1222,7 +1222,7 @@ static inline int MPIDI_OFI_do_get_accumulate(const void *origin_addr,
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
     if (sigreq) {
-        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        *sigreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT((*sigreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
         MPIR_Request_add_ref(*sigreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -217,7 +217,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_put_get(MPIR_Win * w
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),
@@ -280,7 +280,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_accumulate(MPIR_Win 
         + MPIDI_OFI_align_iov_len(alloc_iovs * t_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),
@@ -351,7 +351,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_allocate_win_request_get_accumulate(MPIR_
         + MPIDI_OFI_align_iov_len(alloc_iovs * r_size)
         + MPIDI_OFI_IOVEC_ALIGN - 1;    /* in case iov_store[0] is not aligned as we want */
 
-    req = (MPIDI_OFI_win_request_t *) MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
+    req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     req->noncontig =
         (MPIDI_OFI_win_noncontig_t *) MPL_malloc((alloc_iov_size) + sizeof(*(req->noncontig)),

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -128,7 +128,6 @@ static inline int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 #define MAX_OFI_MUTEXES 4
 
 /* Field accessor macros */
-#define MPIDI_OFI_OBJECT_HEADER_SIZE       offsetof(MPIDI_OFI_offset_checker_t,  pad)
 #define MPIDI_OFI_AMREQUEST(req,field)     ((req)->dev.ch4.am.netmod_am.ofi.field)
 #define MPIDI_OFI_AMREQUEST_HDR(req,field) ((req)->dev.ch4.am.netmod_am.ofi.req_hdr->field)
 #define MPIDI_OFI_AMREQUEST_HDR_PTR(req)   ((req)->dev.ch4.am.netmod_am.ofi.req_hdr)
@@ -419,11 +418,6 @@ typedef struct {
     int tag;
 } MPIDI_OFI_send_control_t;
 
-typedef struct {
-    MPIR_OBJECT_HEADER;
-    void *pad;
-} MPIDI_OFI_offset_checker_t;
-
 typedef struct MPIDI_OFI_seg_state {
     MPI_Aint buf_limit;         /* Maximum data size in bytes which a single OFI call can handle.
                                  * This value remains constant once seg_state is initialized. */
@@ -502,7 +496,6 @@ typedef struct {
 
 typedef struct MPIDI_OFI_win_request {
     MPIR_OBJECT_HEADER;
-    char pad[MPIDI_REQUEST_HDR_SIZE - MPIDI_OFI_OBJECT_HEADER_SIZE];
     struct fi_context context[MPIDI_OFI_CONTEXT_STRUCTS];       /* fixed field, do not move */
     int event_id;               /* fixed field, do not move */
     struct MPIDI_OFI_win_request *next;

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     if (message_h) {
         *flag = 1;
-        req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE);
+        req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE, 0);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).message_handler = message_h;

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -23,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_recv_cmpl_cb(void *request, ucs_status_t
     if (ucp_request->req)
         rreq = ucp_request->req;
     else
-        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+        rreq = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
 
     if (unlikely(status == UCS_ERR_CANCELED)) {
         MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
@@ -148,7 +148,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
         ucp_request_release(ucp_request);
     } else {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+            req = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -76,7 +76,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
         /* Create an MPI request and return. The completion cb will complete
          * the request and release ucp_request. */
         MPIR_Request *req = NULL;
-        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+        req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
         ucp_request->req = req;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
 
     if (ucp_request) {
         if (req == NULL)
-            req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+            req = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
         MPIR_Request_add_ref(req);
         ucp_request->req = req;
         MPIDI_UCX_REQ(req).ucp_request = ucp_request;

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -367,7 +367,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -472,7 +472,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_raccumulate(const void *origin_addr
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -521,7 +521,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget_accumulate(const void *origin_
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);
@@ -632,7 +632,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
     MPIR_ERR_CHECK(mpi_errno);
 
     /* create a completed request for user. */
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
     MPIR_Assert(sreq);
 
     MPIR_Request_add_ref(sreq);

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -361,7 +361,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_win_hash_clear(MPIR_Win * win)
 
 #define MPIDI_Request_create_null_rreq(rreq_, mpi_errno_, FAIL_)        \
     do {                                                                \
-        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);         \
+        (rreq_) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);         \
         if ((rreq_) != NULL) {                                          \
             MPIR_cc_set(&(rreq_)->cc, 0);                               \
             MPIR_Status_set_procnull(&(rreq_)->status);                 \

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -220,7 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_RECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(RECV, NULL /*send_buf */ , buf, count, datatype,
@@ -257,7 +257,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -288,7 +288,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_imrecv_safe(void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_IMRECV_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV);
+    MPIR_Request *request = MPIR_Request_create(MPIR_REQUEST_KIND__RECV, 0);
     MPIR_ERR_CHKANDSTMT(request == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(IMRECV, NULL /*send_buf */ , buf, count, datatype,
@@ -372,7 +372,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPID_RECV_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_RECV_INIT);
 
-    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV);
+    rreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_RECV, 0);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = rreq;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -254,7 +254,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
      *       threshold for lightweight send is controlled by lower layer. It'll be nice
      *       if the lower layer expose the threshold.
      */
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -291,7 +291,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(CSEND, buf, count, datatype, rank, tag, comm,
@@ -325,7 +325,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(ISEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -362,7 +362,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISEND_COLL_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_csend_enqueue(ICSEND, buf, count, datatype, rank, tag, comm,
@@ -396,7 +396,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_SSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -431,7 +431,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_ISSEND_SAFE);
 
 #ifdef MPIDI_CH4_USE_WORK_QUEUES
-    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND);
+    *(req) = MPIR_Request_create(MPIR_REQUEST_KIND__SEND, 0);
     MPIR_ERR_CHKANDSTMT((*req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
     MPIDI_workq_pt2pt_enqueue(SSEND, buf, NULL /*recv_buf */ , count, datatype,
@@ -682,7 +682,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_PSEND_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_PSEND_INIT);
 
-    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND);
+    sreq = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_SEND, 0);
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
 

--- a/src/mpid/ch4/src/ch4r_request.h
+++ b/src/mpid/ch4/src/ch4r_request.h
@@ -22,7 +22,7 @@ static inline MPIR_Request *MPIDIG_request_create(MPIR_Request_kind_t kind, int 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_REQUEST_CREATE);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_REQUEST_CREATE);
 
-    req = MPIR_Request_create(kind);
+    req = MPIR_Request_create(kind, 0);
     if (req == NULL)
         goto fn_fail;
 

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -268,7 +268,7 @@ static int group_id(rte_grp_handle_t group)
 static void *get_coll_handle(void)
 {
     MPIR_Request *req;
-    req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
+    req = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
     MPIR_Request_add_ref(req);
     return (void *) req;
 }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -471,7 +471,7 @@ int MPIDU_Sched_start(MPIR_Sched_t * sp, MPIR_Comm * comm, int tag, MPIR_Request
     MPIR_Assert(s->entries != NULL);
 
     /* now create and populate the request */
-    r = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
+    r = MPIR_Request_create(MPIR_REQUEST_KIND__COLL, 0);
     if (!r)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     /* FIXME is this right when comm/datatype GC is used? */

--- a/src/util/mpir_handlemem.c
+++ b/src/util/mpir_handlemem.c
@@ -67,6 +67,7 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr)
     MPIR_Handle_common *ptr;
     int leaked_handles = FALSE;
     int directSize = objmem->direct_size;
+    /* NOTE: direct could be NULL (and directSize == 0) */
     char *direct = (char *) objmem->direct;
     char *directEnd = (char *) direct + directSize * objmem->size - 1;
     int nDirect = 0;
@@ -86,7 +87,7 @@ int MPIR_check_handles_on_finalize(void *objmem_ptr)
     while (ptr) {
         /* printf("Looking at %p\n", ptr); */
         /* Find where this object belongs */
-        if ((char *) ptr >= direct && (char *) ptr < directEnd) {
+        if (direct && (char *) ptr >= direct && (char *) ptr < directEnd) {
             nDirect++;
         } else {
             void **indirect = (void **) objmem->indirect;


### PR DESCRIPTION
## Pull Request Description
Extend handle object for request objects to have multiple pools.
Multiple pools allows request objects to be allocated and freed in
parallel, critical for threading performance.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)\
      PR #4273
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
