### PR TITLE
config: fix enable-thread-cs=global for ch4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -538,8 +538,9 @@ AC_ARG_ENABLE(thread-cs,
 	AC_HELP_STRING([--enable-thread-cs=type],
 			[Choose the method used for critical sections
                          and other atomic updates when multiple
-                         threads are present.  Values may be global
-                         (default), per-object, per-vci, lock-free]),,enable_thread_cs=global)
+                         threads are present.  Values may be default, global,
+                         per-object, per-vci, lock-free. By default, CH3 uses global,
+                         while CH4 uses per-vci.]),,enable_thread_cs=default)
 
 AC_ARG_ENABLE(vci-method,
 	AC_HELP_STRING([--enable-vci-method=type],
@@ -1455,10 +1456,16 @@ fi
 # Check for value thread_cs choice; set the refcount default if necessary
 thread_granularity=MPICH_THREAD_GRANULARITY__SINGLE
 thread_refcount=MPICH_REFCOUNT__NONE
-if test "$device_name" = "ch4" ; then
-    enable_thread_cs="per-vci"
-fi
 if test "$enable_threads" = "multiple" ; then
+    # default depends on ch3 or ch4
+    if test "$enable_thread_cs" = "default" ; then
+        if test "$device_name" = "ch4" ; then
+            enable_thread_cs="per-vci"
+        else
+            enable_thread_cs="global"
+        fi
+    fi
+
     case $enable_thread_cs in
     global)
     thread_granularity=MPICH_THREAD_GRANULARITY__GLOBAL

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -31,8 +31,10 @@
 ################################################################################
 
 # xfail ch4 bugs
-ch4 * * * * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
-ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
+* * * ch4:ofi * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
+* * * ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
+* * * ch4:ucx * sed -i "s+\(^idup_comm_gen .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
+* * * ch4:ucx * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/comm/testlist
 ################################################################################
 # xfail known failures of UCX build for Hackathon
 * * * ch4:ucx * sed -i "s+\(^win_large_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
@@ -53,9 +55,9 @@ ch4 * * * * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket3794+g" test/mpi/threads/co
 * * am-only ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 ################################################################################
 #ch3:ofi
-ofi * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ofi * * ch3:ofi * sed -i  "s+\(^manyrma2 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-ofi * * ch3:ofi * sed -i  "s+\(^manyrma2_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch3:ofi * sed -i  "s+\(^manyrma2 .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
+* * * ch3:ofi * sed -i  "s+\(^manyrma2_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 ################################################################################
 # f08 related problems xfail them for easy testing
 * intel * * * sed -i "s+\(^commattrf08 .*\)+\1 xfail=issue3820+g" test/mpi/f08/attr/testlist


### PR DESCRIPTION
Previous mistakes make ch4 always uses per-vci model. This patch fixes it.

## Pull Request Description

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
