### PR TITLE
coll: fix MPI_Bcast overflow

### DIFF
--- a/src/mpi/coll/bcast/bcast.h
+++ b/src/mpi/coll/bcast/bcast.h
@@ -11,7 +11,7 @@
 #include "mpiimpl.h"
 
 int MPII_Scatter_for_bcast(void *buffer, int count, MPI_Datatype datatype,
-                           int root, MPIR_Comm * comm_ptr, int nbytes, void *tmp_buf,
+                           int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes, void *tmp_buf,
                            int is_contig, MPIR_Errflag_t * errflag);
 
 #endif /* BCAST_H_INCLUDED */

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -39,12 +39,13 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    int scatter_size;
+    MPI_Aint scatter_size;
     MPI_Aint curr_size, recv_size = 0;
     int j, k, i, tmp_mask, is_contig;
     MPI_Aint type_size, nbytes = 0;
-    int relative_dst, dst_tree_root, my_tree_root, send_offset;
-    int recv_offset, tree_root, nprocs_completed, offset;
+    int relative_dst, dst_tree_root, my_tree_root;
+    int tree_root, nprocs_completed;
+    MPI_Aint send_offset, recv_offset, offset;
     MPIR_CHKLMEM_DECL(1);
     MPI_Aint true_extent, true_lb;
     void *tmp_buf;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -32,7 +32,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     int rank, comm_size;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    int scatter_size;
+    MPI_Aint scatter_size;
     int j, i, is_contig;
     MPI_Aint nbytes, type_size;
     int left, right, jnext;
@@ -101,7 +101,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     j = rank;
     jnext = left;
     for (i = 1; i < comm_size; i++) {
-        int left_count, right_count, left_disp, right_disp, rel_j, rel_jnext;
+        MPI_Aint left_count, right_count, left_disp, right_disp, rel_j, rel_jnext;
 
         rel_j = (j - root + comm_size) % comm_size;
         rel_jnext = (jnext - root + comm_size) % comm_size;

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -23,14 +23,14 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                            MPI_Datatype datatype ATTRIBUTE((unused)),
                            int root,
                            MPIR_Comm * comm_ptr,
-                           int nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t * errflag)
+                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t * errflag)
 {
     MPI_Status status;
     int rank, comm_size, src, dst;
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
-    int scatter_size, recv_size = 0;
+    MPI_Aint scatter_size, recv_size = 0;
     MPI_Aint curr_size, send_size;
 
     comm_size = comm_ptr->local_size;


### PR DESCRIPTION
Change-Id: I91da229b9021d1e47bb3cb25e6e5e165a08e4920

## Pull Request Description
MPI_Bcast may overflow if using 'scatter_ring_allgather' or 'scatter_recursive_doubling_allgather'. See #3308

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
