### PR TITLE
ch4/ofi: Provide count attribute when creating address vector

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1198,6 +1198,7 @@ static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
             av_attr.type = FI_AV_MAP;
         }
         av_attr.rx_ctx_bits = MPIDI_OFI_MAX_ENDPOINTS_BITS;
+        av_attr.count = MPIR_Process.size;
 
         av_attr.name = NULL;
         av_attr.flags = 0;
@@ -1312,6 +1313,7 @@ static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av)
         av_attr.type = FI_AV_MAP;
     }
     av_attr.rx_ctx_bits = MPIDI_OFI_MAX_ENDPOINTS_BITS;
+    av_attr.count = MPIR_Process.size;
 
     char av_name[128];
     MPL_snprintf(av_name, sizeof(av_name), "FI_NAMED_AV_%d\n", MPIR_Process.appnum);


### PR DESCRIPTION
## Pull Request Description

Address vector size is known ahead of creation, so provide it as an
attribute to libfabric. Some providers may be able to use the
information for efficiency or correctness.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
