### PR TITLE
init: fix the order of async init and finalize

### DIFF
--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -127,6 +127,11 @@ int MPI_Finalize(void)
     mpi_errno = MPII_finalize_async();
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* Setting isThreaded to 0 to trick any operations used within
+     * MPI_Finalize to think that we are running in a single threaded
+     * environment. */
+    MPIR_ThreadInfo.isThreaded = 0;
+
     mpi_errno = MPII_finalize_local_proc_attrs();
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -137,11 +142,6 @@ int MPI_Finalize(void)
 
     /* Signal the debugger that we are about to exit. */
     MPIR_Debugger_set_aborting(NULL);
-
-    /* Setting isThreaded to 0 to trick any operations used within
-     * MPID_Finalize to think that we are running in a single threaded
-     * environment. */
-    MPIR_ThreadInfo.isThreaded = 0;
 
     mpi_errno = MPID_Finalize();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -42,8 +42,6 @@ static int MPIR_async_thread_initialized = 0;
 
 static MPIR_Comm *progress_comm_ptr;
 static MPID_Thread_id_t progress_thread_id;
-static MPID_Thread_mutex_t progress_mutex;
-static MPID_Thread_cond_t progress_cond;
 static volatile int progress_thread_done = 0;
 
 /* We can use whatever tag we want; we use a different communicator
@@ -79,18 +77,6 @@ static void progress_fn(void *data)
     mpi_errno = MPIR_Wait(&request, &status);
     MPIR_Assert(!mpi_errno);
 
-    /* Send a signal to the main thread saying we are done */
-    MPID_Thread_mutex_lock(&progress_mutex, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
-    progress_thread_done = 1;
-
-    MPID_Thread_mutex_unlock(&progress_mutex, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
-    MPID_Thread_cond_signal(&progress_cond, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
 
@@ -112,14 +98,6 @@ int MPIR_Init_async_thread(void)
     MPIR_Comm_get_ptr(MPI_COMM_SELF, comm_self_ptr);
     mpi_errno = MPIR_Comm_dup_impl(comm_self_ptr, NULL, &progress_comm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
-
-    MPID_Thread_cond_create(&progress_cond, &err);
-    MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**cond_create", "**cond_create %s",
-                         strerror(err));
-
-    MPID_Thread_mutex_create(&progress_mutex, &err);
-    MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**mutex_create", "**mutex_create %s",
-                         strerror(err));
 
     MPID_Thread_create((MPID_Thread_func_t) progress_fn, NULL, &progress_thread_id, &err);
     MPIR_ERR_CHKANDJUMP1(err, mpi_errno, MPI_ERR_OTHER, "**mutex_create", "**mutex_create %s",
@@ -157,26 +135,9 @@ int MPIR_Finalize_async_thread(void)
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
 
-    MPID_Thread_mutex_lock(&progress_mutex, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
-    while (!progress_thread_done) {
-        MPID_Thread_cond_wait(&progress_cond, &progress_mutex, &mpi_errno);
-        MPIR_Assert(!mpi_errno);
-    }
-
-    MPID_Thread_mutex_unlock(&progress_mutex, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
     MPID_Thread_join(progress_thread_id);
 
     mpi_errno = MPIR_Comm_free_impl(progress_comm_ptr);
-    MPIR_Assert(!mpi_errno);
-
-    MPID_Thread_cond_destroy(&progress_cond, &mpi_errno);
-    MPIR_Assert(!mpi_errno);
-
-    MPID_Thread_mutex_destroy(&progress_mutex, &mpi_errno);
     MPIR_Assert(!mpi_errno);
 
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPIR_FINALIZE_ASYNC_THREAD);

--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -168,6 +168,8 @@ int MPIR_Finalize_async_thread(void)
     MPID_Thread_mutex_unlock(&progress_mutex, &mpi_errno);
     MPIR_Assert(!mpi_errno);
 
+    MPID_Thread_join(progress_thread_id);
+
     mpi_errno = MPIR_Comm_free_impl(progress_comm_ptr);
     MPIR_Assert(!mpi_errno);
 

--- a/src/mpid/ch3/include/mpid_thread.h
+++ b/src/mpid/ch3/include/mpid_thread.h
@@ -26,6 +26,7 @@ typedef MPIDU_Thread_func_t  MPID_Thread_func_t;
 #define MPID_Thread_create       MPIDU_Thread_create
 #define MPID_Thread_exit         MPIDU_Thread_exit
 #define MPID_Thread_self         MPIDU_Thread_self
+#define MPID_Thread_join         MPIDU_Thread_join
 #define MPID_Thread_same       MPIDU_Thread_same
 #define MPID_Thread_yield        MPIDU_Thread_yield
 

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -36,8 +36,8 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_Thread_exit         MPIDU_Thread_exit
 #define MPID_Thread_self         MPIDU_Thread_self
 #define MPID_Thread_join         MPIDU_Thread_join
-#define MPID_Thread_same       MPIDU_Thread_same
-#define MPID_Thread_same       MPIDU_Thread_same
+#define MPID_Thread_same         MPIDU_Thread_same
+#define MPID_Thread_yield        MPIDU_Thread_yield
 
 #define MPID_Thread_cond_create MPIDU_Thread_cond_create
 #define MPID_Thread_cond_destroy MPIDU_Thread_cond_destroy

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -35,6 +35,7 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_Thread_create       MPIDU_Thread_create
 #define MPID_Thread_exit         MPIDU_Thread_exit
 #define MPID_Thread_self         MPIDU_Thread_self
+#define MPID_Thread_join         MPIDU_Thread_join
 #define MPID_Thread_same       MPIDU_Thread_same
 #define MPID_Thread_same       MPIDU_Thread_same
 

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -206,6 +206,7 @@ M*/
 #define MPIDU_Thread_create       MPL_thread_create
 #define MPIDU_Thread_exit         MPL_thread_exit
 #define MPIDU_Thread_self         MPL_thread_self
+#define MPIDU_Thread_join       MPL_thread_join
 #define MPIDU_Thread_same       MPL_thread_same
 
 /*@

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -51,6 +51,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
 
 #define MPL_thread_exit()
 #define MPL_thread_self(id_) ABT_thread_self_id(id_)
+#define MPL_thread_join(id_) ABT_thread_join(id_)
 #define MPL_thread_same(id1_, id2_, same_)  ABT_thread_equal(id1_, id2_, same_)
 
 /* ======================================================================

--- a/src/mpl/include/mpl_thread_posix.h
+++ b/src/mpl/include/mpl_thread_posix.h
@@ -48,6 +48,11 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
         *(id_) = pthread_self();                \
     } while (0)
 
+#define MPL_thread_join(id_)                    \
+    do {                                        \
+        pthread_join(id_, NULL);                \
+    } while (0)
+
 #define MPL_thread_same(id1_, id2_, same_)                              \
     do {                                                                \
         *(same_) = pthread_equal(*(id1_), *(id2_)) ? TRUE : FALSE;      \

--- a/src/mpl/include/mpl_thread_solaris.h
+++ b/src/mpl/include/mpl_thread_solaris.h
@@ -42,6 +42,11 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id,
         *(id_ptr_) = thr_self();                \
     } while (0)
 
+#define MPL_thread_join(id_ptr_)                \
+    do {                                        \
+        thr_join(id_ptr_, NULL, NULL);          \
+    } while (0)
+
 #define MPL_thread_same(id1_ptr_, id2_ptr_, same_ptr_)                  \
     do {                                                                \
         *(same_ptr_) = (*(id1_ptr_) == *(id2_ptr_)) ? TRUE : FALSE;     \

--- a/src/mpl/include/mpl_thread_win.h
+++ b/src/mpl/include/mpl_thread_win.h
@@ -41,6 +41,7 @@ typedef void (*MPL_thread_func_t) (void *data);
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * id, int *err);
 void MPL_thread_exit(void);
 void MPL_thread_self(MPL_thread_id_t * id);
+void MPL_thread_join(MPL_thread_id_t * id);
 void MPL_thread_same(MPL_thread_id_t * id1, MPL_thread_id_t * id2, int *same);
 void MPL_thread_yield();
 

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -46,17 +46,12 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     thread_info =
         (struct MPLI_thread_info *) MPL_malloc(sizeof(struct MPLI_thread_info), MPL_MEM_THREAD);
     if (thread_info != NULL) {
-        pthread_attr_t attr;
 
         thread_info->func = func;
         thread_info->data = data;
 
-        pthread_attr_init(&attr);
-        pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-
-        err = pthread_create(idp, &attr, MPLI_thread_start, thread_info);
+        err = pthread_create(idp, NULL, MPLI_thread_start, thread_info);
         /* FIXME: convert error to an MPL_THREAD_ERR value */
-        pthread_attr_destroy(&attr);
     } else {
         err = 1000000000;
     }

--- a/src/mpl/src/thread/mpl_thread_win.c
+++ b/src/mpl/src/thread/mpl_thread_win.c
@@ -89,6 +89,11 @@ void MPL_thread_self(MPL_thread_id_t * id)
     *id = GetCurrentThread();
 }
 
+void MPL_thread_join(MPL_thread_id_t * id)
+{
+    WaitForSingleObject(id, INFINITE);
+}
+
 void MPL_thread_same(MPL_thread_id_t * id1, MPL_thread_id_t * id2, int *same)
 {
     *same = (*id1 == *id2) ? TRUE : FALSE;


### PR DESCRIPTION
## Pull Request Description
Async thread progress assumes runtime environment and therefore needs to
be started at the end of init and closed before finalize.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
      Weekly test with `MPIR_CVAR_ASYNC_PROGRESS=1` hangs at finalize. This is caused by PR #4199
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
