### PR TITLE
ch4/am: store recv buffer info in the recv-request

### DIFF
--- a/src/mpid/ch4/generic/mpidig_msg.h
+++ b/src/mpid/ch4/generic/mpidig_msg.h
@@ -19,6 +19,22 @@
                          rreq->status.MPI_SOURCE, rreq->status.MPI_TAG, \
                          (int) data_sz, (int) in_data_sz)
 
+/* caching recv buffer information */
+MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_init(int is_contig, MPI_Aint in_data_sz,
+                                               void *data, MPI_Aint data_sz, MPIR_Request * rreq)
+{
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async));
+    p->is_contig = is_contig;
+    p->in_data_sz = in_data_sz;
+    if (is_contig) {
+        p->iov_one.iov_base = data;
+        p->iov_one.iov_len = data_sz;
+    } else {
+        p->iov_ptr = data;
+        p->iov_num = data_sz;
+    }
+}
+
 /* synchronous single-payload data transfer. This is the common case */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPI_Aint in_data_sz,
                                                void *data, MPI_Aint data_sz,

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -96,8 +96,7 @@ static inline int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr)
     MPIR_Request *rreq = NULL;
     void *p_data;
     void *in_data;
-
-    size_t data_sz, in_data_sz;
+    size_t data_sz;
     int is_contig;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_HANDLE_SHORT_AM);
@@ -105,7 +104,7 @@ static inline int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr)
 
     /* note: msg_hdr + 1 points to the payload */
     p_data = in_data = (char *) (msg_hdr + 1) + msg_hdr->am_hdr_sz;
-    in_data_sz = data_sz = msg_hdr->data_sz;
+    data_sz = msg_hdr->data_sz;
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, (msg_hdr + 1),
                                                        &p_data, &data_sz, 0 /* is_local */ ,
@@ -115,7 +114,7 @@ static inline int MPIDI_OFI_handle_short_am(MPIDI_OFI_am_header_t * msg_hdr)
         goto fn_exit;
 
     /* TODO: if we pass a flag, the callback could do all the following */
-    MPIDIG_recv_copy(in_data, in_data_sz, p_data, data_sz, is_contig, rreq);
+    MPIDIG_recv_copy(in_data, rreq);
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -16,13 +16,13 @@ static void am_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t *
     MPIR_Request *rreq = NULL;
     void *p_data;
     void *in_data;
-    size_t data_sz, in_data_sz;
+    size_t data_sz;
     int is_contig;
     MPIDI_UCX_am_header_t *msg_hdr = (MPIDI_UCX_am_header_t *) am_buf;
 
     p_data = in_data =
         (char *) msg_hdr->payload + (info->length - msg_hdr->data_sz - sizeof(*msg_hdr));
-    in_data_sz = data_sz = msg_hdr->data_sz;
+    data_sz = msg_hdr->data_sz;
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
                                                        &p_data, &data_sz, 0 /* is_local */ ,
@@ -31,7 +31,7 @@ static void am_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t *
     if (!rreq)
         return;
 
-    MPIDIG_recv_copy(in_data, in_data_sz, p_data, data_sz, is_contig, rreq);
+    MPIDIG_recv_copy(in_data, rreq);
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
 }

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -106,8 +106,8 @@ static int progress_recv(int blocking)
         } else {
             if (is_contig && (in_total_data_sz == payload_left)) {
                 /* got single complete payload */
-                MPIDIG_recv_copy(payload, payload_left, p_data, p_data_sz, is_contig, rreq);
-                /* Call the function to handle the completed receipt of the message. */
+                MPIDIG_recv_copy(payload, rreq);
+
                 MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
 
                 MPIDI_POSIX_eager_recv_commit(&transaction);
@@ -116,7 +116,7 @@ static int progress_recv(int blocking)
             }
 
             /* prepare for asynchronous transfer */
-            MPIDIG_recv_setup(is_contig, in_total_data_sz, p_data, p_data_sz, rreq);
+            MPIDIG_recv_setup(rreq);
 
             MPIR_Assert(MPIDI_POSIX_global.active_rreq[transaction.src_grank] == NULL);
             MPIDI_POSIX_global.active_rreq[transaction.src_grank] = rreq;


### PR DESCRIPTION
## Pull Request Description

The receive buffer and iov information are from the receive datatype and thus belong to the upper layer rather than the transport-layer such as posix, ofi, and ucx. Store them inside the `rreq` (receiving request object) rather than passing them back and forth as api parameters between the two layers.

Once the data structure dealing with receiving datatype is contained, it is much easier to experiment with different packing/unpacking schemes. For example, we are flexible in choosing the data structure and when and where to add caching information.

Note: after this PR, in `xxx_target_msg_cb`, the recv data buffer information are both set in the request object as well as returned to the transport via pointer parameters. This is redundant. The plan is to move all reference using data from request object, then remove the pointer parameters from the api. Ideally, all these reference will be contained inside `mpidig_msg.h`.

## Expected Impact
* simpler interface
* isolation to facilitate refactor

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       This is the 2nd split from PR #4306.
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
