### PR TITLE
Dtpools: remove automatic description generation

### DIFF
--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -98,20 +98,25 @@ int main(int argc, char *argv[])
 
         if (attrval != 1) {
             errs++;
-            printf("attrval is %d, should be 1, before dup in type %s\n", attrval,
-                   obj.DTP_description);
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            printf("attrval is %d, should be 1, before dup in type %s\n", attrval, desc);
         }
         MPI_Type_dup(type, &duptype);
         /* Check that the attribute was copied */
         if (attrval != 2) {
             errs++;
-            printf("Attribute not incremented when type dup'ed (%s)\n", obj.DTP_description);
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            printf("Attribute not incremented when type dup'ed (%s)\n", desc);
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         MPI_Type_free(&duptype);
         if (attrval != 1) {
             errs++;
-            printf("Attribute not decremented when duptype %s freed\n", obj.DTP_description);
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            printf("Attribute not decremented when duptype %s freed\n", desc);
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         /* Check that the attribute was freed in the duptype */
@@ -120,8 +125,9 @@ int main(int argc, char *argv[])
             DTP_obj_free(obj);
             if (attrval != 0) {
                 errs++;
-                fprintf(stderr, "Attribute not decremented when type %s freed\n",
-                        obj.DTP_description);
+                char *desc;
+                DTP_obj_get_description(obj, &desc);
+                fprintf(stderr, "Attribute not decremented when type %s freed\n", desc);
                 MPI_Abort(MPI_COMM_WORLD, 1);
             }
         } else {

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -114,9 +114,10 @@ int main(int argc, char *argv[])
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {
+                        char *desc;
+                        DTP_obj_get_description(obj, &desc);
                         fprintf(stderr,
-                                "Data received with type %s does not match data sent\n",
-                                obj.DTP_description);
+                                "Data received with type %s does not match data sent\n", desc);
                         fflush(stderr);
                     }
                 }

--- a/test/mpi/cxx/attr/fkeyvaltypex.cxx
+++ b/test/mpi/cxx/attr/fkeyvaltypex.cxx
@@ -110,19 +110,25 @@ int main(int argc, char *argv[])
 
         if (attrval != 1) {
             errs++;
-            cerr << "attrval is " << attrval << ", should be 1, before dup in type " << obj.DTP_description
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            cerr << "attrval is " << attrval << ", should be 1, before dup in type " << desc
                 << "\n";
         }
         duptype = type.Dup();
         /* Check that the attribute was copied */
         if (attrval != 2) {
             errs++;
-            cerr << "Attribute not incremented when type dup'ed (" << obj.DTP_description << ")\n";
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            cerr << "Attribute not incremented when type dup'ed (" << desc << ")\n";
         }
         duptype.Free();
         if (attrval != 1) {
             errs++;
-            cerr << "Attribute not decremented when duptype " << obj.DTP_description << " freed\n";
+            char *desc;
+            DTP_obj_get_description(obj, &desc);
+            cerr << "Attribute not decremented when duptype " << desc << " freed\n";
         }
         /* Check that the attribute was freed in the duptype */
 
@@ -130,7 +136,9 @@ int main(int argc, char *argv[])
             DTP_obj_free(obj);
             if (attrval != 0) {
                 errs++;
-                cerr << "Attribute not decremented when type " << obj.DTP_description << "reed\n";
+                char *desc;
+                DTP_obj_get_description(obj, &desc);
+                cerr << "Attribute not decremented when type " << desc << "reed\n";
             }
         } else {
             MPI_Type_delete_attr(type, saveKeyval);

--- a/test/mpi/cxx/datatype/packsizex.cxx
+++ b/test/mpi/cxx/datatype/packsizex.cxx
@@ -76,11 +76,15 @@ int main(int argc, char *argv[])
         size2 = type.Pack_size(2, comm);
         if (size1 <= 0 || size2 <= 0) {
             errs++;
-            cerr << "Pack size of datatype " << msobj.DTP_description << " is not positive\n";
+            char *desc;
+            DTP_obj_get_description(msobj, &desc);
+            cerr << "Pack size of datatype " << desc << " is not positive\n";
         }
         if (size1 >= size2) {
             errs++;
-            cerr << "Pack size of 2 of " << msobj.DTP_description <<
+            char *desc;
+            DTP_obj_get_description(msobj, &desc);
+            cerr << "Pack size of 2 of " << desc <<
                 " is smaller or the same as the pack size of 1 instance\n";
         }
 
@@ -94,11 +98,15 @@ int main(int argc, char *argv[])
             size2 = type.Pack_size(2, comm);
             if (size1 <= 0 || size2 <= 0) {
                 errs++;
-                cerr << "Pack size of datatype " << mrobj.DTP_description << " is not positive\n";
+                char *desc;
+                DTP_obj_get_description(mrobj, &desc);
+                cerr << "Pack size of datatype " << desc << " is not positive\n";
             }
             if (size1 >= size2) {
                 errs++;
-                cerr << "Pack size of 2 of " << mrobj.DTP_description <<
+                char *desc;
+                DTP_obj_get_description(mrobj, &desc);
+                cerr << "Pack size of 2 of " << desc <<
                     " is smaller or the same as the pack size of 1 instance\n";
             }
         }

--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -22,9 +22,6 @@ typedef struct {
     MPI_Aint DTP_bufsize;
     MPI_Aint DTP_buf_offset;
 
-    /* datatype description for debugging purposes */
-    char *DTP_description;
-
     void *priv;
 } DTP_obj_s;
 
@@ -41,6 +38,7 @@ int DTP_pool_free(DTP_pool_s dtp);
 
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize);
 int DTP_obj_free(DTP_obj_s obj);
+int DTP_obj_get_description(DTP_obj_s obj, char **desc);
 
 int DTP_obj_buf_init(DTP_obj_s obj, void *buf, int val_start, int val_stride, MPI_Aint val_count);
 int DTP_obj_buf_check(DTP_obj_s obj, void *buf, int val_start, int val_stride, MPI_Aint val_count);

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -130,9 +130,6 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
             DTPI_ERR_CHK_MPI_RC(rc);
         }
 
-        rc = DTPI_populate_dtp_desc(obj_priv, dtpi, &obj->DTP_description);
-        DTPI_ERR_CHK_RC(rc);
-
         /* find the buffer size that we need */
         MPI_Aint true_lb, true_extent;
         MPI_Aint lb, extent;
@@ -173,6 +170,21 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
     goto fn_exit;
 }
 
+int DTP_obj_get_description(DTP_obj_s obj, char **desc)
+{
+    DTPI_obj_s *obj_priv = obj.priv;
+    int rc = DTP_SUCCESS;
+
+    rc = DTPI_populate_dtp_desc(obj_priv, obj_priv->dtp.priv, desc);
+    DTPI_ERR_CHK_RC(rc);
+
+  fn_exit:
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 /*
  * DTP_obj_free - free previously created datatype idx
  */
@@ -190,7 +202,6 @@ int DTP_obj_free(DTP_obj_s obj)
 
     DTPI_obj_free(obj_priv);
     DTPI_FREE(obj.priv);
-    DTPI_FREE(obj.DTP_description);
 
     DTPI_FUNC_EXIT();
 

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -112,8 +112,10 @@ int main(int argc, char *argv[])
                 sendcount = send_obj.DTP_type_count;
                 sendtype = send_obj.DTP_datatype;
 
+                char *desc;
+                DTP_obj_get_description(send_obj, &desc);
                 MTestPrintfMsg(1, "Sending count = %d of sendtype %s of total size %d bytes\n",
-                               count[0], send_obj.DTP_description, nbytes * count[0]);
+                               count[0], desc, nbytes * count[0]);
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++) {
                     err =
@@ -158,10 +160,12 @@ int main(int argc, char *argv[])
                     err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
                     if (err != DTP_SUCCESS) {
                         if (errs < 10) {
+                            char *recv_desc, *send_desc;
+                            DTP_obj_get_description(recv_obj, &recv_desc);
+                            DTP_obj_get_description(send_obj, &send_desc);
                             fprintf(stderr,
                                     "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld, message iteration %d of %d\n",
-                                    recv_obj.DTP_description, send_obj.DTP_description,
-                                    count[0], nmsg, maxmsg);
+                                    recv_desc, send_desc, count[0], nmsg, maxmsg);
                             fflush(stderr);
                         }
                         errs++;

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -141,9 +141,12 @@ int main(int argc, char *argv[])
                 err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
                 if (err != DTP_SUCCESS) {
                     if (errs < 10) {
+                        char *recv_desc, *send_desc;
+                        DTP_obj_get_description(recv_obj, &recv_desc);
+                        DTP_obj_get_description(send_obj, &send_desc);
                         fprintf(stderr,
                                 "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
-                                recv_obj.DTP_description, send_obj.DTP_description, count[0]);
+                                recv_desc, send_desc, count[0]);
                     }
                     errs++;
                 }

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -119,9 +119,12 @@ int main(int argc, char *argv[])
         err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
         if (err != DTP_SUCCESS) {
             if (errs < 10) {
+                char *recv_desc, *send_desc;
+                DTP_obj_get_description(recv_obj, &recv_desc);
+                DTP_obj_get_description(send_obj, &send_desc);
                 fprintf(stderr,
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
-                        recv_obj.DTP_description, send_obj.DTP_description, count[0]);
+                        recv_desc, send_desc, count[0]);
                 fflush(stderr);
             }
             errs++;
@@ -154,9 +157,12 @@ int main(int argc, char *argv[])
         err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
         if (err != DTP_SUCCESS) {
             if (errs < 10) {
+                char *recv_desc, *send_desc;
+                DTP_obj_get_description(recv_obj, &recv_desc);
+                DTP_obj_get_description(send_obj, &send_desc);
                 fprintf(stderr,
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
-                        recv_obj.DTP_description, send_obj.DTP_description, count[0]);
+                        recv_desc, send_desc, count[0]);
                 fflush(stderr);
             }
             errs++;
@@ -189,9 +195,12 @@ int main(int argc, char *argv[])
         err = DTP_obj_buf_check(recv_obj, recvbuf, 0, 1, count[0]);
         if (err != DTP_SUCCESS) {
             if (errs < 10) {
+                char *recv_desc, *send_desc;
+                DTP_obj_get_description(recv_obj, &recv_desc);
+                DTP_obj_get_description(send_obj, &send_desc);
                 fprintf(stderr,
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
-                        recv_obj.DTP_description, send_obj.DTP_description, count[0]);
+                        recv_desc, send_desc, count[0]);
                 fflush(stderr);
             }
             errs++;

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -142,8 +142,10 @@ int main(int argc, char *argv[])
                 if (err) {
                     errs++;
                     if (errs < 10) {
-                        error("Accumulate types: send %s, recv %s\n",
-                              orig_obj.DTP_description, target_obj.DTP_description);
+                        char *orig_desc, *target_desc;
+                        DTP_obj_get_description(orig_obj, &orig_desc);
+                        DTP_obj_get_description(target_obj, &target_desc);
+                        error("Accumulate types: send %s, recv %s\n", orig_desc, target_desc);
                         MTestPrintError(err);
                     }
                 }
@@ -162,9 +164,12 @@ int main(int argc, char *argv[])
                  * transfering data, as a send/recv pair */
                 err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
                 if (err != DTP_SUCCESS) {
+                    char *orig_desc, *target_desc;
+                    DTP_obj_get_description(orig_obj, &orig_desc);
+                    DTP_obj_get_description(target_obj, &target_desc);
                     if (errs < 10) {
                         error("Data received with type %s does not match data sent with type %s\n",
-                              target_obj.DTP_description, orig_obj.DTP_description);
+                              target_desc, orig_desc);
                     }
                     errs++;
                 }

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -161,9 +161,12 @@ int main(int argc, char *argv[])
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {
+                        char *target_desc, *orig_desc;
+                        DTP_obj_get_description(target_obj, &target_desc);
+                        DTP_obj_get_description(orig_obj, &orig_desc);
                         fprintf(stderr,
                                 "Data received with type %s does not match data sent with type %s\n",
-                                target_obj.DTP_description, orig_obj.DTP_description);
+                                target_desc, orig_desc);
                         fflush(stderr);
                     }
                 }

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -146,9 +146,12 @@ int main(int argc, char **argv)
             targetcount = target_obj.DTP_type_count;
             targettype = target_obj.DTP_datatype;
 
+            char *orig_desc, *target_desc;
+            DTP_obj_get_description(orig_obj, &orig_desc);
+            DTP_obj_get_description(target_obj, &target_desc);
             MTestPrintfMsg(1,
                            "Putting count = %d of origtype %s targettype %s\n",
-                           count, orig_obj.DTP_description, target_obj.DTP_description);
+                           count, orig_desc, target_desc);
 
             /* At this point, we have all of the elements that we
              * need to begin the multiple fence and put tests */
@@ -180,8 +183,7 @@ int main(int argc, char **argv)
                 err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
                 if (err) {
                     if (errs++ < MAX_PERR) {
-                        PrintRecvedError("fence2", orig_obj.DTP_description,
-                                         target_obj.DTP_description);
+                        PrintRecvedError("fence2", orig_desc, target_desc);
                     }
                 }
 
@@ -205,8 +207,7 @@ int main(int argc, char **argv)
                 err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     if (errs++ < MAX_PERR) {
-                        PrintRecvedError("fence3", orig_obj.DTP_description,
-                                         target_obj.DTP_description);
+                        PrintRecvedError("fence3", orig_desc, target_desc);
                     }
                 }
 
@@ -239,8 +240,7 @@ int main(int argc, char **argv)
                 err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     if (errs++ < MAX_PERR) {
-                        PrintRecvedError("src fence4", orig_obj.DTP_description,
-                                         target_obj.DTP_description);
+                        PrintRecvedError("src fence4", orig_desc, target_desc);
                     }
                 }
             }
@@ -248,8 +248,7 @@ int main(int argc, char **argv)
                 err = DTP_obj_buf_check(target_obj, targetbuf, 0, 1, count);
                 if (err != DTP_SUCCESS) {
                     if (errs++ < MAX_PERR) {
-                        PrintRecvedError("target fence4", orig_obj.DTP_description,
-                                         target_obj.DTP_description);
+                        PrintRecvedError("target fence4", orig_desc, target_desc);
                     }
                 }
             }

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -32,9 +32,12 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
     targettype = target_obj.DTP_datatype;
     targetcount = target_obj.DTP_type_count;
 
+    char *orig_desc, *target_desc;
+    DTP_obj_get_description(orig_obj, &orig_desc);
+    DTP_obj_get_description(target_obj, &target_desc);
     MTestPrintfMsg(1,
                    "Getting count = %ld of origtype %s - count = %ld target type %s\n",
-                   origcount, orig_obj.DTP_description, targetcount, target_obj.DTP_description);
+                   origcount, orig_desc, targetcount, target_desc);
 
     if (rank == target) {
 #if defined(USE_GET)
@@ -61,7 +64,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
             if (errs < 10) {
                 printf
                     ("Data in target buffer did not match for target datatype %s (get with orig datatype %s)\n",
-                     target_obj.DTP_description, orig_obj.DTP_description);
+                     target_desc, orig_desc);
             }
         }
 #endif
@@ -127,7 +130,7 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
             if (errs < 10) {
                 printf
                     ("Data in origin buffer did not match for origin datatype %s (get with target datatype %s)\n",
-                     orig_obj.DTP_description, target_obj.DTP_description);
+                     orig_desc, target_desc);
             }
         }
 #endif

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -166,9 +166,12 @@ int main(int argc, char *argv[])
                 if (err != DTP_SUCCESS) {
                     errs++;
                     if (errs < 10) {
+                        char *target_desc, *orig_desc;
+                        DTP_obj_get_description(target_obj, &target_desc);
+                        DTP_obj_get_description(orig_obj, &orig_desc);
                         fprintf(stderr,
                                 "Data received with type %s does not match data sent with type %s\n",
-                                target_obj.DTP_description, orig_obj.DTP_description);
+                                target_desc, orig_desc);
                         fflush(stderr);
                     }
                 }


### PR DESCRIPTION
## Pull Request Description

Align with yaksa dtpools. Currently dtpools generates a datatype description string for every created object. This is used for debugging purposes. The generation of such description string can take a long time, especially for complex types, and is not always needed. For this reason this is replaced with a new API that can be used to generate the description only when needed.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
