### PR TITLE
test/dtpools: remove lower bound for buffer size

### DIFF
--- a/test/mpi/dtpools/README
+++ b/test/mpi/dtpools/README
@@ -82,3 +82,6 @@ an object.
 
 2. DTP_MAX_TREE_DEPTH: Sets the maximum datatype tree depth that an
 object can have.
+
+3. DTP_MAX_OBJ_CREATE_ATTEMPTS: Sets the maximum number of attempts allowed
+when creating an object before giving up.

--- a/test/mpi/dtpools/include/dtpools.h
+++ b/test/mpi/dtpools/include/dtpools.h
@@ -13,7 +13,8 @@
 #define DTP_ERR_ARG                (-1)
 #define DTP_ERR_OUT_OF_RESOURCES   (-2)
 #define DTP_ERR_MPI                (-3)
-#define DTP_ERR_OTHER              (-4)
+#define DTP_ERR_MAXED_ATTEMPTS     (-4)
+#define DTP_ERR_OTHER              (-5)
 
 typedef struct {
     MPI_Datatype DTP_datatype;

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -82,8 +82,9 @@ int DTP_pool_free(DTP_pool_s dtp)
     goto fn_exit;
 }
 
-#define DTPI_DEFAULT_MAX_TREE_DEPTH (3)
-#define DTPI_DEFAULT_MAX_BUFSIZE    (1024 * 1024 * 1024)
+#define DTPI_DEFAULT_MAX_TREE_DEPTH          (3)
+#define DTPI_DEFAULT_MAX_OBJ_CREATE_ATTEMPTS (100)
+#define DTPI_DEFAULT_MAX_BUFSIZE             (1024 * 1024 * 1024)
 
 /*
  * DTP_obj_create - create dtp object inside the pool
@@ -97,22 +98,25 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
     int rc = DTP_SUCCESS;
     DTPI_pool_s *dtpi = dtp.priv;
     int max_tree_depth;
+    int max_obj_create_attempts;        /* set the max number of object create
+                                         * and fail if exceed */
     DTPI_obj_s *obj_priv = NULL;
 
     DTPI_FUNC_ENTER();
 
     DTPI_ERR_ARG_CHECK(!dtpi, rc);
 
-    /* The code will enter deadloop if maxbufsize is too small or overflown to negative.
-     * Use 100000 as an arbitary sanity guard.
-     */
-    DTPI_ERR_ARG_CHECK(maxbufsize < 100000, rc);
-
     /* find number of nestings */
     if (getenv("DTP_MAX_TREE_DEPTH"))
         max_tree_depth = atoi(getenv("DTP_MAX_TREE_DEPTH"));
     else
         max_tree_depth = DTPI_DEFAULT_MAX_TREE_DEPTH;
+
+    /* find the max number of attempts when creating an object */
+    if (getenv("DTP_MAX_OBJ_CREATE_ATTEMPTS"))
+        max_obj_create_attempts = atoi(getenv("DTP_MAX_OBJ_CREATE_ATTEMPTS"));
+    else
+        max_obj_create_attempts = DTPI_DEFAULT_MAX_OBJ_CREATE_ATTEMPTS;
 
     int attr_tree_depth = DTPI_rand(dtpi) % (max_tree_depth + 1);
 
@@ -163,6 +167,10 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
         } else {
             rc = DTP_obj_free(*obj);
             DTPI_ERR_CHK_RC(rc);
+            if (--max_obj_create_attempts < 0) {
+                rc = DTP_ERR_MAXED_ATTEMPTS;
+                goto fn_fail;
+            }
         }
     }
 

--- a/test/mpi/dtpools/src/dtpools.c
+++ b/test/mpi/dtpools/src/dtpools.c
@@ -90,6 +90,7 @@ int DTP_pool_free(DTP_pool_s dtp)
  *
  * dtp:         datatype pool handle
  * obj:         created object handle
+ * maxbufsize:  maximum buffer size allowed
  */
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, MPI_Aint maxbufsize)
 {


### PR DESCRIPTION
## Pull Request Description
Currently the object create code in dtpools only allows `maxbufsize`  that is bigger than a certain arbitrary threshold (100000). This is to avoid that the generated buffer size for objects is always bigger than the allowed max buffer size. In this cases dtpools tries creating the object again and might never succeed, ending up in an infinite loop. Remove the lower threshold and make the code break out of the loop after a max attempt threshold is reached.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
