### PR TITLE
romio: Use tr for replacing + to space in list of file systems

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -757,7 +757,7 @@ if test -n "$FILE_SYSTEM" ; then
    # we could set the IFS to tokenize FILE_SYSTEM, but the FILE_SYSTEM env var
    # is used in multiple places in the build system: get rid of the '+'s so we
    # can use the 'for x in $FILE_SYSTEM ...' idiom 
-   FILE_SYSTEM=`echo $FILE_SYSTEM|sed -e 's/\+/ /g'`
+   FILE_SYSTEM=`echo $FILE_SYSTEM|tr '+' ' '`
    for x in $FILE_SYSTEM
    do
       found=no


### PR DESCRIPTION
## Pull Request Description

The `sed` regexp currently used causes troubles with BusyBox `sed`, making it
impossible to configure file systems:
```
sandbox:${WORKSPACE} # FILE_SYSTEM="testfs ufs nfs"
sandbox:${WORKSPACE} # FILE_SYSTEM=`echo $FILE_SYSTEM|sed -e 's/\+/ /g'`
sed: bad regex '\+': Repetition not preceded by valid expression
sandbox:${WORKSPACE} # echo $FILE_SYSTEM

sandbox:${WORKSPACE} #
```
For such a simple substitution `tr` is much better and doesn't require using
a potentially incompatible regexp.

This came out while trying to build mpich with
[`BinaryBuilder.jl`](https://github.com/JuliaPackaging/BinaryBuilder.jl).

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Make it possible to properly configure MPICH in BusyBox-based systems.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
