### PR TITLE
ch4: change OFI NM_recv_cancel to be non-blocking

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -872,6 +872,8 @@ int MPIDI_OFI_handle_cq_error(int vni_idx, ssize_t ret)
                     req = MPIDI_OFI_context_to_request(e.op_context);
                     MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                     MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
+                    MPIR_STATUS_SET_COUNT(req->status, 0);
+                    MPIDIU_request_complete(req);
                     break;
 
                 case FI_ENOMSG:

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -409,20 +409,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq)
                              fi_strerror(-ret));
     }
 
-    if (ret == 0) {
-        while ((!MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) && (!MPIR_cc_is_complete(&rreq->cc))) {
-            /* The cancel is local and must complete, so only poll this device (not global progress) */
-            if ((mpi_errno = MPIDI_OFI_progress(0, 0)) != MPI_SUCCESS)
-                goto fn_exit;
-        }
-
-        if (MPIR_STATUS_GET_CANCEL_BIT(rreq->status)) {
-            MPIR_STATUS_SET_CANCEL_BIT(rreq->status, TRUE);
-            MPIR_STATUS_SET_COUNT(rreq->status, 0);
-            MPIDIU_request_complete(rreq);
-        }
-    }
-
   fn_exit:
     MPIR_FUNC_VERBOSE_EXIT(MPID_STATE_MPIDI_NM_MPI_CANCEL_RECV);
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
Change NM OFI level implementation of cancel_recv to be non-blocking, in order to fulfill MPI standard.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
