### PR TITLE
misc: miscellaneous fixes

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -407,7 +407,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_send(const void *buf, MPI_Aint count,
 #endif
     {
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, (*request == NULL), 0ULL, 0);
+                                   context_offset, addr, request, (*request == NULL), 0ULL,
+                                   MPIR_ERR_NONE);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SEND);
@@ -472,7 +473,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ssend(const void *buf, MPI_Aint count,
 #endif
     {
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND, 0);
+                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
+                                   MPIR_ERR_NONE);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_SSEND);
@@ -497,7 +499,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
 #endif
     {
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, 0ULL, 0);
+                                   context_offset, addr, request, 0, 0ULL, MPIR_ERR_NONE);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISEND);
@@ -562,7 +564,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_issend(const void *buf, MPI_Aint count
 #endif
     {
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND, 0);
+                                   context_offset, addr, request, 0, MPIDI_OFI_SYNC_SEND,
+                                   MPIR_ERR_NONE);
     }
 
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_ISSEND);

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -782,9 +782,10 @@ fi
 
 PAC_ARG_ATOMIC_PRIMITIVES
 
-AC_DEFUN([MPL_ATOMIC_TEST_PROGRAM], [AC_LANG_PROGRAM([[
-        #include "$1"
-    ]],[[
+AC_DEFUN([MPL_ATOMIC_TEST_PROGRAM], [AC_LANG_SOURCE([[
+    #include "$1"
+    int main()
+    {
         struct MPL_atomic_int_t a, b;
         int c;
 
@@ -807,6 +808,7 @@ AC_DEFUN([MPL_ATOMIC_TEST_PROGRAM], [AC_LANG_PROGRAM([[
         MPL_atomic_read_write_barrier();
 
         return c;
+    }
     ]])]
 )
 

--- a/src/mpl/src/thread/mpl_thread_uti.c
+++ b/src/mpl/src/thread/mpl_thread_uti.c
@@ -85,6 +85,7 @@ void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp
     if (errp != NULL) {
         *errp = err;
     }
+    return;
   uti_destroy_and_exit:
     err = uti_attr_destroy(&uti_attr);
     goto uti_exit;

--- a/src/pm/hydra2/libhydra/timeout/hydra_timeout.c
+++ b/src/pm/hydra2/libhydra/timeout/hydra_timeout.c
@@ -54,7 +54,7 @@ int HYD_get_timeout_signal(struct timeout_s *timeout)
 
 int HYD_get_time_left(struct timeout_s *timeout)
 {
-    if (timeout->start_time <= 0) {
+    if (timeout->sec <= 0) {
         return -1;
     }
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -39,8 +39,6 @@
 # xfail known failures of UCX build for Hackathon
 * * * ch4:ucx * sed -i "s+\(^win_large_shm .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
 * * * ch4:ucx * sed -i "s+\(^strided_putget_indexed_shared .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist
-# am-only failures
-* * am-only ch4:ucx * sed -i "s+\(^large_type_sendrec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
 ################################################################################
 # xfail known failures of OFI build for Hackathon
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist


### PR DESCRIPTION
## Description

A draft PR for testing custom jenkins script

Fixing miscellaneous issues:

* Remove large_type_sendrecv xfail for ucx tests -- they seem to be good now.

* On salaris with solaris studio, mpl atomic configure tests has a warning resulting in no MPL_atomics

* A mistake in uti from a previous commit resulted in a dead loop during launching async thread.

* Squash warnings of mix int/enum in ch4/ofi from Intel compilers

* Fix a bug -- use of uninitialized variable in timeout code in `hydra2`

## Expected Impact

Get more nightly tests running.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
