### PR TITLE
mpl/bt: Use external free function

### DIFF
--- a/src/mpl/src/bt/mpl_bt.c
+++ b/src/mpl/src/bt/mpl_bt.c
@@ -20,7 +20,7 @@ void MPL_backtrace_show(FILE * output)
     for (_mpl_backtrace_size_t i = 0; i < frames; i++)
         fprintf(output, "%s\n", strs[i]);
 
-    MPL_free(strs);
+    MPL_external_free(strs);
 }
 #else
 void MPL_backtrace_show(FILE * output)


### PR DESCRIPTION
## Pull Request Description

Memory containing backtrace information is allocated by an external
library. Therefore, it cannot be freed by the default MPL_free, since
there may be incorrect assumptions about how the memory was
allocated. Use external free function instead, which was added for
this purpose.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix backtrace when configured together with memory tracing.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
