### PR TITLE
refcount: Remove predefined object refcount option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -561,13 +561,6 @@ AC_ARG_ENABLE(mutex-timing,
 	AC_HELP_STRING([--enable-mutex-timing], [calculate the time spent waiting on mutexes]),
 	AC_DEFINE(MPIU_MUTEX_WAIT_TIME,1,[Define to enable timing mutexes]))
 
-AC_ARG_ENABLE([predefined-refcount],
-	AS_HELP_STRING([--enable-predefined-refcount],
-                       [control whether predefined objects like
-		       MPI_COMM_WORLD are reference counted (default
-		       depends on --enable-thread-cs choice)]),[],
-              [enable_predefined_refcount=default])
-
 AC_ARG_ENABLE(weak-symbols,
 	AC_HELP_STRING([--enable-weak-symbols],
 			[Use weak symbols to implement PMPI routines (default)]),,
@@ -1524,7 +1517,6 @@ if test "$enable_threads" = "multiple" ; then
     lock-free|lock_free|lockfree)
     thread_granularity=MPICH_THREAD_GRANULARITY__LOCKFREE
     if test "$enable_refcount" = "default" ; then enable_refcount=lock-free ; fi
-    if test "$enable_predefined_refcount" = "default" ; then enable_predefined_refcount=no ; fi
     AC_MSG_ERROR([--enable-thread-cs=lock-free is not supported yet, please select a different granularity])
     ;;
     *)
@@ -1558,10 +1550,6 @@ if test "$enable_mdta" = "yes" ; then
     if test "$enable_threads" != "multiple" -o "$device_name" != "ch4" -o "$enable_thread_cs" != "global" ; then
         AC_MSG_ERROR([--enable-mdta is not supported for this setting])
     fi
-fi
-
-if test "$enable_predefined_refcount" = "no" ; then
-    AC_DEFINE([MPICH_THREAD_SUPPRESS_PREDEFINED_REFCOUNTS],[1],[define to disable reference counting predefined objects like MPI_COMM_WORLD])
 fi
 
 AC_DEFINE_UNQUOTED([MPICH_THREAD_REFCOUNT],$thread_refcount,[Method used to implement refcount updates])

--- a/src/include/mpir_errhandler.h
+++ b/src/include/mpir_errhandler.h
@@ -71,25 +71,13 @@ extern MPIR_Object_alloc_t MPIR_Errhandler_mem;
 extern MPIR_Errhandler MPIR_Errhandler_builtin[];
 extern MPIR_Errhandler MPIR_Errhandler_direct[];
 
-/* We never reference count the builtin error handler objects, regardless of how
- * we decide to reference count the other predefined objects.  If we get to the
- * point where we never reference count *any* of the builtin objects then we
- * should probably remove these checks and let them fall through to the checks
- * for BUILTIN down in the MPIR_Object_* routines. */
 #define MPIR_Errhandler_add_ref(_errhand)                               \
     do {                                                                  \
-        if (!HANDLE_IS_BUILTIN((_errhand)->handle)) { \
-            MPIR_Object_add_ref(_errhand);                              \
-        }                                                                 \
+        MPIR_Object_add_ref(_errhand);                                  \
     } while (0)
 #define MPIR_Errhandler_release_ref(_errhand, _inuse)                   \
     do {                                                                  \
-        if (!HANDLE_IS_BUILTIN((_errhand)->handle)) { \
-            MPIR_Object_release_ref((_errhand), (_inuse));              \
-        }                                                                 \
-        else {                                                            \
-            *(_inuse) = 1;                                                \
-        }                                                                 \
+        MPIR_Object_release_ref((_errhand), (_inuse));                  \
     } while (0)
 
 void MPIR_Errhandler_free(MPIR_Errhandler * errhan_ptr);

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -327,11 +327,6 @@ typedef OPA_int_t Handle_ref_count;
 #error invalid value for MPICH_THREAD_REFCOUNT
 #endif
 
-/* TODO someday we should probably always suppress predefined object refcounting,
- * but we don't have total confidence in it yet.  So until we gain sufficient
- * confidence, this is a configurable option. */
-#if defined(MPICH_THREAD_SUPPRESS_PREDEFINED_REFCOUNTS)
-
 /* The assumption here is that objects with handles of type HANDLE_KIND_BUILTIN
  * will be created/destroyed only at MPI_Init/MPI_Finalize time and don't need
  * to be reference counted.  This can be a big performance win on some
@@ -373,16 +368,6 @@ typedef OPA_int_t Handle_ref_count;
                                                      MPIR_Object_get_ref(objptr_))) \
                 }                                                       \
     } while (0)
-
-#else /* !defined(MPICH_THREAD_SUPPRESS_PREDEFINED_REFCOUNTS) */
-
-/* the base case, where we just always manipulate the reference counts */
-#define MPIR_Object_add_ref(objptr_)            \
-    MPIR_Object_add_ref_always((objptr_))
-#define MPIR_Object_release_ref(objptr_,inuse_ptr_)             \
-    MPIR_Object_release_ref_always((objptr_),(inuse_ptr_))
-
-#endif
 
 
 /* end reference counting macros */


### PR DESCRIPTION
## Pull Request Description

Always suppress refcounting on predefined objects, as they will be
created/destroyed during init/finalize.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

none

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
