### PR TITLE
ch4/ofi: remove emulated injection

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -21,7 +21,6 @@ static int send_huge_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
 static int ssend_ack_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
 static uintptr_t recv_rbase(MPIDI_OFI_huge_recv_t * recv);
 static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 static int accept_probe_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
 static int dynproc_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
 static int am_isend_event(struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
@@ -480,24 +479,6 @@ static int chunk_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
     return MPI_SUCCESS;
 }
 
-static int inject_emu_event(struct fi_cq_tagged_entry *wc, MPIR_Request * req)
-{
-    int incomplete;
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_INJECT_EMU_EVENT);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_INJECT_EMU_EVENT);
-
-    MPIR_cc_decr(req->cc_ptr, &incomplete);
-
-    if (!incomplete) {
-        MPL_free(MPIDI_OFI_REQUEST(req, util.inject_buf));
-        MPIR_Request_free(req);
-        OPA_decr_int(&MPIDI_OFI_global.am_inflight_inject_emus);
-    }
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_INJECT_EMU_EVENT);
-    return MPI_SUCCESS;
-}
-
 int MPIDI_OFI_rma_done_event(struct fi_cq_tagged_entry *wc, MPIR_Request * in_req)
 {
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_RMA_DONE_EVENT);
@@ -767,10 +748,6 @@ int MPIDI_OFI_dispatch_function(struct fi_cq_tagged_entry *wc, MPIR_Request * re
 
             case MPIDI_OFI_EVENT_CHUNK_DONE:
                 mpi_errno = chunk_done_event(wc, req);
-                break;
-
-            case MPIDI_OFI_EVENT_INJECT_EMU:
-                mpi_errno = inject_emu_event(wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_DYNPROC_DONE:

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -691,7 +691,6 @@ int MPIDI_OFI_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_
 
         MPIDIG_am_reg_cb(MPIDI_OFI_INTERNAL_HANDLER_CONTROL, NULL, &MPIDI_OFI_control_handler);
     }
-    OPA_store_int(&MPIDI_OFI_global.am_inflight_inject_emus, 0);
     OPA_store_int(&MPIDI_OFI_global.am_inflight_rma_send_mrs, 0);
 
     /* Initalize RMA keys allocator */
@@ -743,11 +742,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
         MPIR_Allreduce(&barrier[0], &barrier[1], 1, MPI_INT, MPI_SUM, MPIR_Process.comm_world,
                        &errflag);
     MPIR_ERR_CHECK(mpi_errno);
-
-    /* Progress until we drain all inflight injection emulation requests */
-    while (OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) > 0)
-        MPIDI_OFI_PROGRESS();
-    MPIR_Assert(OPA_load_int(&MPIDI_OFI_global.am_inflight_inject_emus) == 0);
 
     /* Tearing down endpoints */
     for (i = 1; i < MPIDI_OFI_global.num_ctx; i++) {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -369,7 +369,6 @@ typedef struct {
     void *am_bufs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDI_OFI_am_repost_request_t am_reqs[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     MPIDIU_buf_pool_t *am_buf_pool;
-    OPA_int_t am_inflight_inject_emus;
     OPA_int_t am_inflight_rma_send_mrs;
     /* Sequence number trackers for active messages */
     void *am_send_seq_tracker;


### PR DESCRIPTION
## Pull Request Description

Emulated injection is used when an am protocol calls `MPIDI_NM_am_send_hdr` with too large an header that does not fit inside eager limit. This code setup is convoluted because we should decide whether to do inject or send based on eager limit in the first place rather than make a premature decision and the add more code to do fallback (emulation).

One possible reason for this per-mature decision is `MPIDI_NM_am_send_hdr` does not have a request and does not need origin-side completion. We should note that this condition is orthogonal to whether use injection or normal send. Ideally, we should decide whether to do injection based on total message size; then we should decide whether to do origin-completion based on whether a request object is supplied.

This PR currently simply removes the emulated injection and replaced with an assertion. It will break if there is protocols use a header greater than (or close to) inject-size. I suspect most current existing am protocols fit inside the eager limit.

To complete the PR, we'll need additional commit to unify `am_isend` and `am_send_hdr`, decide inject or normal send based on message size, and decide whether to do request completion based on whether `request == NULL`.

Of course for the large message without a request object - because the protocol does not care about completion -- the same emulation mechanism is needed. We'll not only memcpy the entire message (header + payload), and we'll track it before finalize.

Ideally, we should put some minimum eager limit constant (say 64bytes), so the protocol can easily decide whether to allocate request. We'll simply demand all protocols that exceed this minimum always supply request object (and potentially completion callback).

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
