### PR TITLE
mpl/atomic: fix barrier implementations of lock-based atomic code

### DIFF
--- a/src/mpl/include/mpl_atomic_by_lock.h
+++ b/src/mpl/include/mpl_atomic_by_lock.h
@@ -137,27 +137,31 @@ MPLI_ATOMIC_DECL_FUNC_PTR(void *, ptr)
 #undef MPLI_ATOMIC_DECL_FUNC_FAA
 #undef MPLI_ATOMIC_DECL_FUNC_VAL
 #undef MPLI_ATOMIC_DECL_FUNC_PTR
-#undef MPLI_ATOMIC_CS_ENTER
-#undef MPLI_ATOMIC_CS_EXIT
 /* lock/unlock provides barrier */
 static inline void MPL_atomic_write_barrier(void)
 {
-    ;
+    MPLI_ATOMIC_CS_ENTER();
+    MPLI_ATOMIC_CS_EXIT();
 }
 
 static inline void MPL_atomic_read_barrier(void)
 {
-    ;
+    MPLI_ATOMIC_CS_ENTER();
+    MPLI_ATOMIC_CS_EXIT();
 }
 
 static inline void MPL_atomic_read_write_barrier(void)
 {
-    ;
+    MPLI_ATOMIC_CS_ENTER();
+    MPLI_ATOMIC_CS_EXIT();
 }
 
 static inline void MPL_atomic_compiler_barrier(void)
 {
-    ;
+    __asm__ __volatile__("":::"memory");
 }
+
+#undef MPLI_ATOMIC_CS_ENTER
+#undef MPLI_ATOMIC_CS_EXIT
 
 #endif /* MPL_ATOMIC_BY_LOCK_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

This PR fixes a bug in MPL/atomic in lock-based emulation mode by adding empty lock and unlock to memory barriers.

`__asm__ __volatile__("":::"memory");` is used for the compiler barrier.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

It is necessary for correctness. This fix only applies to the lock-based mode, a fallback mode that is not used on most machines.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
