### PR TITLE
misc: fixes for single threaded build

### DIFF
--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -40,6 +40,13 @@ extern MPIR_Thread_info_t MPIR_ThreadInfo;
 #define MPIR_THREAD_CHECK_END
 #endif /* MPICH_IS_THREADED */
 
+/* During run time, `isThreaded` should be used, but it still need to be guarded */
+#if defined(MPICH_IS_THREADED)
+#define MPIR_IS_THREADED    MPIR_ThreadInfo.isThreaded
+#else
+#define MPIR_IS_THREADED    0
+#endif
+
 /* ------------------------------------------------------------ */
 /* Global thread model, used for non-performance-critical paths */
 /* CONSIDER:

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -588,7 +588,7 @@ static csel_node_s *prune_tree(csel_node_s * root, MPIR_Comm * comm_ptr)
     for (csel_node_s * node = root; node;) {
         switch (node->type) {
             case CSEL_NODE_TYPE__OPERATOR__IS_MULTI_THREADED:
-                if (MPIR_ThreadInfo.isThreaded == node->u.is_multi_threaded.val)
+                if (MPIR_IS_THREADED == node->u.is_multi_threaded.val)
                     node = node->success;
                 else
                     node = node->failure;
@@ -1180,7 +1180,7 @@ void *MPIR_Csel_search(void *csel_, MPIR_Csel_coll_sig_s coll_info)
     for (node = root; node;) {
         switch (node->type) {
             case CSEL_NODE_TYPE__OPERATOR__IS_MULTI_THREADED:
-                if (MPIR_ThreadInfo.isThreaded == node->u.is_multi_threaded.val)
+                if (MPIR_IS_THREADED == node->u.is_multi_threaded.val)
                     node = node->success;
                 else
                     node = node->failure;

--- a/src/mpi/init/finalize.c
+++ b/src/mpi/init/finalize.c
@@ -130,7 +130,9 @@ int MPI_Finalize(void)
     /* Setting isThreaded to 0 to trick any operations used within
      * MPI_Finalize to think that we are running in a single threaded
      * environment. */
+#ifdef MPICH_IS_THREADED
     MPIR_ThreadInfo.isThreaded = 0;
+#endif
 
     mpi_errno = MPII_finalize_local_proc_attrs();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/init/initthread.c
+++ b/src/mpi/init/initthread.c
@@ -152,7 +152,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     /* Setting isThreaded to 0 to trick any operations used within
      * MPID_Init to think that we are running in a single threaded
      * environment. */
+#ifdef MPICH_IS_THREADED
     MPIR_ThreadInfo.isThreaded = 0;
+#endif
 
     MPL_atomic_store_int(&MPIR_Process.mpich_state, MPICH_MPI_STATE__IN_INIT);
 
@@ -200,7 +202,9 @@ int MPIR_Init_thread(int *argc, char ***argv, int user_required, int *provided)
     /**********************************************************************/
 
     /* Reset isThreaded to the actual thread level */
+#ifdef MPICH_IS_THREADED
     MPIR_ThreadInfo.isThreaded = (MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
+#endif
 
     mpi_errno = MPII_init_async();
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -935,10 +935,8 @@ MPID_nem_mpich_blocking_recv(MPID_nem_cell_ptr_t *cell, int *in_fbox, int comple
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPID_NEM_MPICH_BLOCKING_RECV);
     DO_PAPI (PAPI_reset (PAPI_EventSet));
 
-#ifdef MPICH_IS_THREADED
     /* We should never enter this function in a multithreaded app */
-    MPIR_Assert(!MPIR_ThreadInfo.isThreaded);
-#endif
+    MPIR_Assert(!MPIR_IS_THREADED);
 
 #ifdef USE_FASTBOX
     if (poll_active_fboxes(cell)) goto fbox_l;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -357,11 +357,7 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
         {
             /* make progress receiving */
             /* check queue */
-            if (MPID_nem_safe_to_block_recv() && is_blocking
-#ifdef MPICH_IS_THREADED
-                && !MPIR_ThreadInfo.isThreaded
-#endif
-                )
+            if (MPID_nem_safe_to_block_recv() && is_blocking && !MPIR_IS_THREADED)
             {
                 mpi_errno = MPID_nem_mpich_blocking_recv(&cell, &in_fbox, progress_state->ch.completion_count);
             }

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -168,11 +168,7 @@ static int MPIDI_CH3i_Progress_wait(MPID_Progress_state * progress_state)
             break;      /* break from the do loop */
         }
 
-#ifdef MPICH_IS_THREADED
-
-        /* The logic for this case is just complicated enough that
-         * we write separate code for each possibility */
-        if (MPIR_ThreadInfo.isThreaded) {
+        if (MPIR_IS_THREADED) {
             MPIDI_CH3I_progress_blocked = TRUE;
             mpi_errno = MPIDI_CH3I_Sock_wait(MPIDI_CH3I_sock_set,
                                              MPIDI_CH3I_SOCK_INFINITE_TIME, &event);
@@ -182,11 +178,6 @@ static int MPIDI_CH3i_Progress_wait(MPID_Progress_state * progress_state)
             mpi_errno = MPIDI_CH3I_Sock_wait(MPIDI_CH3I_sock_set,
                                              MPIDI_CH3I_SOCK_INFINITE_TIME, &event);
         }
-
-#else
-        mpi_errno = MPIDI_CH3I_Sock_wait(MPIDI_CH3I_sock_set,
-                                         MPIDI_CH3I_SOCK_INFINITE_TIME, &event);
-#	endif
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno != MPI_SUCCESS) {

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -92,7 +92,7 @@ static inline int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t * err
 
     switch (MPIR_CVAR_BARRIER_POSIX_INTRA_ALGORITHM) {
         case MPIR_CVAR_BARRIER_POSIX_INTRA_ALGORITHM_release_gather:
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_ThreadInfo.isThreaded, mpi_errno,
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED, mpi_errno,
                                            "Barrier release_gather cannot be applied.\n");
             mpi_errno = MPIDI_POSIX_mpi_barrier_release_gather(comm, errflag);
             break;
@@ -153,7 +153,7 @@ static inline int MPIDI_POSIX_mpi_bcast(void *buffer, int count, MPI_Datatype da
 
     switch (MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM) {
         case MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM_release_gather:
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_ThreadInfo.isThreaded, mpi_errno,
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED, mpi_errno,
                                            "Bcast release_gather cannot be applied.\n");
             mpi_errno =
                 MPIDI_POSIX_mpi_bcast_release_gather(buffer, count, datatype, root, comm, errflag);
@@ -218,7 +218,7 @@ static inline int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void *recvbuf, 
 
     switch (MPIR_CVAR_ALLREDUCE_POSIX_INTRA_ALGORITHM) {
         case MPIR_CVAR_ALLREDUCE_POSIX_INTRA_ALGORITHM_release_gather:
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_ThreadInfo.isThreaded &&
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED &&
                                            MPIR_Op_is_commutative(op), mpi_errno,
                                            "Allreduce release_gather cannot be applied.\n");
             mpi_errno =
@@ -497,7 +497,7 @@ static inline int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf, int
 
     switch (MPIR_CVAR_REDUCE_POSIX_INTRA_ALGORITHM) {
         case MPIR_CVAR_REDUCE_POSIX_INTRA_ALGORITHM_release_gather:
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_ThreadInfo.isThreaded &&
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED &&
                                            MPIR_Op_is_commutative(op), mpi_errno,
                                            "Reduce release_gather cannot be applied.\n");
             mpi_errno =

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -287,13 +287,16 @@ typedef struct {
 
 #define MAX_CH4_MUTEXES 6
 
-/* per-VCI structure */
-typedef struct MPIDI_vci {
-    int attr;
-    MPID_Thread_mutex_t lock;
-} MPIDI_vci_t MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
+/* per-VCI structure -- using union to force minimum size */
+typedef union MPIDI_vci {
+    struct {
+        int attr;
+        MPID_Thread_mutex_t lock;
+    } vci;
+    char pad[MPL_CACHELINE_SIZE];
+} MPIDI_vci_t;
 
-#define MPIDI_VCI(i) MPIDI_global.vci[i]
+#define MPIDI_VCI(i) MPIDI_global.vci[i].vci
 
 typedef struct MPIDI_CH4_Global_t {
     MPIR_Request *request_test;

--- a/src/mpid/common/hcoll/hcoll_init.c
+++ b/src/mpid/common/hcoll/hcoll_init.c
@@ -91,11 +91,7 @@ int hcoll_initialize(void)
     init_opts->base_tag = MPIR_FIRST_HCOLL_TAG;
     init_opts->max_tag = MPIR_LAST_HCOLL_TAG;
 
-#if defined MPICH_IS_THREADED
-    init_opts->enable_thread_support = MPIR_ThreadInfo.isThreaded;
-#else
-    init_opts->enable_thread_support = 0;
-#endif
+    init_opts->enable_thread_support = MPIR_IS_THREADED;
 
     mpi_errno = hcoll_init_with_opts(&init_opts);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpl/include/mpl_thread.h
+++ b/src/mpl/include/mpl_thread.h
@@ -39,6 +39,8 @@ typedef int MPL_thread_tls_key_t;
 typedef void (*MPL_thread_func_t) (void *data);
 #define MPL_thread_mutex_create(mutex_ptr_, err_ptr_)  { *((int*)err_ptr_) = 0;}
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = 0;}
+#define MPL_thread_init(err_ptr_)      do { } while (0)
+#define MPL_thread_finalize(err_ptr_)  do { } while (0)
 #else
 #error "thread package (MPL_THREAD_PACKAGE_NAME) not defined or unknown"
 #endif

--- a/test/mpi/include/mpithreadtest.h
+++ b/test/mpi/include/mpithreadtest.h
@@ -28,6 +28,9 @@
 #if !defined(THREAD_PACKAGE_NAME)
 #error "thread package (THREAD_PACKAGE_NAME) not defined"
 
+#elif THREAD_PACKAGE_NAME == THREAD_PACKAGE_NONE
+/* Empty. No threaded tests should run. */
+
 #elif THREAD_PACKAGE_NAME == THREAD_PACKAGE_WIN
 #include <windows.h>
 #define MTEST_THREAD_RETURN_TYPE DWORD
@@ -55,6 +58,7 @@
 
 #endif
 
+#if THREAD_PACKAGE_NAME != THREAD_PACKAGE_NONE
 int MTest_Start_thread(MTEST_THREAD_RETURN_TYPE(*fn) (void *p), void *arg);
 int MTest_Join_threads(void);
 int MTest_thread_lock_create(MTEST_THREAD_LOCK_TYPE *);
@@ -67,4 +71,7 @@ int MTest_thread_barrier_free(void);
 
 void MTest_init_thread_pkg(int argc, char **argv);
 void MTest_finalize_thread_pkg(void);
+
+#endif
+
 #endif /* MPITHREADTEST_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description
* Enforce minimul struct size using align attribute (to break false
sharing) is nice when it works. But it ultimately is a compiler
extension and may not always work. When it doesn't work -- e.g. when
`--enable-thread=single --with-thread-package=none` -- it is difficult
to understand why and how to fix. This patch replace it with explict
union for more reliability.

* add macro guard for accessing `MPIR_ThreadInfo.isThreaded`.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
