### PR TITLE
mpl/atomic: fix namespaces

### DIFF
--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -12,29 +12,29 @@
 #include <pthread.h>
 
 /* defined in mpl_atomic.c */
-extern pthread_mutex_t MPL_emulation_lock;
+extern pthread_mutex_t MPLI_emulation_lock;
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_ENTER()         \
-    do {                                         \
-        pthread_mutex_lock(&MPL_emulation_lock); \
+#define MPLI_ATOMIC_CS_ENTER()                    \
+    do {                                          \
+        pthread_mutex_lock(&MPLI_emulation_lock); \
     } while (0)
 
-#define MPL_ATOMIC_IPC_SINGLE_CS_EXIT()              \
-    do {                                             \
-        pthread_mutex_unlock(&MPL_emulation_lock);   \
+#define MPLI_ATOMIC_CS_EXIT()                       \
+    do {                                            \
+        pthread_mutex_unlock(&MPLI_emulation_lock); \
     } while (0)
 
 
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                               \
 struct MPL_atomic_ ## NAME ## _t {                                             \
     volatile TYPE v;                                                           \
 };                                                                             \
@@ -42,98 +42,103 @@ static inline TYPE MPL_atomic_relaxed_load_ ## NAME                            \
                                 (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     val = (TYPE)ptr->v;                                                        \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return val;                                                                \
 }                                                                              \
 static inline TYPE MPL_atomic_acquire_load_ ## NAME                            \
                                 (const struct MPL_atomic_ ## NAME ## _t * ptr) \
 {                                                                              \
     TYPE val;                                                                  \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     val = (TYPE)ptr->v;                                                        \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return val;                                                                \
 }                                                                              \
 static inline void MPL_atomic_relaxed_store_ ## NAME                           \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     ptr->v = val;                                                              \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
 }                                                                              \
 static inline void MPL_atomic_release_store_ ## NAME                           \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     ptr->v = val;                                                              \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
 }                                                                              \
 static inline TYPE MPL_atomic_cas_ ## NAME                                     \
                 (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE oldv, TYPE newv) \
 {                                                                              \
     TYPE prev;                                                                 \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     prev = (TYPE)ptr->v;                                                       \
     if (prev == oldv)                                                          \
         ptr->v = newv;                                                         \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_swap_ ## NAME                                    \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     prev = (TYPE)ptr->v;                                                       \
     ptr->v = val;                                                              \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return prev;                                                               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                  \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     prev = (TYPE)ptr->v;                                                       \
     ptr->v += val;                                                             \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return prev;                                                               \
 }                                                                              \
 static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
     TYPE prev;                                                                 \
-    MPL_ATOMIC_IPC_SINGLE_CS_ENTER();                                          \
+    MPLI_ATOMIC_CS_ENTER();                                                    \
     prev = (TYPE)ptr->v;                                                       \
     ptr->v -= val;                                                             \
-    MPL_ATOMIC_IPC_SINGLE_CS_EXIT();                                           \
+    MPLI_ATOMIC_CS_EXIT();                                                     \
     return prev;                                                               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
 
 /* int */
-MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int)
 /* int32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
 /* uint32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
 /* int64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
 /* uint64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
 /* void * */
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
-
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
+#undef MPLI_ATOMIC_CS_ENTER
+#undef MPLI_ATOMIC_CS_EXIT
 /* lock/unlock provides barrier */
 static inline void MPL_atomic_write_barrier(void)
 {

--- a/src/mpl/include/mpl_atomic_c11.h
+++ b/src/mpl/include/mpl_atomic_c11.h
@@ -22,20 +22,20 @@
 
 #if __STDC_VERSION__ >= 201710L
 // C17 obsoletes ATOMIC_VAR_INIT.
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 #else
-#define MPL_ATOMIC_INITIALIZER(val_) { ATOMIC_VAR_INIT(val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { ATOMIC_VAR_INIT(val_) }
 #endif
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
 #define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
-        MPL_ATOMIC_INITIALIZER((intptr_t)(val_))
+        MPLI_ATOMIC_INITIALIZER((intptr_t)(val_))
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)        \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)       \
 struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE v;                                                             \
 };                                                                             \
@@ -76,7 +76,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
                                           memory_order_acq_rel);               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)           \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)          \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
@@ -90,20 +90,23 @@ static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
                                            memory_order_acq_rel);              \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_TYPE)
 
-MPL_ATOMIC_DECL_FUNC_VAL(int, int, atomic_int, int)
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32, atomic_int_fast32_t, int_fast32_t)
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, atomic_uint_fast32_t, uint_fast32_t)
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64, atomic_int_fast64_t, int_fast64_t)
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, atomic_uint_fast64_t, uint_fast64_t)
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, atomic_intptr_t, intptr_t)
-
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int, atomic_int, int)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32, atomic_int_fast32_t, int_fast32_t)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, atomic_uint_fast32_t, uint_fast32_t)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64, atomic_int_fast64_t, int_fast64_t)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, atomic_uint_fast64_t, uint_fast64_t)
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr, atomic_intptr_t, intptr_t)
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
 static inline void MPL_atomic_write_barrier(void)
 {
     atomic_thread_fence(memory_order_release);

--- a/src/mpl/include/mpl_atomic_gcc_atomic.h
+++ b/src/mpl/include/mpl_atomic_gcc_atomic.h
@@ -15,16 +15,16 @@
 #pragma error_messages (off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
 #endif
 
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                               \
 struct MPL_atomic_ ## NAME ## _t {                                             \
      TYPE volatile v;                                                          \
 };                                                                             \
@@ -61,7 +61,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
     return __atomic_exchange_n(&ptr->v, val, __ATOMIC_ACQ_REL);                \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
@@ -73,26 +73,29 @@ static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
     return __atomic_fetch_sub(&ptr->v, val, __ATOMIC_ACQ_REL);                 \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
 
 /* int */
-MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int)
 /* int32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
 /* uint32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
 /* int64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
 /* uint64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
 /* void * */
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
-
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
 static inline void MPL_atomic_write_barrier(void)
 {
     __atomic_thread_fence(__ATOMIC_RELEASE);

--- a/src/mpl/include/mpl_atomic_gcc_sync.h
+++ b/src/mpl/include/mpl_atomic_gcc_sync.h
@@ -15,19 +15,19 @@
 #pragma error_messages (off, E_ARG_INCOMPATIBLE_WITH_ARG_L)
 #endif
 
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
 
 /* The following implementation assumes that loads/stores are atomic on the
  * current platform, even though this may not be true at all. */
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                               \
 struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE volatile v;                                                           \
 };                                                                             \
@@ -74,7 +74,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
     return prev;                                                               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                  \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
@@ -88,26 +88,29 @@ static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
                                 /* protected variables: */ &ptr->v);           \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
 
 /* int */
-MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int)
 /* int32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
 /* uint32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
 /* int64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
 /* uint64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
 /* void * */
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
-
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
 static inline void MPL_atomic_write_barrier(void)
 {
     __sync_synchronize();

--- a/src/mpl/include/mpl_atomic_none.h
+++ b/src/mpl/include/mpl_atomic_none.h
@@ -9,19 +9,19 @@
 
 #include <stdint.h>
 
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_PTR_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
 
 /* The following implementation assumes that loads/stores are atomic on the
  * current platform, even though this may not be true at all. */
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                                \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)                               \
 struct MPL_atomic_ ## NAME ## _t {                                             \
     TYPE v;                                                                    \
 };                                                                             \
@@ -61,7 +61,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
     return prev;                                                               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                   \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)                                  \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
 {                                                                              \
@@ -77,26 +77,29 @@ static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
     return prev;                                                               \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME)
 
 /* int */
-MPL_ATOMIC_DECL_FUNC_VAL(int, int)
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int)
 /* int32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32)
 /* uint32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32)
 /* int64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64)
 /* uint64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64)
 /* void * */
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr)
-
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr)
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
 /* Null barriers */
 static inline void MPL_atomic_write_barrier(void)
 {

--- a/src/mpl/include/mpl_atomic_nt_intrinsics.h
+++ b/src/mpl/include/mpl_atomic_nt_intrinsics.h
@@ -11,19 +11,19 @@
 #include <windows.h>
 #include <intrin.h>
 
-#define MPL_ATOMIC_INITIALIZER(val_) { (val_) }
+#define MPLI_ATOMIC_INITIALIZER(val_) { (val_) }
 
-#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPL_ATOMIC_INITIALIZER(val_)
-#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPL_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT_T_INITIALIZER(val_)    MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT32_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT32_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_INT64_T_INITIALIZER(val_)  MPLI_ATOMIC_INITIALIZER(val_)
+#define MPL_ATOMIC_UINT64_T_INITIALIZER(val_) MPLI_ATOMIC_INITIALIZER(val_)
 #if MPL_SIZEOF_VOID_P == 4
 #define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
-        MPL_ATOMIC_INITIALIZER((long)(val_))
+        MPLI_ATOMIC_INITIALIZER((long)(val_))
 #elif MPL_SIZEOF_VOID_P == 8
 #define MPL_ATOMIC_PTR_T_INITIALIZER(val_) \
-        MPL_ATOMIC_INITIALIZER((__int64)(val_))
+        MPLI_ATOMIC_INITIALIZER((__int64)(val_))
 #else
 #error "MPL_SIZEOF_VOID_P not valid"
 #endif
@@ -40,8 +40,8 @@
  * Someone with more Windows expertise should feel free to improve these.
  */
 
-#define MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC, \
-                                    CAST_TO_ATOMIC, SUFFIX)                    \
+#define MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,\
+                                     CAST_TO_ATOMIC, SUFFIX)                   \
 struct MPL_atomic_ ## NAME ## _t {                                             \
     ATOMIC_TYPE volatile v;                                                    \
 };                                                                             \
@@ -83,7 +83,7 @@ static inline TYPE MPL_atomic_swap_ ## NAME                                    \
                              CAST_TO_ATOMIC(val)));                            \
 }
 
-#define MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,    \
+#define MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, CAST_FROM_ATOMIC,   \
                                  CAST_TO_ATOMIC, SUFFIX)                       \
 static inline TYPE MPL_atomic_fetch_add_ ## NAME                               \
                             (struct MPL_atomic_ ## NAME ## _t * ptr, TYPE val) \
@@ -98,45 +98,50 @@ static inline TYPE MPL_atomic_fetch_sub_ ## NAME                               \
                              (&ptr->v, -CAST_TO_ATOMIC(val)));                 \
 }
 
-#define MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE)      (TYPE)
-#define MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE) (ATOMIC_TYPE)
-#define MPL_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE)      (TYPE)(LONG_PTR)
-#define MPL_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE) (ATOMIC_TYPE)(LONG_PTR)
+#define MPLI_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE)      (TYPE)
+#define MPLI_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE) (ATOMIC_TYPE)
+#define MPLI_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE)      (TYPE)(LONG_PTR)
+#define MPLI_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE) (ATOMIC_TYPE)(LONG_PTR)
 
-#define MPL_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
-                                    MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
-                                    MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE),\
-                                    SUFFIX) \
-        MPL_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, \
-                                 MPL_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
-                                 MPL_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE), \
-                                 SUFFIX) \
+#define MPLI_ATOMIC_DECL_FUNC_VAL(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
+            MPLI_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
+            MPLI_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE), SUFFIX) \
+        MPLI_ATOMIC_DECL_FUNC_FAA(TYPE, NAME, ATOMIC_TYPE, \
+            MPLI_ATOMIC_CAST_FROM_ATOMIC_VAL(TYPE), \
+            MPLI_ATOMIC_CAST_TO_ATOMIC_VAL(ATOMIC_TYPE), SUFFIX)
 
-#define MPL_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
-        MPL_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
-                                    MPL_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE), \
-                                    MPL_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE),\
-                                    SUFFIX)
+#define MPLI_ATOMIC_DECL_FUNC_PTR(TYPE, NAME, ATOMIC_TYPE, SUFFIX) \
+        MPLI_ATOMIC_DECL_FUNC_COMMON(TYPE, NAME, ATOMIC_TYPE, \
+            MPLI_ATOMIC_CAST_FROM_ATOMIC_PTR(TYPE), \
+            MPLI_ATOMIC_CAST_TO_ATOMIC_PTR(ATOMIC_TYPE), SUFFIX)
 
 /* int */
-MPL_ATOMIC_DECL_FUNC_VAL(int, int, long, /*empty */)
+MPLI_ATOMIC_DECL_FUNC_VAL(int, int, long, /* empty */)
 /* int32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int32_t, int32, long, /*empty */)
+MPLI_ATOMIC_DECL_FUNC_VAL(int32_t, int32, long, /* empty */)
 /* uint32_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, long, /*empty */)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint32_t, uint32, long, /* empty */)
 /* int64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(int64_t, int64, __int64, 64)
+MPLI_ATOMIC_DECL_FUNC_VAL(int64_t, int64, __int64, 64)
 /* uint64_t */
-MPL_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, __int64, 64)
+MPLI_ATOMIC_DECL_FUNC_VAL(uint64_t, uint64, __int64, 64)
 /* void * */
 #if MPL_SIZEOF_VOID_P == 4
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, long, /* empty */)
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr, long, /* empty */)
 #elif MPL_SIZEOF_VOID_P == 8
-MPL_ATOMIC_DECL_FUNC_PTR(void *, ptr, __int64, 64)
+MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr, __int64, 64)
 #else
 #error "MPL_SIZEOF_VOID_P not valid"
 #endif
+#undef MPLI_ATOMIC_DECL_FUNC_COMMON
+#undef MPLI_ATOMIC_DECL_FUNC_FAA
+#undef MPLI_ATOMIC_CAST_FROM_ATOMIC_VAL
+#undef MPLI_ATOMIC_CAST_TO_ATOMIC_VAL
+#undef MPLI_ATOMIC_CAST_FROM_ATOMIC_PTR
+#undef MPLI_ATOMIC_CAST_TO_ATOMIC_PTR
+#undef MPLI_ATOMIC_DECL_FUNC_VAL
+#undef MPLI_ATOMIC_DECL_FUNC_PTR
 /* Barriers */
 static inline void MPL_atomic_write_barrier(void)
 {

--- a/src/mpl/src/atomic/mpl_atomic.c
+++ b/src/mpl/src/atomic/mpl_atomic.c
@@ -14,6 +14,6 @@
 #ifdef MPL_HAVE_PTHREAD_H
 #include <pthread.h>
 
-pthread_mutex_t MPL_emulation_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t MPLI_emulation_lock = PTHREAD_MUTEX_INITIALIZER;
 
 #endif /* MPL_HAVE_PTHREAD_H */


### PR DESCRIPTION
## Pull Request Description

The MPL/atomic headers did not follow the namespace convention of MPICH. This PR fixes it without changing the logic.

Specifically, this PR does the following:
- Rename `MPL_emulation_lock` to `MPLI_emulation_lock` since this is used only in the MPL/atomics module.
- Rename `MPL_ATOMIC_INITIALIZER` to `MPLI_ATOMIC_INITIALIZER` since this should not be directly used by users but needs to be exposed.
- Remove a suffix, `MPL_`, from local MPL macros such as `MPL_ATOMIC_DELC_XXX` macros (which become `ATOMIC_DELC_XXX`) and undefine them after they are used.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This is just a clean-up.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
