### PR TITLE
warnings: squash -Wformat-zero-length

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -440,8 +440,6 @@ if test "$enable_strict_done" != "yes" ; then
     #   -Wno-sign-compare -- read() and write() return bytes read/written
     #       as a signed value, but we often compare this to size_t (or
     #	    msg_sz_t) variables.
-    #   -Wno-format-zero-length -- this warning is irritating and useless, since
-    #                              a zero-length format string is very well defined
     # These were removed to reduce warnings:
     #   -Wcast-qual -- Sometimes we need to cast "volatile char*" to 
     #	    "char*", e.g., for memcpy.
@@ -513,7 +511,6 @@ if test "$enable_strict_done" != "yes" ; then
         -Winvalid-pch
         -Wno-pointer-sign
         -Wvariadic-macros
-        -Wno-format-zero-length
         -Wtype-limits
         -Werror-implicit-function-declaration
         -Wstack-usage=262144

--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -31,7 +31,8 @@
             } else if (MPIR_CVAR_COLLECTIVE_FALLBACK == MPIR_CVAR_COLLECTIVE_FALLBACK_print) { \
                 if ((rank) == 0) {                                      \
                     fprintf(stderr, "User set collective algorithm is not usable for the provided arguments\n"); \
-                    fprintf(stderr, ""  __VA_ARGS__);                   \
+                    fprintf(stderr, "  "  __VA_ARGS__);                 \
+                    fprintf(stderr, "\n");                              \
                     fflush(stderr);                                     \
                 }                                                       \
                 goto fallback;                                          \


### PR DESCRIPTION
## Pull Request Description

On ubuntu 18.04 with gcc-7.4.0, it warns `-Wformat-zero-length` by default. With our inline headers being included in every source file, the warning (with color highlighting) is very annoying. Seems it is not too much hassle to squash them.


## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
