### PR TITLE
ch3: Convert direct PMI calls to use MPIR_pmi APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1723,9 +1723,6 @@ if test -n "${with_pmix}" -a "${with_pmix}" != "no" ; then
     # disable built-in PMI and process managers
     with_pmi="no"
     with_pm="no"
-    if test "${device_name}" != "ch4" ; then
-        AC_MSG_ERROR([$device_name does not support PMIx])
-    fi
     PAC_PUSH_FLAG([LIBS])
     PAC_CHECK_HEADER_LIB_FATAL(pmix, pmix.h, pmix, PMIx_Init)
     PAC_APPEND_FLAG([-lpmix],[WRAPPER_LIBS])

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -39,6 +39,8 @@ int MPIR_pmi_init(void);
 void MPIR_pmi_finalize(void);
 void MPIR_pmi_abort(int exit_code, const char *error_msg);
 
+void MPIR_pmi_singleton_init(void);
+
 /* PMI getters for private fields */
 int MPIR_pmi_max_key_size(void);
 int MPIR_pmi_max_val_size(void);

--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -12,7 +12,6 @@
 
 #include "mpid_nem_impl.h"
 #include "mpir_objects.h"
-#include "pmi.h"
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_endpoint.h>
@@ -167,22 +166,6 @@ typedef struct {
                                 MPIR_ERR_CHECK(mpi_errno);	        \
 		} while (_ret == -FI_EAGAIN);				\
 	} while (0)
-
-
-#define PMI_RC(FUNC,STR)                                        \
-  do                                                            \
-    {                                                           \
-      pmi_errno  = FUNC;                                        \
-      MPIR_ERR_##CHKANDJUMP4(pmi_errno!=PMI_SUCCESS,            \
-                           mpi_errno,                           \
-                           MPI_ERR_OTHER,                       \
-                           "**ofi_"#STR,                        \
-                           "**ofi_"#STR" %s %d %s %s",          \
-                           __SHORT_FILE__,                      \
-                           __LINE__,                            \
-                           __func__,                            \
-                           #STR);                               \
-    } while (0)
 
 #define MPIDI_CH3I_NM_OFI_RC(FUNC)                          \
   do                                                        \

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -8,11 +8,6 @@
 
 #include "tcp_impl.h"
 #include "socksm.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 /* FIXME trace/log all the state transitions */
 
@@ -828,16 +823,9 @@ int MPID_nem_tcp_connect(struct MPIDI_VC *const vc)
          */
         if (vc->pg != NULL) {   /* VC is not a temporary one */
             char *bc;
-            int pmi_errno;
             int val_max_sz;
 
-#ifdef USE_PMI2_API
-            val_max_sz = PMI2_MAX_VALLEN;
-#else
-            pmi_errno = PMI_KVS_Get_value_length_max(&val_max_sz);
-            MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_OTHER, "**fail", "**fail %d",
-                                 pmi_errno);
-#endif
+            val_max_sz = MPIR_pmi_max_val_size();
             MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc", MPL_MEM_OTHER);
 
             sc->is_tmpvc = FALSE;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_ckpt.c
@@ -32,7 +32,6 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 #include <string.h>
 #include <libcr.h>
 #include <stdio.h>
-#include "pmi.h"
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif
@@ -213,52 +212,22 @@ int MPIDI_nem_ckpt_finalize(void)
 static int reinit_pmi(void)
 {
     int ret;
-    int has_parent = 0;
     int pg_rank, pg_size;
     int kvs_name_sz, pg_id_sz;
     
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_REINIT_PMI);
-
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_REINIT_PMI);
 
     /* Init pmi and do some sanity checks */
-    ret = PMI_Init(&has_parent);
+    ret = MPIR_pmi_init();
     CHECK_ERR(ret, "pmi_init");
 
-    ret = PMI_Get_rank(&pg_rank);
-    CHECK_ERR(ret, "pmi_get_rank");
+    CHECK_ERR(MPIR_Process.size != MPIDI_Process.my_pg->size, "pg size differs after restart");
+    CHECK_ERR(MPIR_Process.rank != MPIDI_Process.my_pg_rank, "pg rank differs after restart");
 
-    ret = PMI_Get_size(&pg_size);
-    CHECK_ERR(ret, "pmi_get_size");
-
-    CHECK_ERR(pg_size != MPIDI_Process.my_pg->size, "pg size differs after restart");
-    CHECK_ERR(pg_rank != MPIDI_Process.my_pg_rank, "pg rank differs after restart");
-
-    /* get new pg_id */
-    ret = PMI_KVS_Get_name_length_max(&pg_id_sz);
-    CHECK_ERR(ret, "pmi_get_id_length_max");
-    
-    MPL_free(MPIDI_Process.my_pg->id);
-   
-    MPIDI_Process.my_pg->id = MPL_malloc(pg_id_sz + 1, MPL_MEM_ADDRESS);
-    CHECK_ERR(MPIDI_Process.my_pg->id == NULL, "malloc failed");
-
-    ret = PMI_KVS_Get_my_name(MPIDI_Process.my_pg->id, pg_id_sz);
-    CHECK_ERR(ret, "pmi_kvs_get_my_name");
-
-    /* get new kvsname */
-    ret = PMI_KVS_Get_name_length_max(&kvs_name_sz);
-    CHECK_ERR(ret, "PMI_KVS_Get_name_length_max");
-    
     MPL_free(MPIDI_Process.my_pg->connData);
-   
-    MPIDI_Process.my_pg->connData = MPL_malloc(kvs_name_sz + 1, MPL_MEM_ADDRESS);
-    CHECK_ERR(MPIDI_Process.my_pg->connData == NULL, "malloc failed");
+    MPIDI_Process.my_pg->connData = MPL_strdup(MPIR_pmi_job_id());
 
-    ret = PMI_KVS_Get_my_name(MPIDI_Process.my_pg->connData, kvs_name_sz);
-    CHECK_ERR(ret, "PMI_Get_my_name");
-
-    
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_REINIT_PMI);
     return 0;
 }

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
@@ -6,10 +6,6 @@
 
 #include "mpid_nem_impl.h"
 #include "mpid_nem_nets.h"
-#ifndef USE_PMI2_API
-#include "pmi.h"
-#endif
-
 #include "mpidi_nem_statistics.h"
 #include "mpidu_init_shm.h"
 

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -5,7 +5,6 @@
  */
 
 #include "mpidi_ch3_impl.h"
-#include "pmi.h"
 #include "mpidu_sock.h"
 #include "utlist.h"
 
@@ -167,7 +166,6 @@ static int MPIDI_CH3i_Progress_wait(MPID_Progress_state * progress_state)
             MPIDI_CH3_Progress_signal_completion();
             break;      /* break from the do loop */
         }
-
 #ifdef MPICH_IS_THREADED
 
         /* The logic for this case is just complicated enough that

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -33,10 +33,6 @@
 int gethostname(char *name, size_t len);
 # endif
 
-/* Default PMI version to use */
-#define MPIDI_CH3I_DEFAULT_PMI_VERSION 1
-#define MPIDI_CH3I_DEFAULT_PMI_SUBVERSION 1
-
 /* group of processes detected to have failed.  This is a subset of
    comm_world group. */
 extern MPIR_Group *MPIDI_Failed_procs_group;

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -10,85 +10,15 @@
    Place all of this within the mpid_comm_spawn_multiple file */
 
 #ifndef MPIDI_CH3_HAS_NO_DYNAMIC_PROCESS
-/* 
- * We require support for the PMI calls.  If a channel cannot support
- * a PMI call, it should provide a stub and return an error code.
- */
    
-
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
-
 /* Define the name of the kvs key used to provide the port name to the
    children */
 #define PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
 
-/* FIXME: We can avoid these two routines if we define PMI as using 
-   MPI info values */
-/* Turn a SINGLE MPI_Info into an array of PMI_keyvals (return the pointer
-   to the array of PMI keyvals) */
-static int  mpi_to_pmi_keyvals( MPIR_Info *info_ptr, PMI_keyval_t **kv_ptr,
-				int *nkeys_ptr )
-{
-    char key[MPI_MAX_INFO_KEY];
-    PMI_keyval_t *kv = 0;
-    int          i, nkeys = 0, vallen, flag, mpi_errno=MPI_SUCCESS;
-
-    if (!info_ptr || info_ptr->handle == MPI_INFO_NULL) {
-	goto fn_exit;
-    }
-
-    MPIR_Info_get_nkeys_impl( info_ptr, &nkeys );
-    if (nkeys == 0) {
-	goto fn_exit;
-    }
-    kv = (PMI_keyval_t *)MPL_malloc( nkeys * sizeof(PMI_keyval_t), MPL_MEM_DYNAMIC );
-    if (!kv) { MPIR_ERR_POP(mpi_errno); }
-
-    for (i=0; i<nkeys; i++) {
-	mpi_errno = MPIR_Info_get_nthkey_impl( info_ptr, i, key );
-	if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
-	MPIR_Info_get_valuelen_impl( info_ptr, key, &vallen, &flag );
-        MPIR_ERR_CHKANDJUMP1(!flag, mpi_errno, MPI_ERR_OTHER,"**infonokey", "**infonokey %s", key);
-
-	kv[i].key = MPL_strdup(key);
-	kv[i].val = MPL_malloc( vallen + 1, MPL_MEM_DYNAMIC );
-	if (!kv[i].key || !kv[i].val) { 
-	    MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem" );
-	}
-	MPIR_Info_get_impl( info_ptr, key, vallen+1, kv[i].val, &flag );
-        MPIR_ERR_CHKANDJUMP1(!flag, mpi_errno, MPI_ERR_OTHER,"**infonokey", "**infonokey %s", key);
-	MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,TERSE,(MPL_DBG_FDEST,"key: <%s>, value: <%s>\n", kv[i].key, kv[i].val));
-    }
-
- fn_fail:
- fn_exit:
-    *kv_ptr    = kv;
-    *nkeys_ptr = nkeys;
-    return mpi_errno;
-}
-/* Free the entire array of PMI keyvals */
-static void free_pmi_keyvals(PMI_keyval_t **kv, int size, int *counts)
-{
-    int i,j;
-
-    for (i=0; i<size; i++)
-    {
-	for (j=0; j<counts[i]; j++)
-	{
-            MPL_free((char *)kv[i][j].key);
-            MPL_free(kv[i][j].val);
-	}
-        MPL_free(kv[i]);
-    }
-}
-
 /*
  * MPIDI_CH3_Comm_spawn_multiple()
  */
+/* FIXME: there shouldn't be any difference from CH4 MPID_Comm_spawn_multiple */ 
 int MPIDI_Comm_spawn_multiple(int count, char **commands,
                                   char ***argvs, const int *maxprocs,
                                   MPIR_Info **info_ptrs, int root,
@@ -96,9 +26,8 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
                                   **intercomm, int *errcodes) 
 {
     char port_name[MPI_MAX_PORT_NAME];
-    int *info_keyval_sizes=0, i, mpi_errno=MPI_SUCCESS;
-    PMI_keyval_t **info_keyval_vectors=0, preput_keyval_vector;
-    int *pmi_errcodes = 0, pmi_errno;
+    int i, mpi_errno=MPI_SUCCESS;
+    int *pmi_errcodes = 0;
     int total_num_processes, should_accept = 1;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_COMM_SPAWN_MULTIPLE);
 
@@ -123,110 +52,16 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 	/* Open a port for the spawned processes to connect to */
 	/* FIXME: info may be needed for port name */
         mpi_errno = MPID_Open_port(NULL, port_name);
-	/* --BEGIN ERROR HANDLING-- */
         MPIR_ERR_CHECK(mpi_errno);
-	/* --END ERROR HANDLING-- */
 
-	/* Spawn the processes */
-#ifdef USE_PMI2_API
-        MPIR_Assert(count > 0);
-        {
-            int *argcs = MPL_malloc(count*sizeof(int), MPL_MEM_DYNAMIC);
-            struct MPIR_Info preput;
-            struct MPIR_Info *preput_p[1] = { &preput };
-
-            MPIR_Assert(argcs);
-            /*
-            info_keyval_sizes = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
-            */
-
-            /* FIXME cheating on constness */
-            preput.key = (char *)PARENT_PORT_KVSKEY;
-            preput.value = port_name;
-            preput.next = NULL;
-
-            /* compute argcs array */
-            for (i = 0; i < count; ++i) {
-                argcs[i] = 0;
-                if (argvs != NULL && argvs[i] != NULL) {
-                    while (argvs[i][argcs[i]]) {
-                        ++argcs[i];
-                    }
-                }
-
-                /* a fib for now */
-                /*
-                info_keyval_sizes[i] = 0;
-                */
-            }
-            /* XXX DJG don't need this, PMI API is thread-safe? */
-            /*MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);*/
-            /* release the global CS for spawn PMI calls */
-            MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-            pmi_errno = PMI2_Job_Spawn(count, (const char **)commands,
-                                       argcs, (const char ***)argvs,
-                                       maxprocs,
-                                       info_keyval_sizes, (const MPIR_Info **)info_ptrs,
-                                       1, (const struct MPIR_Info **)preput_p,
-                                       NULL, 0,
-                                       /*jobId, jobIdSize,*/ /* XXX DJG job stuff? */
-                                       pmi_errcodes);
-            MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-            /*MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);*/
-            MPL_free(argcs);
-            if (pmi_errno != PMI2_SUCCESS) {
-                MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER,
-                     "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-            }
-        }
-#else
-        /* FIXME: This is *really* awkward.  We should either
-           Fix on MPI-style info data structures for PMI (avoid unnecessary
-           duplication) or add an MPIU_Info_getall(...) that creates
-           the necessary arrays of key/value pairs */
-
-        /* convert the infos into PMI keyvals */
-        info_keyval_sizes   = (int *) MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
-        info_keyval_vectors = 
-            (PMI_keyval_t**) MPL_malloc(count * sizeof(PMI_keyval_t*), MPL_MEM_DYNAMIC);
-        if (!info_keyval_sizes || !info_keyval_vectors) { 
-            MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem");
-        }
-
-        if (!info_ptrs) {
-            for (i=0; i<count; i++) {
-                info_keyval_vectors[i] = 0;
-                info_keyval_sizes[i]   = 0;
-            }
-        }
-        else {
-            for (i=0; i<count; i++) {
-                mpi_errno = mpi_to_pmi_keyvals( info_ptrs[i], 
-                                                &info_keyval_vectors[i],
-                                                &info_keyval_sizes[i] );
-                if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
-            }
-        }
-
+        struct MPIR_PMI_KEYVAL preput_keyval_vector;
         preput_keyval_vector.key = PARENT_PORT_KVSKEY;
         preput_keyval_vector.val = port_name;
 
+        mpi_errno = MPIR_pmi_spawn_multiple(count, commands, argvs, maxprocs, info_ptrs,
+                                            1, &preput_keyval_vector, pmi_errcodes);
+        MPIR_ERR_CHECK(mpi_errno);
 
-        MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-        pmi_errno = PMI_Spawn_multiple(count, (const char **)
-                                       commands, 
-                                       (const char ***) argvs,
-                                       maxprocs, info_keyval_sizes,
-                                       (const PMI_keyval_t **)
-                                       info_keyval_vectors, 1, 
-                                       &preput_keyval_vector,
-                                       pmi_errcodes);
-	MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-        if (pmi_errno != PMI_SUCCESS) {
-	    MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER,
-		 "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-        }
-#endif
 
 	if (errcodes != MPI_ERRCODES_IGNORE) {
 	    for (i=0; i<total_num_processes; i++) {
@@ -276,11 +111,6 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
     }
 
  fn_exit:
-    if (info_keyval_vectors) {
-	free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-	MPL_free(info_keyval_sizes);
-	MPL_free(info_keyval_vectors);
-    }
     MPL_free(pmi_errcodes);
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_COMM_SPAWN_MULTIPLE);
     return mpi_errno;
@@ -301,7 +131,7 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 
 /* This function is used only with mpid_init to set up the parent communicator
    if there is one.  The routine should be in this file because the parent 
-   port name is setup with the "preput" arguments to PMI_Spawn_multiple */
+   port name is setup with the "preput" arguments to MPIR_pmi_spawn_multiple */
 static char *parent_port_name = 0;    /* Name of parent port if this
 					 process was spawned (and is root
 					 of comm world) or null */
@@ -309,35 +139,16 @@ static char *parent_port_name = 0;    /* Name of parent port if this
 int MPIDI_CH3_GetParentPort(char ** parent_port)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
     char val[MPIDI_MAX_KVS_VALUE_LEN];
 
     if (parent_port_name == NULL)
     {
-	char *kvsname = NULL;
-	/* We can always use PMI_KVS_Get on our own process group */
-	MPIDI_PG_GetConnKVSname( &kvsname );
-#ifdef USE_PMI2_API
-        {
-            int vallen = 0;
-            MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-            pmi_errno = PMI2_KVS_Get(kvsname, PMI2_ID_NULL, PARENT_PORT_KVSKEY, val, sizeof(val), &vallen);
-            MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-            if (pmi_errno)
-                MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmi_kvsget", "**pmi_kvsget %s", PARENT_PORT_KVSKEY);
-        }
-#else
-	MPID_THREAD_CS_ENTER(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-	pmi_errno = PMI_KVS_Get( kvsname, PARENT_PORT_KVSKEY, val, sizeof(val));
-	MPID_THREAD_CS_EXIT(POBJ, MPIR_THREAD_POBJ_PMI_MUTEX);
-	if (pmi_errno) {
-            mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL, __func__, __LINE__, MPI_ERR_OTHER, "**pmi_kvsget", "**pmi_kvsget %d", pmi_errno);
-            goto fn_exit;
-	}
-#endif
+        mpi_errno = MPIR_pmi_kvs_get(-1, PARENT_PORT_KVSKEY, val, sizeof(val));
+        MPIR_ERR_CHECK(mpi_errno);
+
 	parent_port_name = MPL_strdup(val);
 	if (parent_port_name == NULL) {
-	    MPIR_ERR_POP(mpi_errno); /* FIXME DARIUS */
+            MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER,"**nomem");
 	}
     }
 

--- a/src/mpid/ch3/src/mpid_abort.c
+++ b/src/mpid/ch3/src/mpid_abort.c
@@ -6,12 +6,6 @@
 
 #include "mpidimpl.h"
 
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
-
 /* FIXME: This routine *or* MPI_Abort should provide abort callbacks,
    similar to the support in MPI_Finalize */
 
@@ -75,16 +69,12 @@ int MPID_Abort(MPIR_Comm * comm, int mpi_errno, int exit_code,
     MPL_error_printf("%s\n", error_msg);
     fflush(stderr);
 
-    /* FIXME: What is the scope for PMI_Abort?  Shouldn't it be one or more
+    /* FIXME: What is the scope for PMI abort?  Shouldn't it be one or more
        process groups?  Shouldn't abort of a communicator abort either the
        process groups of the communicator or only the current process?
-       Should PMI_Abort have a parameter for which of these two cases to
+       Should PMI abort have a parameter for which of these two cases to
        perform? */
-#ifdef USE_PMI2_API
-    PMI2_Abort(TRUE, error_msg);
-#else
-    PMI_Abort(exit_code, error_msg);
-#endif
+    MPIR_pmi_abort(exit_code, error_msg);   
 
     /* pmi_abort should not return but if it does, exit here.  If it does,
        add the function exit code before calling the final exit.  */

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -5,11 +5,6 @@
  */
 
 #include "mpidimpl.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 /* Generates a bitarray based on orig_comm where all procs in group are marked with 1 */
 static void group_to_bitarray(MPIR_Group *group, MPIR_Comm *orig_comm, int **bitarray, int *bitarray_size) {

--- a/src/mpid/ch3/src/mpid_finalize.c
+++ b/src/mpid/ch3/src/mpid_finalize.c
@@ -58,7 +58,7 @@ int MPID_Finalize(void)
       * can both close the connection.
       * 
       * Processes with no pending receives and no connections can exit, 
-      * calling PMI_Finalize to let the process manager know that they
+      * calling PMI finalize to let the process manager know that they
       * are in a controlled exit.  
       *
       * Processes that still have open connections must then try to contact
@@ -124,7 +124,7 @@ int MPID_Finalize(void)
     if (mpi_errno) { MPIR_ERR_POP(mpi_errno); }
 
     /* Tell the process group code that we're done with the process groups.
-       This will notify PMI (with PMI_Finalize) if necessary.  It
+       This will notify PMI (with PMI finalize) if necessary.  It
        also frees all PG structures, including the PG for COMM_WORLD, whose 
        pointer is also saved in MPIDI_Process.my_pg */
     mpi_errno = MPIDI_PG_Finalize();

--- a/src/mpid/ch3/src/mpid_get_universe_size.c
+++ b/src/mpid/ch3/src/mpid_get_universe_size.c
@@ -5,11 +5,6 @@
  */
 
 #include "mpidimpl.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 /*
  * MPID_Get_universe_size - Get the universe size from the process manager
@@ -22,35 +17,9 @@
 int MPID_Get_universe_size(int  * universe_size)
 {
     int mpi_errno = MPI_SUCCESS;
-#ifdef USE_PMI2_API
-    char val[PMI2_MAX_VALLEN];
-    int found = 0;
-    char *endptr;
-    
-    mpi_errno = PMI2_Info_GetJobAttr("universeSize", val, sizeof(val), &found);
+
+    mpi_errno = MPIR_pmi_get_universe_size(universe_size);
     MPIR_ERR_CHECK(mpi_errno);
-
-    if (!found)
-	*universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;
-    else {
-        *universe_size = strtol(val, &endptr, 0);
-        MPIR_ERR_CHKINTERNAL(endptr - val != strlen(val), mpi_errno, "can't parse universe size");
-    }
-
-#else
-    int pmi_errno = PMI_SUCCESS;
-
-    pmi_errno = PMI_Get_universe_size(universe_size);
-    if (pmi_errno != PMI_SUCCESS) {
-	MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, 
-			     "**pmi_get_universe_size",
-			     "**pmi_get_universe_size %d", pmi_errno);
-    }
-    if (*universe_size < 0)
-    {
-	*universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;
-    }
-#endif
     
 fn_exit:
     return mpi_errno;

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -22,11 +22,6 @@ char *MPIDI_DBG_parent_str = "?";
 
 /* FIXME: the PMI init function should ONLY do the PMI operations, not the 
    process group or bc operations.  These should be in a separate routine */
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 #include "datatype.h"
 
@@ -142,7 +137,7 @@ int MPID_Init(int requested, int *provided)
 
     /*
      * Let the channel perform any necessary initialization
-     * The channel init should assume that PMI_Init has been called and that
+     * The channel init should assume that PMI init has been called and that
      * the basic information about the job has been extracted from PMI (e.g.,
      * the size and rank of this process, and the process group id)
      */

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -431,19 +431,10 @@ static int init_pg(int *has_parent, int *pg_rank_p, MPIDI_PG_t **pg_p)
  */
 int MPIDI_CH3I_BCInit( char **bc_val_p, int *val_max_sz_p )
 {
-    int pmi_errno;
     int mpi_errno = MPI_SUCCESS;
-#ifdef USE_PMI2_API
-    *val_max_sz_p = PMI2_MAX_VALLEN;
-#else
-    pmi_errno = PMI_KVS_Get_value_length_max(val_max_sz_p);
-    if (pmi_errno != PMI_SUCCESS)
-    {
-        MPIR_ERR_SETANDJUMP1(mpi_errno,MPI_ERR_OTHER,
-                             "**pmi_kvs_get_value_length_max",
-                             "**pmi_kvs_get_value_length_max %d", pmi_errno);
-    }
-#endif
+
+    *val_max_sz_p = MPIR_pmi_max_val_size();
+
     /* This memroy is returned by this routine */
     *bc_val_p = MPL_malloc(*val_max_sz_p, MPL_MEM_ADDRESS);
     if (*bc_val_p == NULL) {

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -1067,17 +1067,11 @@ int MPIU_PG_Printall( FILE *fp )
 
 int MPIDI_PG_CheckForSingleton( void )
 {
-
-#ifdef USE_PMI2_API
-    /* PMI2 FIXME for now we just always assume we aren't doing singleton init */
-#else
+    /* TODO: fix the hackiness */
     if (strstr((char*)pg_world->id,"singinit_kvs") == (char *)pg_world->id) {
-	char buf[256];
-	/* Force an enroll */
-	PMI_KVS_Get( "foobar", "foobar", buf, sizeof(buf) );
-	PMI_KVS_Get_my_name( pg_world->id, 256 );
-	PMI_KVS_Get_my_name( pg_world->connData, 256 );
+        MPIR_pmi_singleton_init();
+        MPL_strncpy(pg_world->id, MPIR_pmi_job_id(), 256);
+        MPL_strncpy(pg_world->connData, MPIR_pmi_job_id(), 256);
     }
-#endif
     return MPI_SUCCESS;
 }

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -5,13 +5,6 @@
  */
 
 #include "mpidimpl.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
-
-#define MAX_JOBID_LEN 1024
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -72,7 +65,7 @@ int MPIDI_PG_Finalize(void)
 	MPIU_PG_Printall( stdout );
     }
 
-    /* FIXME - straighten out the use of PMI_Finalize - no use after 
+    /* FIXME - straighten out the use of PMI finalize - no use after 
        PG_Finalize */
     if (pg_world->connData) {
         MPIR_pmi_finalize();
@@ -551,7 +544,7 @@ int MPIDI_PG_SetConnInfo( int rank, const char *connString )
    ...
 
    The "conninfo for rank 0" etc. for the original (MPI_COMM_WORLD)
-   process group are stored in the PMI_KVS space with the keys 
+   process group are stored in the PMI kvs space with the keys 
    p<rank>-businesscard .  
 
    Fixme: Add a routine to publish the connection info to this file so that

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -740,18 +740,9 @@ static int connToString( char **buf_p, int *slen, MPIDI_PG_t *pg )
 #endif
 
     pg_id = pg->id;
-    /* FIXME: This is a hack, and it doesn't even work */
-    /*    MPIDI_PrintConnStrToFile( stdout, __FILE__, __LINE__, 
-	  "connToString: pg id is", (char *)pg_id );*/
-    /* This is intended to cause a process to transition from a singleton
-       to a non-singleton. */
-    /* XXX DJG TODO figure out what this little bit is all about. */
     if (strstr( pg_id, "singinit_kvs" ) == pg_id) {
-#ifdef USE_PMI2_API
-        MPIR_Assertp(0); /* don't know what to do here for pmi2 yet.  DARIUS */
-#else
-	PMI_KVS_Get_my_name( pg->id, 256 );
-#endif
+        /* don't know what to do here */
+        MPIR_Assertp(0);
     }
     
     while (*pg_id) str[len++] = *pg_id++;

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -5,11 +5,6 @@
  */
 
 #include "mpidi_ch3_impl.h"
-#ifdef USE_PMI2_API
-#include "pmi2.h"
-#else
-#include "pmi.h"
-#endif
 
 #include "mpidu_sock.h"
 
@@ -152,7 +147,6 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_Connection_t * conn = NULL;
     int id_sz;
-    int pmi_errno;
     MPIR_CHKPMEM_DECL(2);
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_CONNECTION_ALLOC);
 
@@ -161,17 +155,9 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
     MPIR_CHKPMEM_MALLOC(conn,MPIDI_CH3I_Connection_t*,
 			sizeof(MPIDI_CH3I_Connection_t),mpi_errno,"conn", MPL_MEM_DYNAMIC);
 
-    /* FIXME: This size is unchanging, so get it only once (at most); 
-       we might prefer for connections to simply point at the single process
-       group to which the remote process belong */
-#ifdef USE_PMI2_API
-    id_sz = MPID_MAX_JOBID_LEN;
-#else
-    pmi_errno = PMI_KVS_Get_name_length_max(&id_sz);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno,MPI_ERR_OTHER, 
-			     "**pmi_get_id_length_max",
-			     "**pmi_get_id_length_max %d", pmi_errno);
-#endif
+    id_sz = 256;
+    MPIR_Assert(strlen(MPIR_pmi_job_id()) < id_sz);
+
     MPIR_CHKPMEM_MALLOC(conn->pg_id,char*,id_sz + 1,mpi_errno,"conn->pg_id", MPL_MEM_DYNAMIC);
     conn->pg_id[0] = 0;           /* Be careful about pg_id in case a later 
 				     error */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -158,6 +158,19 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
 #endif
 }
 
+void MPIR_pmi_singleton_init(void)
+{
+#ifdef USE_PMI1_API
+    /* Force an enroll */
+    char buf[256];
+    PMI_KVS_Get("foobar", "foobar", buf, sizeof(buf));
+#else
+    /* TODO: figure what to do for other PMI */
+    MPIR_Assert(0);
+#endif
+    MPIR_pmi_init();
+}
+
 /* getters for internal constants */
 int MPIR_pmi_max_key_size(void)
 {


### PR DESCRIPTION
## Pull Request Description

We have abstracted most of the direct PMI calls to APIs in `mpir_pmi.c`. However, ch3 code still has quite a few places using legacy code. This prevents using PMI2 or PMIx on ch3 in many places. This PR attempts to convert all direct PMI calls in ch3 to MPIR_pmi APIs.
## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
