### PR TITLE
ch4/am: make rndz descision from generic layer

### DIFF
--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -32,16 +32,16 @@ static inline int mpidig_eager_limit(int is_local)
 static inline int MPIDIG_do_eager_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                        int rank, int tag, MPIR_Comm * comm, int context_offset,
                                        MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                       int type, MPIR_Errflag_t errflag);
+                                       MPIR_Errflag_t errflag);
 static inline int MPIDIG_do_rndv_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                       MPI_Aint data_sz,
                                       int rank, int tag, MPIR_Comm * comm, int context_offset,
                                       MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                      int type, MPIR_Errflag_t errflag);
+                                      MPIR_Errflag_t errflag);
 static inline int MPIDIG_do_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                   int rank, int tag, MPIR_Comm * comm, int context_offset,
                                   MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                  int type, MPIR_Errflag_t errflag);
+                                  MPIR_Errflag_t errflag);
 
 static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                     int rank, int tag, MPIR_Comm * comm, int context_offset,
@@ -54,21 +54,21 @@ static inline int MPIDIG_isend_impl(const void *buf, MPI_Aint count, MPI_Datatyp
 
     int is_local = MPIDI_av_is_local(addr);
     if (type == MPIDIG_SSEND_REQ) {
-        return MPIDIG_do_ssend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                               request, type, errflag);
+        return MPIDIG_do_ssend(buf, count, datatype, rank, tag, comm, context_offset,
+                               addr, request, errflag);
     } else if (data_sz > mpidig_eager_limit(is_local)) {
         return MPIDIG_do_rndv_send(buf, count, datatype, data_sz, rank, tag, comm, context_offset,
-                                   addr, request, type, errflag);
+                                   addr, request, errflag);
     } else {
-        return MPIDIG_do_eager_send(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                    request, type, errflag);
+        return MPIDIG_do_eager_send(buf, count, datatype, rank, tag, comm, context_offset,
+                                    addr, request, errflag);
     }
 }
 
 static inline int MPIDIG_do_eager_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                        int rank, int tag, MPIR_Comm * comm, int context_offset,
                                        MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                       int type, MPIR_Errflag_t errflag)
+                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = *request;
@@ -116,7 +116,7 @@ static inline int MPIDIG_do_eager_send(const void *buf, MPI_Aint count, MPI_Data
 static inline int MPIDIG_do_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                   int rank, int tag, MPIR_Comm * comm, int context_offset,
                                   MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                  int type, MPIR_Errflag_t errflag)
+                                  MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS, c;
     MPIR_Request *sreq = *request;
@@ -170,7 +170,7 @@ static inline int MPIDIG_do_rndv_send(const void *buf, MPI_Aint count, MPI_Datat
                                       MPI_Aint data_sz,
                                       int rank, int tag, MPIR_Comm * comm, int context_offset,
                                       MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                      int type, MPIR_Errflag_t errflag)
+                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = *request;

--- a/src/mpid/ch4/generic/mpidig_send.h
+++ b/src/mpid/ch4/generic/mpidig_send.h
@@ -14,19 +14,47 @@
 
 #include "ch4_impl.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE
+      category    : CH4
+      type        : int
+      default     : -1
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If set to positive number, this cvar controls the message size at which CH4 switches from eager to rendezvous mode.
+        If the number is negative, underlying netmod or shmmod automatically uses an optimal number depending on
+        the underlying fabric or shared memory architecture.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 #define MPIDIG_AM_SEND_HDR_SIZE  sizeof(MPIDIG_hdr_t)
 
 static inline int mpidig_eager_limit(int is_local)
 {
+    if (MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE > 0) {
+        return MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE;
+    }
+
+    int thresh;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    return MPIDI_NM_am_eager_limit() - MPIDIG_AM_SEND_HDR_SIZE;
+    thresh = MPIDI_NM_am_eager_limit();
 #else
     if (is_local) {
-        return MPIDI_SHM_am_eager_limit() - MPIDIG_AM_SEND_HDR_SIZE;
+        thresh = MPIDI_SHM_am_eager_limit();
     } else {
-        return MPIDI_NM_am_eager_limit() - MPIDIG_AM_SEND_HDR_SIZE;
+        thresh = MPIDI_NM_am_eager_limit();
     }
 #endif
+    thresh -= MPIDIG_AM_SEND_HDR_SIZE;
+    MPIR_Assert(thresh > 0);
+
+    return thresh;
 }
 
 static inline int MPIDIG_do_eager_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/mpid/ch4/netmod/include/netmod.h
+++ b/src/mpid/ch4/netmod/include/netmod.h
@@ -44,6 +44,7 @@ typedef int (*MPIDI_NM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src_
                                           const void *data, MPI_Count count, MPI_Datatype datatype,
                                           MPIR_Request * sreq);
 typedef size_t(*MPIDI_NM_am_hdr_max_sz_t) (void);
+typedef size_t(*MPIDI_NM_am_eager_limit_t) (void);
 typedef int (*MPIDI_NM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx, int *lpid_ptr,
                                          bool is_remote);
 typedef int (*MPIDI_NM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
@@ -412,6 +413,7 @@ typedef struct MPIDI_NM_funcs {
     MPIDI_NM_am_send_hdr_reply_t am_send_hdr_reply;
     MPIDI_NM_am_isend_reply_t am_isend_reply;
     MPIDI_NM_am_hdr_max_sz_t am_hdr_max_sz;
+    MPIDI_NM_am_eager_limit_t am_eager_limit;
 } MPIDI_NM_funcs_t;
 
 typedef struct MPIDI_NM_native_funcs {
@@ -560,6 +562,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      MPI_Count count, MPI_Datatype datatype,
                                                      MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr,
                                                     bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_impl.h
+++ b/src/mpid/ch4/netmod/include/netmod_impl.h
@@ -110,6 +110,15 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)
+{
+    int ret;
+
+    ret = MPIDI_NM_func->am_eager_limit();
+
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                     int *lpid_ptr, bool is_remote)
 {

--- a/src/mpid/ch4/netmod/ofi/func_table.c
+++ b/src/mpid/ch4/netmod/ofi/func_table.c
@@ -56,7 +56,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ofi_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
-    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz
+    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
+    .am_eager_limit = MPIDI_NM_am_eager_limit
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ofi_funcs = {

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -123,6 +123,11 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
     return MPL_MIN(max_shortsend, max_representable);
 }
 
+static inline size_t MPIDI_NM_am_eager_limit(void)
+{
+    return MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t);
+}
+
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id, const void *am_hdr, size_t am_hdr_sz)

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -349,27 +349,6 @@ static inline int MPIDI_OFI_do_am_isend(int rank,
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     send_buf = (char *) buf + dt_true_lb;
 
-    if (handler_id == MPIDIG_SEND &&
-        am_hdr_sz + data_sz + sizeof(MPIDI_OFI_am_header_t) > MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE) {
-        MPIDIG_send_long_req_msg_t lreq_hdr;
-
-        MPIR_Memcpy(&lreq_hdr.hdr, am_hdr, am_hdr_sz);
-        lreq_hdr.data_sz = data_sz;
-        lreq_hdr.sreq_ptr = sreq;
-        MPIDIG_REQUEST(sreq, req->lreq).src_buf = buf;
-        MPIDIG_REQUEST(sreq, req->lreq).count = count;
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDIG_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDIG_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
-        MPIDIG_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
-        MPIDIG_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;
-        MPIDIG_REQUEST(sreq, rank) = rank;
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_REQ,
-                                         &lreq_hdr, sizeof(lreq_hdr));
-        MPIR_ERR_CHECK(mpi_errno);
-        goto fn_exit;
-    }
-
     MPIDI_OFI_AMREQUEST(sreq, req_hdr) = NULL;
     mpi_errno = MPIDI_OFI_am_init_request(am_hdr, am_hdr_sz, sreq);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1407,13 +1407,7 @@ static int open_fabric(void)
 
     MPIDI_OFI_global.max_buffered_send = prov->tx_attr->inject_size;
     MPIDI_OFI_global.max_buffered_write = prov->tx_attr->inject_size;
-    if (MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE > 0 &&
-        MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE <= prov->ep_attr->max_msg_size) {
-        /* Truncate max_msg_size to a user-selected value */
-        MPIDI_OFI_global.max_msg_size = MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE;
-    } else {
-        MPIDI_OFI_global.max_msg_size = prov->ep_attr->max_msg_size;
-    }
+    MPIDI_OFI_global.max_msg_size = MPL_MIN(prov->ep_attr->max_msg_size, MPIR_AINT_MAX);
     MPIDI_OFI_global.max_order_raw = prov->ep_attr->max_order_raw_size;
     MPIDI_OFI_global.max_order_war = prov->ep_attr->max_order_war_size;
     MPIDI_OFI_global.max_order_waw = prov->ep_attr->max_order_waw_size;

--- a/src/mpid/ch4/netmod/stubnm/func_table.c
+++ b/src/mpid/ch4/netmod/stubnm/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_stubnm_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
-    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz
+    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
+    .am_eager_limit = MPIDI_NM_am_eager_limit
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_stubnm_funcs = {

--- a/src/mpid/ch4/netmod/stubnm/stubnm_am.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_am.h
@@ -55,6 +55,12 @@ static inline size_t MPIDI_NM_am_hdr_max_sz(void)
     return 0;
 }
 
+static inline size_t MPIDI_NM_am_eager_limit(void)
+{
+    MPIR_Assert(0);
+    return 0;
+}
+
 static inline int MPIDI_NM_am_send_hdr(int rank,
                                        MPIR_Comm * comm,
                                        int handler_id, const void *am_hdr, size_t am_hdr_sz)

--- a/src/mpid/ch4/netmod/ucx/func_table.c
+++ b/src/mpid/ch4/netmod/ucx/func_table.c
@@ -54,7 +54,8 @@ MPIDI_NM_funcs_t MPIDI_NM_ucx_funcs = {
     .am_isendv = MPIDI_NM_am_isendv,
     .am_send_hdr_reply = MPIDI_NM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_NM_am_isend_reply,
-    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz
+    .am_hdr_max_sz = MPIDI_NM_am_hdr_max_sz,
+    .am_eager_limit = MPIDI_NM_am_eager_limit
 };
 
 MPIDI_NM_native_funcs_t MPIDI_NM_native_ucx_funcs = {

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -331,6 +331,11 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_hdr_max_sz(void)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_NM_am_eager_limit(void)
+{
+    return (MPIDI_UCX_MAX_AM_EAGER_SZ - sizeof(MPIDI_UCX_am_header_t));
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
                                                   MPIR_Comm * comm,
                                                   int handler_id, const void *am_hdr,

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -67,26 +67,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
-    if (handler_id == MPIDIG_SEND &&
-        am_hdr_sz + sizeof(MPIDI_UCX_am_header_t) + data_sz > MPIDI_UCX_MAX_AM_EAGER_SZ) {
-        MPIDIG_send_long_req_msg_t lreq_hdr;
-
-        MPIR_Memcpy(&lreq_hdr.hdr, am_hdr, am_hdr_sz);
-        lreq_hdr.data_sz = data_sz;
-        lreq_hdr.sreq_ptr = sreq;
-        MPIDIG_REQUEST(sreq, req->lreq).src_buf = data;
-        MPIDIG_REQUEST(sreq, req->lreq).count = count;
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
-        MPIDIG_REQUEST(sreq, req->lreq).datatype = datatype;
-        MPIDIG_REQUEST(sreq, req->lreq).tag = lreq_hdr.hdr.tag;
-        MPIDIG_REQUEST(sreq, req->lreq).rank = lreq_hdr.hdr.src_rank;
-        MPIDIG_REQUEST(sreq, req->lreq).context_id = lreq_hdr.hdr.context_id;
-        MPIDIG_REQUEST(sreq, rank) = rank;
-        mpi_errno = MPIDI_NM_am_send_hdr(rank, comm, MPIDIG_SEND_LONG_REQ,
-                                         &lreq_hdr, sizeof(lreq_hdr));
-        MPIR_ERR_CHECK(mpi_errno);
-        goto fn_exit;
-    }
 
     ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
     ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);

--- a/src/mpid/ch4/shm/include/shm.h
+++ b/src/mpid/ch4/shm/include/shm.h
@@ -48,6 +48,7 @@ typedef int (*MPIDI_SHM_am_isend_reply_t) (MPIR_Context_id_t context_id, int src
                                            MPI_Count count, MPI_Datatype datatype,
                                            MPIR_Request * sreq);
 typedef size_t(*MPIDI_SHM_am_hdr_max_sz_t) (void);
+typedef size_t(*MPIDI_SHM_am_eager_limit_t) (void);
 typedef int (*MPIDI_SHM_comm_get_lpid_t) (MPIR_Comm * comm_ptr, int idx,
                                           int *lpid_ptr, bool is_remote);
 typedef int (*MPIDI_SHM_get_local_upids_t) (MPIR_Comm * comm, size_t ** local_upid_size,
@@ -459,6 +460,7 @@ typedef struct MPIDI_SHM_funcs {
     MPIDI_SHM_am_send_hdr_reply_t am_send_hdr_reply;
     MPIDI_SHM_am_isend_reply_t am_isend_reply;
     MPIDI_SHM_am_hdr_max_sz_t am_hdr_max_sz;
+    MPIDI_SHM_am_eager_limit_t am_eager_limit;
 } MPIDI_SHM_funcs_t;
 
 typedef struct MPIDI_SHM_native_funcs {
@@ -601,6 +603,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_am_isend_reply(MPIR_Context_id_t context_
                                                       MPI_Count count, MPI_Datatype datatype,
                                                       MPIR_Request * sreq) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr,
                                                      bool is_remote) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -306,6 +306,11 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_hdr_max_sz(void)
     return MPL_MIN(max_shortsend, max_representable);
 }
 
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_am_eager_limit(void)
+{
+    return MPIDI_POSIX_DEFAULT_SHORT_SEND_SIZE - (sizeof(MPIDI_POSIX_am_header_t));
+}
+
 /* Enqueue a request header onto the postponed message queue. This is a helper function and most
  * likely shouldn't be used outside of this file. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_enqueue_req_hdr(const void *am_hdr, size_t am_hdr_sz,

--- a/src/mpid/ch4/shm/src/func_table.c
+++ b/src/mpid/ch4/shm/src/func_table.c
@@ -58,7 +58,8 @@ MPIDI_SHM_funcs_t MPIDI_SHM_src_funcs = {
     .am_isendv = MPIDI_SHM_am_isendv,
     .am_send_hdr_reply = MPIDI_SHM_am_send_hdr_reply,
     .am_isend_reply = MPIDI_SHM_am_isend_reply,
-    .am_hdr_max_sz = MPIDI_SHM_am_hdr_max_sz
+    .am_hdr_max_sz = MPIDI_SHM_am_hdr_max_sz,
+    .am_eager_limit = MPIDI_SHM_am_eager_limit
 };
 
 MPIDI_SHM_native_funcs_t MPIDI_SHM_native_src_funcs = {

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -117,6 +117,15 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void)
+{
+    int ret;
+
+    ret = MPIDI_POSIX_am_eager_limit();
+
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_init(MPIR_Request * req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_SHM_AM_REQUEST_INIT);

--- a/src/mpid/ch4/shm/src/shm_impl.h
+++ b/src/mpid/ch4/shm/src/shm_impl.h
@@ -117,6 +117,15 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_hdr_max_sz(void)
     return ret;
 }
 
+MPL_STATIC_INLINE_PREFIX size_t MPIDI_SHM_am_eager_limit(void)
+{
+    int ret;
+
+    ret = MPIDI_SHM_src_funcs.am_eager_limit();
+
+    return ret;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_comm_get_lpid(MPIR_Comm * comm_ptr, int idx,
                                                      int *lpid_ptr, bool is_remote)
 {

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -78,18 +78,6 @@ cvars:
         direct (default)
         handoff
 
-    - name        : MPIR_CVAR_CH4_EAGER_MAX_MSG_SIZE
-      category    : CH4
-      type        : int
-      default     : -1
-      class       : device
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        If set to positive number, this cvar controls the message size at which CH4 switches from eager to rendezvous mode.
-        If the number is negative, underlying netmod or shmmod automatically uses an optimal number depending on
-        the underlying fabric or shared memory architecture.
-
     - name        : MPIR_CVAR_CH4_NUM_VCIS
       category    : CH4
       type        : int

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -381,7 +381,7 @@ int MPIDIG_send_target_msg_cb(int handler_id, void *am_hdr, void **data, size_t 
         /* MPIDI_CS_ENTER(); */
         while (TRUE) {
             rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
-                                         &MPIDIG_COMM(root_comm, posted_list));
+                                         is_local, &MPIDIG_COMM(root_comm, posted_list));
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             if (rreq) {
                 int is_cancelled;
@@ -488,7 +488,7 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data
         /* MPIDI_CS_ENTER(); */
         while (TRUE) {
             rreq = MPIDIG_dequeue_posted(hdr->src_rank, hdr->tag, hdr->context_id,
-                                         &MPIDIG_COMM(root_comm, posted_list));
+                                         is_local, &MPIDIG_COMM(root_comm, posted_list));
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             if (rreq) {
                 int is_cancelled;

--- a/src/mpid/ch4/src/ch4r_callbacks.c
+++ b/src/mpid/ch4/src/ch4r_callbacks.c
@@ -553,8 +553,12 @@ int MPIDIG_send_long_req_target_msg_cb(int handler_id, void *am_hdr, void **data
         }
         MPID_THREAD_CS_EXIT(VCI, MPIDIU_THREAD_MPIDIG_GLOBAL_MUTEX);
     } else {
-        /* Matching receive was posted, tell the netmod */
-        MPIR_Comm_release(root_comm);   /* -1 for posted_list */
+        /* Matching receive was posted */
+        rreq->comm = root_comm;
+        /* NOTE: we are skipping MPIR_Comm_release for taking off posted_list since we are holding
+         * the reference to root_comm in the rreq. We need to hold on to this reference so the comm
+         * may remain valid by the time we send ack (using the comm).
+         */
         MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_LONG_RTS;
         MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = lreq_hdr->sreq_ptr;
         MPIDIG_REQUEST(rreq, rank) = hdr->src_rank;

--- a/src/mpid/ch4/src/ch4r_recvq.h
+++ b/src/mpid/ch4/src/ch4r_recvq.h
@@ -148,7 +148,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_find_unexp(int rank, int tag,
 
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_posted(int rank, int tag,
                                                              MPIR_Context_id_t context_id,
-                                                             MPIDIG_rreq_t ** list)
+                                                             int is_local, MPIDIG_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
     MPIDIG_rreq_t *curr, *tmp;
@@ -158,13 +158,18 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_posted(int rank, int tag,
     MPIR_T_PVAR_TIMER_START(RECVQ, time_failed_matching_postedq);
     DL_FOREACH_SAFE(*list, curr, tmp) {
         MPIR_T_PVAR_COUNTER_INC(RECVQ, posted_recvq_match_attempts, 1);
-        req = curr->request;
-        if (MPIDIG_match_posted(rank, tag, context_id, req)) {
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+        /* NOTE: extra negation to force logical comparisons */
+        if (!MPIDI_REQUEST(curr->request, is_local) != !is_local) {
+            continue;
+        }
+#endif
+        if (MPIDIG_match_posted(rank, tag, context_id, curr->request)) {
+            req = curr->request;
             DL_DELETE(*list, curr);
             MPIR_T_PVAR_LEVEL_DEC(RECVQ, posted_recvq_length, 1);
             break;
         }
-        req = NULL;
     }
     if (!req)
         MPIR_T_PVAR_TIMER_END(RECVQ, time_failed_matching_postedq);
@@ -305,7 +310,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_find_unexp(int rank, int tag,
 
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_dequeue_posted(int rank, int tag,
                                                              MPIR_Context_id_t context_id,
-                                                             MPIDIG_rreq_t ** list)
+                                                             int is_local, MPIDIG_rreq_t ** list)
 {
     MPIR_Request *req = NULL;
     MPIDIG_rreq_t *curr, *tmp;

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -44,10 +44,6 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
 # am-only failures
-* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf .*\)+\1 xfail=ticket3915+g" test/mpi/f77/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf90 .*\)+\1 xfail=ticket3915+g" test/mpi/f90/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^[ip]*ssendf08 .*\)+\1 xfail=issue3915+g" test/mpi/f08/pt2pt/testlist
-
 * * am-only ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 * * am-only ch4:ofi * sed -i "s+\(^huge_anysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 * * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist


### PR DESCRIPTION
## Pull Request Description

The current way of letting netmod overwrite send protocol into long_send is awkward. Not only it duplicates code, spreads protocol, it also complicates the active message api interfaces.

This PR attempts to make the rndz decision from the generic layer. It uses the netmod api MPIDI_NM_am_hdr_max_sz, so individual netmod still can make its individual choice. It should be noted that this api is used in multiple places. It might be a good idea to add a new api, e.g. `MPIDI_NM_am_eager_limit`.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       Fixes #3915
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand

