### PR TITLE
ch4/posix: Add LMT/RNDV Module

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -195,9 +195,12 @@ typedef struct MPIDIG_req_t {
     MPIDIG_req_ext_t *req;
     void *buffer;
     MPI_Aint count;
+    MPI_Aint user_count; /* Count in terms of number of datatypes as opposed to bytes. */
     int rank;
     int tag;
     MPIR_Context_id_t context_id;
+    int error_bits; /* Keeps track of any error bits being transferred that need to be reported back
+                       to the user when the call is completed. */
     MPI_Datatype datatype;
 } MPIDIG_req_t;
 

--- a/src/mpid/ch4/shm/posix/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/Makefile.mk
@@ -34,6 +34,7 @@ noinst_HEADERS += src/mpid/ch4/shm/posix/posix_am.h        \
 
 mpi_core_sources += src/mpid/ch4/shm/posix/globals.c    \
                     src/mpid/ch4/shm/posix/posix_progress.c \
+                    src/mpid/ch4/shm/posix/posix_callbacks.c \
                     src/mpid/ch4/shm/posix/posix_comm.c \
                     src/mpid/ch4/shm/posix/posix_init.c \
                     src/mpid/ch4/shm/posix/posix_op.c \
@@ -43,5 +44,6 @@ mpi_core_sources += src/mpid/ch4/shm/posix/globals.c    \
                     src/mpid/ch4/shm/posix/posix_eager_array.c
 
 include $(top_srcdir)/src/mpid/ch4/shm/posix/eager/Makefile.mk
+include $(top_srcdir)/src/mpid/ch4/shm/posix/lmt/Makefile.mk
 
 endif

--- a/src/mpid/ch4/shm/posix/lmt/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/lmt/Makefile.mk
@@ -1,0 +1,20 @@
+## -*- Mode: Makefile; -*-
+## vim: set ft=automake :
+##
+## (C) 2019 by Argonne National Laboratory.
+##     See COPYRIGHT in top-level directory.
+##
+##  Portions of this code were written by Intel Corporation.
+##  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+##  to Argonne National Laboratory subject to Software Grant and Corporate
+##  Contributor License Agreement dated February 8, 2012.
+##
+
+AM_CPPFLAGS += -I$(top_srcdir)/src/mpid/ch4/shm/posix/lmt/include
+AM_CPPFLAGS += -I$(top_builddir)/src/mpid/ch4/shm/posix/lmt/include
+
+noinst_HEADERS += src/mpid/ch4/shm/posix/lmt/include/posix_lmt.h \
+                  src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h
+
+include $(top_srcdir)/src/mpid/ch4/shm/posix/lmt/rndv/Makefile.mk
+

--- a/src/mpid/ch4/shm/posix/lmt/include/posix_lmt.h
+++ b/src/mpid/ch4/shm/posix/lmt/include/posix_lmt.h
@@ -1,0 +1,34 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#ifndef POSIX_LMT_H_INCLUDED
+#define POSIX_LMT_H_INCLUDED
+
+#include "mpidimpl.h"
+#include "posix_impl.h"
+#include "shm_types.h"
+
+int MPIDI_POSIX_lmt_init(int rank, int size);
+int MPIDI_POSIX_lmt_finalize(void);
+
+int MPIDI_POSIX_lmt_send_rts(void *buf, int grank, int tag, int error_bits, MPIR_Comm * comm,
+                             size_t data_sz, int handler_id, MPIR_Request * sreq);
+int MPIDI_POSIX_lmt_recv(MPIR_Request * req);
+
+int MPIDI_POSIX_lmt_progress(void);
+
+void MPIDI_POSIX_lmt_recv_posted_hook(int grank);
+void MPIDI_POSIX_lmt_recv_completed_hook(int grank);
+
+int MPIDI_POSIX_lmt_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_POSIX_lmt_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+
+#endif /* POSIX_LMT_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h
+++ b/src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h
@@ -1,0 +1,18 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+#ifndef POSIX_LMT_PRE_H_INCLUDED
+#define POSIX_LMT_PRE_H_INCLUDED
+
+/* *INDENT-OFF* */
+#include "../rndv/rndv_pre.h"
+/* *INDENT-ON* */
+
+#endif /* POSIX_LMT_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h.in
+++ b/src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h.in
@@ -1,0 +1,18 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+#ifndef POSIX_LMT_PRE_H_INCLUDED
+#define POSIX_LMT_PRE_H_INCLUDED
+
+/* *INDENT-OFF* */
+@ch4_posix_lmt_pre_include@
+/* *INDENT-ON* */
+
+#endif /* POSIX_LMT_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/lmt/rndv/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/Makefile.mk
@@ -1,0 +1,20 @@
+## -*- Mode: Makefile; -*-
+## vim: set ft=automake :
+##
+## (C) 2019 by Argonne National Laboratory.
+##     See COPYRIGHT in top-level directory.
+##
+##  Portions of this code were written by Intel Corporation.
+##  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+##  to Argonne National Laboratory subject to Software Grant and Corporate
+##  Contributor License Agreement dated February 8, 2012.
+##
+
+if BUILD_CH4_SHM_POSIX_LMT_RNDV
+
+mpi_core_sources += src/mpid/ch4/shm/posix/lmt/rndv/rndv_init.c \
+                    src/mpid/ch4/shm/posix/lmt/rndv/rndv_send.c \
+                    src/mpid/ch4/shm/posix/lmt/rndv/rndv_recv.c \
+                    src/mpid/ch4/shm/posix/lmt/rndv/rndv_progress.c \
+                    src/mpid/ch4/shm/posix/lmt/rndv/rndv_control.c
+endif

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv.h
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv.h
@@ -1,0 +1,97 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_POSIX_LMT_PIPELINE_THRESHOLD
+      category    : CH4
+      type        : int
+      default     : 131072
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If the message is smaller than this threshold, copy the entire message into the pipeline
+        copy buffer at once instead of pipelining. If it is larger than this message, copy it into
+        the copy buffer using the size of each copy buffer segment as the chunk size (32KB is
+        defined in rndv.h).
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+#include "mpiimpl.h"
+#include "mpidu_generic_queue.h"
+#include "posix_lmt.h"
+#include "posix_am.h"
+
+/* Describes ongoing operations so the progress engine can move them along. */
+typedef struct lmt_rndv_wait_element {
+    /* The function that needs to be called to progress this wait element. Probably will be a send
+     * function or a receive function. */
+    int (*progress) (MPIR_Request * req, int local_rank, bool * done);
+
+    /* The request that describes the operation and has all of the information needed to make
+     * progress on it. */
+    MPIR_Request *req;
+
+    /* Pointer to the next element in the list. */
+    struct lmt_rndv_wait_element *next;
+} lmt_rndv_wait_element_t;
+
+typedef struct {
+    lmt_rndv_wait_element_t *head, *tail;
+} lmt_rndv_queue_t;
+
+/* Ensures that the size of this int will be one cache line. */
+typedef union {
+    volatile int val;
+    char padding[MPIDU_SHM_CACHE_LINE_LEN];
+} lmt_rndv_cacheline_int_t;
+
+#define MPIDI_LMT_NUM_BUFS 8
+#define MPIDI_LMT_COPY_BUF_LEN (32 * 1024)
+/* For smaller messages, use a smaller pipeline size to make the memcopies faster and get more
+ * overlap. */
+#define MPIDI_LMT_SMALL_PIPELINE_MAX (MPIDI_LMT_COPY_BUF_LEN / 2)
+
+/* Struct to describe the metadata needed to perform a pipelined copy between two processes. */
+typedef struct {
+    /* Set if the sender is currently in the progress function for this buffer. */
+    lmt_rndv_cacheline_int_t sender_present;
+
+    /* Set if the receiver is currently in the progress function for this buffer. */
+    lmt_rndv_cacheline_int_t receiver_present;
+
+    /* The length of the data in each of the buffer chunks */
+    lmt_rndv_cacheline_int_t len[MPIDI_LMT_NUM_BUFS];
+
+    /* This buffer is used when there is some data that couldn't be copied out of the previous
+     * buffer. */
+    volatile char underflow_buf[MPIDU_SHM_CACHE_LINE_LEN];
+
+    /* The buffers used for copying the data through the shared memory region. The are partitioned
+     * as a series of copy buffers. */
+    volatile char buf[MPIDI_LMT_NUM_BUFS][MPIDI_LMT_COPY_BUF_LEN];
+} lmt_rndv_copy_buf_t;
+
+/* An array of copy buffer pointers to be filled in on demand. */
+extern lmt_rndv_copy_buf_t **rndv_send_copy_bufs;
+extern lmt_rndv_copy_buf_t **rndv_recv_copy_bufs;
+/* Handles for the copy buffers that can be serialized to send to the communication partner. */
+extern MPL_shm_hnd_t *rndv_send_copy_buf_handles;
+extern MPL_shm_hnd_t *rndv_recv_copy_buf_handles;
+/* Array of queued operations between the current process and all other local processes. */
+extern lmt_rndv_queue_t *rndv_send_queues;
+extern lmt_rndv_queue_t *rndv_recv_queues;
+
+int lmt_rndv_recv_progress(MPIR_Request * req, int local_rank, bool * done);
+int lmt_rndv_send_progress(MPIR_Request * req, int local_rank, bool * done);

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_control.c
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_control.c
@@ -1,0 +1,190 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "rndv.h"
+
+/* Handle incoming ready to send (RTS) message by setting up a shared memory segment and enqueuing
+ * the message into a list to progressed.
+ *
+ * ctrl_hdr - The struct containing the control message
+ */
+int MPIDI_POSIX_lmt_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Comm *root_comm;
+
+    MPIDI_SHM_lmt_rndv_long_msg_t *lmt_rndv_long_msg = &ctrl_hdr->lmt_rndv_long_msg;
+    MPIR_Request *rreq = NULL, *anysource_partner;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_LMT_CTRL_SEND_LMT_MSG_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LMT_CTRL_SEND_LMT_MSG_CB);
+
+    /* Try to match a posted receive request.
+     * root_comm cannot be NULL if a posted receive request exists, because
+     * we increase its refcount at enqueue time. */
+    root_comm = MPIDIG_context_id_to_comm(lmt_rndv_long_msg->context_id);
+
+    if (root_comm) {
+        int continue_matching = 1;
+        while (TRUE) {
+            rreq = MPIDIG_dequeue_posted(lmt_rndv_long_msg->rank, lmt_rndv_long_msg->tag,
+                                         lmt_rndv_long_msg->context_id,
+                                         &MPIDIG_COMM(root_comm, posted_list));
+
+            if (rreq) {
+                int is_cancelled;
+                MPIDI_anysrc_try_cancel_partner(rreq, &is_cancelled);
+                if (!is_cancelled) {
+                    MPIR_Comm_release(root_comm);       /* -1 for posted_list */
+                    MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(rreq, datatype));
+                    continue;
+                }
+
+                /* NOTE: NM partner is freed at MPIDI_anysrc_try_cancel_partner, no need to call
+                 * MPIDI_anysrc_free_partner during completion. */
+            }
+            break;
+        }
+    }
+
+    if (rreq) {
+        /* Matching receive was posted */
+        MPIR_Comm_release(root_comm);   /* -1 for posted_list */
+        rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank) = lmt_rndv_long_msg->rank;
+        rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag) = lmt_rndv_long_msg->tag;
+        MPIR_STATUS_SET_COUNT(rreq->status, lmt_rndv_long_msg->data_sz);
+        MPIDIG_REQUEST(rreq, count) = lmt_rndv_long_msg->data_sz;
+        MPIDIG_REQUEST(rreq, context_id) = lmt_rndv_long_msg->context_id;
+        MPIDIG_REQUEST(rreq, error_bits) = lmt_rndv_long_msg->error_bits;
+        MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = (MPIR_Request *) lmt_rndv_long_msg->sreq_ptr;
+        /* This is a posted receive -- no need to cleanup rreq.match_req when it completes. */
+        MPIDIG_REQUEST(rreq, req->rreq.match_req) = NULL;
+        if (lmt_rndv_long_msg->handler_id == MPIDIG_SSEND_REQ)
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_PEER_SSEND;
+        MPIDI_REQUEST(rreq, is_local) = 1;
+        rreq->status.MPI_ERROR = MPI_SUCCESS;
+
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_data_sz) = lmt_rndv_long_msg->data_sz;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_msg_offset) = 0;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_buf_num) = 0;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_leftover) = 0;
+
+        /* Complete setting up pipelined receive */
+        mpi_errno = MPIDI_POSIX_lmt_recv(rreq);
+
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    } else {
+        /* Enqueue unexpected receive request */
+        rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2);
+        MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+
+        /* store CH4 am rreq info */
+        MPIDIG_REQUEST(rreq, buffer) = NULL;
+        rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, rank) = lmt_rndv_long_msg->rank;
+        rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, tag) = lmt_rndv_long_msg->tag;
+        MPIR_STATUS_SET_COUNT(rreq->status, lmt_rndv_long_msg->data_sz);
+        MPIDIG_REQUEST(rreq, count) = lmt_rndv_long_msg->data_sz;
+        MPIDIG_REQUEST(rreq, context_id) = lmt_rndv_long_msg->context_id;
+        MPIDIG_REQUEST(rreq, error_bits) = lmt_rndv_long_msg->error_bits;
+        MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr) = (MPIR_Request *) lmt_rndv_long_msg->sreq_ptr;
+        if (lmt_rndv_long_msg->handler_id == MPIDIG_SSEND_REQ)
+            MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_PEER_SSEND;
+        MPIDIG_REQUEST(rreq, req->status) |= MPIDIG_REQ_LONG_RTS;
+        MPIDI_REQUEST(rreq, is_local) = 1;
+        rreq->status.MPI_ERROR = MPI_SUCCESS;
+
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_data_sz) = lmt_rndv_long_msg->data_sz;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_msg_offset) = 0;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_buf_num) = 0;
+        MPIDI_POSIX_AMREQUEST(rreq, lmt.lmt_leftover) = 0;
+
+        if (root_comm) {
+            MPIR_Comm_add_ref(root_comm);       /* +1 for unexp_list */
+            MPIDIG_enqueue_unexp(rreq, &MPIDIG_COMM(root_comm, unexp_list));
+        } else {
+            MPIDIG_enqueue_unexp(rreq,
+                                 MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_LMT_CTRL_SEND_LMT_MSG_CB);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Handle incoming clear to send (CTS) message by setting up a shared memory segment and enqueuing
+ * the message into a list to progressed.
+ *
+ * ctrl_hdr - The struct containing the control message
+ */
+int MPIDI_POSIX_lmt_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_LMT_CTRL_SEND_LMT_ACK_CB);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LMT_CTRL_SEND_LMT_ACK_CB);
+
+    MPIR_CHKPMEM_DECL(1);
+
+    MPIR_Request *sreq = (MPIR_Request *) ctrl_hdr->lmt_rndv_long_ack.sreq_ptr;
+    int serialized_handle_len = ctrl_hdr->lmt_rndv_long_ack.copy_buf_serialized_handle_len;
+    char *serialized_handle = ctrl_hdr->lmt_rndv_long_ack.copy_buf_serialized_handle;
+    const int grank = MPIDIU_rank_to_lpid(MPIDIG_REQUEST(sreq, rank),
+                                          MPIDIG_context_id_to_comm(MPIDIG_REQUEST(sreq,
+                                                                                   context_id)));
+    int receiver_local_rank = MPIDI_POSIX_global.local_ranks[grank];
+
+    /* Check to see if this copy buffer has been set up before and do so if not */
+    if (NULL == rndv_send_copy_bufs[receiver_local_rank]) {
+        mpi_errno = MPL_shm_hnd_deserialize(rndv_send_copy_buf_handles[receiver_local_rank],
+                                            serialized_handle, serialized_handle_len);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        mpi_errno = MPL_shm_seg_attach(rndv_send_copy_buf_handles[receiver_local_rank],
+                                       sizeof(lmt_rndv_copy_buf_t),
+                                       (void **) &rndv_send_copy_bufs[receiver_local_rank], 0);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    }
+
+    /* Create a new "wait element" for this lmt transfer in case more than one is started at the
+     * same time */
+    lmt_rndv_wait_element_t *element;
+    MPIR_CHKPMEM_MALLOC(element, lmt_rndv_wait_element_t *, sizeof(lmt_rndv_wait_element_t),
+                        mpi_errno, "LMT RNDV wait element", MPL_MEM_SHM);
+    element->progress = lmt_rndv_send_progress;
+    element->req = sreq;
+    GENERIC_Q_ENQUEUE(&rndv_send_queues[receiver_local_rank], element, next);
+
+    /* If this is an ssend, mark that the request has synchronized */
+    if (ctrl_hdr->lmt_rndv_long_ack.handler_id & MPIDIG_SSEND_REQ)
+        MPID_Request_complete(sreq);
+
+    /* TODO - Create a queue where in progress messages go to shorten the progress polling time. */
+
+    /* Try to make progress on lmt messages before queuing the new one */
+    mpi_errno = MPIDI_POSIX_lmt_progress();
+    /* Want to capture the output of the progress function, but not return an error immediately
+     * because just kicking the progress engine may not indicate a problem with this particular
+     * receive. */
+
+    MPIR_CHKPMEM_COMMIT();
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LMT_CTRL_SEND_LMT_ACK_CB);
+    return mpi_errno;
+  fn_fail:
+    MPIR_CHKPMEM_REAP();
+    goto fn_exit;
+}

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_init.c
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_init.c
@@ -1,0 +1,130 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "rndv.h"
+
+/* These are defined in rndv.h */
+lmt_rndv_copy_buf_t **rndv_send_copy_bufs;
+lmt_rndv_copy_buf_t **rndv_recv_copy_bufs;
+MPL_shm_hnd_t *rndv_send_copy_buf_handles;
+MPL_shm_hnd_t *rndv_recv_copy_buf_handles;
+lmt_rndv_queue_t *rndv_send_queues;
+lmt_rndv_queue_t *rndv_recv_queues;
+
+/* Initialize all of the state necesary for the POSIX/LMT/RNDV module. Neither of the two inputs are
+ * used.
+ *
+ * rank - The global rank of the calling process.
+ * size - The number of processes in MPI_COMM_WORLD
+ */
+int MPIDI_POSIX_lmt_init(int rank, int size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int i;
+
+    MPIR_CHKPMEM_DECL(6);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_LMT_INIT);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_INIT);
+
+    /* Allocate space for the copy buffer pointers and handles. The structs themselves will be
+     * allocated on demand later. All of these _could_ be sized at num_local-1 instead of num_local
+     * since this code won't be used for loopback messages, but it would make tracking the ranks
+     * much more difficult so it's much simpler to just have one extra that doesn't get used. */
+    MPIR_CHKPMEM_MALLOC(rndv_send_copy_bufs, lmt_rndv_copy_buf_t **,
+                        sizeof(lmt_rndv_copy_buf_t *) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV send copy buffers", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(rndv_recv_copy_bufs, lmt_rndv_copy_buf_t **,
+                        sizeof(lmt_rndv_copy_buf_t *) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV recv copy buffers", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(rndv_send_copy_buf_handles, MPL_shm_hnd_t *,
+                        sizeof(MPL_shm_hnd_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV send copy buffer handles", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(rndv_recv_copy_buf_handles, MPL_shm_hnd_t *,
+                        sizeof(MPL_shm_hnd_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV recv copy buffer handles", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(rndv_send_queues, lmt_rndv_queue_t *,
+                        sizeof(lmt_rndv_queue_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV send wait event queues", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(rndv_recv_queues, lmt_rndv_queue_t *,
+                        sizeof(lmt_rndv_queue_t) * MPIDI_POSIX_global.num_local, mpi_errno,
+                        "LMT RNDV recv wait event queues", MPL_MEM_SHM);
+
+    for (i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        mpi_errno = MPL_shm_hnd_init(&rndv_send_copy_buf_handles[i]);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPL_shm_hnd_init(&rndv_recv_copy_buf_handles[i]);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+        rndv_send_copy_bufs[i] = NULL;
+        rndv_recv_copy_bufs[i] = NULL;
+        rndv_send_queues[i].head = NULL;
+        rndv_send_queues[i].tail = NULL;
+        rndv_recv_queues[i].head = NULL;
+        rndv_recv_queues[i].tail = NULL;
+    }
+
+    MPIR_CHKPMEM_COMMIT();
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_LMT_INIT);
+    return mpi_errno;
+  fn_fail:
+    MPIR_CHKPMEM_REAP();
+    goto fn_exit;
+}
+
+/* Clean up the state of the POSIX/LMT/RNDV module. */
+int MPIDI_POSIX_lmt_finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_LMT_FINALIZE);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_FINALIZE);
+
+    for (int i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        if (rndv_send_copy_bufs[i]) {
+            mpi_errno = MPL_shm_seg_detach(rndv_send_copy_buf_handles[i],
+                                           (void **) &rndv_send_copy_bufs[i],
+                                           sizeof(lmt_rndv_copy_buf_t));
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+        if (rndv_recv_copy_bufs[i]) {
+            mpi_errno = MPL_shm_seg_detach(rndv_recv_copy_buf_handles[i],
+                                           (void **) &rndv_recv_copy_bufs[i],
+                                           sizeof(lmt_rndv_copy_buf_t));
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+    }
+
+    for (int i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        mpi_errno = MPL_shm_hnd_finalize(&rndv_send_copy_buf_handles[i]);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+        mpi_errno = MPL_shm_hnd_finalize(&rndv_recv_copy_buf_handles[i]);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    }
+
+    MPL_free(rndv_send_copy_bufs);
+    MPL_free(rndv_recv_copy_bufs);
+    MPL_free(rndv_send_copy_buf_handles);
+    MPL_free(rndv_recv_copy_buf_handles);
+    MPL_free(rndv_send_queues);
+    MPL_free(rndv_recv_queues);
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_FINALIZE);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_pre.h
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_pre.h
@@ -1,0 +1,65 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+#ifndef POSIX_LMT_RNDV_PRE_H_INCLUDED
+#define POSIX_LMT_RNDV_PRE_H_INCLUDED
+
+#include "mpiimpl.h"
+
+/* This is a somewhat arbitray limit, but it appears that in mpl_shm_mmap.c, this will never be
+ * longer than 30 characters so we'll use 48 just to be safe. */
+#define MPIDI_MAX_HANDLE_LEN 48
+
+/* Struct to track data needed for the RTS message in the RNDV protocol. */
+typedef struct {
+    uint64_t sreq_ptr;          /* A "serialized" version of the pointer to the send request. Needed
+                                 * so the receiver can help the sender match the request when the
+                                 * CTS message comes back. */
+    uint64_t data_sz;           /* Data size in bytes */
+
+    MPI_Aint rank;              /* The rank of the sending process. */
+    int tag;                    /* The tag used when sending the message. */
+    MPIR_Context_id_t context_id;       /* The context id used to send the message (includes the offset) */
+    int error_bits;             /* The error bits used during collective communication. */
+    int handler_id;             /* The handler type of the message. Used to tell the sender when an
+                                 * MPI_SSEND is done. */
+} MPIDI_SHM_lmt_rndv_long_msg_t;
+
+typedef struct {
+    uint64_t sreq_ptr;          /* A "serialized" version of the pointer to the send request. Needed
+                                 * so the receiver can help the sender match the request when the
+                                 * CTS message comes back. */
+    uint64_t rreq_ptr;          /* A "serialized" version of the receive request. */
+    int handler_id;             /* The handler type of the message. Used to tell the sender when an
+                                 * MPI_SSEND is done. */
+
+    int copy_buf_serialized_handle_len; /* The length of the serialized handle. */
+    char copy_buf_serialized_handle[MPIDI_MAX_HANDLE_LEN];      /* Serialized handle for the shared
+                                                                 * memory region */
+} MPIDI_SHM_lmt_rndv_long_ack_t;
+
+#define MPIDI_SHM_LMT_CTRL_MESSAGE_TYPES \
+    MPIDI_SHM_lmt_rndv_long_msg_t lmt_rndv_long_msg; \
+    MPIDI_SHM_lmt_rndv_long_ack_t lmt_rndv_long_ack;
+
+/* Goes in the MPIDIG_req_t struct to describe LMT-related  requests. */
+#define MPIDI_SHM_LMT_AM_DECL size_t lmt_data_sz;      /* The size of the data in the message */ \
+                              int lmt_buf_num;         /* The number of the buffer being used */ \
+                                                       /* at the moment. */                      \
+                              intptr_t lmt_msg_offset; /* The offset of the current point */     \
+                                                       /* that's been transfered into the */     \
+                                                       /* original message buffer. */            \
+                              intptr_t lmt_leftover;   /* The amount of data "left over" from the */
+                                                       /* previous memory segment that needs to */
+                                                       /* be transfered before the next one. */
+
+
+
+#endif /* POSIX_LMT_RNDV_PRE_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_progress.c
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_progress.c
@@ -1,0 +1,284 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "rndv.h"
+
+/* Progress function for the RNDV submodule. This will call the various functions needed to make
+ * progress on individual wait elements. */
+int MPIDI_POSIX_lmt_progress()
+{
+    int mpi_errno = MPI_SUCCESS;
+    lmt_rndv_wait_element_t *wait_element;
+    bool done;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_LMT_PROGRESS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_PROGRESS);
+
+    /* Iterate over the list of all rndv queues and make progress on each if there is a request
+     * present. */
+    /* TODO - Change this to use a single queue to make polling faster. */
+    for (int i = 0; i < MPIDI_POSIX_global.num_local; i++) {
+        wait_element = GENERIC_Q_HEAD(rndv_send_queues[i]);
+        if (wait_element) {
+            mpi_errno = wait_element->progress(wait_element->req, i, &done);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+
+            if (done) {
+                GENERIC_Q_DEQUEUE(&rndv_send_queues[i], &wait_element, next);
+                MPL_free(wait_element);
+            }
+        }
+        wait_element = GENERIC_Q_HEAD(rndv_recv_queues[i]);
+        if (wait_element) {
+            mpi_errno = wait_element->progress(wait_element->req, i, &done);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+
+            if (done) {
+                GENERIC_Q_DEQUEUE(&rndv_recv_queues[i], &wait_element, next);
+                MPL_free(wait_element);
+            }
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_LMT_PROGRESS);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Make progress on requests involved in receiving a message
+ *
+ * req - The request describing the message
+ * local_rank - The local rank of the progress from which the message is coming (local rank is the
+ *              rank of the processes only present on this node).
+ * done - Return value to indicate whether the reqeust is complete
+ */
+int lmt_rndv_recv_progress(MPIR_Request * req, int local_rank, bool * done)
+{
+    int mpi_errno = MPI_SUCCESS;
+    char *src_buf;
+    intptr_t last, expected_last;
+    lmt_rndv_copy_buf_t *copy_buf = rndv_recv_copy_bufs[local_rank];
+    intptr_t msg_offset = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_msg_offset);
+    intptr_t data_sz = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_data_sz);
+    intptr_t leftover = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_leftover);
+    int buf_num = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_buf_num);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_LMT_RNDV_RECV_PROGRESS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LMT_RNDV_RECV_PROGRESS);
+
+    /* Each time through the progres engine, the receiver will copy out one chunk of the message. */
+    if (0 == copy_buf->len[buf_num].val) {
+        *done = false;
+        goto fn_exit;
+    }
+
+    OPA_read_barrier();
+
+    /* Calculate correct starting position based on whether there was leftover in the previous
+     * iteration. */
+    src_buf = ((char *) copy_buf->buf[buf_num]) - leftover;
+    last = expected_last = (data_sz - msg_offset <= leftover + copy_buf->len[buf_num].val) ?
+        data_sz : (msg_offset + leftover + copy_buf->len[buf_num].val);
+
+    MPI_Aint actual_unpack_bytes;
+    MPIR_Typerep_unpack(src_buf, last - msg_offset, MPIDIG_REQUEST(req, buffer),
+                        MPIDIG_REQUEST(req, user_count), MPIDIG_REQUEST(req, datatype),
+                        msg_offset, &actual_unpack_bytes);
+    last = msg_offset + actual_unpack_bytes;
+
+    /* We had leftover data from the previous buffer so we should now mark that buffer empty */
+    if (leftover && buf_num > 0) {
+        /* Make sure that any unpacking is done before unsetting the value to prevent another
+         * process overwriting. */
+        OPA_read_write_barrier();
+        copy_buf->len[buf_num - 1].val = 0;
+    }
+
+    if (last < expected_last) {
+        /* We have leftover data in the buffer that wasn't copied out by the datatype engine */
+        char *leftover_ptr = (char *) src_buf + last - msg_offset;
+        leftover = expected_last - last;
+
+        /* Ensure that we're not going to overwrite some data in the copy_buf struct that we
+         * shoulnd't be touching. */
+        MPIR_Assert(leftover <= MPIDU_SHM_CACHE_LINE_LEN);
+
+        if (buf_num == MPIDI_LMT_NUM_BUFS - 1) {
+            /* If wrapping back to the starting buffer, copy the data directly to that buffer */
+            MPIR_Memcpy(((char *) copy_buf->buf[0]) - leftover, leftover_ptr, leftover);
+
+            /* Make sure that any unpacking is done before unsetting the value to prevent
+             * another process overwriting. */
+            OPA_read_write_barrier();
+            copy_buf->len[buf_num].val = 0;
+        } else {
+            char tmp_buf[MPIDU_SHM_CACHE_LINE_LEN];
+
+            /* Otherwise, we need to copy to a tempbuf first to make sure the two addresses
+             * don't overlap each other. */
+            MPIR_Memcpy(tmp_buf, leftover_ptr, leftover);
+            MPIR_Memcpy(((char *) copy_buf->buf[buf_num + 1]) - leftover, tmp_buf, leftover);
+        }
+    } else {
+        /* Everything was unpacked so this can be marked as empty */
+        leftover = 0;
+
+        /* Make sure that any unpacking is done before unsetting the value to prevent another
+         * process overwriting. */
+        OPA_read_write_barrier();
+        copy_buf->len[buf_num].val = 0;
+    }
+
+    msg_offset = last;
+    buf_num = (buf_num + 1) % MPIDI_LMT_NUM_BUFS;
+
+    if (last < data_sz) {
+        *done = false;
+        /* Keep track of the status of the operation so the next time the progress engine is
+         * called, it knows where to restart. */
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_msg_offset) = msg_offset;
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_data_sz) = data_sz;
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_buf_num) = buf_num;
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_leftover) = leftover;
+    } else {
+        MPIR_Request *match_req = MPIDIG_REQUEST(req, req->rreq.match_req);
+        *done = true;
+        MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(req, datatype));
+
+        if (MPIDI_POSIX_AMREQUEST(req, req_hdr)) {
+            MPL_free(MPIDI_POSIX_AMREQUEST_HDR(req, pack_buffer));
+            MPIDI_POSIX_AMREQUEST_HDR(req, pack_buffer) = NULL;
+        }
+
+        /* If there is a match request, it probably means that CH4 allocated a request on our
+         * behalf and we matched an unexpected request. This happens when using the handoff
+         * model. The match request is the one that will be returned to the user so copy over
+         * the important information and clean up both requests. */
+        if (match_req != NULL) {
+            MPIR_Request *match_partner = MPIDI_REQUEST_ANYSOURCE_PARTNER(match_req);
+            match_req->status.MPI_SOURCE = req->status.MPI_SOURCE;
+            match_req->status.MPI_TAG = req->status.MPI_TAG;
+            match_req->status.MPI_ERROR = req->status.MPI_ERROR;
+            MPIR_STATUS_SET_COUNT(match_req->status, MPIR_STATUS_GET_COUNT(req->status));
+            if (unlikely(match_partner)) {
+                /* This was an ANY_SOURCE receive -- we need to cancel NM recv and free it too */
+                mpi_errno = MPIDI_NM_mpi_cancel_recv(match_partner);
+                if (mpi_errno)
+                    MPIR_ERR_POP(mpi_errno);
+
+                MPIDI_REQUEST_ANYSOURCE_PARTNER(match_req) = NULL;
+                MPIDI_REQUEST_ANYSOURCE_PARTNER(match_partner) = NULL;
+                MPIR_Request_free(match_partner);
+            }
+            MPIR_Request_add_ref(match_req);
+            mpi_errno = MPID_Request_complete(match_req);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+            /* This is the request that was created at the time we handled the unexpected
+             * message. However, because a match_req was created when the handoff to the
+             * progress thread was done, this request (`req`) is no longer needed and will not be
+             * returned to the user. So decrement the reference counter twice (accomplished by
+             * calling MPIR_Request_free twice). */
+            MPIR_Request_free(req);
+            MPIR_Request_free(req);
+        } else {
+            mpi_errno = MPID_Request_complete(req);
+            if (mpi_errno)
+                MPIR_ERR_POP(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_LMT_RNDV_RECV_PROGRESS);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+
+/* Make progress on requests involved in sending a message
+ *
+ * req - The request describing the message
+ * local_rank - The local rank of the progress from which the message is coming (local rank is the
+ *              rank of the processes only present on this node).
+ * done - Return value to indicate whether the request is complete
+ */
+int lmt_rndv_send_progress(MPIR_Request * req, int local_rank, bool * done)
+{
+    int mpi_errno = MPI_SUCCESS;
+    size_t copy_limit, max_pack_bytes, actual_pack_bytes;
+    lmt_rndv_copy_buf_t *copy_buf = rndv_send_copy_bufs[local_rank];
+    intptr_t msg_offset = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_msg_offset);
+    intptr_t data_sz = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_data_sz);
+    int buf_num = MPIDI_POSIX_AMREQUEST(req, lmt.lmt_buf_num);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_LMT_RNDV_SEND_PROGRESS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_LMT_RNDV_SEND_PROGRESS);
+
+    /* Each time through the progres engine, the receiver will copy out one chunk of the message. */
+    if (0 != copy_buf->len[buf_num].val) {
+        *done = false;
+        goto fn_exit;
+    }
+
+    OPA_read_write_barrier();
+
+    /* TODO - Add checks to see whether the sender is present to stay in this progress loop
+     * longer while progress is being made. */
+
+    if (data_sz <= MPIR_CVAR_CH4_POSIX_LMT_PIPELINE_THRESHOLD) {
+        copy_limit = MPIDI_LMT_SMALL_PIPELINE_MAX;
+    } else {
+        copy_limit = MPIDI_LMT_COPY_BUF_LEN;
+    }
+
+    max_pack_bytes = (data_sz - msg_offset <= copy_limit) ? data_sz - msg_offset : copy_limit;
+    MPIR_Typerep_pack(MPIDIG_REQUEST(req, buffer), MPIDIG_REQUEST(req, user_count),
+                      MPIDIG_REQUEST(req, datatype), msg_offset,
+                      (void *) copy_buf->buf[buf_num], max_pack_bytes, &actual_pack_bytes);
+
+    OPA_write_barrier();
+
+    MPIR_Assign_trunc(copy_buf->len[buf_num].val, actual_pack_bytes, int);
+    msg_offset += actual_pack_bytes;
+
+    buf_num = (buf_num + 1) % MPIDI_LMT_NUM_BUFS;
+
+    if (msg_offset < data_sz) {
+        *done = false;
+        /* Keep track of the status of the operation so the next time the progress engine is
+         * called, it knows where to restart. */
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_msg_offset) = msg_offset;
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_data_sz) = data_sz;
+        MPIDI_POSIX_AMREQUEST(req, lmt.lmt_buf_num) = buf_num;
+    } else {
+        *done = true;
+        MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(req, datatype));
+
+        if (MPIDI_POSIX_AMREQUEST(req, req_hdr)) {
+            MPL_free(MPIDI_POSIX_AMREQUEST_HDR(req, pack_buffer));
+            MPIDI_POSIX_AMREQUEST_HDR(req, pack_buffer) = NULL;
+        }
+
+        mpi_errno = MPID_Request_complete(req);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+    }
+
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_LMT_RNDV_SEND_PROGRESS);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_recv.c
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_recv.c
@@ -1,0 +1,121 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "rndv.h"
+#include "shm_control.h"
+
+/* Set up the CTS message to go to the sender of the LMT. It should include a handle for a shared
+ * memory buffer.
+ * req - Request representing the large message transfer operation
+ */
+int MPIDI_POSIX_lmt_recv(MPIR_Request * req)
+{
+    char *serialized_handle;
+    int mpi_errno;
+    int dt_contig ATTRIBUTE((unused));
+    MPIR_Datatype *dt_ptr;
+    MPI_Aint data_sz, dt_true_lb ATTRIBUTE((unused));
+
+    MPIR_CHKPMEM_DECL(1);
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_LMT_RECV);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_RECV);
+
+    MPIDI_Datatype_get_info(MPIDIG_REQUEST(req, user_count), MPIDIG_REQUEST(req, datatype),
+                            dt_contig, data_sz, dt_ptr, dt_true_lb);
+    if (data_sz < MPIDIG_REQUEST(req, count)) {
+        MPIR_ERR_SET2(req->status.MPI_ERROR, MPI_ERR_TRUNCATE, "**truncate", "**truncate %d %d",
+                      MPIDIG_REQUEST(req, count), data_sz);
+        MPIDIG_REQUEST(req, count) = data_sz;
+    }
+
+    /* Calculate local rank of the sending process. */
+    const int grank = MPIDIU_rank_to_lpid(MPIDIG_REQUEST(req, rank),
+                                          MPIDIG_context_id_to_comm(MPIDIG_REQUEST(req,
+                                                                                   context_id)));
+    int sender_local_rank = MPIDI_POSIX_global.local_ranks[grank];
+
+    /* TODO - Add a second array of shared memory buffers so there can be one ongoing message in
+     * both directions. */
+    /* Check to see if there is already a buffer allocated and if not, create one and store it in
+     * the local array to track them. */
+    if (NULL == rndv_recv_copy_bufs[sender_local_rank]) {
+        int i;
+
+        mpi_errno = MPL_shm_seg_create_and_attach(rndv_recv_copy_buf_handles[sender_local_rank],
+                                                  sizeof(lmt_rndv_copy_buf_t),
+                                                  (void **) &rndv_recv_copy_bufs[sender_local_rank],
+                                                  0);
+        if (mpi_errno)
+            MPIR_ERR_POP(mpi_errno);
+
+        rndv_recv_copy_bufs[sender_local_rank]->sender_present.val = 0;
+        rndv_recv_copy_bufs[sender_local_rank]->receiver_present.val = 0;
+
+        for (i = 0; i < MPIDI_LMT_NUM_BUFS; i++) {
+            rndv_recv_copy_bufs[sender_local_rank]->len[i].val = 0;
+        }
+    }
+    /* Get a serialized version of the buffer handle */
+    mpi_errno = MPL_shm_hnd_get_serialized_by_ref(rndv_recv_copy_buf_handles[sender_local_rank],
+                                                  &serialized_handle);
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
+    /* Send CTS message to the sender */
+    MPIDI_SHM_ctrl_hdr_t msg;
+    msg.lmt_rndv_long_ack.sreq_ptr = (uint64_t) MPIDIG_REQUEST(req, req->rreq.peer_req_ptr);
+    msg.lmt_rndv_long_ack.rreq_ptr = (uint64_t) req;
+    if (MPIDIG_REQUEST(req, req->status) & MPIDIG_REQ_PEER_SSEND)
+        msg.lmt_rndv_long_ack.handler_id = MPIDIG_SSEND_REQ;
+    else
+        msg.lmt_rndv_long_ack.handler_id = 0;
+    MPL_strncpy(msg.lmt_rndv_long_ack.copy_buf_serialized_handle, serialized_handle,
+                MPIDI_MAX_HANDLE_LEN);
+    msg.lmt_rndv_long_ack.copy_buf_serialized_handle_len = (int) strlen(serialized_handle) + 1;
+    MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(req, rank),
+                           MPIDIG_context_id_to_comm(MPIDIG_REQUEST(req, context_id)),
+                           MPIDI_SHM_SEND_LMT_ACK, &msg);
+
+    /* Create a new "wait element" for this lmt transfer in case more than one is started at the
+     * same time. */
+    lmt_rndv_wait_element_t *element;
+    MPIR_CHKPMEM_MALLOC(element, lmt_rndv_wait_element_t *, sizeof(lmt_rndv_wait_element_t),
+                        mpi_errno, "LMT RNDV wait element", MPL_MEM_SHM);
+    element->progress = lmt_rndv_recv_progress;
+    element->req = req;
+    GENERIC_Q_ENQUEUE(&rndv_recv_queues[sender_local_rank], element, next);
+
+    /* TODO - Create a queue where in progress messages go to shorten the progress polling time. */
+
+    /* Try to make progress on lmt messages before queuing the new one. */
+    mpi_errno = MPIDI_POSIX_lmt_progress();
+    /* Want to capture the output of the progress function, but not return an error immediately
+     * because just kicking the progress engine may not indicate a problem with this particular
+     * receive. */
+
+    MPIR_CHKPMEM_COMMIT();
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_LMT_RECV);
+    return MPI_SUCCESS;
+  fn_fail:
+    MPIR_CHKPMEM_REAP();
+    goto fn_exit;
+}
+
+void MPIDI_POSIX_lmt_recv_posted_hook(int grank)
+{
+    return;
+}
+
+void MPIDI_POSIX_lmt_recv_completed_hook(int grank)
+{
+    return;
+}

--- a/src/mpid/ch4/shm/posix/lmt/rndv/rndv_send.c
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/rndv_send.c
@@ -1,0 +1,57 @@
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include "rndv.h"
+#include "shm_control.h"
+
+/* Construct the LMT RTS information and send it to the receiver
+ *
+ * buf - The data to be sent via the LMT protocol
+ * grank - The global rank information for the receiver
+ * tag - The tag of the message being sent
+ * error_bits - The error bits information used by collective to track whether an error occurred
+ * comm - The communicator used to send the message
+ * data_sz - The size of the data stored in buf
+ * sreq - The send request being used to store all of the metadata
+ */
+int MPIDI_POSIX_lmt_send_rts(void *buf, int grank, int tag, int error_bits, MPIR_Comm * comm,
+                             size_t data_sz, int handler_id, MPIR_Request * sreq)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_SHM_ctrl_hdr_t ctrl_hdr;
+    MPIDI_SHM_lmt_rndv_long_msg_t *long_msg_hdr = &ctrl_hdr.lmt_rndv_long_msg;
+
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_LMT_SEND_RTS);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_LMT_SEND_RTS);
+
+    MPIR_Datatype_add_ref_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
+
+    MPIDI_Datatype_check_size(MPIDIG_REQUEST(sreq, datatype), MPIDIG_REQUEST(sreq, count),
+                              MPIDI_POSIX_AMREQUEST(sreq, lmt.lmt_data_sz));
+    MPIDI_POSIX_AMREQUEST(sreq, lmt.lmt_msg_offset) = 0;
+    MPIDI_POSIX_AMREQUEST(sreq, lmt.lmt_buf_num) = 0;
+
+    /* Construct and send the RTS message with the control message protocol. */
+
+    long_msg_hdr->sreq_ptr = (uint64_t) sreq;
+
+    long_msg_hdr->rank = comm->rank;
+    long_msg_hdr->tag = tag;
+    long_msg_hdr->context_id = MPIDIG_REQUEST(sreq, context_id);
+    long_msg_hdr->error_bits = error_bits;
+    long_msg_hdr->data_sz = data_sz;
+    long_msg_hdr->handler_id = handler_id;
+
+    mpi_errno = MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(sreq, rank), comm, MPIDI_SHM_SEND_LMT_MSG,
+                                       &ctrl_hdr);
+
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_LMT_SEND_RTS);
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/posix/lmt/rndv/subconfigure.m4
+++ b/src/mpid/ch4/shm/posix/lmt/rndv/subconfigure.m4
@@ -1,0 +1,20 @@
+[#] start of __file__
+dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
+
+AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+    AM_COND_IF([BUILD_CH4],[
+        for lmt in $ch4_posix_lmt_modules ; do
+            AS_CASE([$lmt],[rndv],[build_ch4_shm_posix_lmt_rndv=yes])
+            if test $lmt = "rndv" ; then
+                AC_DEFINE(HAVE_CH4_SHM_LMT_RNDV,1,[RNDV submodule is built])
+            fi
+        done
+    ])
+    AM_CONDITIONAL([BUILD_CH4_SHM_POSIX_LMT_RNDV],[test "X$build_ch4_shm_posix_lmt_rndv" = "Xyes"])
+])dnl
+
+AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+])dnl end _BODY
+
+[#] end of __file__
+

--- a/src/mpid/ch4/shm/posix/posix_callbacks.c
+++ b/src/mpid/ch4/shm/posix/posix_callbacks.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+
+#include "mpidimpl.h"
+#include "posix_types.h"
+#include "ch4_types.h"
+#include "posix_eager.h"
+#include "posix_noinline.h"
+
+int MPIDI_POSIX_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    return MPIDI_POSIX_lmt_ctrl_send_lmt_rts_cb(ctrl_hdr);
+}
+
+int MPIDI_POSIX_ctrl_send_lmt_cts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
+{
+    return MPIDI_POSIX_lmt_ctrl_send_lmt_cts_cb(ctrl_hdr);
+}

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -128,6 +128,9 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits)
     mpi_errno = MPIDI_POSIX_coll_init(rank, size);
     MPIR_ERR_CHECK(mpi_errno);
 
+    mpi_errno = MPIDI_POSIX_lmt_init(rank, size);
+    MPIR_ERR_CHECK(mpi_errno);
+
     MPIR_CHKPMEM_COMMIT();
 
   fn_exit:
@@ -154,6 +157,9 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
     MPL_free(MPIDI_POSIX_global.active_rreq);
 
     mpi_errno = MPIDI_POSIX_coll_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDI_POSIX_lmt_finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
     MPL_free(MPIDI_POSIX_global.local_ranks);

--- a/src/mpid/ch4/shm/posix/posix_lmt_array.c.in
+++ b/src/mpid/ch4/shm/posix/posix_lmt_array.c.in
@@ -1,0 +1,23 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2019 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ *
+ *  Portions of this code were written by Intel Corporation.
+ *  Copyright (C) 2011-2019 Intel Corporation.  Intel provides this material
+ *  to Argonne National Laboratory subject to Software Grant and Corporate
+ *  Contributor License Agreement dated February 8, 2012.
+ */
+
+#include <mpidimpl.h>
+#include "posix_lmt.h"
+
+/* *INDENT-OFF* */
+/* forward declaration of funcs structs defined in lmt modules */
+extern MPIDI_POSIX_lmt_funcs_t @ch4_posix_lmt_func_decl@;
+
+MPIDI_POSIX_lmt_funcs_t *MPIDI_POSIX_lmt_funcs[@ch4_posix_lmt_array_sz@] = { 0 };
+int MPIDI_num_posix_lmt_fabrics = @ch4_posix_lmt_array_sz@;
+char MPIDI_POSIX_lmt_strings[@ch4_posix_lmt_array_sz@][MPIDI_MAX_POSIX_LMT_STRING_LEN] =
+    { @ch4_posix_lmt_strings@ };
+/* *INDENT-ON* */

--- a/src/mpid/ch4/shm/posix/posix_noinline.h
+++ b/src/mpid/ch4/shm/posix/posix_noinline.h
@@ -61,5 +61,7 @@ void *MPIDI_POSIX_mpi_alloc_mem(size_t size, MPIR_Info * info_ptr);
 int MPIDI_POSIX_mpi_free_mem(void *ptr);
 
 int MPIDI_POSIX_progress(int blocking);
+int MPIDI_POSIX_ctrl_send_lmt_msg_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
+int MPIDI_POSIX_ctrl_send_lmt_ack_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr);
 
 #endif

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -12,8 +12,8 @@
 #ifndef POSIX_PRE_H_INCLUDED
 #define POSIX_PRE_H_INCLUDED
 
-#include <mpi.h>
 #include "release_gather_types.h"
+#include "posix_lmt_pre.h"
 
 #define MPIDI_POSIX_MAX_AM_HDR_SIZE     (32)
 
@@ -112,6 +112,10 @@ typedef struct MPIDI_POSIX_am_request {
     int eager_recv_posted_hook_grank;
 
     MPIDI_POSIX_am_request_header_t *req_hdr;
+
+    struct {
+        MPIDI_SHM_LMT_AM_DECL;
+    } lmt;
 
 #ifdef POSIX_AM_REQUEST_INLINE
     MPIDI_POSIX_am_request_header_t req_hdr_buffer;

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -208,6 +208,10 @@ int MPIDI_POSIX_progress(int blocking)
     mpi_errno = progress_send(blocking);
     MPIR_ERR_CHECK(mpi_errno);
 
+    mpi_errno = MPIDI_POSIX_lmt_progress();
+    if (mpi_errno)
+        MPIR_ERR_POP(mpi_errno);
+
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_POSIX_PROGRESS);
     return mpi_errno;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -12,6 +12,7 @@
 #ifndef POSIX_TYPES_H_INCLUDED
 #define POSIX_TYPES_H_INCLUDED
 
+#include "posix_lmt_pre.h"
 #include "mpidu_init_shm.h"
 
 enum {
@@ -29,6 +30,8 @@ enum {
 #define MPIDI_POSIX_AMREQUEST_HDR_PTR(req)    ((req)->dev.ch4.am.shm_am.posix.req_hdr)
 #define MPIDI_POSIX_REQUEST(req, field)       ((req)->dev.ch4.shm.posix.field)
 #define MPIDI_POSIX_COMM(comm)                (&(comm)->dev.ch4.shm.posix)
+
+#define MPIDI_SHM_POSIX_CTRL_MESSAGE_TYPES      MPIDI_SHM_LMT_CTRL_MESSAGE_TYPES
 
 typedef struct {
     MPIDIU_buf_pool_t *am_buf_pool;

--- a/src/mpid/ch4/shm/posix/subconfigure.m4
+++ b/src/mpid/ch4/shm/posix/subconfigure.m4
@@ -107,6 +107,91 @@ MPIDI_POSIX_eager_${posix_eager}_recv_transaction_t ${posix_eager};"
             src/mpid/ch4/shm/posix/eager/include/posix_eager_pre.h
     ])
 
+    AC_ARG_WITH(ch4-posix-lmt-modules,
+    [ --with-ch4-posix-lmt-modules=module-list
+    CH4 POSIX lmt arguments:
+            rndv - Use rendezvous module with shared memory pipelining
+            ],
+            [posix_lmt_modules=$withval],
+            [posix_lmt_modules=])
+
+    if test -z "${posix_lmt_modules}" ; then
+        ch4_posix_lmt_modules="rndv"
+    else
+        ch4_posix_lmt_modules=`echo ${posix_lmt_modules} | sed -e 's/,/ /g'`
+    fi
+
+    export ch4_posix_lmt_modules
+
+    ch4_posix_lmt_func_decl=""
+    ch4_posix_lmt_func_array=""
+    ch4_posix_lmt_strungs=""
+    ch4_posix_lmt_pre_include=""
+
+    posix_lmt_index=0
+
+    echo "Parsing POSIX lmt arguments"
+
+    for posix_lmt in $ch4_posix_lmt_modules; do
+
+        if test ! -d $srcdir/src/mpid/ch4/shm/posix/lmt/${posix_lmt} ; then
+            AC_MSG_ERROR([POSIX lmt module ${posix_lmt} is unknown "$srcdir/src/mpid/ch4/shm/posixlmt/${posix_lmt}"])
+        fi
+
+        posix_lmt_macro=`echo $posix_lmt | tr 'abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'`
+        posix_lmt_macro="MPIDI_POSIX_${posix_lmt_macro}"
+
+        if test -z "$ch4_posix_lmt_array" ; then
+            ch4_posix_lmt_array="$posix_lmt_macro"
+        else
+            ch4_posix_lmt_array="$ch4_posix_lmt_array, $posix_lmt_macro"
+        fi
+
+        if test -z "$ch4_posix_lmt_func_decl" ; then
+            ch4_posix_lmt_func_decl="MPIDI_POSIX_lmt_${posix_lmt}_funcs"
+        else
+            ch4_posix_lmt_func_decl="${ch4_posix_lmt_func_decl}, MPIDI_POSIX_lmt_${posix_lmt}_funcs"
+        fi
+
+        if test -z "$ch4_posix_lmt_func_array" ; then
+            ch4_posix_lmt_func_array="&MPIDI_POSIX_lmt_${posix_lmt}_funcs"
+        else
+            ch4_posix_lmt_func_array="${ch4_posix_lmt_func_array}, &MPIDI_POSIX_lmt_${posix_lmt}_funcs"
+        fi
+
+        if test -z "$ch4_posix_lmt_strings" ; then
+            ch4_posix_lmt_strings="\"$posix_lmt\""
+        else
+            ch4_posix_lmt_strings="$ch4_posix_lmt_strings, \"$posix_lmt\""
+        fi
+
+        if test -z "$ch4_posix_lmt_pre_include" ; then
+            ch4_posix_lmt_pre_include="#include \"../${posix_lmt}/${posix_lmt}_pre.h\""
+        else
+            ch4_posix_lmt_pre_include="${ch4_posix_lmt_pre_include}
+#include \"../${posix_lmt}/${posix_lmt}_pre.h\""
+        fi
+
+        posix_lmt_index=`expr $posix_lmt_index + 1`
+    done
+
+    ch4_posix_lmt_array_sz=$posix_lmt_index
+
+    echo "There are $ch4_posix_lmt_array_sz POSIX lmt modules (${ch4_posix_lmt_modules})"
+
+    AC_SUBST(ch4_posix_lmt_modules)
+    AC_SUBST(ch4_posix_lmt_array)
+    AC_SUBST(ch4_posix_lmt_array_sz)
+    AC_SUBST(ch4_posix_lmt_strings)
+    AC_SUBST(ch4_posix_lmt_func_decl)
+    AC_SUBST(ch4_posix_lmt_func_array)
+    AC_SUBST(ch4_posix_lmt_pre_include)
+    AC_SUBST(ch4_posix_lmt_recv_transaction_decl)
+
+    AC_CONFIG_FILES([
+            src/mpid/ch4/shm/posix/lmt/include/posix_lmt_pre.h
+    ])
+
     # the POSIX shmmod depends on the common shm code
     build_mpid_common_shm=yes
     ])

--- a/src/mpid/ch4/shm/src/shm_control.c
+++ b/src/mpid/ch4/shm/src/shm_control.c
@@ -15,6 +15,12 @@ int MPIDI_SHM_ctrl_dispatch(int ctrl_id, void *ctrl_hdr)
     int mpi_errno = MPI_SUCCESS;
 
     switch (ctrl_id) {
+        case MPIDI_SHM_SEND_LMT_MSG:
+            mpi_errno = MPIDI_POSIX_ctrl_send_lmt_msg_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
+        case MPIDI_SHM_SEND_LMT_ACK:
+            mpi_errno = MPIDI_POSIX_ctrl_send_lmt_ack_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);
+            break;
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
         case MPIDI_SHM_XPMEM_SEND_LMT_RTS:
             mpi_errno = MPIDI_XPMEM_ctrl_send_lmt_rts_cb((MPIDI_SHM_ctrl_hdr_t *) ctrl_hdr);

--- a/src/mpid/ch4/shm/src/shm_inline.h
+++ b/src/mpid/ch4/shm/src/shm_inline.h
@@ -11,6 +11,7 @@
 #ifndef SHM_INLINE_H_INCLUDED
 #define SHM_INLINE_H_INCLUDED
 
+#include "posix_lmt.h"
 #include "shm_am.h"
 #include "shm_coll.h"
 #include "shm_hooks.h"

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -18,6 +18,17 @@
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
 
 cvars:
+    - name        : MPIR_CVAR_CH4_SHM_LMT_MSG_SIZE
+      category    : CH4
+      type        : int
+      default     : 65536
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If a send message size is larger than MPIR_CVAR_CH4_SHM_LMT_MSG_SIZE (in bytes),
+        then enable large message transfer protocols for intranode communication.
+
     - name        : MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE
       category    : CH4
       type        : int

--- a/src/mpid/ch4/shm/src/shm_types.h
+++ b/src/mpid/ch4/shm/src/shm_types.h
@@ -12,6 +12,8 @@
 #ifndef SHM_TYPES_H_INCLUDED
 #define SHM_TYPES_H_INCLUDED
 
+#include "posix_types.h"
+
 typedef enum {
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     MPIDI_SHM_XPMEM_SEND_LMT_RTS,       /* issued by sender to initialize XPMEM protocol with sbuf info */
@@ -20,6 +22,8 @@ typedef enum {
     MPIDI_SHM_XPMEM_SEND_LMT_RECV_FIN,  /* issued by receiver to notify completion of coop copy or single copy */
     MPIDI_SHM_XPMEM_SEND_LMT_CNT_FREE,  /* issued by sender to notify free counter obj in coop copy */
 #endif
+    MPIDI_SHM_SEND_LMT_MSG,
+    MPIDI_SHM_SEND_LMT_ACK,
     MPIDI_SHM_CTRL_IDS_MAX
 } MPIDI_SHM_ctrl_id_t;
 
@@ -61,6 +65,7 @@ typedef MPIDI_SHM_ctrl_xpmem_send_lmt_send_fin_t MPIDI_SHM_ctrl_xpmem_send_lmt_r
 #endif
 
 typedef union {
+    MPIDI_SHM_POSIX_CTRL_MESSAGE_TYPES
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     MPIDI_SHM_ctrl_xpmem_send_lmt_rts_t xpmem_slmt_rts;
     MPIDI_SHM_ctrl_xpmem_send_lmt_cts_t xpmem_slmt_cts;


### PR DESCRIPTION
## Pull Request Description

Add a new type of module for the POSIX shared memory system to support
large messages called LMT (large message transfer). This module allows
different types of submodules to support large messages (as oppposed to
the existing eager modules).

Also add the first module of the LMT type called RNDV (rendezvous). This
implements a simple rendezvous protocol for POSIX shared memory messages
using the active message layer to shape and match messages along with
control messages sent through the eager module to set up the transfer.

Part of #3525 

## Expected Impact

Improve large message transfer performance.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
