### PR TITLE
config: simplified configure for hwloc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 	path = src/mpid/ch4/netmod/ofi/libfabric
 	url = https://github.com/pmodels/libfabric
 [submodule "src/hwloc"]
-	path = src/hwloc
+	path = modules/hwloc
 	url = https://github.com/pmodels/hwloc
 [submodule "src/mpid/ch4/netmod/ucx/ucx"]
 	path = src/mpid/ch4/netmod/ucx/ucx

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,12 +4,12 @@
 #     See COPYRIGHT in top-level directory.
 #
 
-ACLOCAL_AMFLAGS = -I confdb -I src/hwloc/config
+ACLOCAL_AMFLAGS = -I confdb
 
 # automake requires that we initialize variables to something, even just empty,
 # before appending to them with "+="
-AM_CFLAGS = @VISIBILITY_CFLAGS@ @HWLOC_EMBEDDED_CFLAGS@
-AM_CPPFLAGS = @HWLOC_EMBEDDED_CPPFLAGS@
+AM_CFLAGS = @VISIBILITY_CFLAGS@
+AM_CPPFLAGS =
 AM_FFLAGS =
 AM_FCFLAGS =
 include_HEADERS =
@@ -50,7 +50,7 @@ pkgconfigdir = @pkgconfigdir@
 errnames_txt_files = 
 
 external_subdirs = @mplsrcdir@ @opasrcdir@ @zmsrcdir@ @hwlocsrcdir@ @jsonsrcdir@
-external_ldflags = @mpllibdir@ @opalibdir@ @zmlibdir@ @hwloclibdir@ @netloclibdir@
+external_ldflags = @mpllibdir@ @opalibdir@ @zmlibdir@
 external_libs = @WRAPPER_LIBS@
 mpi_convenience_libs =
 pmpi_convenience_libs = @opalib@ @mpllib@ @zmlib@ @hwloclib@ @jsonlib@

--- a/autogen.sh
+++ b/autogen.sh
@@ -598,10 +598,10 @@ echo "###########################################################"
 echo
 
 # hwloc is always required
-check_submodule_presence src/hwloc
+check_submodule_presence modules/hwloc
 
 # external packages that require autogen.sh to be run for each of them
-externals="src/pm/hydra src/pm/hydra2 src/mpi/romio src/openpa src/hwloc test/mpi modules/json-c"
+externals="src/pm/hydra src/pm/hydra2 src/mpi/romio src/openpa modules/hwloc test/mpi modules/json-c"
 
 if [ "yes" = "$do_izem" ] ; then
     check_submodule_presence src/izem
@@ -660,8 +660,8 @@ for destdir in $confdb_dirs ; do
 done
 
 # Copying hwloc to hydra
-sync_external src/hwloc src/pm/hydra/tools/topo/hwloc/hwloc
-sync_external src/hwloc src/pm/hydra2/libhydra/topo/hwloc/hwloc
+sync_external modules/hwloc src/pm/hydra/tools/topo/hwloc/hwloc
+sync_external modules/hwloc src/pm/hydra2/libhydra/topo/hwloc/hwloc
 # remove .git directories to avoid confusing git clean
 rm -rf src/pm/hydra/tools/topo/hwloc/hwloc/.git
 rm -rf src/pm/hydra2/libhydra/topo/hwloc/hwloc/.git

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -9,8 +9,7 @@ dnl this case if it ever arises.
 AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     AC_ARG_WITH([$1],
                 [AC_HELP_STRING([--with-$1=[[PATH]]],
-                                [specify path where $1 include directory and lib directory can be found])],,
-                [with_$1=$2])
+                                [specify path where $1 include directory and lib directory can be found. Use "system" if the library can be found in the system path.])])
     AC_ARG_WITH([$1-include],
                 [AC_HELP_STRING([--with-$1-include=PATH],
                                 [specify path where $1 include directory can be found])],
@@ -28,25 +27,33 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                           with_$1_lib=""])],
                 [])
 
+    # "system" means we don't need do anything, otherwise --
     # The args have been sanitized into empty/non-empty values above.
     # Now append -I/-L args to CPPFLAGS/LDFLAGS, with more specific options
     # taking priority
 
-    AS_IF([test -n "${with_$1_include}"],
-          [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
-          [AS_IF([test -n "${with_$1}"],
-                 [PAC_APPEND_FLAG([-I${with_$1}/include],[CPPFLAGS])])])
+    case "${with_$1}" in
+        embedded|system|no)
+            # skip
+            ;;
+        *)
+        AS_IF([test -n "${with_$1_include}"],
+            [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
+            [AS_IF([test -n "${with_$1}"],
+                    [PAC_APPEND_FLAG([-I${with_$1}/include],[CPPFLAGS])])])
 
-    AS_IF([test -n "${with_$1_lib}"],
-          [PAC_APPEND_FLAG([-L${with_$1_lib}],[LDFLAGS])],
-          [AS_IF([test -n "${with_$1}"],
-                 dnl is adding lib64 by default really the right thing to do?  What if
-                 dnl we are on a 32-bit host that happens to have both lib dirs available?
-                 [PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])
-                  AS_IF([test -d "${with_$1}/lib64"],
-		        [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])])
-                 ])
-          ])
+        AS_IF([test -n "${with_$1_lib}"],
+            [PAC_APPEND_FLAG([-L${with_$1_lib}],[LDFLAGS])],
+            [AS_IF([test -n "${with_$1}"],
+                    dnl is adding lib64 by default really the right thing to do?  What if
+                    dnl we are on a 32-bit host that happens to have both lib dirs available?
+                    [PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])
+                    AS_IF([test -d "${with_$1}/lib64"],
+                            [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])])
+                    ])
+            ])
+            ;;
+    esac
 ])
 
 

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -64,11 +64,18 @@ dnl The xxx is specified in the "with_option" parameter.
 dnl
 dnl NOTE: This macro expects a corresponding PAC_SET_HEADER_LIB_PATH
 dnl macro (or equivalent logic) to be used before this macro is used.
+dnl
+dnl NOTE: since setting LIBS may break runtime checks (e.g. AC_CHECK_SIZEOF), we
+dnl prepend the library to WRAPPER_LIBS instead.
+
 AC_DEFUN([PAC_CHECK_HEADER_LIB],[
     failure=no
     AC_CHECK_HEADER([$1],,failure=yes)
+    PAC_PUSH_FLAG(LIBS)
     AC_CHECK_LIB($2,$3,,failure=yes)
+    PAC_POP_FLAG(LIBS)
     if test "$failure" = "no" ; then
+       PAC_PREPEND_FLAG([-l$2], [WRAPPER_LIBS])
        $4
     else
        $5

--- a/configure.ac
+++ b/configure.ac
@@ -1301,10 +1301,6 @@ else
    fi
    AC_MSG_RESULT([$have_hwloc])
 
-   # FIXME: Disable hwloc on Cygwin for now. The hwloc package,
-   # atleast as of 1.0.2, does not install correctly on Cygwin
-   AS_CASE([$host], [*-*-cygwin], [have_hwloc=no])
-
    if test "$have_hwloc" = "yes" ; then
       hwloclib="-lhwloc"
       if test -d ${with_hwloc_prefix}/lib64 ; then

--- a/configure.ac
+++ b/configure.ac
@@ -1250,110 +1250,40 @@ PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/json-c],[CPPFLAGS])
 PAC_APPEND_FLAG([-I${master_top_builddir}/modules/json-c],[CPPFLAGS])
 
 # ----------------------------------------------------------------------------
-# HWLOC
+# HWLOC / NETLOC
 # ----------------------------------------------------------------------------
-# Allow the user to override the hwloc location (from embedded to user
-# path)
-# HWLOC
-AC_ARG_WITH([hwloc-prefix],
-            [AS_HELP_STRING([[--with-hwloc-prefix[=DIR]]],
-                            [use the HWLOC library installed in DIR,
-                             rather than the one included in src/hwloc.  Pass
-                             "embedded" to force usage of the HWLOC source
-                             distributed with MPICH.])],
-            [],dnl action-if-given
-            [with_hwloc_prefix=embedded]) dnl action-if-not-given
+
 hwlocsrcdir=""
 AC_SUBST([hwlocsrcdir])
-hwloclibdir=""
-AC_SUBST([hwloclibdir])
 hwloclib=""
 AC_SUBST([hwloclib])
 
-if test "$with_hwloc_prefix" = "no" ; then
-   have_hwloc=no
-elif test "$with_hwloc_prefix" = "embedded" ; then
-   # Disable visibility when setting up hwloc
-   PAC_PUSH_FLAG([enable_visibility])
-   enable_visibility=no;
-   HWLOC_SETUP_CORE([src/hwloc],[have_hwloc=yes],[have_hwloc=no],[1])
-   # Only build hwloc in embedded mode
-   if test "$have_hwloc" = "yes" ; then
-      use_embedded_hwloc=yes
-      hwlocsrcdir="src/hwloc"
-      hwloclib="$HWLOC_EMBEDDED_LDADD"
-      PAC_PREPEND_FLAG([$HWLOC_EMBEDDED_LIBS], [WRAPPER_LIBS])
-      PAC_APPEND_FLAG([$HWLOC_EMBEDDED_LDFLAGS], [WRAPPER_LDFLAGS])
-      # if possible, do not expose hwloc symbols in libmpi.so
-      PAC_PREPEND_FLAG([$VISIBILITY_CFLAGS], [HWLOC_CFLAGS])
-   fi
-   PAC_POP_FLAG([enable_visibility])
+if test -n "$with_hwloc" -a "$with_hwloc" != "embedded" ; then
+    PAC_SET_HEADER_LIB_PATH([hwloc])
+    PAC_CHECK_HEADER_LIB([hwloc.h],[hwloc],[hwloc_topology_set_pid],[have_hwloc=yes],[have_hwloc=no]) 
+
+    PAC_SET_HEADER_LIB_PATH([netloc])
+    dnl FIXME: use a netloc function to use PAC_CHECK_HEADER_LIB
+    AC_CHECK_HEADER([netloc.h],[have_netloc=yes],[have_netloc=no]) 
 else
-   AC_CHECK_HEADERS([hwloc.h])
-   # hwloc_topology_set_pid was added in hwloc-1.0.0, which is our
-   # minimum required version
-   AC_CHECK_LIB([hwloc],[hwloc_topology_set_pid])
-   AC_MSG_CHECKING([if non-embedded hwloc works])
-   if test "$ac_cv_header_hwloc_h" = "yes" -a "$ac_cv_lib_hwloc_hwloc_topology_set_pid" = "yes" ; then
-      have_hwloc=yes
-   else
-      have_hwloc=no
-   fi
-   AC_MSG_RESULT([$have_hwloc])
-
-   if test "$have_hwloc" = "yes" ; then
-      hwloclib="-lhwloc"
-      if test -d ${with_hwloc_prefix}/lib64 ; then
-         PAC_APPEND_FLAG([-L${with_hwloc_prefix}/lib64],[WRAPPER_LDFLAGS])
-         hwloclibdir="-L${with_hwloc_prefix}/lib64"
-      else
-	 hwloclibdir="-L${with_hwloc_prefix}/lib"
-      fi
-   fi
+    PAC_PUSH_FLAG([CFLAGS])
+    CFLAGS="$VISIBILITY_CFLAGS"
+    PAC_CONFIG_SUBDIR_ARGS([modules/hwloc], [--enable-embedded-mode --disable-visibility],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
+    PAC_POP_FLAG([CFLAGS])
+    hwlocsrcdir="${master_top_builddir}/modules/hwloc"
+    hwloclib="${master_top_builddir}/modules/hwloc/hwloc/libhwloc_embedded.la"
+    PAC_APPEND_FLAG([-I${use_top_srcdir}/modules/hwloc/include],[CPPFLAGS])
+    PAC_APPEND_FLAG([-I${master_top_builddir}/modules/hwloc/include],[CPPFLAGS])
+    have_hwloc=yes
+    dnl TODO: add option to configure netloc
+    have_netloc=no
 fi
 
 if test "$have_hwloc" = "yes" ; then
-   AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
+    AC_DEFINE(HAVE_HWLOC,1,[Define if hwloc is available])
 fi
-
-HWLOC_DO_AM_CONDITIONALS
-
-# ----------------------------------------------------------------------------
-# NETLOC
-# ----------------------------------------------------------------------------
-AC_ARG_WITH([netloc-prefix],
-            [AS_HELP_STRING([[--with-netloc-prefix[=DIR]]],
-                            [use the NETLOC library installed in DIR]) or system to use the system library], [],
-                            [with_netloc_prefix=no])
-
-netloclibdir=""
-AC_SUBST([netloclibdir])
-
-if test "$have_hwloc" = "yes" ; then
-    if test "${with_netloc_prefix}" != "no" ; then
-        if test "${with_netloc_prefix}" != "system"; then
-            # The user specified an already-installed Netloc; just sanity check,
-            # don't subconfigure it
-            AS_IF([test -s "${with_netloc_prefix}/include/netloc.h"],
-              [:],[AC_MSG_ERROR([the Netloc installation in "${with_netloc_prefix}" appears broken])])
-            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CPPFLAGS])
-            PAC_APPEND_FLAG([-I${with_netloc_prefix}/include],[CFLAGS])
-            PAC_PREPEND_FLAG([-lnetloc],[WRAPPER_LIBS])
-            if test -d ${with_netloc_prefix}/lib64 ; then
-                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib64],[WRAPPER_LDFLAGS])
-                netloclibdir="-L${with_netloc_prefix}/lib64"
-            else
-                PAC_APPEND_FLAG([-L${with_netloc_prefix}/lib],[WRAPPER_LDFLAGS])
-                netloclibdir="-L${with_netloc_prefix}/lib"
-            fi
-       else
-           AC_LINK_IFELSE([AC_LANG_PROGRAM([#include "netloc.h"
-                                   ],
-                                   [])],
-                          [AC_MSG_ERROR([the Netloc installation seems to be added from system path])], [])
-       fi
-       AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available in either user specified path or in system path])
-    fi
+if test "$have_netloc" = "yes" ; then
+    AC_DEFINE(HAVE_NETLOC,1,[Define if netloc is available])
 fi
 
 # ----------------------------------------------------------------------------

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1013,6 +1013,9 @@ CFLAGS=""
 AX_GCC_FUNC_ATTRIBUTE(fallthrough)
 PAC_POP_ALL_FLAGS
 
+dnl PAC_CHECK_HEADER_LIB sets WRAPPER_LIBS, transfer it to LIBS
+LIBS="$WRAPPER_LIBS $LIBS"
+
 dnl Final output
 AC_CONFIG_FILES([Makefile localdefs include/mpl_timer.h])
 AC_OUTPUT

--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -290,7 +290,6 @@ for hydra_bss_name in ${hydra_bss_names}; do
 		PAC_POP_FLAG(LIBS)
                 if test "$have_pbs_launcher" = "yes" ; then
 		    available_launchers="$available_launchers pbs"
-		    PAC_APPEND_FLAG([-ltorque],[WRAPPER_LIBS])
                 fi
 		available_rmks="$available_rmks pbs"
 		;;


### PR DESCRIPTION
## Pull Request Description

PR #3540 had some pending discussions, on the comment that the current config option for hwloc can be simplified and unified. This PR implements that alternative.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
