### PR TITLE
ch4/ucx: fix a mrecv early request completion bug

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -68,11 +68,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_UCX_MRECV_CMPL_CB);
 
     /* complete the request if we have it, or allocate a status object */
-    if (ucp_request->req) {
+    int has_request = (ucp_request->req != NULL);
+    if (has_request) {
         MPIR_Request *rreq = ucp_request->req;
-        MPIDIU_request_complete(rreq);
-        ucp_request->req = NULL;
-        ucp_request_release(ucp_request);
         mrecv_status = &rreq->status;
     } else {
         mrecv_status = MPL_malloc(sizeof(MPI_Status), MPL_MEM_BUFFER);
@@ -89,6 +87,13 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_mrecv_cmpl_cb(void *request, ucs_status_
     mrecv_status->MPI_SOURCE = MPIDI_UCX_get_source(info->sender_tag);
     mrecv_status->MPI_TAG = MPIDI_UCX_get_tag(info->sender_tag);
 
+    /* complete the request */
+    if (has_request) {
+        MPIR_Request *rreq = ucp_request->req;
+        MPIDIU_request_complete(rreq);
+        ucp_request->req = NULL;
+        ucp_request_release(ucp_request);
+    }
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_UCX_MRECV_CMPL_CB);
 }
 


### PR DESCRIPTION

## Pull Request Description

PR #4345 gets too big in scope while the bug exist in current master. This PR provides a temporary patch before #4345 gets ready.

This bug is triggered (1 out around 30 chance) by test
thread/pt2pt/mt_probe_sendrecv_huge. It happens when mpi-layer retrieves
the request status before ucx-layer sets it.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
