### PR TITLE
Debug logging cleanup

### DIFF
--- a/src/mpi/init/init_dbg_logging.c
+++ b/src/mpi/init/init_dbg_logging.c
@@ -40,8 +40,7 @@ void MPII_init_dbg_logging(void)
      * If the parent comm is not NULL, we always give the world number
      * as "1" (false). */
     MPL_dbg_init(NULL, NULL, TRUE, TRUE,
-                 MPIR_Process.comm_parent != NULL, MPIR_Process.comm_world->rank,
-                 MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
+                 MPIR_Process.comm_parent != NULL, MPIR_Process.comm_world->rank);
 
     MPIR_DBG_INIT = MPL_dbg_class_alloc("INIT", "init");
     MPIR_DBG_PT2PT = MPL_dbg_class_alloc("PT2PT", "pt2pt");

--- a/src/mpi/init/init_dbg_logging.c
+++ b/src/mpi/init/init_dbg_logging.c
@@ -27,11 +27,8 @@ MPL_dbg_class MPIR_DBG_STRING;
 
 void MPII_pre_init_dbg_logging(int *argc, char ***argv)
 {
-    /* set last arg, wtimeNotReady, to 0 will cause reset time_origin
-     * (for dbg messages), which should be OK here.
-     */
     /* we are ignoring any argument error here as they shouldn't affect MPI operations */
-    MPL_dbg_pre_init(argc, argv, 0);
+    MPL_dbg_pre_init(argc, argv);
 }
 
 void MPII_init_dbg_logging(void)

--- a/src/mpi/init/init_dbg_logging.c
+++ b/src/mpi/init/init_dbg_logging.c
@@ -36,8 +36,7 @@ void MPII_init_dbg_logging(void)
     /* FIXME: This is a hack to handle the common case of two worlds.
      * If the parent comm is not NULL, we always give the world number
      * as "1" (false). */
-    MPL_dbg_init(NULL, NULL, TRUE, TRUE,
-                 MPIR_Process.comm_parent != NULL, MPIR_Process.comm_world->rank);
+    MPL_dbg_init(MPIR_Process.comm_parent != NULL, MPIR_Process.comm_world->rank);
 
     MPIR_DBG_INIT = MPL_dbg_class_alloc("INIT", "init");
     MPIR_DBG_PT2PT = MPL_dbg_class_alloc("PT2PT", "pt2pt");

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -146,6 +146,6 @@ int MPL_dbg_outevent(const char *, int, int, int, const char *, ...) ATTRIBUTE((
 /* *INDENT-ON* */
 
 int MPL_dbg_init(int *, char ***, int, int, int, int);
-int MPL_dbg_pre_init(int *, char ***, int);
+int MPL_dbg_pre_init(int *, char ***);
 
 #endif /* MPL_DBG_H_INCLUDED */

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -145,7 +145,7 @@ void MPL_dbg_class_register(MPL_dbg_class cls, const char *ucname, const char *l
 int MPL_dbg_outevent(const char *, int, int, int, const char *, ...) ATTRIBUTE((format(printf, 5, 6)));
 /* *INDENT-ON* */
 
-int MPL_dbg_init(int *, char ***, int, int, int, int, int);
+int MPL_dbg_init(int *, char ***, int, int, int, int);
 int MPL_dbg_pre_init(int *, char ***, int);
 
 #endif /* MPL_DBG_H_INCLUDED */

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -145,7 +145,7 @@ void MPL_dbg_class_register(MPL_dbg_class cls, const char *ucname, const char *l
 int MPL_dbg_outevent(const char *, int, int, int, const char *, ...) ATTRIBUTE((format(printf, 5, 6)));
 /* *INDENT-ON* */
 
-int MPL_dbg_init(int *, char ***, int, int, int, int);
 int MPL_dbg_pre_init(int *, char ***);
+int MPL_dbg_init(int, int);
 
 #endif /* MPL_DBG_H_INCLUDED */

--- a/src/mpl/src/dbg/mpl_dbg.c
+++ b/src/mpl/src/dbg/mpl_dbg.c
@@ -484,7 +484,7 @@ int MPL_dbg_pre_init(int *argc_p, char ***argv_p)
     return MPL_DBG_SUCCESS;
 }
 
-int MPL_dbg_init(int *argc_p, char ***argv_p, int has_args, int has_env, int wnum, int wrank)
+int MPL_dbg_init(int wnum, int wrank)
 {
     int ret;
     FILE *dbg_fp = NULL;
@@ -502,20 +502,6 @@ int MPL_dbg_init(int *argc_p, char ***argv_p, int has_args, int has_env, int wnu
     }
 
     dbg_fp = get_fp();
-
-    /* Check to see if any debugging was selected.  The order of these
-     * tests is important, as they allow general defaults to be set,
-     * followed by more specific modifications. */
-    /* Both of these may have already been set in the PreInit call; if
-     * the command line and/or environment variables are set before
-     * the full initialization, then don't call the routines to check
-     * those values (as they were already handled in DBG_PreInit) */
-    /* First, the environment variables */
-    if (!has_env)
-        dbg_process_env();
-    /* Now the command-line arguments */
-    if (!has_args)
-        dbg_process_args(argc_p, argv_p);
 
     world_num = wnum;
     world_rank = wrank;

--- a/src/mpl/src/dbg/mpl_dbg.c
+++ b/src/mpl/src/dbg/mpl_dbg.c
@@ -50,7 +50,6 @@ static char temp_filename[MAXPATHLEN] = "";
 static int world_num = 0;
 static int world_rank = -1;
 static int which_rank = -1;     /* all ranks */
-static int reset_time_origin = 1;
 static double time_origin = 0.0;
 
 static int dbg_usage(const char *, const char *);
@@ -445,7 +444,7 @@ MPL_dbg_class MPL_DBG_ALL = ~(0);       /* pre-initialize the ALL class */
  * full initialization is not required for updating the environment
  * and/or command-line arguments.
  */
-int MPL_dbg_pre_init(int *argc_p, char ***argv_p, int wtimeNotReady)
+int MPL_dbg_pre_init(int *argc_p, char ***argv_p)
 {
     MPL_time_t t;
 
@@ -465,11 +464,9 @@ int MPL_dbg_pre_init(int *argc_p, char ***argv_p, int wtimeNotReady)
 
     dbg_process_args(argc_p, argv_p);
 
-    if (wtimeNotReady == 0) {
-        MPL_wtime(&t);
-        MPL_wtime_todouble(&t, &time_origin);
-        reset_time_origin = 0;
-    }
+    MPL_wtime_init();
+    MPL_wtime(&t);
+    MPL_wtime_todouble(&t, &time_origin);
 
     /* Allocate the predefined classes */
     MPL_DBG_ROUTINE_ENTER = MPL_dbg_class_alloc("ROUTINE_ENTER", "routine_enter");
@@ -506,14 +503,6 @@ int MPL_dbg_init(int *argc_p, char ***argv_p, int has_args, int has_env, int wnu
 
     dbg_fp = get_fp();
 
-    /* We may need to wait until the device is set up to initialize
-     * the timer */
-    if (reset_time_origin) {
-        MPL_time_t t;
-        MPL_wtime(&t);
-        MPL_wtime_todouble(&t, &time_origin);
-        reset_time_origin = 0;
-    }
     /* Check to see if any debugging was selected.  The order of these
      * tests is important, as they allow general defaults to be set,
      * followed by more specific modifications. */


### PR DESCRIPTION
## Pull Request Description

Some cleanup for the debug logging initialization.  It removes dependencies from threading and timer initialization, but still has a dependency on device initialization in order to get world ID and world rank.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
