### PR TITLE
ch4/ucx: refactor handling of local persistence data

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -11,52 +11,85 @@
 
 #include "ucx_impl.h"
 
+#define MPIDI_UCX_SHORT_DATA_SZ  16 * 1024
+
 MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_isend_callback(void *request, ucs_status_t status)
 {
     MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-    MPIR_Request *req = ucp_request->req;
-    int handler_id = req->dev.ch4.am.netmod_am.ucx.handler_id;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_AM_ISEND_CALLBACK);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_AM_ISEND_CALLBACK);
 
-    MPL_free(req->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
-    MPIDIG_global.origin_cbs[handler_id] (req);
-    ucp_request->req = NULL;
+    if (ucp_request->u.am_send.pack_buffer) {
+        MPL_free(ucp_request->u.am_send.pack_buffer);
+    }
+    if (ucp_request->u.am_send.sreq) {
+        MPIDIG_global.origin_cbs[ucp_request->u.am_send.handler_id] (ucp_request->u.am_send.sreq);
+    }
+    MPIDI_UCX_UCP_REQUEST_RELEASE(ucp_request);
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_AM_ISEND_CALLBACK);
 }
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_am_send_callback(void *request, ucs_status_t status)
-{
-    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-
-    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_AM_SEND_CALLBACK);
-    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_AM_SEND_CALLBACK);
-
-    MPL_free(ucp_request->buf);
-    ucp_request->buf = NULL;
-    ucp_request_release(ucp_request);
-
-    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_AM_SEND_CALLBACK);
-}
-
-
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
-                                               MPIR_Comm * comm,
-                                               int handler_id,
-                                               const void *am_hdr,
-                                               size_t am_hdr_sz,
-                                               const void *data,
-                                               MPI_Count count, MPI_Datatype datatype,
-                                               MPIR_Request * sreq)
+/* internal routine for sending data. `send_buf` will be freed on completion. If there is
+   `payload` (when not NULL), an iov of length 2 will be used to avoid extra copy. */
+MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_am_send_internal(int rank, MPIR_Comm * comm, int handler_id,
+                                                        void *send_buf, MPI_Aint send_size,
+                                                        void *payload, MPI_Aint payload_size,
+                                                        MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    ucp_ep_h ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
+    uint64_t ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
+
     MPIDI_UCX_ucp_request_t *ucp_request;
-    ucp_ep_h ep;
-    uint64_t ucx_tag;
-    char *send_buf;
+    if (payload == NULL) {
+        ucp_request = (void *) ucp_tag_send_nb(ep, send_buf, send_size,
+                                               ucp_dt_make_contig(1), ucx_tag,
+                                               &MPIDI_UCX_am_isend_callback);
+    } else {
+        MPIR_Assert(sreq);
+        ucp_dt_iov_t *iov = MPIDI_UCX_AM_REQUEST(sreq, iov);
+        iov[0].buffer = send_buf;
+        iov[0].length = send_size;
+        iov[1].buffer = payload;
+        iov[1].length = payload_size;
+        ucp_request = (void *) ucp_tag_send_nb(ep, iov, 2,
+                                               ucp_dt_make_iov(), ucx_tag,
+                                               &MPIDI_UCX_am_isend_callback);
+    }
+    MPIDI_UCX_CHK_REQUEST(ucp_request);
+
+    if (ucp_request == NULL) {
+        /* immediately completed */
+        MPL_free(send_buf);
+        if (sreq) {
+            MPIDIG_global.origin_cbs[handler_id] (sreq);
+        }
+    } else {
+        /* let callback to complete */
+        ucp_request->u.am_send.sreq = sreq;
+        ucp_request->u.am_send.handler_id = handler_id;
+        ucp_request->u.am_send.pack_buffer = send_buf;
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_am_isend(int rank,
+                                                   MPIR_Comm * comm,
+                                                   int handler_id,
+                                                   const void *am_hdr,
+                                                   size_t am_hdr_sz,
+                                                   const void *data,
+                                                   MPI_Count count, MPI_Datatype datatype,
+                                                   MPIR_Request * sreq)
+{
+    int mpi_errno = MPI_SUCCESS;
     size_t data_sz;
     MPI_Aint dt_true_lb;
     MPIR_Datatype *dt_ptr;
@@ -68,52 +101,72 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
-
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
     ucx_hdr.data_sz = data_sz;
 
+    char *send_buf;
+    MPI_Aint send_size;
     if (dt_contig) {
-        /* just pack and send for now */
-        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
-        MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
-        MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
-        MPIR_Memcpy(send_buf + am_hdr_sz + sizeof(ucx_hdr), (char *) data + dt_true_lb, data_sz);
+        send_size = sizeof(ucx_hdr) + am_hdr_sz + data_sz;
+        if (send_size <= MPIDI_UCX_SHORT_DATA_SZ) {
+            /* just pack and send for now */
+            send_buf = MPL_malloc(send_size, MPL_MEM_BUFFER);
+            MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
+            MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
+            MPIR_Memcpy(send_buf + am_hdr_sz + sizeof(ucx_hdr), (char *) data + dt_true_lb,
+                        data_sz);
+            mpi_errno = MPIDI_UCX_am_send_internal(rank, comm, handler_id, send_buf, send_size,
+                                                   NULL, 0, sreq);
+        } else {
+            /* pack headers and send payload as a 2nd iov */
+            send_size = sizeof(ucx_hdr) + am_hdr_sz;
+            send_buf = MPL_malloc(send_size, MPL_MEM_BUFFER);
+            MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
+            MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
+            mpi_errno = MPIDI_UCX_am_send_internal(rank, comm, handler_id, send_buf, send_size,
+                                                   (char *) data + dt_true_lb, data_sz, sreq);
+        }
     } else {
-        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
+        send_size = sizeof(ucx_hdr) + am_hdr_sz + data_sz;
+        send_buf = MPL_malloc(send_size, MPL_MEM_BUFFER);
 
         MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
         MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
 
         MPI_Aint actual_pack_bytes;
-        mpi_errno =
-            MPIR_Typerep_pack(data, count, datatype, 0, send_buf + am_hdr_sz + sizeof(ucx_hdr),
-                              data_sz, &actual_pack_bytes);
+        mpi_errno = MPIR_Typerep_pack(data, count, datatype, 0,
+                                      send_buf + am_hdr_sz + sizeof(ucx_hdr), data_sz,
+                                      &actual_pack_bytes);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
+        mpi_errno = MPIDI_UCX_am_send_internal(rank, comm, handler_id, send_buf, send_size,
+                                               NULL, 0, sreq);
     }
 
-    ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
-                                                              data_sz + am_hdr_sz + sizeof(ucx_hdr),
-                                                              ucp_dt_make_contig(1), ucx_tag,
-                                                              &MPIDI_UCX_am_isend_callback);
-    MPIDI_UCX_CHK_REQUEST(ucp_request);
+  fn_exit:
+    MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
 
-    /* send is done. free all resources and complete the request */
-    if (ucp_request == NULL) {
-        MPL_free(send_buf);
-        MPIDIG_global.origin_cbs[handler_id] (sreq);
-        goto fn_exit;
-    }
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
+                                               MPIR_Comm * comm,
+                                               int handler_id,
+                                               const void *am_hdr,
+                                               size_t am_hdr_sz,
+                                               const void *data,
+                                               MPI_Count count, MPI_Datatype datatype,
+                                               MPIR_Request * sreq)
+{
+    int mpi_errno = MPI_SUCCESS;
 
-    /* set the ch4r request inside the UCP request */
-    sreq->dev.ch4.am.netmod_am.ucx.pack_buffer = send_buf;
-    sreq->dev.ch4.am.netmod_am.ucx.handler_id = handler_id;
-    ucp_request->req = sreq;
-    ucp_request_release(ucp_request);
+    MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND);
+    MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND);
 
+    mpi_errno = MPIDI_UCX_do_am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz,
+                                      data, count, datatype, sreq);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND);
@@ -133,9 +186,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
 {
     int mpi_errno = MPI_SUCCESS;
     size_t am_hdr_sz = 0, i;
-    MPIDI_UCX_ucp_request_t *ucp_request;
-    ucp_ep_h ep;
-    uint64_t ucx_tag;
     char *send_buf;
     size_t data_sz;
     MPI_Aint dt_true_lb;
@@ -146,9 +196,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISENDV);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISENDV);
-
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
     for (i = 0; i < iov_len; i++) {
@@ -176,24 +223,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isendv(int rank,
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Assert(actual_pack_bytes == data_sz);
     }
-    ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
-                                                              data_sz + am_hdr_sz + sizeof(ucx_hdr),
-                                                              ucp_dt_make_contig(1), ucx_tag,
-                                                              &MPIDI_UCX_am_isend_callback);
-    MPIDI_UCX_CHK_REQUEST(ucp_request);
 
-    /* send is done. free all resources and complete the request */
-    if (ucp_request == NULL) {
-        MPL_free(send_buf);
-        MPIDIG_global.origin_cbs[handler_id] (sreq);
-        goto fn_exit;
-    }
-
-    /* set the ch4r request inside the UCP request */
-    sreq->dev.ch4.am.netmod_am.ucx.pack_buffer = send_buf;
-    sreq->dev.ch4.am.netmod_am.ucx.handler_id = handler_id;
-    ucp_request->req = sreq;
-    ucp_request_release(ucp_request);
+    int send_size = data_sz + am_hdr_sz + sizeof(ucx_hdr);
+    mpi_errno = MPIDI_UCX_am_send_internal(rank, comm, handler_id, send_buf, send_size,
+                                           NULL, 0, sreq);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISENDV);
@@ -214,82 +247,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend_reply(MPIR_Context_id_t context_i
                                                      MPI_Datatype datatype, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_UCX_ucp_request_t *ucp_request;
-    ucp_ep_h ep;
-    ucp_datatype_t dt;
-    uint64_t ucx_tag;
-    char *send_buf;
-    void *send_buf_p;
-    size_t data_sz;
-    size_t total_sz;
-    MPI_Aint dt_true_lb;
-    MPIR_Datatype *dt_ptr;
-    int dt_contig;
-    MPIDI_UCX_am_header_t ucx_hdr;
-    MPIR_Comm *use_comm;
-    ucp_dt_iov_t *iov = sreq->dev.ch4.am.netmod_am.ucx.iov;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
 
-    use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
-
-    MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
-
-    /* initialize our portion of the hdr */
-    ucx_hdr.handler_id = handler_id;
-    ucx_hdr.data_sz = data_sz;
-
-    if (dt_contig) {
-        send_buf = MPL_malloc(sizeof(ucx_hdr) + am_hdr_sz, MPL_MEM_BUFFER);
-        MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
-        MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
-
-        iov[0].buffer = send_buf;
-        iov[0].length = sizeof(ucx_hdr) + am_hdr_sz;
-        iov[1].buffer = (char *) data + dt_true_lb;
-        iov[1].length = data_sz;
-
-        send_buf_p = iov;
-        dt = ucp_dt_make_iov();
-        total_sz = 2;
-    } else {
-        send_buf = MPL_malloc(data_sz + am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
-
-        MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
-        MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
-
-        MPI_Aint actual_pack_bytes;
-        mpi_errno =
-            MPIR_Typerep_pack(data, count, datatype, 0, send_buf + am_hdr_sz + sizeof(ucx_hdr),
-                              data_sz, &actual_pack_bytes);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Assert(actual_pack_bytes == data_sz);
-
-        send_buf_p = send_buf;
-        dt = ucp_dt_make_contig(1);
-        total_sz = data_sz + am_hdr_sz + sizeof(ucx_hdr);
-    }
-    ucp_request =
-        (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep,
-                                                    send_buf_p, total_sz, dt, ucx_tag,
-                                                    &MPIDI_UCX_am_isend_callback);
-    MPIDI_UCX_CHK_REQUEST(ucp_request);
-
-    /* send is done. free all resources and complete the request */
-    if (ucp_request == NULL) {
-        MPL_free(send_buf);
-        MPIDIG_global.origin_cbs[handler_id] (sreq);
-        goto fn_exit;
-    }
-
-    /* set the ch4r request inside the UCP request */
-    sreq->dev.ch4.am.netmod_am.ucx.pack_buffer = send_buf;
-    sreq->dev.ch4.am.netmod_am.ucx.handler_id = handler_id;
-    ucp_request->req = sreq;
-    ucp_request_release(ucp_request);
+    MPIR_Comm *comm = MPIDIG_context_id_to_comm(context_id);
+    mpi_errno = MPIDI_UCX_do_am_isend(src_rank, comm, handler_id, am_hdr, am_hdr_sz,
+                                      data, count, datatype, sreq);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_ISEND_REPLY);
@@ -322,39 +286,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
                                                   size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_UCX_ucp_request_t *ucp_request;
-    ucp_ep_h ep;
-    uint64_t ucx_tag;
-    char *send_buf;
-    MPIDI_UCX_am_header_t ucx_hdr;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
 
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
-
-    /* initialize our portion of the hdr */
-    ucx_hdr.handler_id = handler_id;
-    ucx_hdr.data_sz = 0;
-
-    /* just pack and send for now */
-    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
-    MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
-    MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
-
-    ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
-                                                              am_hdr_sz + sizeof(ucx_hdr),
-                                                              ucp_dt_make_contig(1), ucx_tag,
-                                                              &MPIDI_UCX_am_send_callback);
-    MPIDI_UCX_CHK_REQUEST(ucp_request);
-
-    if (ucp_request == NULL) {
-        /* inject is done */
-        MPL_free(send_buf);
-    } else {
-        ucp_request->buf = send_buf;
-    }
+    mpi_errno =
+        MPIDI_UCX_do_am_isend(rank, comm, handler_id, am_hdr, am_hdr_sz, NULL, 0, MPI_BYTE, NULL);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_SEND_HDR);
@@ -369,39 +306,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Context_id_t contex
                                                         size_t am_hdr_sz)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_UCX_ucp_request_t *ucp_request;
-    ucp_ep_h ep;
-    uint64_t ucx_tag;
-    char *send_buf;
-    MPIDI_UCX_am_header_t ucx_hdr;
-    MPIR_Comm *use_comm;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);
 
-    use_comm = MPIDIG_context_id_to_comm(context_id);
-    ep = MPIDI_UCX_COMM_TO_EP(use_comm, src_rank);
-    ucx_tag = MPIDI_UCX_init_tag(0, MPIR_Process.comm_world->rank, MPIDI_UCX_AM_TAG);
-
-    /* initialize our portion of the hdr */
-    ucx_hdr.handler_id = handler_id;
-
-    /* just pack and send for now */
-    send_buf = MPL_malloc(am_hdr_sz + sizeof(ucx_hdr), MPL_MEM_BUFFER);
-    MPIR_Memcpy(send_buf, &ucx_hdr, sizeof(ucx_hdr));
-    MPIR_Memcpy(send_buf + sizeof(ucx_hdr), am_hdr, am_hdr_sz);
-    ucp_request = (MPIDI_UCX_ucp_request_t *) ucp_tag_send_nb(ep, send_buf,
-                                                              am_hdr_sz + sizeof(ucx_hdr),
-                                                              ucp_dt_make_contig(1), ucx_tag,
-                                                              &MPIDI_UCX_am_send_callback);
-    MPIDI_UCX_CHK_REQUEST(ucp_request);
-
-    if (ucp_request == NULL) {
-        /* inject is done */
-        MPL_free(send_buf);
-    } else {
-        ucp_request->buf = send_buf;
-    }
+    MPIR_Comm *comm = MPIDIG_context_id_to_comm(context_id);
+    MPIDI_NM_am_send_hdr(src_rank, comm, handler_id, am_hdr, am_hdr_sz);
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_AM_SEND_HDR_REPLY);

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -18,6 +18,8 @@
 
 #define MPIDI_UCX_COMM(comm)     ((comm)->dev.ch4.netmod.ucx)
 #define MPIDI_UCX_REQ(req)       ((req)->dev.ch4.netmod.ucx)
+#define MPIDI_UCX_AM_REQUEST(req,field)    ((req)->dev.ch4.am.netmod_am.ucx.field)
+
 #define COMM_TO_INDEX(comm,rank) MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
 #define MPIDI_UCX_COMM_TO_EP(comm,rank) \
     MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(comm, rank)).dest

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -16,10 +16,7 @@ static void request_init_callback(void *request);
 
 static void request_init_callback(void *request)
 {
-
-    MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-    ucp_request->req = NULL;
-
+    memset(request, 0, sizeof(MPIDI_UCX_ucp_request_t));
 }
 
 int MPIDI_UCX_mpi_init_hook(int rank, int size, int appnum, int *tag_bits, MPIR_Comm * init_comm)

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -114,9 +114,7 @@ typedef union {
  */
 
 typedef struct {
-    int handler_id;
-    char *pack_buffer;
-    ucp_dt_iov_t iov[2];
+    ucp_dt_iov_t iov[2];        /* used to avoid extra copy of payload */
 } MPIDI_UCX_am_request_t;
 
 /* ---- Other types -------- */

--- a/src/mpid/ch4/netmod/ucx/ucx_pre.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_pre.h
@@ -13,26 +13,117 @@
 
 #define MPIDI_UCX_KVSAPPSTRLEN 4096
 
-typedef union {
+/* ---- MPIDI_UCX_ucp_request_t --------
+ *
+ * UCX xxx_nb functions, e.g. ucp_tag_recv_nb, will allocate (inside ucp) a ucp_request object
+ * to track between call-site and callback. The object is a union of different types based on
+ * operations.
+ *
+ * For recv, either `struct ucx_recv` or `struct ucx_recv_cb` will be used depending on whether
+ * it's an immediate completion. The `is_set` flag is used to signal between the call-site
+ * and the callback. Note that both call-site and callback are pretected by the same mutex, so
+ * there won't be race conditions.
+ */
+
+/* async recv, set rreq and let callback to complete */
+struct ucx_recv {
+    MPIR_Request *rreq;
+};
+
+/* recv immediate complete, callback sets status */
+struct ucx_recv_cb {
+    MPI_Status status;
+};
+
+/* async send, set sreq and let callback to complete */
+struct ucx_send {
+    MPIR_Request *sreq;
+};
+
+/* send immediate complete, callback is skipped */
+
+/* async am send, set sreq and let callback to complete */
+struct ucx_am_send {
+    MPIR_Request *sreq;
+    int handler_id;
+    void *pack_buffer;
+};
+
+/* am recv, use static variable and caller wait for callback completion */
+
+/* async put/get */
+struct ucx_rma {
     MPIR_Request *req;
-    MPI_Status *status;
-    void *buf;
-} MPIDI_UCX_ucp_request_t;
+};
+
+/* rma put/get immediate complete, callback is skipped */
 
 typedef struct {
-    ucp_datatype_t ucp_datatype;
-} MPIDI_UCX_dt_t;
+    int is_set;                 /* only used for recv */
+    union {
+        struct ucx_recv recv;
+        struct ucx_recv_cb recv_cb;
+        struct ucx_send send;
+        struct ucx_am_send am_send;
+        struct ucx_rma rma;
+    } u;
+} MPIDI_UCX_ucp_request_t;
+
+/* `ucp_request` objects are managed by ucx internally. `request_init_callback` (ref. ucx_init.c)
+ * is only called at ucx memory pool init time. We need explicitly clear the object before
+ * `ucp_request_release`, or we'll have a corrupted `ucp_request` object next operation.
+ */
+#define MPIDI_UCX_UCP_REQUEST_RELEASE(ucp_request) \
+    do { \
+        memset(ucp_request, 0, sizeof(MPIDI_UCX_ucp_request_t)); \
+        ucp_request_release(ucp_request); \
+    } while (0)
+
+/* ---- MPIDI_UCX_request_t ---------
+ *
+ * For tracking data between operations, we use the request objects. We define one
+ * struct for each operation/usage, and define MPIDI_UCX_request_t as a union.
+ */
+
+/* for between mprobe and mrecv */
+typedef struct {
+    ucp_tag_message_h message_h;
+} MPIDI_UCX_req_mprobe_t;
+
+/* for between recv and cancel_recv */
+typedef struct {
+    void *ucp_request;          /* needed by ucp_request_cancel */
+} MPIDI_UCX_req_recv_t;
+
+/* for between send and cancel_send */
+typedef struct {
+    void *ucp_request;          /* needed by ucp_request_cancel */
+} MPIDI_UCX_req_send_t;
 
 typedef union {
-    ucp_tag_message_h message_handler;
-    MPIDI_UCX_ucp_request_t *ucp_request;
+    MPIDI_UCX_req_mprobe_t mprobe;
+    MPIDI_UCX_req_recv_t recv;
+    MPIDI_UCX_req_send_t send;
 } MPIDI_UCX_request_t;
+
+/* ---- MPIDI_UCX_am_request_t ---------
+ *
+ * Similar to MPIDI_UCX_request_t but used for tracking data within an AM protocol.
+ * We can't use MPIDI_UCX_request_t because these need co-exist with upper-layer
+ * AM data.
+ */
 
 typedef struct {
     int handler_id;
     char *pack_buffer;
     ucp_dt_iov_t iov[2];
 } MPIDI_UCX_am_request_t;
+
+/* ---- Other types -------- */
+
+typedef struct {
+    ucp_datatype_t ucp_datatype;
+} MPIDI_UCX_dt_t;
 
 typedef struct MPIDI_UCX_am_header_t {
     uint64_t handler_id;

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -36,7 +36,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
         req = (MPIR_Request *) MPIR_Request_create(MPIR_REQUEST_KIND__MPROBE, 0);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
-        MPIDI_UCX_REQ(req).message_handler = message_h;
+
+        MPIDI_UCX_req_mprobe_t *mprobe = &MPIDI_UCX_REQ(req).mprobe;
+        mprobe->message_h = message_h;
 
         if (status != MPI_STATUS_IGNORE) {
             status->MPI_SOURCE = MPIDI_UCX_get_source(info.sender_tag);
@@ -44,10 +46,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
             count = info.length;
             MPIR_STATUS_SET_COUNT(*status, count);
         }
+
+        *message = req;
     } else {
         *flag = 0;
+        *message = NULL;
     }
-    *message = req;
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.c
@@ -20,8 +20,8 @@ static void am_handler(void *request, ucs_status_t status, ucp_tag_recv_info_t *
     int is_contig;
     MPIDI_UCX_am_header_t *msg_hdr = (MPIDI_UCX_am_header_t *) am_buf;
 
-    p_data = in_data =
-        (char *) msg_hdr->payload + (info->length - msg_hdr->data_sz - sizeof(*msg_hdr));
+    int am_hdr_size = info->length - msg_hdr->data_sz - sizeof(*msg_hdr);
+    p_data = in_data = (char *) msg_hdr->payload + am_hdr_size;
     data_sz = msg_hdr->data_sz;
 
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, msg_hdr->payload,
@@ -65,7 +65,7 @@ int MPIDI_UCX_progress(int vci, int blocking)
         }
 
         /* free resources for handled message */
-        ucp_request_release(ucp_request);
+        MPIDI_UCX_UCP_REQUEST_RELEASE(ucp_request);
         MPL_free(am_buf);
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_request.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_request.h
@@ -13,13 +13,10 @@
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_init(MPIR_Request * req)
 {
-    req->dev.ch4.am.netmod_am.ucx.pack_buffer = NULL;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_NM_am_request_finalize(MPIR_Request * req)
 {
-    MPL_free((req)->dev.ch4.am.netmod_am.ucx.pack_buffer);
-    /* MPIR_Request_free(req); */
 }
 
 #endif /* UCX_REQUEST_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -14,17 +14,17 @@
 MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_rma_cmpl_cb(void *request, ucs_status_t status)
 {
     MPIDI_UCX_ucp_request_t *ucp_request = (MPIDI_UCX_ucp_request_t *) request;
-    MPIR_Request *req = ucp_request->req;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_UCX_RMA_CMPL_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_RMA_CMPL_CB);
 
     MPIR_Assert(status == UCS_OK);
+
+    MPIR_Request *req = ucp_request->u.rma.req;
     if (req) {
         MPID_Request_complete(req);
-        ucp_request->req = NULL;
     }
-    ucp_request_free(ucp_request);
+    MPIDI_UCX_UCP_REQUEST_RELEASE(ucp_request);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_RMA_CMPL_CB);
 }
 
@@ -79,7 +79,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
         req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
-        ucp_request->req = req;
+        ucp_request->u.rma.req = req;
         *reqptr = req;
 
         MPIDI_UCX_WIN(win).target_sync[target_rank].need_sync = MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL;
@@ -173,7 +173,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
         req = MPIR_Request_create(MPIR_REQUEST_KIND__RMA, 0);
         MPIR_ERR_CHKANDSTMT(req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Request_add_ref(req);
-        ucp_request->req = req;
+        ucp_request->u.rma.req = req;
         *reqptr = req;
 
         MPIDI_UCX_WIN(win).target_sync[target_rank].need_sync = MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL;


### PR DESCRIPTION
## Pull Request Description

In ucx netmod we need two types of local persistence. One is between calling ucp non-blocking routines and its callbacks, for example, `ucp_tag_recv_nb` and its completion callback. The other is between different but connected operations, for example, between `MPIDI_NM_mpi_mprobe` and `MPIDI_NM_mpi_mrecv`. The former uses `ucp_request`, a data block maintained by ucx internally; The latter stores data inside an `MPIR_Request` object. 

Both data structures are custom defined depending on operations. The existing code put the actually needed datatype, such as `MPI_Status`, `void *`, `MPIR_Request *`, etc. directly as part of a union. The code is less clear as it is confusing on when and why each of these fields is being used. This PR put these fields into operation or context defined structure -- even when the structure only contains a single field. This forces the code to refer to the context first before using the actual data field, enforces better readability. For two, with per operation structure, it is easy to extend the persistence data structure for debugging or feature extensions.

The refactor should also fix an intermittent mrecv bug due to completing a request before setting status.
 
## Expected Impact

## Author Checklist
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
