### PR TITLE
strerror: simplify the thread-safe strerror function.

### DIFF
--- a/src/util/mpir_strerror.c
+++ b/src/util/mpir_strerror.c
@@ -6,18 +6,13 @@
 
 #include "mpiimpl.h"
 
-#if defined(HAVE_STRERROR_R) && defined(NEEDS_STRERROR_R_DECL)
-#if defined(STRERROR_R_CHAR_P)
-char *strerror_r(int errnum, char *strerrbuf, size_t buflen);
-#else
+#if defined(NEEDS_STRERROR_R_DECL)
 int strerror_r(int errnum, char *strerrbuf, size_t buflen);
 #endif
-#endif
 
-/* ideally, provides a thread-safe version of strerror */
+/* thread-safe version of strerror, similar to C11 strerror_s */
 const char *MPIR_Strerror(int errnum)
 {
-#if defined(HAVE_STRERROR_R)
     char *buf;
     MPIR_Per_thread_t *per_thread = NULL;
     int err = 0;
@@ -25,31 +20,7 @@ const char *MPIR_Strerror(int errnum)
     MPID_THREADPRIV_KEY_GET_ADDR(MPIR_Per_thread_key, MPIR_Per_thread, per_thread, &err);
     MPIR_Assert(err == 0);
     buf = per_thread->strerrbuf;
-#if defined(STRERROR_R_CHAR_P)
-    /* strerror_r returns char ptr (old GNU-flavor).  Static strings for known
-     * errnums are in returned buf, unknown errnums put a message in buf and
-     * return buf */
-    buf = strerror_r(errnum, buf, MPIR_STRERROR_BUF_SIZE);
-#else
-    /* strerror_r returns an int */
     strerror_r(errnum, buf, MPIR_STRERROR_BUF_SIZE);
-#endif
+
     return buf;
-
-#elif defined(HAVE_STRERROR)
-    /* MT - not guaranteed to be thread-safe, but on may platforms it will be
-     * anyway for the most common cases (looking up an error string in a table
-     * of constants).
-     *
-     * Using a mutex here would be an option, but then you need a version
-     * without the mutex to call when interpreting errors from mutex functions
-     * themselves. */
-    return strerror(errnum);
-
-#else
-    /* nowadays this case is most likely to happen because of a configure or
-     * internal header file inclusion bug rather than an actually missing
-     * strerror routine */
-    return "(strerror() unavailable on this platform)"
-#endif
 }


### PR DESCRIPTION
#2215  Pull Request Description

The MPIR_Strerror function is basically a poor man's implementation of
the C11 strerror_s function.  Since we now rely on POSIX 2001, we no
longer need to maintain the older variants of strerror.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
