### PR TITLE
ch4/ofi: Always request FI_DIRECTED_RECV with FI_TAGGED

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1598,8 +1598,12 @@ bool match_global_settings(struct fi_info * prov)
      * but as more and more providers supported this feature, the decision was made to
      * require it. */
     CHECK_CAP(MPIDI_OFI_ENABLE_TAGGED,
-              !(prov->caps & FI_TAGGED) || !(prov->caps & FI_DIRECTED_RECV) ||
-              prov->domain_attr->cq_data_size < 4);
+              !(prov->caps & FI_TAGGED) || prov->domain_attr->cq_data_size < 4);
+
+    /* OFI provider doesn't expose FI_DIRECTED_RECV by default for performance consideration.
+     * MPICH should request this flag to enable it. */
+    if (MPIDI_OFI_ENABLE_TAGGED)
+        prov->caps |= FI_DIRECTED_RECV;
 
     CHECK_CAP(MPIDI_OFI_ENABLE_AM,
               (prov->caps & (FI_MSG | FI_MULTI_RECV)) != (FI_MSG | FI_MULTI_RECV));


### PR DESCRIPTION
FI_DIRECTED_RECV has performance impact on OFI providers, it should
not be enabled unless application requests this flag. MPICH should
avoid using this flag to check TAG is supported or not.

Co-authored by: Chongxiao Cao <chongxiao.cao@intel.com>

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
