### PR TITLE
xfails: misc exclusions for osx

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -72,6 +72,13 @@
 * * * * osx sed -i "s+\(^fileerrretx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
 * * * * osx sed -i "s+\(^throwtestfilex .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
 * gnu debug ch3:tcp osx sed -i "s+\(^namepubx .*\)+\1 xfail=issue3506+g" test/mpi/cxx/spawn/testlist
+* intel default ch3:tcp osx sed -i "s+\(^statusesf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/pt2pt/testlist
+* intel default ch3:tcp osx sed -i "s+\(^vw_inplacef08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
+* intel default ch3:tcp osx sed -i "s+\(^red_scat_blockf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
+* intel default ch3:tcp osx sed -i "s+\(^nonblocking_inpf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/coll/testlist
+* intel default ch3:tcp osx sed -i "s+\(^structf .*\)+\1 xfail=issue4374+g" test/mpi/f08/datatype/testlist
+* intel default ch3:tcp osx sed -i "s+\(^aintf08 .*\)+\1 xfail=issue4374+g" test/mpi/f08/rma/testlist
+* intel default ch3:tcp osx sed -i "s+\(^dgraph_unwftf90 .*\)+\1 xfail=issue4374+g" test/mpi/f08/top/testlist
 ################################################################################
 # xfail active message accumulates with short_int (only CH4 fails)
 * * * * * sed -i "s+\(^atomic_get_short_int .*\)+\1 xfail=ticket3380+g" test/mpi/rma/testlist

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -71,6 +71,7 @@
 * * * * osx sed -i "s+\(^commerrx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/errhan/testlist
 * * * * osx sed -i "s+\(^fileerrretx .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
 * * * * osx sed -i "s+\(^throwtestfilex .*\)+\1 xfail=ticket0+g" test/mpi/errors/cxx/io/testlist
+* gnu debug ch3:tcp osx sed -i "s+\(^namepubx .*\)+\1 xfail=issue3506+g" test/mpi/cxx/spawn/testlist
 ################################################################################
 # xfail active message accumulates with short_int (only CH4 fails)
 * * * * * sed -i "s+\(^atomic_get_short_int .*\)+\1 xfail=ticket3380+g" test/mpi/rma/testlist


### PR DESCRIPTION
## Pull Request Description

Add to xfail exclusions for those tests that are currently failing in Jenkins nightly test.

Outside, fixed `test-worker.sh` in mpich-jenkins-scripts that mis-uses `&&` instead of `-a`, which probably resulted in those failures in `noerrorchecking` config. Apparently on osx, it only works with `--enable-fast=O1`.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
