### PR TITLE
pm/remshell: Fix bad strcmp comparison

### DIFF
--- a/src/pm/remshell/mpiexec.c
+++ b/src/pm/remshell/mpiexec.c
@@ -419,7 +419,7 @@ static int AddEnvSetToCmdLine(const char *envName, const char *envValue, const c
             else
                 sname++;
             /* printf("Sname is %s\n", sname); */
-            if (strcmp(sname, "bash") == 0 || strcmp(sname, "sh") || strcmp(sname, "ash") == 0)
+            if (strcmp(sname, "bash") == 0 || strcmp(sname, "sh") == 0 || strcmp(sname, "ash") == 0)
                 useCSHFormat = 0;
             else
                 useCSHFormat = 1;


### PR DESCRIPTION
## Pull Request Description
There detection of shells were in some cases wrong, and csh shell was never selected.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
