### PR TITLE
test/mpi/threads: fix mt_probe tests

### DIFF
--- a/test/mpi/threads/pt2pt/mt_probe_impl.c
+++ b/test/mpi/threads/pt2pt/mt_probe_impl.c
@@ -295,7 +295,14 @@ MTEST_THREAD_RETURN_TYPE run_test(void *arg)
 #else
     MTestPrintfMsg(2, "Testing probe_normal\n");
     p->result = test_probe_normal(p->id, p->iter, p->count, p->buff, p->comm, p->tag, p->verify);
-    MPI_Barrier(p->comm);
+
+    /* Barrier across threads. */
+    MTest_thread_barrier(NTHREADS);
+    if (p->id == 0) {
+        MPI_Barrier(p->comm);
+    }
+    MTest_thread_barrier(NTHREADS);
+
     MTestPrintfMsg(2, "Testing probe_nullproc\n");
     p->result += test_probe_nullproc(p->id, p->iter, p->count, p->buff, p->comm, p->tag, p->verify);
 #endif


### PR DESCRIPTION
## Pull Request Description

In mt_probe tests, `MPI_Barrier(MPI_COMM_WORLD)` (=` MPI_Barrier(p->comm)`) is called by all the threads while only one thread per process can call it.  This patch fixes it.

Fixes issue #4408 
Reference PR #4405
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This PR should potentially fix the following tests:
```
pt2pt/mt_probe_isendrecv
pt2pt/mt_probe_sendrecv
pt2pt/mt_iprobe_isendrecv
pt2pt/mt_iprobe_sendrecv
pt2pt/mt_mprobe_isendrecv
pt2pt/mt_mprobe_sendrecv
pt2pt/mt_mprobe_sendirecv
pt2pt/mt_improbe_isendrecv
pt2pt/mt_improbe_sendrecv
```

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
