### PR TITLE
ch4/ofi: use unpack buffer to accelerate am-lmt transfer

### DIFF
--- a/src/mpid/ch4/generic/am/mpidig_am_msg.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_msg.h
@@ -67,6 +67,22 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_get_recv_data(int *is_contig, void **p_data
     }
 }
 
+/* Sometime the transport just need info to make algorithm choice */
+MPL_STATIC_INLINE_PREFIX int MPIDIG_get_recv_iov_count(MPIR_Request * rreq)
+{
+    MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async));
+    if (p->recv_type == MPIDIG_RECV_DATATYPE) {
+        MPI_Aint num_iov;
+        MPIR_Typerep_iov_len(MPIDIG_REQUEST(rreq, count), MPIDIG_REQUEST(rreq, datatype),
+                             p->in_data_sz, &num_iov);
+        return num_iov;
+    } else if (p->recv_type == MPIDIG_RECV_CONTIG) {
+        return 1;
+    } else {
+        return p->iov_num;
+    }
+}
+
 /* synchronous single-payload data transfer. This is the common case */
 /* TODO: if transport flag callback, synchronous copy can/should be done inside the callback */
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rreq)

--- a/src/mpid/ch4/generic/am/mpidig_am_msg.h
+++ b/src/mpid/ch4/generic/am/mpidig_am_msg.h
@@ -141,9 +141,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_copy(void *in_data, MPIR_Request * rre
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_setup(MPIR_Request * rreq)
 {
     MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->async));
+    p->offset = 0;
     if (p->recv_type == MPIDIG_RECV_DATATYPE) {
-        p->offset = 0;
-        /* rreq status to be set */
+        /* it's ready, rreq status to be set */
     } else if (p->recv_type == MPIDIG_RECV_CONTIG) {
         p->iov_ptr = &(p->iov_one);
         p->iov_num = 1;
@@ -212,6 +212,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_copy_seg(void *payload, MPI_Aint payloa
     } else {
         /* MPIDIG_RECV_CONTIG and MPIDIG_RECV_IOV */
         p->in_data_sz -= payload_sz;
+        p->offset += payload_sz;
         int iov_done = 0;
         for (int i = 0; i < p->iov_num; i++) {
             if (payload_sz < p->iov_ptr[i].iov_len) {

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -165,10 +165,10 @@ typedef enum {
 typedef struct MPIDIG_req_async {
     MPIDIG_recv_type recv_type;
     MPI_Aint in_data_sz;
+    MPI_Aint offset;
     struct iovec *iov_ptr;      /* used with MPIDIG_RECV_IOV */
     int iov_num;                /* used with MPIDIG_RECV_IOV */
     struct iovec iov_one;       /* used with MPIDIG_RECV_CONTIG */
-    MPI_Aint offset;            /* used with MPIDIG_RECV_DATATYPE */
 } MPIDIG_rreq_async_t;
 
 typedef struct MPIDIG_req_ext_t {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -203,24 +203,22 @@ static inline int MPIDI_OFI_do_rdma_read(void *dst,
     goto fn_exit;
 }
 
-static inline void do_long_am_recv(int is_contig, void *p_data, MPI_Aint data_sz,
-                                   MPI_Aint in_data_sz, MPIR_Request * rreq,
+static inline void do_long_am_recv(MPI_Aint in_data_sz, MPIR_Request * rreq,
                                    MPIDI_OFI_lmt_msg_payload_t * lmt_msg);
 static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
                                               MPIDI_OFI_lmt_msg_payload_t * lmt_msg, void *am_hdr)
 {
-    int c, mpi_errno = MPI_SUCCESS, is_contig = 0;
+    int c, mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL;
-    void *p_data;
-    MPI_Aint data_sz, in_data_sz;
+    size_t in_data_sz;
 
     MPIR_FUNC_VERBOSE_STATE_DECL(MPID_STATE_MPIDI_OFI_DO_HANDLE_LONG_AM);
     MPIR_FUNC_VERBOSE_ENTER(MPID_STATE_MPIDI_OFI_DO_HANDLE_LONG_AM);
 
-    in_data_sz = data_sz = msg_hdr->data_sz;
+    in_data_sz = msg_hdr->data_sz;
     /* note: setting is_local, is_async to 0, 1 */
     MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (msg_hdr->handler_id, am_hdr,
-                                                       NULL, data_sz, 0, 1, &rreq);
+                                                       NULL, in_data_sz, 0, 1, &rreq);
 
     if (!rreq)
         goto fn_exit;
@@ -232,7 +230,7 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
 
     MPIR_cc_incr(rreq->cc_ptr, &c);
 
-    if (!data_sz) {
+    if (!in_data_sz) {
         MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
         MPID_Request_complete(rreq);
         goto fn_exit;
@@ -242,9 +240,8 @@ static inline int MPIDI_OFI_do_handle_long_am(MPIDI_OFI_am_header_t * msg_hdr,
     MPIDI_OFI_AMREQUEST_HDR(rreq, lmt_info) = *lmt_msg;
     MPIDI_OFI_AMREQUEST_HDR(rreq, rreq_ptr) = (void *) rreq;
 
-    MPIDIG_get_recv_data(&is_contig, &p_data, &data_sz, rreq);
-    do_long_am_recv(is_contig, p_data, data_sz, in_data_sz, rreq, lmt_msg);
-    /* missing completion? */
+    do_long_am_recv(in_data_sz, rreq, lmt_msg);
+    /* completion in lmt event functions */
 
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_OFI_DO_HANDLE_LONG_AM);
@@ -437,16 +434,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_lmt_unpack_event(MPIR_Request * rreq)
     }
 }
 
-static inline void do_long_am_recv(int is_contig, void *p_data, MPI_Aint data_sz,
-                                   MPI_Aint in_data_sz, MPIR_Request * rreq,
+static inline void do_long_am_recv(MPI_Aint in_data_sz, MPIR_Request * rreq,
                                    MPIDI_OFI_lmt_msg_payload_t * lmt_msg)
 {
-    if (is_contig) {
-        do_long_am_recv_contig(p_data, data_sz, in_data_sz, rreq, lmt_msg);
-    } else if (in_data_sz / data_sz < MPIR_CVAR_CH4_OFI_AM_IOV_MIN_SEG_SIZE) {
+    int num_iov = MPIDIG_get_recv_iov_count(rreq);
+    if (num_iov > 1 && in_data_sz / num_iov < MPIR_CVAR_CH4_OFI_AM_IOV_MIN_SEG_SIZE) {
+        /* noncontig data with mostly tiny segments */
         do_long_am_recv_unpack(in_data_sz, rreq, lmt_msg);
     } else {
-        do_long_am_recv_iov(p_data, data_sz, in_data_sz, rreq, lmt_msg);
+        int is_contig;
+        void *p_data;
+        MPI_Aint data_sz;
+        MPIDIG_get_recv_data(&is_contig, &p_data, &data_sz, rreq);
+        if (is_contig) {
+            do_long_am_recv_contig(p_data, data_sz, in_data_sz, rreq, lmt_msg);
+        } else {
+            do_long_am_recv_iov(p_data, data_sz, in_data_sz, rreq, lmt_msg);
+        }
     }
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -101,9 +101,24 @@ typedef struct {
 } MPIDI_OFI_lmt_msg_t;
 
 typedef struct {
+    MPIDI_OFI_lmt_msg_payload_t *lmt_msg;
+    void *unpack_buffer;
+    MPI_Aint pack_size;
+} MPIDI_OFI_lmt_unpack_t;
+
+typedef enum {
+    MPIDI_OFI_AM_LMT_IOV,
+    MPIDI_OFI_AM_LMT_UNPACK
+} MPIDI_OFI_lmt_type_t;
+
+typedef struct {
     MPIDI_OFI_lmt_msg_payload_t lmt_info;
-    uint64_t lmt_cntr;
     struct fid_mr *lmt_mr;
+    MPIDI_OFI_lmt_type_t lmt_type;
+    union {
+        uint64_t lmt_cntr;
+        MPIDI_OFI_lmt_unpack_t unpack;
+    } lmt_u;
     void *pack_buffer;
     MPIR_Request *rreq_ptr;
     void *am_hdr;

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -28,7 +28,7 @@ allgather2 10
 allgather3 10
 allgatherv2 10
 allgatherv3 10
-allgatherv4 4 timeLimit=600
+allgatherv4 4
 allgather_struct 10
 bcasttest 4
 bcasttest 8
@@ -131,11 +131,11 @@ nonblocking 10 mpiversion=3.0
 nonblocking2 1 mpiversion=3.0
 nonblocking2 4 mpiversion=3.0
 nonblocking2 5 mpiversion=3.0
-nonblocking2 10 timeLimit=420 mpiversion=3.0
+nonblocking2 10 mpiversion=3.0
 nonblocking3 1 mpiversion=3.0
 nonblocking3 4 mpiversion=3.0
 nonblocking3 5 mpiversion=3.0
-nonblocking3 10 timeLimit=600 mpiversion=3.0
+nonblocking3 10 mpiversion=3.0
 iallred 2 mpiversion=3.0
 # ibarrier will hang forever if it fails, but will complete quickly if it
 # succeeds

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -43,13 +43,6 @@
 # xfail known failures of OFI build for Hackathon
 * * * ch4:ofi * sed -i "s+\(^ibsend .*\)+\1 xfail=ticket0+g" test/mpi/threads/pt2pt/testlist
 * * * ch4:ofi * sed -i "s+\(^large_acc_flush_local .*\)+\1 xfail=issue3251+g" test/mpi/rma/testlist
-# am-only failures
-* * am-only ch4:ofi * sed -i "s+\(^cancelanysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^huge_anysrc .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
-* * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
-* * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
-* * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
-* * am-only ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 ################################################################################
 #ch3:ofi
 * * * ch3:ofi * sed -i  "s+\(^manyget .*\)+\1 xfail=ticket0+g" test/mpi/rma/testlist

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -49,7 +49,6 @@
 * * am-only ch4:ofi * sed -i "s+\(^idup_nb .*\)+\1 xfail=ticket0+g" test/mpi/threads/comm/testlist
 * * am-only ch4:ofi * sed -i "s+\(^allgatherv4 .*\)+\1 xfail=ticket0+g" test/mpi/coll/testlist
 * * am-only ch4:ofi * sed -i "s+\(^large_vec .*\)+\1 xfail=ticket0+g" test/mpi/datatype/testlist
-* * am-only ch4:ofi * sed -i "s+\(^pingping .* arg=-sendcnt=65530 .*\)+\1 xfail=issue3886+g" test/mpi/pt2pt/testlist.dtp
 * * am-only ch4:ofi * sed -i "s+\(^many_isend .*\)+\1 xfail=ticket0+g" test/mpi/pt2pt/testlist
 ################################################################################
 #ch3:ofi
@@ -100,7 +99,6 @@
 * * * ch4:ofi * sed -i "s|\(^lockall_dt.* [0-9]* arg=-type=.* arg=-count=32768 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist.dtp
 * * * ch4:ofi * sed -i "s|\(^accfence1 [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist.dtp
 * * * ch4:ofi * sed -i "s|\(^accpscw1 [0-9]* arg=-type=.* arg=-count=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/rma/testlist.dtp
-* * * ch4:ofi * sed -i "s|\(^pingping [0-9]* arg=-type=.* arg=-sendcnt=262144 .*\)|\1 xfail=ticket2965|g" test/mpi/pt2pt/testlist.dtp
 # intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (includeing the aborted ones)
 * * * * * sed -i "s+\(^intercomm_abort .*\)+\1 xfail=ticket0+g" test/mpi/errors/comm/testlist
 # disable large datatype test for valgrind as it dies with valgrind running out of memory.

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -1,6 +1,6 @@
 sendrecv2 2
 sendrecv3 2
-sendflood 8 timeLimit=600
+sendflood 8
 sendall 4
 anyall 2
 eagerdt 2


### PR DESCRIPTION
## Pull Request Description
 When the non-contig datatype consists of many small segments, it is more    efficient to transfer/rdma an unpack buffer of certain size and use    MPIR_Typerep_unpack, instead of use direct rdma-read on every iov    segment.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
       Partially fixes issue #3886 
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
