### PR TITLE
ch4/xpmem: fix a bug and convert atomics to MPL

### DIFF
--- a/src/mpid/ch4/shm/xpmem/xpmem_control.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_control.c
@@ -74,7 +74,7 @@ int MPIDI_XPMEM_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
     if (root_comm) {
         while (TRUE) {
             rreq = MPIDIG_dequeue_posted(slmt_rts_hdr->src_rank, slmt_rts_hdr->tag,
-                                         slmt_rts_hdr->context_id,
+                                         slmt_rts_hdr->context_id, 1,
                                          &MPIDIG_COMM(root_comm, posted_list));
 #ifndef MPIDI_CH4_DIRECT_NETMOD
             if (rreq) {

--- a/src/mpid/ch4/shm/xpmem/xpmem_pre.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_pre.h
@@ -48,7 +48,7 @@ typedef union MPIDI_XPMEM_cnt {
     MPIR_Handle_common common;  /* ensure sufficient bytes required for MPIR_Handle_common */
     struct {
         MPIR_OBJECT_HEADER;
-        OPA_int_t counter;
+        MPL_atomic_int_t counter;
     } obj;
 } MPIDI_XPMEM_cnt_t;
 

--- a/src/mpid/ch4/shm/xpmem/xpmem_recv.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_recv.h
@@ -45,7 +45,7 @@ cvars:
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_do_lmt_coop_copy(const void *src_buf,
                                                           size_t data_sz, void *dest_buf,
-                                                          OPA_int_t * counter_ptr,
+                                                          MPL_atomic_int_t * counter_ptr,
                                                           uint64_t req_ptr,
                                                           MPIR_Request * local_req, int *fin_type,
                                                           int *copy_type)
@@ -66,7 +66,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_do_lmt_coop_copy(const void *src_buf,
 
     /* TODO: implement OPA_fetch_and_incr_int uint64_t to directly change cur_offset
      * instead of computing it in each copy */
-    while ((cur_chunk = OPA_fetch_and_incr_int(counter_ptr)) < total_chunk) {
+    while ((cur_chunk = MPL_atomic_fetch_add_int(counter_ptr, 1)) < total_chunk) {
         cur_offset = ((uint64_t) cur_chunk) * MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE;
         copy_sz =
             cur_offset + MPIR_CVAR_CH4_XPMEM_COOP_COPY_CHUNK_SIZE <=
@@ -135,7 +135,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_coop_recv(uint64_t src_offse
     /* allocate shm counter */
     MPIDI_XPMEM_REQUEST(rreq, counter_ptr) =
         (MPIDI_XPMEM_cnt_t *) MPIR_Handle_obj_alloc(&MPIDI_XPMEM_cnt_mem);
-    OPA_store_int(&MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.counter, 0);
+    MPL_atomic_store_int(&MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.counter, 0);
     if (HANDLE_GET_KIND(MPIDI_XPMEM_REQUEST(rreq, counter_ptr)->obj.handle) == HANDLE_KIND_DIRECT) {
         slmt_cts_hdr->coop_counter_direct_flag = 1;
         slmt_cts_hdr->coop_counter_offset =


### PR DESCRIPTION
## Pull Request Description

Previous commit 
https://github.com/pmodels/mpich/pull/4330/commits/21870d1749af04f6ffe009998ca1a5a2eac6b921 broke xpmem. This PR fixes it.

Convert OpenPA atomics to MPL equivallent.

NOTE: this is split from #4390. The original PR gets too extended.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
