### PR TITLE
ch4/iqueue: Optimize grabbing a new cell

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -89,6 +89,8 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
         cell->payload_size = 0;
     }
 
+    transport->last_read_cell = NULL;
+
     /* Run local procs barrier */
     mpi_errno = MPIDU_Init_shm_barrier();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -17,6 +17,14 @@ MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_eager_iqueue_cell_t
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_NEW_CELL);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_EAGER_IQUEUE_NEW_CELL);
 
+    /* Grab the most recently read cell since it's probably still in cache. */
+    if (transport->last_read_cell) {
+        MPIDI_POSIX_eager_iqueue_cell_t *cell = transport->last_read_cell;
+        transport->last_read_cell = NULL;
+        MPIR_Assert(cell->type != MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_NULL);
+        return cell;
+    }
+
     for (i = 0; i < transport->num_cells; i++) {
         cell = MPIDI_POSIX_EAGER_IQUEUE_THIS_CELL(transport, i);
         if (cell->type == MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_NULL) {

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
@@ -52,6 +52,8 @@ typedef struct MPIDI_POSIX_eager_iqueue_transport {
                                                          * cells. */
     MPIDI_POSIX_eager_iqueue_cell_t *last_cell; /* Internal variable to track the last cell to be
                                                  * received when receiving multiple cells. */
+    MPIDI_POSIX_eager_iqueue_cell_t *last_read_cell;    /* Internal variable to track the last cell to
+                                                         * be read, which is probably still in cache. */
 } MPIDI_POSIX_eager_iqueue_transport_t;
 
 extern MPIDI_POSIX_eager_iqueue_transport_t MPIDI_POSIX_eager_iqueue_transport_global;


### PR DESCRIPTION
## Pull Request Description

Keep track of the most recently used cell so we can reuse it when
grabbing a new cell later. This should improve performance because that
cell will already be in cache and will also most likely be empty since
it was just used for a receive.

## Expected Impact

Improves send times by avoiding cache misses during cell allocation.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
