### PR TITLE
ch4/ofi: apply MPIDI_CH4_OFI_SKIP_IPV6 to all cases

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1558,11 +1558,6 @@ static struct fi_info *pick_provider_by_global_settings(struct fi_info *prov_lis
         if (!match_global_settings(prov)) {
             prov = prov->next;
             continue;
-#ifdef MPIDI_CH4_OFI_SKIP_IPV6
-        } else if (prov->addr_format == FI_SOCKADDR_IN6) {
-            prov = prov->next;
-            continue;
-#endif
         } else {
             prov_use = prov;
             break;
@@ -1586,6 +1581,11 @@ bool match_global_settings(struct fi_info * prov)
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE, (MPL_DBG_FDEST, "Provider name: %s",
                                                      prov->fabric_attr->prov_name));
 
+#ifdef MPIDI_CH4_OFI_SKIP_IPV6
+    if (prov->addr_format == FI_SOCKADDR_IN6) {
+        return false;
+    }
+#endif
     CHECK_CAP(MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS,
               prov->domain_attr->max_ep_tx_ctx <= 1 ||
               (prov->caps & FI_NAMED_RX_CTX) != FI_NAMED_RX_CTX);


### PR DESCRIPTION

## Pull Request Description
Previous patch omits when provider name is specificly given, which is
the case in jenkins test where we set MPIR_CVAR_OFI_USE_PROVIDER=sockets.
This patch applies the config option to all cases.

## Expected Impact
Fix osx jenkins ch4-ofi tests.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       See previous PR #4310
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
