### PR TITLE
mpl/atomic: ensure interprocess atomicity of emulation lock

### DIFF
--- a/src/mpl/include/mpl_atomic.h
+++ b/src/mpl/include/mpl_atomic.h
@@ -107,6 +107,10 @@ static void MPL_atomic_compiler_barrier(void);
 #elif defined(MPL_HAVE_NT_INTRINSICS)
 #include "mpl_atomic_nt_intrinsics.h"
 #elif defined(MPL_USE_LOCK_BASED_PRIMITIVES)
+#include <pthread.h>
+typedef pthread_mutex_t MPL_emulation_ipl_t;
+int MPL_atomic_interprocess_lock_init(MPL_emulation_ipl_t * shm_lock, int isLeader);
+int MPL_atomic_interprocess_lock_free(void);
 #include "mpl_atomic_by_lock.h"
 #else
 #error no primitives implementation specified

--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -13,15 +13,22 @@
 
 /* defined in mpl_atomic.c */
 extern pthread_mutex_t MPL_emulation_lock;
+extern MPL_emulation_ipl_t *MPL_emulation_interprocess_lock;
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()         \
-    do {                                         \
-        pthread_mutex_lock(&MPL_emulation_lock); \
+#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()                                       \
+    do {                                                                       \
+        pthread_mutex_lock(&MPL_emulation_lock);                               \
+        if (MPL_emulation_interprocess_lock) {                                 \
+            pthread_mutex_lock(MPL_emulation_interprocess_lock);               \
+        }                                                                      \
     } while (0)
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()              \
-    do {                                             \
-        pthread_mutex_unlock(&MPL_emulation_lock);   \
+#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()                                        \
+    do {                                                                       \
+        if (MPL_emulation_interprocess_lock) {                                 \
+            pthread_mutex_unlock(MPL_emulation_interprocess_lock);             \
+        }                                                                      \
+        pthread_mutex_unlock(&MPL_emulation_lock);                             \
     } while (0)
 
 

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -16,5 +16,52 @@
 #include <pthread.h>
 
 pthread_mutex_t MPL_emulation_lock = PTHREAD_MUTEX_INITIALIZER;
+MPL_emulation_ipl_t *MPL_emulation_interprocess_lock = NULL;
+
+int MPL_atomic_interprocess_lock_init(MPL_emulation_ipl_t * shm_lock, int isLeader)
+{
+    int mpi_errno = 0;          /* MPI_SUCCESS */
+    pthread_mutexattr_t attr;
+
+    /* Take the intranode-process lock. */
+    pthread_mutex_lock(&MPL_emulation_lock);
+
+    MPL_emulation_interprocess_lock = shm_lock;
+
+    if (isLeader) {
+        /* Set the mutex attributes to work correctly on inter-process
+         * shared memory as well. This is required for some compilers
+         * (such as SUN Studio) that don't enable it by default. */
+        if (pthread_mutexattr_init(&attr) ||
+            pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED) ||
+            pthread_mutex_init(MPL_emulation_interprocess_lock, &attr))
+            mpi_errno = 16;     /* MPI_ERR_INTERN */
+    }
+
+    /* Release the intranode-process lock. */
+    pthread_mutex_unlock(&MPL_emulation_lock);
+
+    return mpi_errno;
+}
+
+int MPL_atomic_interprocess_lock_free(void)
+{
+    int mpi_errno = 0;          /* MPI_SUCCESS */
+
+    /* Take the intranode-process lock. */
+    pthread_mutex_lock(&MPL_emulation_lock);
+
+    if (MPL_emulation_interprocess_lock) {
+        if (pthread_mutex_destroy(MPL_emulation_interprocess_lock)) {
+            mpi_errno = 16;
+        } else {
+            MPL_emulation_interprocess_lock = NULL;
+        }
+    }
+
+    /* Release the intranode-process lock. */
+    pthread_mutex_unlock(&MPL_emulation_lock);
+    return mpi_errno;
+}
 
 #endif /* MPL_USE_LOCK_BASED_PRIMITIVES */

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -4,16 +4,17 @@
  *      See COPYRIGHT in top-level directory.
  */
 
+#include "mpl_atomic.h"
+
+#ifdef MPL_USE_LOCK_BASED_PRIMITIVES
+
 /* FIXME For now we rely on pthreads for our IPC locks.  This is fairly
  * portable, although it is obviously not 100% portable.  We need to figure out
  * how to support other threading packages and lock implementations, such as the
  * BG/P lockbox. */
 
-#include "mpl_atomic.h"
-
-#ifdef MPL_HAVE_PTHREAD_H
 #include <pthread.h>
 
 pthread_mutex_t MPL_emulation_lock = PTHREAD_MUTEX_INITIALIZER;
 
-#endif /* MPL_HAVE_PTHREAD_H */
+#endif /* MPL_USE_LOCK_BASED_PRIMITIVES */


### PR DESCRIPTION
## Pull Request Description

The MPL/atomic's emulation lock lacked interprocess atomicity. This PR fixes it by introducing a mechanism similar to OPA's interprocess lock.

Note that, unlike OPA's interprocess lock, MPL/atomics can be used before initializing the interprocess lock since a statically allocated mutex is used when the interprocess lock has not been set up yet. (This requires additional mutex operations: see "Expected Impact".)

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This PR lowers the overall performance of atomic operations when the emulation lock is used.
- Interprocess lock forces serialization of all processes even though intraprocess atoomicity is sufficient in many cases (e.g., process-local completion counters).
- To make the emulation lock work before initialization (and after finalization), it has two mutexes. 

This performance degradation should be fine since the emulation lock is a fallback and thus its performance does not matter much.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
