### PR TITLE
ch4/ofi: Fix MR mode bit usage

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1703,9 +1703,8 @@ static void update_global_settings(struct fi_info *prov_use, struct fi_info *hin
                                prov_use->domain_attr->mr_mode != FI_MR_SCALABLE);
     } else {
         UPDATE_SETTING_BY_INFO(enable_mr_virt_address,
-                               prov_use->domain_attr->mr_mode == FI_MR_VIRT_ADDR);
-        UPDATE_SETTING_BY_INFO(enable_mr_prov_key,
-                               prov_use->domain_attr->mr_mode == FI_MR_PROV_KEY);
+                               prov_use->domain_attr->mr_mode & FI_MR_VIRT_ADDR);
+        UPDATE_SETTING_BY_INFO(enable_mr_prov_key, prov_use->domain_attr->mr_mode & FI_MR_PROV_KEY);
     }
     UPDATE_SETTING_BY_INFO(enable_tagged,
                            (prov_use->caps & FI_TAGGED) &&


### PR DESCRIPTION
## Pull Request Description

Since MR mode is a bitset, checking for `MR_VIRT_ADDR` and `MR_PROV_KEY`
need to be done in bitwise fashion.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
