### PR TITLE
romio: Fix conditional for skipping info processing

### DIFF
--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -28,7 +28,7 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
     /* if we've already set up default hints and the user has not asked us to
      * process any hints (MPI_INFO_NULL), then we can short-circuit hint
      * processing */
-    if (fd->hints->initialized && fd->info == MPI_INFO_NULL) {
+    if (fd->hints->initialized && users_info == MPI_INFO_NULL) {
         *error_code = MPI_SUCCESS;
         return;
     }


### PR DESCRIPTION
## Pull Request Description

Fix short-circuit conditional for info hint processing in
ADIOI_GEN_SetInfo. We can safely skip hint processing if the user
passes MPI_INFO_NULL.

Cherry-picked from #3485.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
