### PR TITLE
coll: squash warnings by assert log_pofk > 0

### DIFF
--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -291,6 +291,7 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
         pofk *= k;
         log_pofk++;
     }
+    MPIR_Assert(log_pofk > 0);
     pofk /= k;
     log_pofk--;
 


### PR DESCRIPTION
## Pull Request Description

Gcc7 is the most zealous in giving out warning and it warns
-Walloc-size-larger-than= by default. Add MPIR_Assert to help it.

I must have patched this warning mutliple times but it always got neglected and lost. 

## Issue
```
LTCC src/mpi/coll/algorithms/recexchalgo/recexchalgo.lo
In file included from ./src/include/mpiimpl.h:196:0,
                 from src/mpi/coll/algorithms/recexchalgo/recexchalgo.c:11:
src/mpi/coll/algorithms/recexchalgo/recexchalgo.c: In function ‘MPII_Recexchalgo_reverse_digits_step2’:
./src/include/mpir_mem.h:129:18: warning: argument 1 value ‘18446744073709551612’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
         pointer_ = (type_)MPL_malloc(nbytes_,class_);                   \
./src/include/mpir_mem.h:148:5: note: in expansion of macro ‘MPIR_CHKLMEM_MALLOC_ORSTMT’
     MPIR_CHKLMEM_MALLOC_ORSTMT(pointer_,type_,nbytes_,rc_,name_,class_,goto fn_fail)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
./src/include/mpir_mem.h:146:5: note: in expansion of macro ‘MPIR_CHKLMEM_MALLOC_ORJUMP’
     MPIR_CHKLMEM_MALLOC_ORJUMP(pointer_,type_,nbytes_,rc_,name_,class_)
     ^~~~~~~~~~~~~~~~~~~~~~~~~~
src/mpi/coll/algorithms/recexchalgo/recexchalgo.c:304:5: note: in expansion of macro ‘MPIR_CHKLMEM_MALLOC’
     MPIR_CHKLMEM_MALLOC(digit, int *, sizeof(int) * log_pofk,
     ^~~~~~~~~~~~~~~~~~~
In file included from ./src/include/mpiimpl.h:31:0,
                 from src/mpi/coll/algorithms/recexchalgo/recexchalgo.c:11:
/usr/include/stdlib.h:539:14: note: in a call to allocation function ‘malloc’ declared here
 extern void *malloc (size_t __size) __THROW __attribute_malloc__ __wur;
              ^~~~~~
```

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
