### PR TITLE
Fix Argobots support

### DIFF
--- a/src/include/mpitimpl.h
+++ b/src/include/mpitimpl.h
@@ -1192,6 +1192,8 @@ extern MPID_Thread_mutex_t mpi_t_mutex;
     do { \
         int err_; \
         MPIR_T_THREAD_CHECK_BEGIN \
+        MPID_Thread_init(&err_); \
+        MPIR_Assert(err_ == 0); \
         MPID_Thread_mutex_create(&mpi_t_mutex, &err_); \
         MPIR_Assert(err_ == 0); \
         MPIR_T_THREAD_CHECK_END \
@@ -1202,6 +1204,8 @@ extern MPID_Thread_mutex_t mpi_t_mutex;
         int err_; \
         MPIR_T_THREAD_CHECK_BEGIN \
         MPID_Thread_mutex_destroy(&mpi_t_mutex, &err_); \
+        MPIR_Assert(err_ == 0); \
+        MPID_Thread_finalize(&err_); \
         MPIR_Assert(err_ == 0); \
         MPIR_T_THREAD_CHECK_END \
     } while (0)

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -25,6 +25,9 @@ typedef ABT_key MPL_thread_tls_key_t;
  *    Creation and misc
  * ======================================================================*/
 
+/* MPL_thread_init()/MPL_thread_finalize() can be called in a nested manner
+ * (e.g., MPI_T_init_thread() and MPI_Init_thread()), but Argobots internally
+ * maintains a counter so it is okay. */
 #define MPL_thread_init(err_ptr_)                                             \
     do {                                                                      \
         int err__;                                                            \

--- a/src/mpl/include/mpl_thread_argobots.h
+++ b/src/mpl/include/mpl_thread_argobots.h
@@ -18,7 +18,7 @@
 
 typedef ABT_mutex MPL_thread_mutex_t;
 typedef ABT_cond MPL_thread_cond_t;
-typedef ABT_thread_id MPL_thread_id_t;
+typedef ABT_thread MPL_thread_id_t;
 typedef ABT_key MPL_thread_tls_key_t;
 
 /* ======================================================================
@@ -50,9 +50,9 @@ typedef void (*MPL_thread_func_t) (void *data);
 void MPL_thread_create(MPL_thread_func_t func, void *data, MPL_thread_id_t * idp, int *errp);
 
 #define MPL_thread_exit()
-#define MPL_thread_self(id_) ABT_thread_self_id(id_)
-#define MPL_thread_join(id_) ABT_thread_join(id_)
-#define MPL_thread_same(id1_, id2_, same_)  ABT_thread_equal(id1_, id2_, same_)
+#define MPL_thread_self(idp_) ABT_thread_self(idp_)
+#define MPL_thread_join(idp_) ABT_thread_free(idp_)
+#define MPL_thread_same(idp1_, idp2_, same_)  ABT_thread_equal(*idp1_, *idp2_, same_)
 
 /* ======================================================================
  *    Scheduling

--- a/test/mpi/threads/comm/idup_deadlock.c
+++ b/test/mpi/threads/comm/idup_deadlock.c
@@ -41,6 +41,7 @@ MTEST_THREAD_RETURN_TYPE test_comm_dup(void *arg)
             wait = 0;
             for (i = 0; i < NUM_THREADS; i++)
                 wait += start_idup[i];
+            MTest_thread_yield();
         } while (wait > NUM_THREADS / 2);
     }
 

--- a/test/mpi/threads/spawn/th_taskmaster.c
+++ b/test/mpi/threads/spawn/th_taskmaster.c
@@ -101,6 +101,10 @@ int main(int argc, char *argv[])
 #endif /* USE_THREADS */
 
 #ifdef USE_THREADS
+        /* Initialize the thread package. It should not be initialized via
+         * MTest_Init_thread since MTest_Finalize cannot be called. */
+        MTest_init_thread_pkg();
+
         /* We need different communicators per thread */
         for (i = 0; i < DEFAULT_TASK_WINDOW; i++)
             CHECK_SUCCESS(MPI_Comm_dup(MPI_COMM_WORLD, &th_comms[i]));
@@ -117,6 +121,9 @@ int main(int argc, char *argv[])
 
         for (i = 0; i < DEFAULT_TASK_WINDOW; i++)
             CHECK_SUCCESS(MPI_Comm_free(&th_comms[i]));
+
+        /* Release the thread package. */
+        MTest_finalize_thread_pkg();
 #else
         /* Directly spawn a child process to perform each task */
         for (i = 0; i < tasks;) {
@@ -141,6 +148,8 @@ int main(int argc, char *argv[])
     }
 
   fn_exit:
+    /* Do not call MTest_Finalize (and thus MTest_Init) to avoid printing extra
+     * "No Errors" as many as spawned MPI processes. */
     MPI_Finalize();
 
     return 0;

--- a/test/mpi/util/mtest_thread_abt.h
+++ b/test/mpi/util/mtest_thread_abt.h
@@ -111,6 +111,14 @@ int MTest_thread_lock_free(MTEST_THREAD_LOCK_TYPE * lock)
     return 0;
 }
 
+int MTest_thread_yield(void)
+{
+    int ret;
+    ret = ABT_thread_yield();
+    MTEST_ABT_ERROR(ret, "ABT_thread_yield");
+    return 0;
+}
+
 /* -------------------------------------------- */
 #define HAVE_MTEST_THREAD_BARRIER 1
 

--- a/test/mpi/util/mtest_thread_pthread.h
+++ b/test/mpi/util/mtest_thread_pthread.h
@@ -80,6 +80,11 @@ int MTest_thread_lock_free(MTEST_THREAD_LOCK_TYPE * lock)
     return err;
 }
 
+int MTest_thread_yield(void)
+{
+    return 0;
+}
+
 /*----------------------------------------------------------------*/
 #if defined(HAVE_PTHREAD_BARRIER_INIT)
 

--- a/test/mpi/util/mtest_thread_win.h
+++ b/test/mpi/util/mtest_thread_win.h
@@ -90,3 +90,8 @@ int MTest_thread_lock_free(MTEST_THREAD_LOCK_TYPE * lock)
     }
     return MTestReturnValue(errs);
 }
+
+int MTest_thread_yield(void)
+{
+    return 0;
+}


### PR DESCRIPTION
## Pull Request Description

This PR fixes Argobots support.

1. Fix `mpl/include/mpl_thread_argobots.h`
This change will not affect the default Pthreads behavior.

2. Call `MPID_Thread_init()` in `MPI_T_init_thread()`
Any `MPID_Thread_` operations should be called after `MPID_Thread_init()`. This will not affect the default Pthreads behavior since the Pthreads version does nothing in `MPID_Thread_init()`.
   - Note `MPI_T_init_thread()` can be called before `MPI_Init_thread()`, so `MPI_T_init_thread()` needs its own `MPID_Thread_init()`.

3. Add `yield()` to a busy loop in `test/mpi/threads/comm/idup_deadlock`
Nonpreemptive threads (e.g., Argobots threads) can cause a deadlock if there is a busy loop. This PR adds a new yield function (`MTest_thread_yield()`) and inserts it into a busy loop in `test/mpi/threads/comm/idup_deadlock`.
This will not affect the default Pthreads behavior since the Pthreads version does nothing in `MTest_thread_yield()`.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

### Note

Regarding `3. MTest_thread_yield()`, there are many options.
1. Add yield
  1.a. [What this PR does] Add `MTest_thread_yield()`, which calls `yield()` only when the underlying thread is nonpreemptive.
  1.b. Add `MTest_thread_scheduling_point()` (instead of `MTest_thread_yield()`). The functionality is the same as that of 1.a.
  1.c. Add `MTest_thread_yield()`, which calls `yield()` even with Pthreads (e.g., `pthread_yield()`).
2. Add another synchronization method that has a scheduling point when the underlying thread is nonpreemptive (e.g., `MTest_thread_lock()`).

## Expected Impact

No performance difference for the default Pthreads version.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
        Fixes #4422.
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
