### PR TITLE
config: not to overide CXX in case of disable-cxx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -708,9 +708,11 @@ dnl lead to weird AM_CONDITIONAL errors and potentially other problems.
 # with "--disable-LANG".  Libtool understands this as a request to disable
 # support for this language. This should save a bit of configure time and also
 # prevent user complaints like ticket #1570.
+#
+# NOTE: we are skipping overiding CXX as some modules (e.g. ucx) may depend on CXX
+#
 AS_IF([test "x$enable_f77" = "xno"],[F77=no])
 AS_IF([test "x$enable_fc"  = "xno"],[FC=no])
-AS_IF([test "x$enable_cxx" = "xno"],[CXX=no])
 
 # suppress default "-g -O2" from AC_PROG_CXX
 : ${CXXFLAGS=""}


### PR DESCRIPTION
## Pull Request Description
Some modules, e.g. ucx, may depend on CXX to compile certain parts.

Reference current weekly tests with `nocxx`:
```
...
make[5]: Entering directory `/var/lib/jenkins-slave/workspace/mpich-master-ch4-special-tests/compiler/gnu/jenkins_configure/nocxx/label/centos64/netmod/ucx/mpich-master/src/mpid/ch4/netmod/ucx/ucx/src/tools/perf/lib'
  CXX      libucxperf_la-uct_tests.lo
  CC       libucxperf_la-libperf.lo
  CXX      libucxperf_la-ucp_tests.lo
../../../../libtool: line 1763: no: command not found
...
```

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
