### PR TITLE
test/mpi: Fix memory leak in mt_pt2pt_common.c

### DIFF
--- a/test/mpi/threads/pt2pt/mt_pt2pt_common.c
+++ b/test/mpi/threads/pt2pt/mt_pt2pt_common.c
@@ -50,6 +50,7 @@ int main(int argc, char **argv)
     MTestArgList *head = MTestArgListCreate(argc, argv);
     count = MTestArgListGetInt(head, "count");
     iter = MTestArgListGetInt(head, "iter");
+    MTestArgListDestroy(head);
 
     if (count <= 0) {
         fprintf(stderr, "-count must be positive.\n");


### PR DESCRIPTION
## Pull Request Description

Free argument list once processing is done. Found with LeakSanitizer.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix a memory leak in mt pt2pt tests.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
