### PR TITLE
misc: follow up on request pool allocations

### DIFF
--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -274,18 +274,17 @@ typedef int Handle_ref_count;
 
 #elif MPICH_THREAD_REFCOUNT == MPICH_REFCOUNT__LOCKFREE
 
-#include "opa_primitives.h"
-typedef OPA_int_t Handle_ref_count;
+typedef MPL_atomic_int_t Handle_ref_count;
 
 #define MPIR_Object_set_ref(objptr_,val)                        \
     do {                                                        \
-        OPA_store_int(&(objptr_)->ref_count, val);              \
+        MPL_atomic_store_int(&(objptr_)->ref_count, val); \
         HANDLE_LOG_REFCOUNT_CHANGE(objptr_, val, "set");        \
     } while (0)
 
 /* must be used with care, since there is no synchronization for this read */
 #define MPIR_Object_get_ref(objptr_) \
-    (OPA_load_int(&(objptr_)->ref_count))
+    (MPL_atomic_load_int(&(objptr_)->ref_count))
 
 #ifdef MPICH_DEBUG_HANDLES
 /*
@@ -300,13 +299,13 @@ typedef OPA_int_t Handle_ref_count;
 #define MPIR_Object_add_ref_always(objptr_)                             \
     do {                                                                \
         int new_ref_;                                                   \
-        new_ref_ = OPA_fetch_and_incr_int(&((objptr_)->ref_count)) + 1; \
+        new_ref_ = MPL_atomic_fetch_add_int(&((objptr_)->ref_count), 1) + 1; \
         HANDLE_LOG_REFCOUNT_CHANGE(objptr_, new_ref_, "incr");          \
         HANDLE_CHECK_REFCOUNT(objptr_,new_ref_,"incr");                 \
     } while (0)
 #define MPIR_Object_release_ref_always(objptr_,inuse_ptr)               \
     do {                                                                \
-        int new_ref_ = OPA_fetch_and_decr_int(&((objptr_)->ref_count)) - 1; \
+        int new_ref_ = MPL_atomic_fetch_sub_int(&((objptr_)->ref_count), 1) - 1; \
         *(inuse_ptr) = new_ref_;                                        \
         HANDLE_LOG_REFCOUNT_CHANGE(objptr_, new_ref_, "decr");          \
         HANDLE_CHECK_REFCOUNT(objptr_,new_ref_,"decr");                 \
@@ -315,12 +314,12 @@ typedef OPA_int_t Handle_ref_count;
 /* MPICH_THREAD_REFCOUNT == MPICH_REFCOUNT__LOCKFREE && !MPICH_DEBUG_HANDLES */
 #define MPIR_Object_add_ref_always(objptr_)     \
     do {                                        \
-        OPA_incr_int(&((objptr_)->ref_count));  \
+        MPL_atomic_fetch_add_int(&((objptr_)->ref_count), 1);  \
     } while (0)
 #define MPIR_Object_release_ref_always(objptr_,inuse_ptr)               \
     do {                                                                \
-        int got_zero_ = OPA_decr_and_test_int(&((objptr_)->ref_count)); \
-        *(inuse_ptr) = got_zero_ ? 0 : 1;                               \
+        int new_ref_ = MPL_atomic_fetch_sub_int(&((objptr_)->ref_count), 1) - 1; \
+        *(inuse_ptr) = new_ref_;                                        \
     } while (0)
 #endif /* MPICH_DEBUG_HANDLES */
 #else

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -359,9 +359,6 @@ static inline MPIR_Request *MPIR_Request_create(MPIR_Request_kind_t kind, int po
 #define MPIR_Request_add_ref(req_p_) \
     do { MPIR_Object_add_ref(req_p_); } while (0)
 
-#define MPIR_Request_release_ref(req_p_, inuse_) \
-    do { MPIR_Object_release_ref(req_p_, inuse_); } while (0)
-
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIR_Request_create_complete(MPIR_Request_kind_t kind)
 {
     MPIR_Request *req;
@@ -381,7 +378,7 @@ static inline void MPIR_Request_free(MPIR_Request * req)
 {
     int inuse;
 
-    MPIR_Request_release_ref(req, &inuse);
+    MPIR_Object_release_ref(req, &inuse);
 
     /* inform the device that we are decrementing the ref-count on
      * this request */

--- a/src/mpid/ch4/netmod/ofi/globals.c
+++ b/src/mpid/ch4/netmod/ofi/globals.c
@@ -166,7 +166,3 @@ MPIDI_OFI_capabilities_t MPIDI_OFI_caps_list[MPIDI_OFI_NUM_SETS] =
      .major_version = MPIDI_OFI_MAJOR_VERSION_MINIMAL,
      .minor_version = MPIDI_OFI_MINOR_VERSION_MINIMAL}
 };
-
-/* MPIDI_OFI_win_request_t objects */
-MPIR_Object_alloc_t MPIDI_OFI_win_request_mem =
-    { 0, 0, 0, 0, MPIR_INTERNAL, sizeof(MPIDI_OFI_win_request_t), NULL, 0 };

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -278,27 +278,17 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_OFI_check_acc_order_size(MPIR_Win * win, s
     return max_size;
 }
 
-extern MPIR_Object_alloc_t MPIDI_OFI_win_request_mem;
-
 MPL_STATIC_INLINE_PREFIX MPIDI_OFI_win_request_t *MPIDI_OFI_win_request_create(void)
 {
     MPIDI_OFI_win_request_t *winreq;
-    winreq = MPIR_Handle_obj_alloc(&MPIDI_OFI_win_request_mem);
-    if (winreq) {
-        MPIR_Object_set_ref(winreq, 1);
-    }
+    winreq = MPL_malloc(sizeof(*winreq), MPL_MEM_OTHER);
     return winreq;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_win_request_complete(MPIDI_OFI_win_request_t * winreq)
 {
-    int in_use;
-    MPIR_Assert(HANDLE_GET_MPI_KIND(winreq->handle) == MPIR_INTERNAL);
-    MPIR_Object_release_ref(winreq, &in_use);
-    if (!in_use) {
-        MPL_free(winreq->noncontig);
-        MPIR_Handle_obj_free(&MPIDI_OFI_win_request_mem, (winreq));
-    }
+    MPL_free(winreq->noncontig);
+    MPL_free(winreq);
 }
 
 /* This function implements netmod vci to vni(context) mapping.


### PR DESCRIPTION
## Pull Request Description

These are misc commits that are split from PR #4285 
* remove a unnecessary macro redirection
* directly malloc MPIDI_OFI_win_request_t objects
* use MPL_atomic for handle object ref_count
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
