### PR TITLE
thread: add MPID_THREAD_CS_YIELD_BEGIN/END macros

### DIFF
--- a/src/mpid/ch3/include/mpid_thread.h
+++ b/src/mpid/ch3/include/mpid_thread.h
@@ -20,6 +20,8 @@ typedef MPIDU_Thread_func_t  MPID_Thread_func_t;
 #define MPID_THREAD_CS_ENTER       MPIDU_THREAD_CS_ENTER
 #define MPID_THREAD_CS_EXIT        MPIDU_THREAD_CS_EXIT
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
+#define MPID_THREAD_CS_YIELD_BEGIN  MPIDU_THREAD_CS_YIELD_BEGIN
+#define MPID_THREAD_CS_YIELD_END    MPIDU_THREAD_CS_YIELD_END
 
 #define MPID_Thread_init         MPIDU_Thread_init
 #define MPID_Thread_finalize     MPIDU_Thread_finalize

--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -23,6 +23,8 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_THREAD_CS_ENTER       MPIDU_THREAD_CS_ENTER
 #define MPID_THREAD_CS_EXIT        MPIDU_THREAD_CS_EXIT
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
+#define MPID_THREAD_CS_YIELD_BEGIN  MPIDU_THREAD_CS_YIELD_BEGIN
+#define MPID_THREAD_CS_YIELD_END    MPIDU_THREAD_CS_YIELD_END
 
 #define MPID_Thread_init           MPIDU_Thread_init
 #define MPID_Thread_finalize       MPIDU_Thread_finalize

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -95,12 +95,9 @@ int MPIDI_OFI_progress(int vci, int blocking);
                             mpi_errno,                      \
                             MPIX_ERR_EAGAIN,                \
                             "**eagain");                    \
-        /* FIXME: by fixing the recursive locking interface to account
-         * for recursive locking in more than one lock (currently limited
-         * to one due to scalar TLS counter), this lock yielding
-         * operation can be avoided since we are inside a finite loop. */\
         MPID_THREAD_CS_YIELD_BEGIN(VCI, MPIDI_global.vci_lock);         \
-        mpi_errno = MPIDI_OFI_retry_progress();                      \
+        /* run global progress to break the potential log jam */        \
+        mpi_errno = MPIDI_Progress_test(MPIDI_PROGRESS_NM | MPIDI_PROGRESS_SHM); \
         MPID_THREAD_CS_YIELD_END(VCI, MPIDI_global.vci_lock);        \
         MPIR_ERR_CHECK(mpi_errno);                               \
         _retry--;                                           \
@@ -189,7 +186,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr()
 
 /* Externs:  see util.c for definition */
 int MPIDI_OFI_handle_cq_error_util(int ep_idx, ssize_t ret);
-int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_control_handler(int handler_id, void *am_hdr,
                               void **data, size_t * data_sz, int is_local, int *is_contig,
                               MPIR_Request ** req);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -99,9 +99,9 @@ int MPIDI_OFI_progress(int vci, int blocking);
          * for recursive locking in more than one lock (currently limited
          * to one due to scalar TLS counter), this lock yielding
          * operation can be avoided since we are inside a finite loop. */\
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_global.vci_lock);         \
+        MPID_THREAD_CS_YIELD_BEGIN(VCI, MPIDI_global.vci_lock);         \
         mpi_errno = MPIDI_OFI_retry_progress();                      \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_global.vci_lock);        \
+        MPID_THREAD_CS_YIELD_END(VCI, MPIDI_global.vci_lock);        \
         MPIR_ERR_CHECK(mpi_errno);                               \
         _retry--;                                           \
     } while (_ret == -FI_EAGAIN);                           \

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -25,14 +25,6 @@ int MPIDI_OFI_handle_cq_error_util(int vni_idx, ssize_t ret)
     return mpi_errno;
 }
 
-int MPIDI_OFI_retry_progress()
-{
-    /* We do not call progress on hooks form netmod level
-     * because it is not reentrant safe.
-     */
-    return MPIDI_Progress_test(MPIDI_PROGRESS_NM | MPIDI_PROGRESS_SHM);
-}
-
 typedef struct MPIDI_OFI_mr_key_allocator_t {
     uint64_t chunk_size;
     uint64_t num_ints;

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -411,8 +411,10 @@ static inline int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank, MPIR_Group
 
 #define MPIDIU_PROGRESS_WHILE(cond)         \
     do {                                        \
+        MPID_THREAD_CS_YIELD_BEGIN(VCI, MPIDI_global.vci_lock); \
         while (cond)                            \
             MPIDIU_PROGRESS();              \
+        MPID_THREAD_CS_YIELD_END(VCI, MPIDI_global.vci_lock); \
     } while (0)
 
 #ifdef HAVE_ERROR_CHECKING

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -93,9 +93,6 @@ M*/
 
 M*/
 
-/* NOTE: Stateful CS_{ENTER,EXIT} currently is only used by ch3:sock and only with
- * GRANULARITY_GLOBAL */
-
 #if defined(MPICH_IS_THREADED)
 #define MPIDU_THREAD_CS_ENTER(name, mutex) MPIDUI_THREAD_CS_ENTER_##name(mutex)
 #define MPIDU_THREAD_CS_EXIT(name, mutex) MPIDUI_THREAD_CS_EXIT_##name(mutex)

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -139,6 +139,9 @@ M*/
                 MPIR_Assert(mutex.count == 0);                          \
                 MPL_thread_self(&mutex.owner);                          \
             }                                                           \
+            else { \
+                MPIR_Assert(0); \
+            } \
             mutex.count++;                                              \
         }                                                               \
     } while (0)
@@ -175,36 +178,8 @@ M*/
     } while (0)
 
 /* MPIDUI_THREAD_CS_YIELD in two parts, to allow code in between unlocked */
-/* FIXME: incorrect. While other thread can take the lock, it won't leave the lock when count > 0
- *        To do it properly, we need manage save the counter, reset to 0, and restor counter.
- */
-#define MPIDUI_THREAD_CS_YIELD_BEGIN(mutex) \
-    do {                                                                \
-        if (MPIR_ThreadInfo.isThreaded) {                               \
-            /* always exit */                                           \
-            mutex.count--;                                              \
-            MPIR_Assert(mutex.count >= 0);                              \
-            mutex.owner = 0;                                            \
-            int err_ = 0;                                               \
-            MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"MPIDU_Thread_mutex_unlock %p", &mutex); \
-            MPIDU_Thread_mutex_unlock(&mutex, &err_);                   \
-            MPIR_Assert(err_ == 0);                                     \
-        }                                                               \
-    } while (0)
-
-#define MPIDUI_THREAD_CS_YIELD_END(mutex) \
-    do {                                                                \
-        if (MPIR_ThreadInfo.isThreaded) {                               \
-            /* always enter */                                          \
-            int err_ = 0;                                               \
-            MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"enter MPIDU_Thread_mutex_lock %p", &mutex); \
-            MPIDU_Thread_mutex_lock(&mutex, &err_, MPL_THREAD_PRIO_HIGH);\
-            MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_mutex_lock %p", &mutex); \
-            MPIR_Assert(err_ == 0);                                     \
-            MPL_thread_self(&mutex.owner);                              \
-            mutex.count++;                                              \
-        }                                                               \
-    } while (0)
+#define MPIDUI_THREAD_CS_YIELD_BEGIN   MPIDUI_THREAD_CS_EXIT
+#define MPIDUI_THREAD_CS_YIELD_END     MPIDUI_THREAD_CS_ENTER
 
 /* MPICH_THREAD_GRANULARITY (set via `--enable-thread-cs=...`) activates one set of locks */
 


### PR DESCRIPTION
## Pull Request Description

In ofi code we need to call progress in-between calling libfabric routines when the return `FI_EAGAIN`. The old code does:
```
MPID_THREAD_CS_EXIT(...)
call progress
MPID_THREAD_CS_ENTER(...)
```

For one, `EXIT` then `ENTER` does not make a good semantic bracket. For two, due to our use of recursive mutex, the `EXIT` has nondeterministic result.
 
## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
