### PR TITLE
misc: fix miscellenous breakages from nightly tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5039,14 +5039,6 @@ dnl PAC_SUBDIR_CACHE_CLEANUP
 # FIXME does the makefile actually need this?
 subsystems="$devsubsystems $subsystems $bindingsubsystems"
 
-# SIZEOF_MPL_ATOMIC_PTR_T is needed by ch3:nemesis. Only works after the MPL
-# configuration is done.
-AC_CHECK_SIZEOF(MPL_atomic_ptr_t,0,[
-#include <pthread.h>
-#include "${master_top_srcdir}/src/mpl/include/mpl_atomic.h"
-pthread_mutex_t *MPL_atomic_emulation_lock;
-])
-
 if test "$enable_f77" != "yes" ; then
     # These are Fortran datatypes ONLY.  Set to null if no Fortran compiler.
     for name in CHARACTER INTEGER REAL LOGICAL COMPLEX DOUBLE_PRECISION \

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -174,11 +174,10 @@ typedef struct MPID_nem_cell_rel_ptr
 }
 MPID_nem_cell_rel_ptr_t;
 
-/* MPID_nem_cell and MPID_nem_abs_cell must be kept in sync so that we
- * can cast between them.  MPID_nem_abs_cell should only be used when
- * a cell is enqueued on a queue local to a single process (e.g., a
- * queue in a network module) where relative pointers are not
- * needed. */
+/* NOTE: for a queue local to a single process (e.g. a queue in a network module),
+ * relative pointers are not needed, and we could use a direct pointer. This
+ * optimization is left as todo when needed.
+ */
 
 typedef struct MPID_nem_cell
 {
@@ -189,16 +188,6 @@ typedef struct MPID_nem_cell
     volatile MPID_nem_pkt_t pkt;
 } MPID_nem_cell_t;
 typedef MPID_nem_cell_t *MPID_nem_cell_ptr_t;
-
-typedef struct MPID_nem_abs_cell
-{
-    struct MPID_nem_abs_cell *next;
-#if (MPID_NEM_CELL_HEAD_LEN > SIZEOF_VOID_P)
-    char padding[MPID_NEM_CELL_HEAD_LEN - sizeof(struct MPID_nem_abs_cell*)];
-#endif
-    volatile MPID_nem_pkt_t pkt;
-} MPID_nem_abs_cell_t;
-typedef MPID_nem_abs_cell_t *MPID_nem_abs_cell_ptr_t;
 
 #define MPID_NEM_CELL_TO_PACKET(cellp) (&(cellp)->pkt)
 #define MPID_NEM_PACKET_TO_CELL(packetp) \

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -145,10 +145,7 @@ typedef struct MPID_nem_pkt_header
 typedef struct MPID_nem_pkt
 {
     MPID_nem_pkt_header_t header;
-    union {
-        char payload[MPID_NEM_MPICH_DATA_LEN];
-        double dummy; /* align paylod to double */
-    } p;
+    char payload[] MPL_ATTR_ALIGNED(8);   /* C99 flexible array member with 8-byte alignment */
 } MPID_nem_pkt_t;
 
 /* Nemesis cells which are to be used in shared memory need to use
@@ -182,7 +179,7 @@ typedef MPID_nem_cell_t *MPID_nem_cell_ptr_t;
 #define MPID_NEM_PACKET_TO_CELL(packetp) \
     ((MPID_nem_cell_ptr_t) ((char*)(packetp) - (char *)MPID_NEM_CELL_TO_PACKET((MPID_nem_cell_ptr_t)0)))
 #define MPID_NEM_MIN_PACKET_LEN (sizeof (MPID_nem_pkt_header_t))
-#define MPID_NEM_MAX_PACKET_LEN (sizeof (MPID_nem_pkt_t))
+#define MPID_NEM_MAX_PACKET_LEN (MPID_NEM_CELL_PAYLOAD_LEN)
 #define MPID_NEM_PACKET_LEN(pkt) ((pkt)->header.datalen + MPID_NEM_MPICH_HEAD_LEN)
 
 #define MPID_NEM_OPT_LOAD     16 
@@ -191,8 +188,6 @@ typedef MPID_nem_cell_t *MPID_nem_cell_ptr_t;
 
 #define MPID_NEM_PACKET_OPT_LEN(pkt) \
     (((pkt)->header.datalen < MPID_NEM_OPT_SIZE) ? (MPID_NEM_OPT_HEAD_LEN) : (MPID_NEM_PACKET_LEN(pkt)))
-
-#define MPID_NEM_PACKET_PAYLOAD(pkt) ((pkt)->header.payload)
 
 typedef struct MPID_nem_queue
 {
@@ -224,6 +219,7 @@ typedef struct MPID_nem_fbox_mpich
     MPID_nem_cell_t cell;
 } MPID_nem_fbox_mpich_t;
 
+#define MPID_NEM_FBOX_LEN     (MPID_NEM_CELL_LEN + offsetof(MPID_nem_fbox_mpich_t, cell))
 #define MPID_NEM_FBOX_DATALEN MPID_NEM_MPICH_DATA_LEN
 
 typedef union 

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_datatypes.h
@@ -84,31 +84,6 @@
    MPID_NEM_CALC_CELL_LEN is the amount of data plus headers in the
        cell.  I.e., how much of a cell would need to be sent over a
        network.
-
-   FIXME: Simplify this maddness!  Maybe something like this:
-
-       typedef struct mpich_pkt {
-           header_field1;
-           header_field2;
-           payload[1];
-       } mpich_pkt_t;
-   
-       typedef struct cell {
-           *next;
-           padding;
-           pkt;
-       } cell_t;
-
-       typedef union cell_container {
-           cell_t cell;
-           char padding[MPID_NEM_CELL_LEN];
-       } cell_container_t;
-
-       #define MPID_NEM_MPICH_DATA_LEN (sizeof(cell_container_t) - sizeof(cell_t) + 1)
-
-   The packet payload can overflow the array in the packet struct up
-   to MPID_NEM_MPICH_DATA_LEN bytes.
-   
 */
 
 #define MPID_NEM_CELL_HEAD_LEN    offsetof(MPID_nem_cell_t, pkt)

--- a/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpid_nem_inline.h
@@ -124,7 +124,7 @@ MPID_nem_mpich_send_header (void* buf, int size, MPIDI_VC_t *vc, int *again)
         
         MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
         
-        MPIR_Memcpy((void *)pbox->cell.pkt.p.payload, buf, size);
+        MPIR_Memcpy((void *)pbox->cell.pkt.payload, buf, size);
 
         MPL_atomic_release_store_int(&pbox->flag.value, 1);
 
@@ -170,7 +170,7 @@ MPID_nem_mpich_send_header (void* buf, int size, MPIDI_VC_t *vc, int *again)
     el->pkt.header.seqno   = vc_ch->send_seqno++;
     MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, el->pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
     
-    MPIR_Memcpy((void *)el->pkt.p.payload, buf, size);
+    MPIR_Memcpy((void *)el->pkt.payload, buf, size);
     DO_PAPI (PAPI_accum_var (PAPI_EventSet, PAPI_vvalues11));
 
     MPL_DBG_MSG (MPIDI_CH3_DBG_CHANNEL, VERBOSE, "--> Sent queue");
@@ -260,7 +260,7 @@ MPID_nem_mpich_sendv (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *again)
 #endif /*PREFETCH_CELL     */
 
     payload_len = MPID_NEM_MPICH_DATA_LEN;
-    cell_buf    = (char *) el->pkt.p.payload; /* cast away volatile */
+    cell_buf    = (char *) el->pkt.payload; /* cast away volatile */
     
     while (*n_iov && payload_len >= (*iov)->MPL_IOV_LEN)
     {
@@ -348,8 +348,8 @@ MPID_nem_mpich_sendv_header (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *aga
         pbox->cell.pkt.header.seqno   = vc_ch->send_seqno++;
         MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
         
-        MPIR_Memcpy((void *)pbox->cell.pkt.p.payload, (*iov)[0].MPL_IOV_BUF, (*iov)[0].MPL_IOV_LEN);
-        MPIR_Memcpy ((char *)pbox->cell.pkt.p.payload + (*iov)[0].MPL_IOV_LEN, (*iov)[1].MPL_IOV_BUF, (*iov)[1].MPL_IOV_LEN);
+        MPIR_Memcpy((void *)pbox->cell.pkt.payload, (*iov)[0].MPL_IOV_BUF, (*iov)[0].MPL_IOV_LEN);
+        MPIR_Memcpy ((char *)pbox->cell.pkt.payload + (*iov)[0].MPL_IOV_LEN, (*iov)[1].MPL_IOV_BUF, (*iov)[1].MPL_IOV_LEN);
         
         MPL_atomic_release_store_int(&pbox->flag.value, 1);
         *n_iov = 0;
@@ -387,10 +387,10 @@ MPID_nem_mpich_sendv_header (MPL_IOV **iov, int *n_iov, MPIDI_VC_t *vc, int *aga
     MPID_nem_queue_dequeue (MPID_nem_mem_region.my_freeQ, &el);
 #endif /*PREFETCH_CELL */
 
-    MPIR_Memcpy((void *)el->pkt.p.payload, (*iov)->MPL_IOV_BUF, sizeof(MPIDI_CH3_Pkt_t));
+    MPIR_Memcpy((void *)el->pkt.payload, (*iov)->MPL_IOV_BUF, sizeof(MPIDI_CH3_Pkt_t));
     buf_offset += sizeof(MPIDI_CH3_Pkt_t);
 
-    cell_buf = (char *)(el->pkt.p.payload) + buf_offset;
+    cell_buf = (char *)(el->pkt.payload) + buf_offset;
     ++(*iov);
     --(*n_iov);
 
@@ -506,12 +506,12 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
             MPL_DBG_STMT (MPIDI_CH3_DBG_CHANNEL, VERBOSE, pbox->cell.pkt.header.type = MPID_NEM_PKT_MPICH_HEAD);
 
             /* copy header */
-            MPIR_Memcpy((void *)pbox->cell.pkt.p.payload, header, header_sz);
+            MPIR_Memcpy((void *)pbox->cell.pkt.payload, header, header_sz);
             
             /* copy data */
             MPI_Aint actual_pack_bytes;
             MPIR_Typerep_pack(buf, count, datatype, *msg_offset,
-                           (char *)pbox->cell.pkt.p.payload + sizeof(MPIDI_CH3_Pkt_t),
+                           (char *)pbox->cell.pkt.payload + sizeof(MPIDI_CH3_Pkt_t),
                            msgsize - *msg_offset, &actual_pack_bytes);
             MPIR_Assert(actual_pack_bytes == msgsize - *msg_offset);
 
@@ -554,7 +554,7 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
 #endif /*PREFETCH_CELL */
 
     /* copy header */
-    MPIR_Memcpy((void *)el->pkt.p.payload, header, header_sz);
+    MPIR_Memcpy((void *)el->pkt.payload, header, header_sz);
     
     buf_offset += sizeof(MPIDI_CH3_Pkt_t);
 
@@ -566,7 +566,7 @@ MPID_nem_mpich_send_seg_header (void *buf, MPI_Aint count, MPI_Datatype datatype
         max_pack_bytes = MPID_NEM_MPICH_DATA_LEN - buf_offset;
 
     MPI_Aint actual_pack_bytes;
-    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.p.payload + buf_offset,
+    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.payload + buf_offset,
                    max_pack_bytes, &actual_pack_bytes);
     datalen = buf_offset + actual_pack_bytes;
     *msg_offset += actual_pack_bytes;
@@ -652,7 +652,7 @@ MPID_nem_mpich_send_seg (void *buf, MPI_Aint count, MPI_Datatype datatype,
         max_pack_bytes = MPID_NEM_MPICH_DATA_LEN;
 
     MPI_Aint actual_pack_bytes;
-    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.p.payload,
+    MPIR_Typerep_pack(buf, count, datatype, *msg_offset, (char *)el->pkt.payload,
                    max_pack_bytes, &actual_pack_bytes);
     datalen = actual_pack_bytes;
     *msg_offset += actual_pack_bytes;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -370,7 +370,7 @@ int MPIDI_CH3I_Progress (MPID_Progress_state *progress_state, int is_blocking)
 
             if (cell)
             {
-                char            *cell_buf    = (char *)cell->pkt.p.payload;
+                char            *cell_buf    = (char *)cell->pkt.payload;
                 intptr_t   payload_len = cell->pkt.header.datalen;
                 MPIDI_CH3_Pkt_t *pkt         = (MPIDI_CH3_Pkt_t *)cell_buf;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -142,6 +142,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPIR_Assert(MPID_NEM_CELL_PAYLOAD_LEN + MPID_NEM_CELL_HEAD_LEN == sizeof(MPID_nem_cell_t));
     /* Make sure payload is aligned on a double */
     MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->pkt.p.payload[0], sizeof(double)));
+    /* Make sure the padding to cacheline size in MPID_nem_queue_t works */
+    MPIR_Assert(MPID_NEM_CACHE_LINE_LEN > 2 * sizeof(MPID_nem_cell_rel_ptr_t));
 
     /* Initialize the business card */
     mpi_errno = MPIDI_CH3I_BCInit( &bc_val, &val_max_remaining );

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -116,8 +116,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     int    val_max_remaining;
     int    grank;
     size_t len;
-    MPID_nem_fastbox_t *fastboxes_p = NULL;
-    MPID_nem_cell_t (*cells_p)[MPID_NEM_NUM_CELLS];
+    void *fastboxes_p = NULL;
+    void *cells_p = NULL;
     MPID_nem_queue_t *recv_queues_p = NULL;
     MPID_nem_queue_t *free_queues_p = NULL;
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
@@ -138,10 +138,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
        pointers. */
     MPIR_Assert(sizeof(MPID_nem_cell_rel_ptr_t) == sizeof(MPL_atomic_ptr_t));
 
-    /* Make sure the cell structure looks like it should */
-    MPIR_Assert(MPID_NEM_CELL_PAYLOAD_LEN + MPID_NEM_CELL_HEAD_LEN == sizeof(MPID_nem_cell_t));
-    /* Make sure payload is aligned on a double */
-    MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->pkt.p.payload[0], sizeof(double)));
+    /* Make sure payload is aligned on 8-byte boundary */
+    MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->pkt.payload[0], 8));
     /* Make sure the padding to cacheline size in MPID_nem_queue_t works */
     MPIR_Assert(MPID_NEM_CACHE_LINE_LEN > 2 * sizeof(MPID_nem_cell_rel_ptr_t));
 
@@ -237,11 +235,11 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Request fastboxes region */
-    size_t fbox_len = MPL_MAX((num_local*((num_local-1)*sizeof(MPID_nem_fastbox_t))),
+    size_t fbox_len = MPL_MAX((num_local*((num_local-1) * MPID_NEM_FBOX_LEN)),
                               MPID_NEM_ASYMM_NULL_VAL);
 
     /* Request data cells region */
-    size_t cells_len = num_local * MPID_NEM_NUM_CELLS * sizeof(MPID_nem_cell_t);
+    size_t cells_len = num_local * MPID_NEM_NUM_CELLS * MPID_NEM_CELL_LEN;
 
     /* Request free q region */
     size_t freeQ_len = num_local * sizeof(MPID_nem_queue_t);
@@ -265,8 +263,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);
 
-    fastboxes_p = (MPID_nem_fastbox_t *) MPID_nem_mem_region.shm_ptr;
-    cells_p = (MPID_nem_cell_t (*)[MPID_NEM_NUM_CELLS])((char *) fastboxes_p + fbox_len);
+    fastboxes_p = (void *) MPID_nem_mem_region.shm_ptr;
+    cells_p = (char *) fastboxes_p + fbox_len;
     free_queues_p = (MPID_nem_queue_t *)((char *) cells_p + cells_len);
     recv_queues_p = (MPID_nem_queue_t *)((char *) free_queues_p + freeQ_len);
 
@@ -275,7 +273,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);
 
     /* find our cell region */
-    MPID_nem_mem_region.Elements = cells_p[local_rank];
+    MPID_nem_mem_region.Elements = (void *) ((char *) cells_p + local_rank * MPID_NEM_NUM_CELLS * MPID_NEM_CELL_LEN);
 
     /* Tables of pointers to shared memory Qs */
     MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.FreeQ, MPID_nem_queue_ptr_t *, num_procs * sizeof(MPID_nem_queue_ptr_t), mpi_errno, "FreeQ", MPL_MEM_SHM);
@@ -292,8 +290,9 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     /* Init and enqueue our free cells */
     for (idx = 0; idx < MPID_NEM_NUM_CELLS; ++idx)
     {
-	MPID_nem_cell_init(&(MPID_nem_mem_region.Elements[idx]));
-	MPID_nem_queue_enqueue(MPID_nem_mem_region.FreeQ[pg_rank], &(MPID_nem_mem_region.Elements[idx]));
+        MPID_nem_cell_t *cell = (void *) ((char *) MPID_nem_mem_region.Elements + idx * MPID_NEM_CELL_LEN);
+        MPID_nem_cell_init(cell);
+        MPID_nem_queue_enqueue(MPID_nem_mem_region.FreeQ[pg_rank], cell);
     }
 
     mpi_errno = MPID_nem_coll_init();
@@ -370,8 +369,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 	}
 	else
 	{
-	    MPID_nem_mem_region.mailboxes.in [i] = &fastboxes_p[MAILBOX_INDEX(i, local_rank)];
-	    MPID_nem_mem_region.mailboxes.out[i] = &fastboxes_p[MAILBOX_INDEX(local_rank, i)];
+	    MPID_nem_mem_region.mailboxes.in [i] = (void *) ((char *) fastboxes_p + (MAILBOX_INDEX(i, local_rank)) * MPID_NEM_FBOX_LEN);
+	    MPID_nem_mem_region.mailboxes.out[i] = (void *) ((char *) fastboxes_p + (MAILBOX_INDEX(local_rank, i)) * MPID_NEM_FBOX_LEN);
 	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.in [i]->common.flag.value, 0);
 	    MPL_atomic_relaxed_store_int(&MPID_nem_mem_region.mailboxes.out[i]->common.flag.value, 0);
 	}

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -140,7 +140,6 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     /* Make sure the cell structure looks like it should */
     MPIR_Assert(MPID_NEM_CELL_PAYLOAD_LEN + MPID_NEM_CELL_HEAD_LEN == sizeof(MPID_nem_cell_t));
-    MPIR_Assert(sizeof(MPID_nem_cell_t) == sizeof(MPID_nem_abs_cell_t));
     /* Make sure payload is aligned on a double */
     MPIR_Assert(MPID_NEM_ALIGNED(&((MPID_nem_cell_t*)0)->pkt.p.payload[0], sizeof(double)));
 

--- a/src/mpid/ch3/channels/sock/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/sock/src/ch3_progress.c
@@ -149,6 +149,7 @@ static int MPIDI_CH3i_Progress_wait(MPID_Progress_state * progress_state)
         }
 
         if (MPIR_IS_THREADED) {
+#if MPICH_IS_THREADED
             if (MPIDI_CH3I_progress_blocked == TRUE) {
                 /*
                  * Another thread is already blocking in the progress engine.
@@ -170,6 +171,7 @@ static int MPIDI_CH3i_Progress_wait(MPID_Progress_state * progress_state)
                                              MPIDI_CH3I_SOCK_INFINITE_TIME, &event);
             MPIDI_CH3I_progress_blocked = FALSE;
             MPIDI_CH3I_progress_wakeup_signalled = FALSE;
+#endif
         } else {
             mpi_errno = MPIDI_CH3I_Sock_wait(MPIDI_CH3I_sock_set,
                                              MPIDI_CH3I_SOCK_INFINITE_TIME, &event);

--- a/src/mpid/ch3/channels/sock/src/sock.c
+++ b/src/mpid/ch3/channels/sock/src/sock.c
@@ -3203,6 +3203,7 @@ int MPIDI_CH3I_Sock_wait(struct MPIDI_CH3I_Sock_set *sock_set, int millisecond_t
                 n_fds = poll(sock_set->pollfds, sock_set->poll_array_elems, millisecond_timeout);
                 MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_POLL);
             } else {
+#ifdef MPICH_IS_THREADED
                 /*
                  * First try a non-blocking poll to see if any immediate
                  * progress can be made.  This avoids the lock manipulation
@@ -3258,6 +3259,7 @@ int MPIDI_CH3I_Sock_wait(struct MPIDI_CH3I_Sock_set *sock_set, int millisecond_t
                     sock_set->pollfds_active = NULL;
                     sock_set->wakeup_posted = FALSE;
                 }
+#endif
             }
 
             if (n_fds > 0) {


### PR DESCRIPTION
## Pull Request Description

* fix a type mismatch-warning:
    ch4/ofi: use MPI_Aint in MPIDI_OFI_do_handle_long_am 
* fix a compilation error
    ch3/sock: add macro guard for single-thread build
*  fix the fragile `SIZEOF_MPL_ATOMIC_PTR_T`. 
    MPL atomic by lock changed the type from `MPL_atomic_emulation_lock` to `MPLI_atomic_emulation_lock` and breaks the config test for some compiler. While the fix can be trivial, it exposes again how awkward and fragile it is to use `SIZEOF_MPL_ATOMIC_PTR_T`. I believe it is worth the effort to simplify that away.
    ch3/nemesis: remove MPID_nem_abs_cell_t 
    refactor cell structure to use C99 flexible array member

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
