### PR TITLE
ch4/am: refactor active message payload transfer

### DIFF
--- a/src/mpid/ch4/generic/Makefile.mk
+++ b/src/mpid/ch4/generic/Makefile.mk
@@ -14,6 +14,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/mpid/ch4/generic
 
 noinst_HEADERS += src/mpid/ch4/generic/mpidig_send.h \
                   src/mpid/ch4/generic/mpidig_recv.h \
+                  src/mpid/ch4/generic/mpidig_msg.h \
                   src/mpid/ch4/generic/mpidig.h
 
 mpi_core_sources += src/mpid/ch4/generic/mpidig_globals.c \

--- a/src/mpid/ch4/generic/mpidig_msg.h
+++ b/src/mpid/ch4/generic/mpidig_msg.h
@@ -12,4 +12,123 @@
  * routines to avoid code duplications.
  */
 
+#define MPIDIG_ERR_TRUNCATE(data_sz, in_data_sz) \
+    MPIR_Err_create_code(rreq->status.MPI_ERROR, MPIR_ERR_RECOVERABLE, \
+                         __func__, __LINE__, \
+                         MPI_ERR_TRUNCATE, "**truncate", "**truncate %d %d %d %d", \
+                         rreq->status.MPI_SOURCE, rreq->status.MPI_TAG, \
+                         (int) data_sz, (int) in_data_sz)
+
+/* synchronous single-payload data transfer. This is the common case */
+MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPI_Aint in_data_sz,
+                                               void *data, MPI_Aint data_sz,
+                                               int is_contig, MPIR_Request * rreq)
+{
+    if (!data || !data_sz) {
+        /* empty case */
+        MPIR_STATUS_SET_COUNT(rreq->status, 0);
+    } else if (is_contig) {
+        /* contig case */
+        if (in_data_sz > data_sz) {
+            rreq->status.MPI_ERROR = MPIDIG_ERR_TRUNCATE(data_sz, in_data_sz);
+        }
+
+        data_sz = MPL_MIN(data_sz, in_data_sz);
+        MPIR_Memcpy(data, in_data, data_sz);
+        MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
+    } else {
+        /* noncontig case */
+        struct iovec *iov = (struct iovec *) data;
+        int iov_len = data_sz;
+
+        int done = 0;
+        int rem = in_data_sz;
+        for (int i = 0; i < iov_len && rem > 0; i++) {
+            int curr_len = MPL_MIN(rem, iov[i].iov_len);
+            MPIR_Memcpy(iov[i].iov_base, (char *) in_data + done, curr_len);
+            rem -= curr_len;
+            done += curr_len;
+        }
+
+        if (rem) {
+            data_sz = in_data_sz - rem;
+            rreq->status.MPI_ERROR = MPIDIG_ERR_TRUNCATE(data_sz, in_data_sz);
+        }
+
+        MPIR_STATUS_SET_COUNT(rreq->status, done);
+    }
+    /* all done */
+}
+
+/* setup for asynchronous multi-segment data transfer (ref posix_progress) */
+MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_setup(int is_contig, MPI_Aint in_data_sz,
+                                                void *data, MPI_Aint data_sz, MPIR_Request * rreq)
+{
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async));
+    p->is_contig = is_contig;
+    p->in_data_sz = in_data_sz;
+    if (is_contig) {
+        p->iov_one.iov_base = data;
+        p->iov_one.iov_len = data_sz;
+        p->iov_ptr = &(p->iov_one);
+        p->iov_num = 1;
+        if (in_data_sz > data_sz) {
+            rreq->status.MPI_ERROR = MPIDIG_ERR_TRUNCATE(data_sz, in_data_sz);
+            MPIR_STATUS_SET_COUNT(rreq->status, data_sz);
+        } else {
+            MPIR_STATUS_SET_COUNT(rreq->status, in_data_sz);
+        }
+    } else {
+        p->iov_ptr = data;
+        p->iov_num = data_sz;
+
+        MPI_Aint recv_sz = 0;
+        for (int i = 0; i < p->iov_num; i++) {
+            recv_sz += p->iov_ptr[i].iov_len;
+        }
+        if (in_data_sz > recv_sz) {
+            rreq->status.MPI_ERROR = MPIDIG_ERR_TRUNCATE(recv_sz, in_data_sz);
+            MPIR_STATUS_SET_COUNT(rreq->status, recv_sz);
+        } else {
+            MPIR_STATUS_SET_COUNT(rreq->status, in_data_sz);
+        }
+    }
+}
+
+/* copy a segment to data buffer recorded in rreq. */
+MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payload_sz,
+                                                  MPIR_Request * rreq)
+{
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async));
+
+    p->in_data_sz -= payload_sz;
+
+    int iov_done = 0;
+    for (int i = 0; i < p->iov_num; i++) {
+        if (payload_sz < p->iov_ptr[i].iov_len) {
+            MPIR_Memcpy(p->iov_ptr[i].iov_base, payload, payload_sz);
+            p->iov_ptr[i].iov_base = (char *) p->iov_ptr[i].iov_base + payload_sz;
+            p->iov_ptr[i].iov_len -= payload_sz;
+            /* not done */
+            break;
+        } else {
+            /* fill one iov */
+            MPIR_Memcpy(p->iov_ptr[i].iov_base, payload, p->iov_ptr[i].iov_len);
+            payload = (char *) payload + p->iov_ptr[i].iov_len;
+            payload_sz -= p->iov_ptr[i].iov_len;
+            iov_done++;
+        }
+    }
+    p->iov_num -= iov_done;
+    p->iov_ptr += iov_done;
+
+    if (p->iov_num == 0 || p->in_data_sz == 0) {
+        /* all done */
+        return 1;
+    } else {
+        /* not done */
+        return 0;
+    }
+}
+
 #endif /* MPIDIG_MSG_H_INCLUDED */

--- a/src/mpid/ch4/generic/mpidig_msg.h
+++ b/src/mpid/ch4/generic/mpidig_msg.h
@@ -1,0 +1,15 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2020 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+#ifndef MPIDIG_MSG_H_INCLUDED
+#define MPIDIG_MSG_H_INCLUDED
+
+/* This file is for supporting routines used for generic layer message matching
+ * and data transfer. They are used by protocols such as send, ssend, and send_long.
+ * Other protocols that share semantic with message transport may also use these
+ * routines to avoid code duplications.
+ */
+
+#endif /* MPIDIG_MSG_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidch4r.h
+++ b/src/mpid/ch4/include/mpidch4r.h
@@ -21,10 +21,11 @@
 #include "ch4r_request.h"
 #include "ch4r_rma_origin_callbacks.h"
 #include "ch4r_rma_target_callbacks.h"
-#include "mpidig_recv.h"
 #include "ch4r_rma.h"
-#include "mpidig_send.h"
 #include "ch4r_win.h"
 #include "ch4r_buf.h"
+#include "mpidig_msg.h"
+#include "mpidig_recv.h"
+#include "mpidig_send.h"
 
 #endif /* MPIDCH4R_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -153,6 +153,17 @@ typedef struct MPIDIG_acc_req_t {
 } MPIDIG_acc_req_t;
 
 typedef int (*MPIDIG_req_cmpl_cb) (MPIR_Request * req);
+
+/* structure used for supporting asynchronous payload transfer */
+typedef struct MPIDIG_req_async {
+    int is_contig;
+    MPI_Aint in_data_sz;
+    struct iovec *iov_ptr;      /* used for non-contig data */
+    int iov_num;
+    struct iovec iov_one;       /* used for contig data */
+    MPI_Aint offset;            /* used for direct unpack (is_contig == -1) */
+} MPIDIG_rreq_async_t;
+
 typedef struct MPIDIG_req_ext_t {
     union {
         MPIDIG_sreq_t sreq;
@@ -164,6 +175,7 @@ typedef struct MPIDIG_req_ext_t {
         MPIDIG_acc_req_t areq;
     };
 
+    MPIDIG_rreq_async_t async;
     struct iovec *iov;
     MPIDIG_req_cmpl_cb target_cmpl_cb;
     uint64_t seq_no;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -207,7 +207,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
@@ -244,7 +244,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_recv_safe(void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_irecv_safe(void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,


### PR DESCRIPTION
## Pull Request Description

Active message target side message callbacks, or handlers, are split into 3 parts -- initial protocol processing, payload transfer,  and target-completion. This is because different transport may require different mechanism to transfer payload. For example, large payload may come in multiple segments asynchronously, or OFI may use rdma-read for large payload. However, most of the payload transfers share the same semantics with very minor details. This PR abstracts the common semantics into a few routines and manage to hide most of the datatype and asynchronous tracking states internal. This not only allows reduce code duplication, it further provides opportunity to modify the semantics and experiment with different payload transfer model.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       This is the first part from splitting PR #4306.
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
