### PR TITLE
mpi/info: Fix preprocessor guards for error checking

### DIFF
--- a/src/mpi/info/info_get.c
+++ b/src/mpi/info/info_get.c
@@ -140,9 +140,8 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen, char *value, int 
 
     /* ... body of routine ...  */
     mpi_errno = MPIR_Info_get_impl(info_ptr, key, valuelen, value, flag);
+    MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
-    if (mpi_errno)
-        goto fn_fail;
 
   fn_exit:
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INFO_GET);
@@ -160,8 +159,8 @@ int MPI_Info_get(MPI_Info info, const char *key, int valuelen, char *value, int 
                                          "**mpi_info_get %I %s %d %p %p", info, key, valuelen,
                                          value, flag);
     }
-    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
 #endif
+    mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/info/info_set.c
+++ b/src/mpi/info/info_set.c
@@ -106,26 +106,24 @@ int MPI_Info_set(MPI_Info info, const char *key, const char *value)
     MPIR_ERR_CHECK(mpi_errno);
     /* ... end of body of routine ... */
 
-#ifdef HAVE_ERROR_CHECKING
   fn_exit:
-#endif
     MPIR_FUNC_TERSE_EXIT(MPID_STATE_MPI_INFO_SET);
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_GLOBAL_MUTEX);
     return mpi_errno;
 
-#ifdef HAVE_ERROR_CHECKING
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
+#ifdef HAVE_ERROR_CHECKING
     {
         mpi_errno =
             MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
                                  "**mpi_info_set", "**mpi_info_set %I %s %s", info, key, value);
     }
+#endif
     mpi_errno = MPIR_Err_return_comm(NULL, __func__, mpi_errno);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
-#endif
 }
 
 


### PR DESCRIPTION
## Pull Request Description

We always check the return code from MPIR_Info_set_impl, so the
failure and exit labels must always be defined. Fixes build error with
--disable-error-checking introduced in [f0bc24757e4b].

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix --disable-error-checking builds.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
