### PR TITLE
ch4: remove debug traces in shm

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_init.c
@@ -34,10 +34,6 @@ int MPIDI_POSIX_fbox_init(int rank, int size)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_FBOX_INIT);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_FBOX_INIT);
 
-#ifdef MPL_USE_DBG_LOGGING
-    MPIDI_CH4_SHM_POSIX_FBOX_GENERAL = MPL_dbg_class_alloc("SHM_POSIX_FBOX", "shm_posix_fbox");
-#endif /* MPL_USE_DBG_LOGGING */
-
     MPIR_CHKPMEM_DECL(3);
 
     MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_eager_fbox_control_global.first_poll_local_ranks,

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_recv.h
@@ -88,25 +88,6 @@ MPIDI_POSIX_eager_recv_begin(MPIDI_POSIX_eager_recv_transaction_t * transaction)
             /* Initialize private transaction part */
             transaction->transport.fbox.fbox_ptr = fbox_in;
 
-#ifdef POSIX_FBOX_DEBUG
-            {
-                int i;
-
-                POSIX_FBOX_TRACE("FBOX_IN  (%s) [", fbox_in->is_header ? "H" : "F");
-
-                for (i = 0; i < fbox_in->payload_sz; i++) {
-                    POSIX_FBOX_TRACE("%02X", ((uint8_t *) (fbox_in->payload))[i]);
-
-                    if (i == 255) {
-                        POSIX_FBOX_TRACE("...");
-                        break;
-                    }
-                }
-
-                POSIX_FBOX_TRACE("]@%d from %d\n", fbox_in->payload_sz, grank);
-            }
-#endif /* POSIX_FBOX_DEBUG */
-
             /* We found a message so return success and stop. */
             mpi_errno = MPIDI_POSIX_OK;
             goto fn_exit;

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_send.h
@@ -84,25 +84,6 @@ MPIDI_POSIX_eager_send(int grank,
 
     fbox_out->payload_sz = fbox_payload_size - fbox_payload_size_left;
 
-#ifdef POSIX_FBOX_DEBUG
-    {
-        int i;
-
-        POSIX_FBOX_TRACE("FBOX_OUT (%s) [", fbox_out->is_header ? "H" : "F");
-
-        for (i = 0; i < fbox_out->payload_sz; i++) {
-            POSIX_FBOX_TRACE("%02X", ((uint8_t *) (fbox_out->payload))[i]);
-
-            if (i == 255) {
-                POSIX_FBOX_TRACE("...");
-                break;
-            }
-        }
-
-        POSIX_FBOX_TRACE("]@%d to %d\n", fbox_out->payload_sz, grank);
-    }
-#endif /* POSIX_FBOX_DEBUG */
-
     /* Update the data ready flag to indicate that there is data in the box for the receiver. */
     MPL_atomic_store_int(&fbox_out->data_ready, 1);
 

--- a/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
+++ b/src/mpid/ch4/shm/posix/eager/fbox/fbox_types.h
@@ -48,11 +48,4 @@ typedef struct MPIDI_POSIX_eager_fbox_control {
 
 extern MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global;
 
-#ifdef MPL_USE_DBG_LOGGING
-extern MPL_dbg_class MPIDI_CH4_SHM_POSIX_FBOX_GENERAL;
-#endif
-
-#define POSIX_FBOX_TRACE(...) \
-    MPL_DBG_MSG_FMT(MPIDI_CH4_SHM_POSIX_FBOX_GENERAL,VERBOSE,(MPL_DBG_FDEST, __VA_ARGS__))
-
 #endif /* POSIX_EAGER_FBOX_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/eager/fbox/globals.c
+++ b/src/mpid/ch4/shm/posix/eager/fbox/globals.c
@@ -10,7 +10,3 @@
    during linking. This is manifested by static linking on mac osx.
 */
 MPIDI_POSIX_eager_fbox_control_t MPIDI_POSIX_eager_fbox_control_global = { 0 };
-
-#ifdef MPL_USE_DBG_LOGGING
-MPL_dbg_class MPIDI_CH4_SHM_POSIX_FBOX_GENERAL;
-#endif

--- a/src/mpid/ch4/shm/posix/globals.c
+++ b/src/mpid/ch4/shm/posix/globals.c
@@ -10,5 +10,4 @@ MPIDI_POSIX_global_t MPIDI_POSIX_global = { 0 };
 
 MPIDI_POSIX_eager_funcs_t *MPIDI_POSIX_eager_func = NULL;
 
-MPL_dbg_class MPIDI_CH4_SHM_POSIX_GENERAL;
 MPL_atomic_uint64_t *MPIDI_POSIX_shm_limit_counter = NULL;

--- a/src/mpid/ch4/shm/posix/posix_am.h
+++ b/src/mpid/ch4/shm/posix/posix_am.h
@@ -101,16 +101,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
     struct iovec iov_left[2];
     struct iovec *iov_left_ptr;
     size_t iov_num_left;
-#ifdef POSIX_AM_DEBUG
-    static int seq_num = 0;
-#endif /* POSIX_AM_DEBUG */
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_POSIX_AM_ISEND);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_POSIX_AM_ISEND);
-
-#ifdef POSIX_AM_DEBUG
-    msg_hdr.seq_num = seq_num++;
-#endif /* POSIX_AM_DEBUG */
 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
@@ -172,19 +165,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_isend(int rank,
 
         goto fn_exit;
     }
-
-    /* pgi compiler can't handle preprocessing within macro argument */
-#ifdef POSIX_AM_DEBUG
-#define _SEQ_NUM msg_hdr_p->seq_num,
-#else
-#define _SEQ_NUM -1
-#endif
-
-    POSIX_TRACE("Direct OUT HDR [ POSIX AM [handler_id %" PRIu64 ", am_hdr_sz %" PRIu64
-                ", data_sz %" PRIu64 ", seq_num = %d], " "tag = %d, src_rank = %d ] to %d\n",
-                (uint64_t) msg_hdr_p->handler_id,
-                (uint64_t) msg_hdr_p->am_hdr_sz, (uint64_t) msg_hdr_p->data_sz, _SEQ_NUM,
-                ((MPIDIG_hdr_t *) am_hdr)->tag, ((MPIDIG_hdr_t *) am_hdr)->src_rank, grank);
 
     result = MPIDI_POSIX_eager_send(grank, &msg_hdr_p, &iov_left_ptr, &iov_num_left);
 
@@ -378,13 +358,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_send_hdr(int rank,
                                                    iov_num_left);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-
-        POSIX_TRACE("Direct OUT HDR [ POSIX AM HDR [handler_id %" PRIu64 ", am_hdr_sz %" PRIu64
-                    ", data_sz %" PRIu64 ", seq_num = %d]] to %d\n",
-                    (uint64_t) msg_hdr_p->handler_id,
-                    (uint64_t) msg_hdr_p->am_hdr_sz, (uint64_t) msg_hdr_p->data_sz,
-                    _SEQ_NUM, grank);
-
         result = MPIDI_POSIX_eager_send(grank, &msg_hdr_p, &iov_left_ptr, &iov_num_left);
         if (unlikely((MPIDI_POSIX_NOK == result) || iov_num_left)) {
             mpi_errno =

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -112,10 +112,6 @@ int MPIDI_POSIX_mpi_init_hook(int rank, int size, int *tag_bits)
     int mpi_errno = MPI_SUCCESS;
     int i, local_rank_0 = -1;
 
-#ifdef MPL_USE_DBG_LOGGING
-    MPIDI_CH4_SHM_POSIX_GENERAL = MPL_dbg_class_alloc("SHM_POSIX", "shm_posix");
-#endif /* MPL_USE_DBG_LOGGING */
-
     MPIDI_POSIX_global.am_buf_pool =
         MPIDIU_create_buf_pool(MPIDI_POSIX_BUF_POOL_NUM, MPIDI_POSIX_BUF_POOL_SIZE);
 

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -62,9 +62,6 @@ typedef struct MPIDI_POSIX_am_header {
     uint32_t handler_id:MPIDI_POSIX_AM_HANDLER_ID_BITS;
     uint64_t am_hdr_sz:MPIDI_POSIX_AM_HDR_SZ_BITS;
     uint64_t data_sz:MPIDI_POSIX_AM_DATA_SZ_BITS;
-#ifdef POSIX_AM_DEBUG
-    int seq_num;
-#endif                          /* POSIX_AM_DEBUG */
 } MPIDI_POSIX_am_header_t;
 
 typedef struct MPIDI_POSIX_am_request_header {

--- a/src/mpid/ch4/shm/posix/posix_progress.c
+++ b/src/mpid/ch4/shm/posix/posix_progress.c
@@ -129,18 +129,6 @@ static int progress_send(int blocking)
         /* Drain postponed queue */
         curr_sreq_hdr = MPIDI_POSIX_global.postponed_queue;
 
-        POSIX_TRACE("Queue OUT HDR [ POSIX AM [handler_id %" PRIu64 ", am_hdr_sz %" PRIu64
-                    ", data_sz %" PRIu64 ", seq_num = %d], request=%p] to %d\n",
-                    curr_sreq_hdr->msg_hdr ? curr_sreq_hdr->msg_hdr->handler_id : (uint64_t) - 1,
-                    curr_sreq_hdr->msg_hdr ? curr_sreq_hdr->msg_hdr->am_hdr_sz : (uint64_t) - 1,
-                    curr_sreq_hdr->msg_hdr ? curr_sreq_hdr->msg_hdr->data_sz : (uint64_t) - 1,
-#ifdef POSIX_AM_DEBUG
-                    curr_sreq_hdr->msg_hdr ? curr_sreq_hdr->msg_hdr->seq_num : -1,
-#else /* POSIX_AM_DEBUG */
-                    -1,
-#endif /* POSIX_AM_DEBUG */
-                    curr_sreq_hdr->request, curr_sreq_hdr->dst_grank);
-
         result = MPIDI_POSIX_eager_send(curr_sreq_hdr->dst_grank,
                                         &curr_sreq_hdr->msg_hdr,
                                         &curr_sreq_hdr->iov_ptr, &curr_sreq_hdr->iov_num);

--- a/src/mpid/ch4/shm/posix/posix_request.h
+++ b/src/mpid/ch4/shm/posix/posix_request.h
@@ -15,8 +15,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_am_request_init(MPIR_Request * req)
     MPIDI_POSIX_AMREQUEST(req, req_hdr) = NULL;
 
     MPIDI_POSIX_EAGER_RECV_INITIALIZE_HOOK(req);
-
-    POSIX_TRACE("Created request %d\n", req->kind);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_am_request_finalize(MPIR_Request * req)
@@ -31,8 +29,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_am_request_finalize(MPIR_Request * req
 
     if (!req_hdr)
         goto fn_exit;
-
-    POSIX_TRACE("Completed request %d (%d)\n", req->kind, req_hdr->dst_grank);
 
     MPIDI_POSIX_am_release_req_hdr(&req_hdr);
     MPIDI_POSIX_AMREQUEST(req, req_hdr) = NULL;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -45,9 +45,5 @@ typedef struct {
 } MPIDI_POSIX_global_t;
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;
-extern MPL_dbg_class MPIDI_CH4_SHM_POSIX_GENERAL;
-
-#define POSIX_TRACE(...) \
-    MPL_DBG_MSG_FMT(MPIDI_CH4_SHM_POSIX_GENERAL,VERBOSE,(MPL_DBG_FDEST, __VA_ARGS__))
 
 #endif /* POSIX_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/xpmem/xpmem_control.c
+++ b/src/mpid/ch4/shm/xpmem/xpmem_control.c
@@ -17,7 +17,6 @@ int MPIDI_XPMEM_ctrl_send_lmt_recv_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RECV_FIN_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RECV_FIN_CB);
 
-    XPMEM_TRACE("send_lmt_recv_fin_cb: complete sreq %p\n", sreq);
     MPIR_Datatype_release_if_not_builtin(MPIDIG_REQUEST(sreq, datatype));
     MPID_Request_complete(sreq);
 
@@ -35,8 +34,6 @@ int MPIDI_XPMEM_ctrl_send_lmt_send_fin_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_SEND_FIN_CB);
-
-    XPMEM_TRACE("send_lmt_send_fin_cb: complete rreq %p\n", rreq);
 
     /* send_fin_cb can only be triggered in cooperative copy, so
      * MPIDI_XPMEM_REQUEST(rreq, counter_ptr) must be set by receiver */
@@ -59,12 +56,6 @@ int MPIDI_XPMEM_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
     MPIR_Comm *root_comm;
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RTS_CB);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_XPMEM_CTRL_SEND_LMT_RTS_CB);
-
-    XPMEM_TRACE("send_lmt_rts_cb: received src_offset 0x%lx, data_sz 0x%lx, sreq_ptr 0x%lx, "
-                "src_lrank %d, match info[src_rank %d, tag %d, context_id 0x%x]\n",
-                slmt_rts_hdr->src_offset, slmt_rts_hdr->data_sz, slmt_rts_hdr->sreq_ptr,
-                slmt_rts_hdr->src_lrank, slmt_rts_hdr->src_rank, slmt_rts_hdr->tag,
-                slmt_rts_hdr->context_id);
 
     /* Try to match a posted receive request.
      * root_comm cannot be NULL if a posted receive request exists, because
@@ -133,8 +124,6 @@ int MPIDI_XPMEM_ctrl_send_lmt_rts_cb(MPIDI_SHM_ctrl_hdr_t * ctrl_hdr)
             MPIDIG_enqueue_unexp(rreq,
                                  MPIDIG_context_id_to_uelist(MPIDIG_REQUEST(rreq, context_id)));
         }
-
-        XPMEM_TRACE("send_lmt_rts_cb: enqueue unexpected, rreq=%p\n", rreq);
     }
 
   fn_exit:

--- a/src/mpid/ch4/shm/xpmem/xpmem_recv.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_recv.h
@@ -145,13 +145,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_coop_recv(uint64_t src_offse
         slmt_cts_hdr->coop_counter_offset = (uint64_t) MPIDI_XPMEM_REQUEST(rreq, counter_ptr);
     }
 
-    XPMEM_TRACE("handle_lmt_coop_recv: shm ctrl_id %d, buf_offset 0x%lx, data_sz 0x%lx, "
-                "sreq_ptr 0x%lx, rreq_ptr 0x%lx, coop_counter_offset 0x%lx, "
-                " local_rank %d, dest %d\n",
-                MPIDI_SHM_XPMEM_SEND_LMT_CTS, slmt_cts_hdr->dest_offset, slmt_cts_hdr->data_sz,
-                slmt_cts_hdr->sreq_ptr, slmt_cts_hdr->rreq_ptr, slmt_cts_hdr->coop_counter_offset,
-                slmt_cts_hdr->dest_lrank, MPIDIG_REQUEST(rreq, rank));
-
     /* Receiver sends CTS packet to sender */
     mpi_errno =
         MPIDI_SHM_do_ctrl_send(MPIDIG_REQUEST(rreq, rank), comm, MPIDI_SHM_XPMEM_SEND_LMT_CTS,
@@ -169,10 +162,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_coop_recv(uint64_t src_offse
                                &MPIDI_XPMEM_global.segmaps[src_lrank].segcache_ubuf);
     MPIR_ERR_CHECK(mpi_errno);
 
-    XPMEM_TRACE("handle_lmt_coop_recv: handle matched rreq %p [source %d, tag %d, context_id 0x%x],"
-                " copy dst %p, src %lx, bytes %ld\n", rreq, MPIDIG_REQUEST(rreq, rank),
-                MPIDIG_REQUEST(rreq, tag), MPIDIG_REQUEST(rreq, context_id),
-                (char *) MPIDIG_REQUEST(rreq, buffer), src_offset, recv_data_sz);
     /* sender and receiver datatypes are both continuous, perform cooperative copy. */
     mpi_errno =
         MPIDI_XPMEM_do_lmt_coop_copy(src_buf, recv_data_sz,
@@ -257,12 +246,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_handle_lmt_single_recv(uint64_t src_off
         MPIDI_XPMEM_seg_regist(src_lrank, src_data_sz, (void *) src_offset, &seg_ptr, &src_buf,
                                &MPIDI_XPMEM_global.segmaps[src_lrank].segcache_ubuf);
     MPIR_ERR_CHECK(mpi_errno);
-
-    XPMEM_TRACE("handle_lmt_single_recv: handle matched rreq %p [source %d, tag %d, "
-                " context_id 0x%x], copy dst %p, src %lx, bytes %ld\n", rreq,
-                MPIDIG_REQUEST(rreq, rank), MPIDIG_REQUEST(rreq, tag),
-                MPIDIG_REQUEST(rreq, context_id), (char *) MPIDIG_REQUEST(rreq, buffer),
-                src_offset, recv_data_sz);
 
     /* Copy data to receive buffer */
     mpi_errno = MPIR_Localcopy(src_buf, recv_data_sz, MPI_BYTE,

--- a/src/mpid/ch4/shm/xpmem/xpmem_send.h
+++ b/src/mpid/ch4/shm/xpmem/xpmem_send.h
@@ -53,12 +53,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_lmt_isend(const void *buf, MPI_Aint cou
     slmt_req_hdr->tag = tag;
     slmt_req_hdr->context_id = comm->context_id + context_offset;
 
-    XPMEM_TRACE("lmt_isend: shm ctrl_id %d, src_offset 0x%lx, data_sz 0x%lx, sreq_ptr 0x%lx, "
-                "src_lrank %d, match info[dest %d, src_rank %d, tag %d, context_id 0x%x]\n",
-                MPIDI_SHM_XPMEM_SEND_LMT_RTS, slmt_req_hdr->src_offset,
-                slmt_req_hdr->data_sz, slmt_req_hdr->sreq_ptr, slmt_req_hdr->src_lrank,
-                rank, slmt_req_hdr->src_rank, slmt_req_hdr->tag, slmt_req_hdr->context_id);
-
     mpi_errno = MPIDI_SHM_do_ctrl_send(rank, comm, MPIDI_SHM_XPMEM_SEND_LMT_RTS, &ctrl_hdr);
     MPIR_ERR_CHECK(mpi_errno);
 


### PR DESCRIPTION
## Pull Request Description

Our shm branch has many runtime debug traces that are not only noisy for log output but also noisy for source code. They are meant to be troubleshooting scaffold and should not be left around after the debugging. This PR removes them. When needed, they can be easily added during a debugging session.
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
