### PR TITLE
ch4/ofi: skip IPv6 in provider selection

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1463,6 +1463,7 @@ static int find_provider(struct fi_info *hints)
         init_hints(hints);
         hints->fabric_attr->prov_name = MPL_strdup(prov_use->fabric_attr->prov_name);
         hints->caps = prov_use->caps;
+        hints->addr_format = prov_use->addr_format;
 
         fi_freeinfo(prov_list);
     } else {
@@ -1560,6 +1561,11 @@ static struct fi_info *pick_provider_by_global_settings(struct fi_info *prov_lis
         if (!match_global_settings(prov)) {
             prov = prov->next;
             continue;
+#ifdef MPIDI_CH4_OFI_SKIP_IPV6
+        } else if (prov->addr_format == FI_SOCKADDR_IN6) {
+            prov = prov->next;
+            continue;
+#endif
         } else {
             prov_use = prov;
             break;

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -22,6 +22,14 @@ AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     if [test "x$ofi_direct_provider" != "x"]; then
        AC_MSG_NOTICE([Enabling OFI netmod direct provider])
     fi
+
+        AC_ARG_ENABLE(ch4-ofi-ipv6,
+            AC_HELP_STRING([--disable-ch4-ofi-ipv6], [Skip providers with addr_format FI_SOCKADDR_IN6])
+        )
+
+        if test "x$enable_ch4_ofi_ipv6" = "xno" ; then
+            AC_DEFINE(MPIDI_CH4_OFI_SKIP_IPV6, 1, [CH4-OFI should skip providers with IPv6])
+        fi
     ])
     AM_CONDITIONAL([BUILD_CH4_NETMOD_OFI],[test "X$build_ch4_netmod_ofi" = "Xyes"])
 ])dnl


### PR DESCRIPTION

## Pull Request Description
Libfabric IPv6 provider crashes on macos. This commit adds a configure
option to skip IPv6 providers.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
