### PR TITLE
Consistently use MPI_Aint for count in CH4 send and recv

### DIFF
--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -68,8 +68,8 @@ int MPID_Progress_activate(int id);
 int MPID_Progress_deactivate(int id);
 MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                                        MPI_Status *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *, int, MPI_Datatype, int, int, MPIR_Comm *, int,
-                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *,
+                                            int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX void MPID_Request_set_completed(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
@@ -83,14 +83,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *, MPI_Aint, MPI_Datatype, in
 MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *, MPI_Aint, MPI_Datatype, int, int,
                                          MPIR_Comm *, int,
                                          MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
-                                            int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
-                                             int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
-                                             int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *, int, MPI_Datatype, int, int, MPIR_Comm *,
-                                             int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *, MPI_Aint, MPI_Datatype, int, int,
+                                            MPIR_Comm *, int,
+                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *, MPI_Aint, MPI_Datatype, int, int,
+                                             MPIR_Comm *, int,
+                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *, MPI_Aint, MPI_Datatype, int, int,
+                                             MPIR_Comm *, int,
+                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *, MPI_Aint, MPI_Datatype, int, int,
+                                             MPIR_Comm *, int,
+                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Startall(int, MPIR_Request *[]) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Accumulate(const void *, int, MPI_Datatype, int, MPI_Aint, int,
                                              MPI_Datatype, MPI_Op,

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -360,7 +360,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Recv_init(void *buf,
-                                            int count,
+                                            MPI_Aint count,
                                             MPI_Datatype datatype,
                                             int rank,
                                             int tag,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -15,7 +15,7 @@
 #include "ch4r_proc.h"
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_send_unsafe(const void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag,
@@ -237,7 +237,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_issend_unsafe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
@@ -277,7 +277,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_safe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
-                                                  int count,
+                                                  MPI_Aint count,
                                                   MPI_Datatype datatype,
                                                   int rank,
                                                   int tag,
@@ -313,7 +313,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_send_coll_safe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,
@@ -348,7 +348,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_safe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
-                                                   int count,
+                                                   MPI_Aint count,
                                                    MPI_Datatype datatype,
                                                    int rank,
                                                    int tag,
@@ -384,7 +384,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend_coll_safe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,
@@ -419,7 +419,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_ssend_safe(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_issend_safe(const void *buf,
-                                               int count,
+                                               MPI_Aint count,
                                                MPI_Datatype datatype,
                                                int rank,
                                                int tag,
@@ -669,7 +669,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Issend(const void *buf,
 /* Common internal rountine for send_init family */
 MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
                                               const void *buf,
-                                              int count,
+                                              MPI_Aint count,
                                               MPI_Datatype datatype,
                                               int rank,
                                               int tag,
@@ -709,7 +709,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_psend_init(MPIDI_ptype ptype,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
-                                            int count,
+                                            MPI_Aint count,
                                             MPI_Datatype datatype,
                                             int rank,
                                             int tag,
@@ -733,7 +733,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_init(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
@@ -756,7 +756,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ssend_init(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,
@@ -779,7 +779,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bsend_init(const void *buf,
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend_init(const void *buf,
-                                             int count,
+                                             MPI_Aint count,
                                              MPI_Datatype datatype,
                                              int rank,
                                              int tag,


### PR DESCRIPTION
## Pull Request Description

Currently we mix use of `int` and `MPI_Aint` for the count argument in CH4 send and recv. Use `MPI_Aint` consistently for all count arguments.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
