### PR TITLE
ch4/am: abstract am message payload transfer in MPIDIG

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am.h
+++ b/src/mpid/ch4/generic/am/mpidig_am.h
@@ -16,12 +16,17 @@
 typedef int (*MPIDIG_am_target_cmpl_cb) (MPIR_Request * req);
 typedef int (*MPIDIG_am_origin_cb) (MPIR_Request * req);
 
-/* Callback function setup by handler register function */
-/* for short cases, output arguments are NULL */
-typedef int (*MPIDIG_am_target_msg_cb)
- (int handler_id, void *am_hdr, void **data,    /* data should be iovs if *is_contig is false */
-  size_t * data_sz, int is_local,       /* SHM or NM directly specifies locality */
-  int *is_contig, MPIR_Request ** req); /* if allocated, need pointer to completion function */
+/* Target message callback, or handler function
+ *
+ * If req on input is NULL, the callback may allocate a request object. If a request
+ * object is returned, the caller is expected to transfer the payload to the request,
+ * and call target_cmpl_cb upon complete.
+ *
+ * If is_async is false/0, a request object will never be returned.
+ */
+typedef int (*MPIDIG_am_target_msg_cb) (int handler_id, void *am_hdr,
+                                        void *data, MPI_Aint data_sz,
+                                        int is_local, int is_async, MPIR_Request ** req);
 
 typedef struct MPIDIG_global_t {
     MPIDIG_am_target_msg_cb target_msg_cbs[MPIDI_AM_HANDLERS_MAX];

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -153,13 +153,19 @@ typedef struct MPIDIG_acc_req_t {
 typedef int (*MPIDIG_req_cmpl_cb) (MPIR_Request * req);
 
 /* structure used for supporting asynchronous payload transfer */
+typedef enum {
+    MPIDIG_RECV_DATATYPE,       /* use the datatype info in MPIDIG_req_t */
+    MPIDIG_RECV_CONTIG,         /* set and use the contig recv-buffer info */
+    MPIDIG_RECV_IOV             /* set and use the iov recv-buffer info */
+} MPIDIG_recv_type;
+
 typedef struct MPIDIG_req_async {
-    int is_contig;
+    MPIDIG_recv_type recv_type;
     MPI_Aint in_data_sz;
-    struct iovec *iov_ptr;      /* used for non-contig data */
-    int iov_num;
-    struct iovec iov_one;       /* used for contig data */
-    MPI_Aint offset;            /* used for direct unpack (is_contig == -1) */
+    struct iovec *iov_ptr;      /* used with MPIDIG_RECV_IOV */
+    int iov_num;                /* used with MPIDIG_RECV_IOV */
+    struct iovec iov_one;       /* used with MPIDIG_RECV_CONTIG */
+    MPI_Aint offset;            /* used with MPIDIG_RECV_DATATYPE */
 } MPIDIG_rreq_async_t;
 
 typedef struct MPIDIG_req_ext_t {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -190,9 +190,8 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
 /* Externs:  see util.c for definition */
 int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
 int MPIDI_OFI_retry_progress(void);
-int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
-                              void **data, size_t * data_sz, int is_local, int *is_contig,
-                              MPIR_Request ** req);
+int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
+                              int is_local, int is_async, MPIR_Request ** req);
 int MPIDI_OFI_control_dispatch(void *buf);
 void MPIDI_OFI_index_datatypes(void);
 int MPIDI_OFI_mr_key_allocator_init(void);

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -195,13 +195,14 @@ static inline int MPIDI_OFI_get_huge(MPIDI_OFI_send_control_t * info)
     goto fn_exit;
 }
 
-int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
-                              void **data,
-                              size_t * data_sz, int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDI_OFI_control_handler(int handler_id, void *am_hdr, void *data, MPI_Aint data_sz,
+                              int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_send_control_t *ctrlsend = (MPIDI_OFI_send_control_t *) am_hdr;
-    *req = NULL;
+
+    if (is_async)
+        *req = NULL;
 
     switch (ctrlsend->type) {
         case MPIDI_OFI_CTRL_HUGEACK:{

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -13,27 +13,19 @@
 static void *am_buf;            /* message buffer has global scope because ucx executes am_handler */
 static void am_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t * info)
 {
-    MPIR_Request *rreq = NULL;
     void *p_data;
     void *in_data;
     size_t data_sz;
-    int is_contig;
     MPIDI_UCX_am_header_t *msg_hdr = (MPIDI_UCX_am_header_t *) am_buf;
 
     p_data = in_data =
         (char *) msg_hdr->payload + (info->length - msg_hdr->data_sz - sizeof(*msg_hdr));
     data_sz = msg_hdr->data_sz;
 
+    /* note: setting is_local, is_async to 0, 0 */
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
-                                                       &p_data, &data_sz, 0 /* is_local */ ,
-                                                       &is_contig, &rreq);
+                                                       p_data, data_sz, 0, 0, NULL);
 
-    if (!rreq)
-        return;
-
-    MPIDIG_recv_copy(in_data, rreq);
-
-    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
 }
 
 int MPIDI_UCX_progress(int vci, int blocking)

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -269,7 +269,7 @@ static int do_send_target(void **data, size_t * p_data_sz, int *is_contig, MPIR_
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_RCV_NON_CONTIG;
     }
 
-    MPIDIG_recv_init(dt_contig, in_total_data_sz, *data, *p_data_sz, rreq);
+    MPIDIG_recv_type_init(in_total_data_sz, rreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_DO_SEND_TARGET);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4r_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_callbacks.h
@@ -24,24 +24,24 @@ void MPIDIG_progress_compl_list(void);
 int MPIDIG_send_origin_cb(MPIR_Request * sreq);
 int MPIDIG_send_long_lmt_origin_cb(MPIR_Request * sreq);
 int MPIDIG_ssend_ack_origin_cb(MPIR_Request * req);
-int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                              int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                              int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                       MPI_Aint in_data_sz, int is_local, int is_async,
                                        MPIR_Request ** req);
-int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_send_long_lmt_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                       MPI_Aint in_data_sz, int is_local, int is_async,
                                        MPIR_Request ** req);
-int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                               int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                   size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_ssend_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint p_data_sz,
+                               int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_ssend_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                   MPI_Aint p_data_sz, int is_local, int is_async,
                                    MPIR_Request ** req);
-int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                       size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_send_long_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                       MPI_Aint p_data_sz, int is_local, int is_async,
                                        MPIR_Request ** req);
 int MPIDIG_comm_abort_origin_cb(MPIR_Request * sreq);
-int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                    int is_local, int *is_contig, MPIR_Request ** req);
+int MPIDIG_comm_abort_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                    int is_local, int is_async, MPIR_Request ** req);
 
 #endif /* CH4R_CALLBACKS_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -26,7 +26,7 @@ static void win_post_proc(const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win);
 static void win_unlock_done(const MPIDIG_win_cntrl_msg_t * info, MPIR_Win * win);
 static int handle_acc_cmpl(MPIR_Request * rreq);
 static int handle_get_acc_cmpl(MPIR_Request * rreq);
-static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPIR_Request * rreq);
+static void handle_acc_data(MPI_Aint in_data_sz, MPIR_Request * rreq);
 static int get_target_cmpl_cb(MPIR_Request * req);
 static int put_target_cmpl_cb(MPIR_Request * rreq);
 static int put_iov_target_cmpl_cb(MPIR_Request * rreq);
@@ -35,8 +35,8 @@ static int get_acc_iov_target_cmpl_cb(MPIR_Request * rreq);
 static int cswap_target_cmpl_cb(MPIR_Request * rreq);
 static int acc_target_cmpl_cb(MPIR_Request * rreq);
 static int get_acc_target_cmpl_cb(MPIR_Request * rreq);
-static int get_ack_target_cmpl_cb(MPIR_Request * get_req);
-static int get_acc_ack_target_cmpl_cb(MPIR_Request * areq);
+static int get_ack_target_cmpl_cb(MPIR_Request * rreq);
+static int get_acc_ack_target_cmpl_cb(MPIR_Request * rreq);
 static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq);
 
 int MPIDIG_RMA_Init_targetcb_pvars(void)
@@ -748,7 +748,7 @@ static int handle_get_acc_cmpl(MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPIR_Request * rreq)
+static void handle_acc_data(MPI_Aint in_data_sz, MPIR_Request * rreq)
 {
     void *p_data = NULL;
     size_t data_sz;
@@ -780,12 +780,12 @@ static void handle_acc_data(void **data, size_t * p_data_sz, int *is_contig, MPI
     for (i = 0; i < MPIDIG_REQUEST(rreq, req->areq.n_iov); i++)
         iov[i].iov_base = (char *) iov[i].iov_base + base;
 
-    MPIDIG_recv_init(1, *p_data_sz, p_data, data_sz, rreq);
+    MPIDIG_recv_init(1, in_data_sz, p_data, data_sz, rreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_HANDLE_ACC_DATA);
 }
 
-static int get_target_cmpl_cb(MPIR_Request * req)
+static int get_target_cmpl_cb(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS, i, c;
     size_t data_sz, offset;
@@ -798,40 +798,40 @@ static int get_target_cmpl_cb(MPIR_Request * req)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_TARGET_CMPL_CB);
 
-    uintptr_t base = (uintptr_t) MPIDIG_REQUEST(req, req->greq.addr);
+    uintptr_t base = (uintptr_t) MPIDIG_REQUEST(rreq, req->greq.addr);
 
-    MPIR_cc_incr(req->cc_ptr, &c);
-    get_ack.greq_ptr = MPIDIG_REQUEST(req, req->greq.greq_ptr);
-    win = MPIDIG_REQUEST(req, req->greq.win_ptr);
+    MPIR_cc_incr(rreq->cc_ptr, &c);
+    get_ack.greq_ptr = MPIDIG_REQUEST(rreq, req->greq.greq_ptr);
+    win = MPIDIG_REQUEST(rreq, req->greq.win_ptr);
     context_id = MPIDIG_win_to_context(win);
 
-    if (MPIDIG_REQUEST(req, req->greq.n_iov) == 0) {
+    if (MPIDIG_REQUEST(rreq, req->greq.n_iov) == 0) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        if (MPIDI_REQUEST(req, is_local))
-            mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
+        if (MPIDI_REQUEST(rreq, is_local))
+            mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
                                                  MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
-                                                 (void *) MPIDIG_REQUEST(req, req->greq.addr),
-                                                 MPIDIG_REQUEST(req, req->greq.count),
-                                                 MPIDIG_REQUEST(req, req->greq.datatype), req);
+                                                 (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
+                                                 MPIDIG_REQUEST(rreq, req->greq.count),
+                                                 MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
         else
 #endif
         {
-            mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
+            mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
                                                 MPIDIG_GET_ACK, &get_ack, sizeof(get_ack),
-                                                (void *) MPIDIG_REQUEST(req, req->greq.addr),
-                                                MPIDIG_REQUEST(req, req->greq.count),
-                                                MPIDIG_REQUEST(req, req->greq.datatype), req);
+                                                (void *) MPIDIG_REQUEST(rreq, req->greq.addr),
+                                                MPIDIG_REQUEST(rreq, req->greq.count),
+                                                MPIDIG_REQUEST(rreq, req->greq.datatype), rreq);
         }
 
-        MPID_Request_complete(req);
+        MPID_Request_complete(rreq);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
-    iov = (struct iovec *) MPIDIG_REQUEST(req, req->greq.dt_iov);
+    iov = (struct iovec *) MPIDIG_REQUEST(rreq, req->greq.dt_iov);
 
     data_sz = 0;
-    for (i = 0; i < MPIDIG_REQUEST(req, req->greq.n_iov); i++) {
+    for (i = 0; i < MPIDIG_REQUEST(rreq, req->greq.n_iov); i++) {
         data_sz += iov[i].iov_len;
     }
 
@@ -839,30 +839,30 @@ static int get_target_cmpl_cb(MPIR_Request * req)
     MPIR_Assert(p_data);
 
     offset = 0;
-    for (i = 0; i < MPIDIG_REQUEST(req, req->greq.n_iov); i++) {
+    for (i = 0; i < MPIDIG_REQUEST(rreq, req->greq.n_iov); i++) {
         /* Adjust a window base address */
         iov[i].iov_base = (char *) iov[i].iov_base + base;
         MPIR_Memcpy(p_data + offset, iov[i].iov_base, iov[i].iov_len);
         offset += iov[i].iov_len;
     }
 
-    MPL_free(MPIDIG_REQUEST(req, req->greq.dt_iov));
-    MPIDIG_REQUEST(req, req->greq.dt_iov) = (void *) p_data;
+    MPL_free(MPIDIG_REQUEST(rreq, req->greq.dt_iov));
+    MPIDIG_REQUEST(rreq, req->greq.dt_iov) = (void *) p_data;
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    if (MPIDI_REQUEST(req, is_local))
-        mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
+    if (MPIDI_REQUEST(rreq, is_local))
+        mpi_errno = MPIDI_SHM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
                                              MPIDIG_GET_ACK, &get_ack, sizeof(get_ack), p_data,
-                                             data_sz, MPI_BYTE, req);
+                                             data_sz, MPI_BYTE, rreq);
     else
 #endif
     {
-        mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(req, rank),
+        mpi_errno = MPIDI_NM_am_isend_reply(context_id, MPIDIG_REQUEST(rreq, rank),
                                             MPIDIG_GET_ACK, &get_ack, sizeof(get_ack), p_data,
-                                            data_sz, MPI_BYTE, req);
+                                            data_sz, MPI_BYTE, rreq);
     }
 
-    MPID_Request_complete(req);
+    MPID_Request_complete(rreq);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_TARGET_CMPL_CB);
@@ -1103,7 +1103,7 @@ static int get_acc_target_cmpl_cb(MPIR_Request * rreq)
     goto fn_exit;
 }
 
-static int get_ack_target_cmpl_cb(MPIR_Request * get_req)
+static int get_ack_target_cmpl_cb(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win;
@@ -1111,21 +1111,21 @@ static int get_ack_target_cmpl_cb(MPIR_Request * get_req)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACK_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACK_TARGET_CMPL_CB);
 
-    if (MPIDIG_REQUEST(get_req, req->status) & MPIDIG_REQ_RCV_NON_CONTIG) {
-        MPL_free(MPIDIG_REQUEST(get_req, req->iov));
+    if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_RCV_NON_CONTIG) {
+        MPL_free(MPIDIG_REQUEST(rreq, req->iov));
     }
 
-    win = MPIDIG_REQUEST(get_req, req->greq.win_ptr);
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(get_req, rank));
+    win = MPIDIG_REQUEST(rreq, req->greq.win_ptr);
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(get_req, req->greq.datatype));
-    MPID_Request_complete(get_req);
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->greq.datatype));
+    MPID_Request_complete(rreq);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACK_TARGET_CMPL_CB);
     return mpi_errno;
 }
 
 
-static int get_acc_ack_target_cmpl_cb(MPIR_Request * areq)
+static int get_acc_ack_target_cmpl_cb(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Win *win;
@@ -1133,16 +1133,16 @@ static int get_acc_ack_target_cmpl_cb(MPIR_Request * areq)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_CMPL_CB);
 
-    if (MPIDIG_REQUEST(areq, req->status) & MPIDIG_REQ_RCV_NON_CONTIG) {
-        MPL_free(MPIDIG_REQUEST(areq, req->iov));
+    if (MPIDIG_REQUEST(rreq, req->status) & MPIDIG_REQ_RCV_NON_CONTIG) {
+        MPL_free(MPIDIG_REQUEST(rreq, req->iov));
     }
 
-    win = MPIDIG_REQUEST(areq, req->areq.win_ptr);
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
-    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
+    win = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
-    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(areq, req->areq.result_datatype));
-    MPID_Request_complete(areq);
+    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, req->areq.result_datatype));
+    MPID_Request_complete(rreq);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_CMPL_CB);
     return mpi_errno;
@@ -1167,8 +1167,8 @@ static int cswap_ack_target_cmpl_cb(MPIR_Request * rreq)
     return mpi_errno;
 }
 
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_put_ack_msg_t *msg_hdr = (MPIDIG_put_ack_msg_t *) am_hdr;
@@ -1188,7 +1188,7 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size
 
     MPID_Request_complete(preq);
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_ack);
@@ -1196,29 +1196,29 @@ int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     return mpi_errno;
 }
 
-int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_acc_ack_msg_t *msg_hdr = (MPIDIG_acc_ack_msg_t *) am_hdr;
     MPIR_Win *win;
-    MPIR_Request *areq;
+    MPIR_Request *rreq;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_ACC_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_ACC_ACK_TARGET_MSG_CB);
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_ack);
 
-    areq = (MPIR_Request *) msg_hdr->req_ptr;
-    win = MPIDIG_REQUEST(areq, req->areq.win_ptr);
+    rreq = (MPIR_Request *) msg_hdr->req_ptr;
+    win = MPIDIG_REQUEST(rreq, req->areq.win_ptr);
 
-    MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
+    MPL_free(MPIDIG_REQUEST(rreq, req->areq.dt_iov));
 
-    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
-    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(areq, rank));
+    MPIDIG_win_remote_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
+    MPIDIG_win_remote_acc_cmpl_cnt_decr(win, MPIDIG_REQUEST(rreq, rank));
 
-    MPID_Request_complete(areq);
+    MPID_Request_complete(rreq);
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_ack);
@@ -1226,54 +1226,66 @@ int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_get_acc_ack_msg_t *msg_hdr = (MPIDIG_get_acc_ack_msg_t *) am_hdr;
-    MPIR_Request *areq;
+    MPIR_Request *rreq;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_MSG_CB);
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_ack);
 
-    areq = (MPIR_Request *) msg_hdr->req_ptr;
+    rreq = (MPIR_Request *) msg_hdr->req_ptr;
 
-    MPL_free(MPIDIG_REQUEST(areq, req->areq.dt_iov));
+    MPL_free(MPIDIG_REQUEST(rreq, req->areq.dt_iov));
 
-    *req = areq;
-    MPIDIG_REQUEST(areq, req->target_cmpl_cb) = get_acc_ack_target_cmpl_cb;
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_ack_target_cmpl_cb;
 
-    MPIDIG_REQUEST(areq, buffer) = MPIDIG_REQUEST(areq, req->areq.result_addr);
-    MPIDIG_REQUEST(areq, count) = MPIDIG_REQUEST(areq, req->areq.result_count);
-    MPIDIG_REQUEST(areq, datatype) = MPIDIG_REQUEST(areq, req->areq.result_datatype);
-    MPIDIG_recv_type_init(*p_data_sz, areq);
+    MPIDIG_REQUEST(rreq, buffer) = MPIDIG_REQUEST(rreq, req->areq.result_addr);
+    MPIDIG_REQUEST(rreq, count) = MPIDIG_REQUEST(rreq, req->areq.result_count);
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(rreq, req->areq.result_datatype);
+    MPIDIG_recv_type_init(in_data_sz, rreq);
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_ACK_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                   int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                   int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_cswap_ack_msg_t *msg_hdr = (MPIDIG_cswap_ack_msg_t *) am_hdr;
-    MPIR_Request *creq;
+    MPIR_Request *rreq;
     uint64_t data_sz;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_CSWAP_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_CSWAP_ACK_TARGET_MSG_CB);
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_cas_ack);
 
-    creq = (MPIR_Request *) msg_hdr->req_ptr;
-    MPIDI_Datatype_check_size(MPIDIG_REQUEST(creq, req->creq.datatype), 1, data_sz);
-    void *result_addr = MPIDIG_REQUEST(creq, req->creq.result_addr);
+    rreq = (MPIR_Request *) msg_hdr->req_ptr;
+    MPIDI_Datatype_check_size(MPIDIG_REQUEST(rreq, req->creq.datatype), 1, data_sz);
+    void *result_addr = MPIDIG_REQUEST(rreq, req->creq.result_addr);
 
-    MPIDIG_recv_init(1, *p_data_sz, result_addr, data_sz, creq);
+    MPIDIG_recv_init(1, in_data_sz, result_addr, data_sz, rreq);
 
-    *req = creq;
-    MPIDIG_REQUEST(creq, req->target_cmpl_cb) = cswap_ack_target_cmpl_cb;
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = cswap_ack_target_cmpl_cb;
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_cas_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_CSWAP_ACK_TARGET_MSG_CB);
@@ -1281,8 +1293,8 @@ int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, si
 }
 
 
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDIG_win_cntrl_msg_t *msg_hdr = (MPIDIG_win_cntrl_msg_t *) am_hdr;
@@ -1331,7 +1343,7 @@ int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
             MPID_Abort(NULL, MPI_ERR_INTERN, 1, buff);
     }
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_win_ctrl);
@@ -1339,8 +1351,8 @@ int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
     return mpi_errno;
 }
 
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1355,10 +1367,9 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    *req = rreq;
 
-    MPIDIG_REQUEST(*req, req->preq.preq_ptr) = msg_hdr->preq_ptr;
-    MPIDIG_REQUEST(*req, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, req->preq.preq_ptr) = msg_hdr->preq_ptr;
+    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -1387,7 +1398,7 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 
         MPIDIG_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
         MPIDIG_REQUEST(rreq, req->preq.n_iov) = msg_hdr->n_iov;
-        MPIDIG_recv_init(0, *p_data_sz, dt_iov, msg_hdr->n_iov, rreq);
+        MPIDIG_recv_init(0, in_data_sz, dt_iov, msg_hdr->n_iov, rreq);
         goto fn_exit;
     }
 
@@ -1396,7 +1407,14 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     MPIDIG_REQUEST(rreq, buffer) = (void *) (base + offset);
     MPIDIG_REQUEST(rreq, count) = msg_hdr->count;
     MPIDIG_REQUEST(rreq, datatype) = msg_hdr->datatype;
-    MPIDIG_recv_type_init(*p_data_sz, rreq);
+    MPIDIG_recv_type_init(in_data_sz, rreq);
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put);
@@ -1406,8 +1424,8 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     goto fn_exit;
 }
 
-int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1423,7 +1441,6 @@ int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
 
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    *req = rreq;
 
     MPIDIG_REQUEST(rreq, req->preq.preq_ptr) = msg_hdr->preq_ptr;
     MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
@@ -1449,10 +1466,17 @@ int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
 
     MPIDIG_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
     MPIDIG_REQUEST(rreq, req->preq.n_iov) = msg_hdr->n_iov;
-    MPIDIG_REQUEST(*req, req->preq.target_addr) = (void *) (offset + base);
+    MPIDIG_REQUEST(rreq, req->preq.target_addr) = (void *) (offset + base);
 
     int data_sz = msg_hdr->n_iov * sizeof(struct iovec);
-    MPIDIG_recv_init(1, *p_data_sz, dt_iov, data_sz, rreq);
+    MPIDIG_recv_init(1, in_data_sz, dt_iov, data_sz, rreq);
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_iov);
@@ -1462,8 +1486,8 @@ int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     goto fn_exit;
 }
 
-int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq, *origin_req;
@@ -1506,7 +1530,7 @@ int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->preq.origin_datatype));
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
   fn_exit:
@@ -1517,8 +1541,8 @@ int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     goto fn_exit;
 }
 
-int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq, *origin_req;
@@ -1563,7 +1587,7 @@ int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
   fn_exit:
@@ -1574,8 +1598,8 @@ int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     goto fn_exit;
 }
 
-int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                         size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                         MPI_Aint in_data_sz, int is_local, int is_async,
                                          MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1621,7 +1645,7 @@ int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **da
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(origin_req, req->areq.origin_datatype));
 
-    if (req)
+    if (is_async)
         *req = NULL;
 
   fn_exit:
@@ -1632,8 +1656,8 @@ int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **da
     goto fn_exit;
 }
 
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -1657,17 +1681,23 @@ int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
 
     void *dt_iov = MPIDIG_REQUEST(rreq, req->preq.dt_iov);
     int n_iov = MPIDIG_REQUEST(rreq, req->preq.n_iov);
-    *req = rreq;
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = put_target_cmpl_cb;
+    MPIDIG_recv_init(0, in_data_sz, dt_iov, n_iov, rreq);
 
-    MPIDIG_recv_init(0, *p_data_sz, dt_iov, n_iov, rreq);
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
+
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_put_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_PUT_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -1678,18 +1708,24 @@ int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, siz
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_acc_data);
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
-    handle_acc_data(data, p_data_sz, is_contig, rreq);
+    handle_acc_data(in_data_sz, rreq);
 
-    *req = rreq;
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = acc_target_cmpl_cb;
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACC_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                      int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -1700,18 +1736,24 @@ int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data,
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_data);
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
-    handle_acc_data(data, p_data_sz, is_contig, rreq);
+    handle_acc_data(in_data_sz, rreq);
 
-    *req = rreq;
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_target_cmpl_cb;
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_data);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_DATA_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                               int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                               int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1728,7 +1770,6 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
 
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    *req = rreq;
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = cswap_target_cmpl_cb;
     MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
@@ -1744,19 +1785,26 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     uintptr_t base = MPIDIG_win_base_at_target(win);
     size_t offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(*req, req->creq.win_ptr) = win;
-    MPIDIG_REQUEST(*req, req->creq.creq_ptr) = msg_hdr->req_ptr;
-    MPIDIG_REQUEST(*req, req->creq.datatype) = msg_hdr->datatype;
-    MPIDIG_REQUEST(*req, req->creq.addr) = (char *) base + offset;
-    MPIDIG_REQUEST(*req, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, req->creq.win_ptr) = win;
+    MPIDIG_REQUEST(rreq, req->creq.creq_ptr) = msg_hdr->req_ptr;
+    MPIDIG_REQUEST(rreq, req->creq.datatype) = msg_hdr->datatype;
+    MPIDIG_REQUEST(rreq, req->creq.addr) = (char *) base + offset;
+    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
 
     MPIR_Assert(dt_contig == 1);
     p_data = MPL_malloc(data_sz * 2, MPL_MEM_RMA);
     MPIR_Assert(p_data);
 
-    MPIDIG_REQUEST(*req, req->creq.data) = p_data;
+    MPIDIG_REQUEST(rreq, req->creq.data) = p_data;
 
-    MPIDIG_recv_init(1, *p_data_sz, p_data, data_sz * 2, *req);
+    MPIDIG_recv_init(1, in_data_sz, p_data, data_sz * 2, rreq);
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_cas);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_CSWAP_TARGET_MSG_CB);
@@ -1765,8 +1813,8 @@ int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t
     goto fn_exit;
 }
 
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1783,7 +1831,6 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    *req = rreq;
 
     MPIDI_Datatype_check_size(msg_hdr->origin_datatype, msg_hdr->origin_count, data_sz);
     if (data_sz) {
@@ -1797,12 +1844,7 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
 
-    if (is_contig) {
-        MPIDIG_recv_init(1, *p_data_sz, p_data, data_sz, rreq);
-    } else {
-        /* I guess we are assuming 0 payload here */
-        MPIR_Assert(p_data_sz == NULL || *p_data_sz == 0);
-    }
+    MPIDIG_recv_init(1, in_data_sz, p_data, data_sz, rreq);
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -1810,21 +1852,24 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     uintptr_t base = MPIDIG_win_base_at_target(win);
     size_t offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(*req, req->areq.win_ptr) = win;
-    MPIDIG_REQUEST(*req, req->areq.req_ptr) = msg_hdr->req_ptr;
-    MPIDIG_REQUEST(*req, req->areq.origin_datatype) = msg_hdr->origin_datatype;
-    MPIDIG_REQUEST(*req, req->areq.target_datatype) = msg_hdr->target_datatype;
-    MPIDIG_REQUEST(*req, req->areq.origin_count) = msg_hdr->origin_count;
-    MPIDIG_REQUEST(*req, req->areq.target_count) = msg_hdr->target_count;
-    MPIDIG_REQUEST(*req, req->areq.target_addr) = (char *) base + offset;
-    MPIDIG_REQUEST(*req, req->areq.op) = msg_hdr->op;
-    MPIDIG_REQUEST(*req, req->areq.data) = p_data;
-    MPIDIG_REQUEST(*req, req->areq.n_iov) = msg_hdr->n_iov;
-    MPIDIG_REQUEST(*req, req->areq.data_sz) = msg_hdr->result_data_sz;
-    MPIDIG_REQUEST(*req, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, req->areq.win_ptr) = win;
+    MPIDIG_REQUEST(rreq, req->areq.req_ptr) = msg_hdr->req_ptr;
+    MPIDIG_REQUEST(rreq, req->areq.origin_datatype) = msg_hdr->origin_datatype;
+    MPIDIG_REQUEST(rreq, req->areq.target_datatype) = msg_hdr->target_datatype;
+    MPIDIG_REQUEST(rreq, req->areq.origin_count) = msg_hdr->origin_count;
+    MPIDIG_REQUEST(rreq, req->areq.target_count) = msg_hdr->target_count;
+    MPIDIG_REQUEST(rreq, req->areq.target_addr) = (char *) base + offset;
+    MPIDIG_REQUEST(rreq, req->areq.op) = msg_hdr->op;
+    MPIDIG_REQUEST(rreq, req->areq.data) = p_data;
+    MPIDIG_REQUEST(rreq, req->areq.n_iov) = msg_hdr->n_iov;
+    MPIDIG_REQUEST(rreq, req->areq.data_sz) = msg_hdr->result_data_sz;
+    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
 
     if (!msg_hdr->n_iov) {
         MPIDIG_REQUEST(rreq, req->areq.dt_iov) = NULL;
+        if (is_async) {
+            *req = NULL;
+        }
         goto fn_exit;
     }
 
@@ -1838,6 +1883,13 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     }
     MPIDIG_REQUEST(rreq, req->areq.dt_iov) = dt_iov;
 
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
+
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_ACC_TARGET_MSG_CB);
@@ -1847,8 +1899,8 @@ int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 }
 
 
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1857,18 +1909,19 @@ int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc);
 
     /* the same handling processing as ACC except the completion handler function. */
-    mpi_errno =
-        MPIDIG_acc_target_msg_cb(handler_id, am_hdr, data, p_data_sz, is_local, is_contig, req);
+    /* set is_async to 1 so we can get rreq back */
+    MPIR_Request *rreq;
+    mpi_errno = MPIDIG_acc_target_msg_cb(handler_id, am_hdr, data, in_data_sz, is_local, 1, &rreq);
 
-    MPIDIG_REQUEST(*req, req->target_cmpl_cb) = get_acc_target_cmpl_cb;
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_target_cmpl_cb;
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1884,7 +1937,6 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
 
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    *req = rreq;
 
     win = (MPIR_Win *) MPIDIU_map_lookup(MPIDI_global.win_map, msg_hdr->win_id);
     MPIR_Assert(win);
@@ -1892,17 +1944,17 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     base = MPIDIG_win_base_at_target(win);
     offset = win->disp_unit * msg_hdr->target_disp;
 
-    MPIDIG_REQUEST(*req, req->areq.win_ptr) = win;
-    MPIDIG_REQUEST(*req, req->areq.req_ptr) = msg_hdr->req_ptr;
-    MPIDIG_REQUEST(*req, req->areq.origin_datatype) = msg_hdr->origin_datatype;
-    MPIDIG_REQUEST(*req, req->areq.target_datatype) = msg_hdr->target_datatype;
-    MPIDIG_REQUEST(*req, req->areq.origin_count) = msg_hdr->origin_count;
-    MPIDIG_REQUEST(*req, req->areq.target_count) = msg_hdr->target_count;
-    MPIDIG_REQUEST(*req, req->areq.target_addr) = (void *) (offset + base);
-    MPIDIG_REQUEST(*req, req->areq.op) = msg_hdr->op;
-    MPIDIG_REQUEST(*req, req->areq.n_iov) = msg_hdr->n_iov;
-    MPIDIG_REQUEST(*req, req->areq.data_sz) = msg_hdr->result_data_sz;
-    MPIDIG_REQUEST(*req, rank) = msg_hdr->src_rank;
+    MPIDIG_REQUEST(rreq, req->areq.win_ptr) = win;
+    MPIDIG_REQUEST(rreq, req->areq.req_ptr) = msg_hdr->req_ptr;
+    MPIDIG_REQUEST(rreq, req->areq.origin_datatype) = msg_hdr->origin_datatype;
+    MPIDIG_REQUEST(rreq, req->areq.target_datatype) = msg_hdr->target_datatype;
+    MPIDIG_REQUEST(rreq, req->areq.origin_count) = msg_hdr->origin_count;
+    MPIDIG_REQUEST(rreq, req->areq.target_count) = msg_hdr->target_count;
+    MPIDIG_REQUEST(rreq, req->areq.target_addr) = (void *) (offset + base);
+    MPIDIG_REQUEST(rreq, req->areq.op) = msg_hdr->op;
+    MPIDIG_REQUEST(rreq, req->areq.n_iov) = msg_hdr->n_iov;
+    MPIDIG_REQUEST(rreq, req->areq.data_sz) = msg_hdr->result_data_sz;
+    MPIDIG_REQUEST(rreq, rank) = msg_hdr->src_rank;
 
     dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
     MPIDIG_REQUEST(rreq, req->areq.dt_iov) = dt_iov;
@@ -1911,13 +1963,20 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     /* Base adjustment for iov will be done after we get the entire iovs,
      * at MPIDIG_acc_data_target_msg_cb */
     int data_sz = sizeof(struct iovec) * msg_hdr->n_iov;
-    MPIDIG_recv_init(1, *p_data_sz, dt_iov, data_sz, rreq);
+    MPIDIG_recv_init(1, in_data_sz, dt_iov, data_sz, rreq);
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = acc_iov_target_cmpl_cb;
     MPIDIG_REQUEST(rreq, req->seq_no) = MPL_atomic_fetch_add_uint64(&MPIDI_global.nxt_seq_no, 1);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
   fn_exit:
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_acc_iov);
@@ -1927,8 +1986,8 @@ int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size
     goto fn_exit;
 }
 
-int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1937,18 +1996,26 @@ int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, 
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_acc_iov);
 
     /* the same handling processing as ACC except the completion handler function. */
+    /* set is_async to 1 so we can get rreq back */
+    MPIR_Request *rreq;
     mpi_errno = MPIDIG_acc_iov_target_msg_cb(handler_id, am_hdr, data,
-                                             p_data_sz, is_local, is_contig, req);
+                                             in_data_sz, is_local, 1, &rreq);
 
-    MPIDIG_REQUEST(*req, req->target_cmpl_cb) = get_acc_iov_target_cmpl_cb;
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_acc_iov_target_cmpl_cb;
 
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_acc_iov);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACC_IOV_TARGET_MSG_CB);
     return mpi_errno;
 }
 
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
@@ -1963,7 +2030,6 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RMA, 1);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
-    *req = rreq;
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_target_cmpl_cb;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     MPIDI_REQUEST(rreq, is_local) = is_local;
@@ -1990,10 +2056,17 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 
         int data_sz = msg_hdr->n_iov * sizeof(*iov);
         MPIDIG_REQUEST(rreq, req->greq.dt_iov) = iov;
-        MPIDIG_recv_init(1, *p_data_sz, iov, data_sz, rreq);
+        MPIDIG_recv_init(1, in_data_sz, iov, data_sz, rreq);
     } else {
-        MPIR_Assert(!p_data_sz || *p_data_sz == 0);
+        MPIR_Assert(!in_data_sz || in_data_sz == 0);
         MPIDIG_recv_init(1, 0, NULL, 0, rreq);
+    }
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     }
 
   fn_exit:
@@ -2004,32 +2077,38 @@ int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     goto fn_exit;
 }
 
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req)
+int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *get_req;
+    MPIR_Request *rreq;
 
     MPIDIG_get_ack_msg_t *msg_hdr = (MPIDIG_get_ack_msg_t *) am_hdr;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDIG_GET_ACK_TARGET_MSG_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDIG_GET_ACK_TARGET_MSG_CB);
     MPIR_T_PVAR_TIMER_START(RMA, rma_targetcb_get_ack);
 
-    get_req = (MPIR_Request *) msg_hdr->greq_ptr;
-    MPIR_Assert(get_req->kind == MPIR_REQUEST_KIND__RMA);
-    *req = get_req;
+    rreq = (MPIR_Request *) msg_hdr->greq_ptr;
+    MPIR_Assert(rreq->kind == MPIR_REQUEST_KIND__RMA);
 
-    MPL_free(MPIDIG_REQUEST(get_req, req->greq.dt_iov));
+    MPL_free(MPIDIG_REQUEST(rreq, req->greq.dt_iov));
 
-    MPIDIG_REQUEST(get_req, req->target_cmpl_cb) = get_ack_target_cmpl_cb;
+    MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = get_ack_target_cmpl_cb;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-    MPIDI_REQUEST(get_req, is_local) = is_local;
+    MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
 
-    MPIDIG_REQUEST(get_req, buffer) = MPIDIG_REQUEST(get_req, req->greq.addr);
-    MPIDIG_REQUEST(get_req, count) = MPIDIG_REQUEST(get_req, req->greq.count);
-    MPIDIG_REQUEST(get_req, datatype) = MPIDIG_REQUEST(get_req, req->greq.datatype);
-    MPIDIG_recv_type_init(*p_data_sz, get_req);
+    MPIDIG_REQUEST(rreq, buffer) = MPIDIG_REQUEST(rreq, req->greq.addr);
+    MPIDIG_REQUEST(rreq, count) = MPIDIG_REQUEST(rreq, req->greq.count);
+    MPIDIG_REQUEST(rreq, datatype) = MPIDIG_REQUEST(rreq, req->greq.datatype);
+    MPIDIG_recv_type_init(in_data_sz, rreq);
+
+    if (is_async) {
+        *req = rreq;
+    } else {
+        MPIDIG_recv_copy(data, rreq);
+        MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
+    }
 
     MPIR_T_PVAR_TIMER_END(RMA, rma_targetcb_get_ack);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDIG_GET_ACK_TARGET_MSG_CB);

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.c
@@ -1355,7 +1355,6 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
-    struct iovec *iov, *dt_iov;
     uintptr_t base;             /* Base address of the window */
     size_t offset;
 
@@ -1384,19 +1383,20 @@ int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t *
     MPIDI_REQUEST(rreq, is_local) = is_local;
 #endif
 
-    MPI_Aint in_total_data_sz = *p_data_sz;
-
     offset = win->disp_unit * msg_hdr->target_disp;
     if (msg_hdr->n_iov) {
-        int i;
+        struct iovec *iov, *dt_iov;
+
         dt_iov = (struct iovec *) MPL_malloc(sizeof(struct iovec) * msg_hdr->n_iov, MPL_MEM_RMA);
         MPIR_Assert(dt_iov);
 
         iov = (struct iovec *) ((char *) am_hdr + sizeof(*msg_hdr));
-        for (i = 0; i < msg_hdr->n_iov; i++) {
+        for (int i = 0; i < msg_hdr->n_iov; i++) {
             dt_iov[i].iov_base = (char *) iov[i].iov_base + base + offset;
             dt_iov[i].iov_len = iov[i].iov_len;
         }
+
+        MPI_Aint in_total_data_sz = *p_data_sz;
 
         MPIDIG_REQUEST(rreq, req->preq.dt_iov) = dt_iov;
         MPIDIG_REQUEST(rreq, req->preq.n_iov) = msg_hdr->n_iov;

--- a/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
+++ b/src/mpid/ch4/src/ch4r_rma_target_callbacks.h
@@ -39,47 +39,47 @@ extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_acc_data ATTRIBUTE((unused));
 extern MPIR_T_pvar_timer_t PVAR_TIMER_rma_targetcb_get_acc_data ATTRIBUTE((unused));
 
 int MPIDIG_RMA_Init_targetcb_pvars(void);
-int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                 size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_put_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                 MPI_Aint in_data_sz, int is_local, int is_async,
                                  MPIR_Request ** req);
-int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                   int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void **data,
-                                         size_t * p_data_sz, int is_local, int *is_contig,
+int MPIDIG_get_acc_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_cswap_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                   int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_win_ctrl_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_put_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_put_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_put_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_acc_iov_ack_target_msg_cb(int handler_id, void *am_hdr, void *data,
+                                         MPI_Aint in_data_sz, int is_local, int is_async,
                                          MPIR_Request ** req);
-int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                  int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                      int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                               int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                     int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                             int is_local, int *is_contig, MPIR_Request ** req);
-int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t * p_data_sz,
-                                 int is_local, int *is_contig, MPIR_Request ** req);
+int MPIDIG_put_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                  int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_acc_data_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                      int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_cswap_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                               int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_acc_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_acc_iov_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                     int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                             int is_local, int is_async, MPIR_Request ** req);
+int MPIDIG_get_ack_target_msg_cb(int handler_id, void *am_hdr, void *data, MPI_Aint in_data_sz,
+                                 int is_local, int is_async, MPIR_Request ** req);
 
 #endif /* CH4R_RMA_TARGET_CALLBACKS_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

For transport that need asynchrounous payload transfer, such as posix,
    it needs store the state of data buffer between segments. Current the
    data copy is implemented inside the am transport. However, only the
    payload informantion is relavant for a transport. The rest, such as
    destination buffer for a datatype, updating the request status, belong
    to the upper layer. The current implementations not only spreads the
    protocol code across multiple layers, it also induces code duplications
    between each transport module.

By abstracting the asynchronous data transfer code into an MPIDIG layer
    inline header, we bring the code to its right context, and reduce code
    duplications.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
        Getting closer to the API outlined in PR #4236
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
