### PR TITLE
test/mpi: free description string

### DIFF
--- a/test/mpi/attr/fkeyvaltype.c
+++ b/test/mpi/attr/fkeyvaltype.c
@@ -101,6 +101,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(obj, &desc);
             printf("attrval is %d, should be 1, before dup in type %s\n", attrval, desc);
+            free(desc);
         }
         MPI_Type_dup(type, &duptype);
         /* Check that the attribute was copied */
@@ -109,6 +110,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(obj, &desc);
             printf("Attribute not incremented when type dup'ed (%s)\n", desc);
+            free(desc);
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         MPI_Type_free(&duptype);
@@ -117,6 +119,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(obj, &desc);
             printf("Attribute not decremented when duptype %s freed\n", desc);
+            free(desc);
             MPI_Abort(MPI_COMM_WORLD, 1);
         }
         /* Check that the attribute was freed in the duptype */
@@ -128,6 +131,7 @@ int main(int argc, char *argv[])
                 char *desc;
                 DTP_obj_get_description(obj, &desc);
                 fprintf(stderr, "Attribute not decremented when type %s freed\n", desc);
+                free(desc);
                 MPI_Abort(MPI_COMM_WORLD, 1);
             }
         } else {

--- a/test/mpi/coll/bcast.c
+++ b/test/mpi/coll/bcast.c
@@ -119,6 +119,7 @@ int main(int argc, char *argv[])
                         fprintf(stderr,
                                 "Data received with type %s does not match data sent\n", desc);
                         fflush(stderr);
+                        free(desc);
                     }
                 }
 

--- a/test/mpi/cxx/attr/fkeyvaltypex.cxx
+++ b/test/mpi/cxx/attr/fkeyvaltypex.cxx
@@ -114,6 +114,7 @@ int main(int argc, char *argv[])
             DTP_obj_get_description(obj, &desc);
             cerr << "attrval is " << attrval << ", should be 1, before dup in type " << desc
                 << "\n";
+            free(desc);
         }
         duptype = type.Dup();
         /* Check that the attribute was copied */
@@ -122,6 +123,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(obj, &desc);
             cerr << "Attribute not incremented when type dup'ed (" << desc << ")\n";
+            free(desc);
         }
         duptype.Free();
         if (attrval != 1) {
@@ -129,6 +131,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(obj, &desc);
             cerr << "Attribute not decremented when duptype " << desc << " freed\n";
+            free(desc);
         }
         /* Check that the attribute was freed in the duptype */
 
@@ -139,6 +142,7 @@ int main(int argc, char *argv[])
                 char *desc;
                 DTP_obj_get_description(obj, &desc);
                 cerr << "Attribute not decremented when type " << desc << "reed\n";
+                free(desc);
             }
         } else {
             MPI_Type_delete_attr(type, saveKeyval);

--- a/test/mpi/cxx/datatype/packsizex.cxx
+++ b/test/mpi/cxx/datatype/packsizex.cxx
@@ -79,6 +79,7 @@ int main(int argc, char *argv[])
             char *desc;
             DTP_obj_get_description(msobj, &desc);
             cerr << "Pack size of datatype " << desc << " is not positive\n";
+            free(desc);
         }
         if (size1 >= size2) {
             errs++;
@@ -86,6 +87,7 @@ int main(int argc, char *argv[])
             DTP_obj_get_description(msobj, &desc);
             cerr << "Pack size of 2 of " << desc <<
                 " is smaller or the same as the pack size of 1 instance\n";
+            free(desc);
         }
 
         if (mrobj.DTP_datatype != msobj.DTP_datatype) {
@@ -101,6 +103,7 @@ int main(int argc, char *argv[])
                 char *desc;
                 DTP_obj_get_description(mrobj, &desc);
                 cerr << "Pack size of datatype " << desc << " is not positive\n";
+                free(desc);
             }
             if (size1 >= size2) {
                 errs++;
@@ -108,6 +111,7 @@ int main(int argc, char *argv[])
                 DTP_obj_get_description(mrobj, &desc);
                 cerr << "Pack size of 2 of " << desc <<
                     " is smaller or the same as the pack size of 1 instance\n";
+                free(desc);
             }
         }
         DTP_obj_free(mrobj);

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
                 DTP_obj_get_description(send_obj, &desc);
                 MTestPrintfMsg(1, "Sending count = %d of sendtype %s of total size %d bytes\n",
                                count[0], desc, nbytes * count[0]);
+                free(desc);
 
                 for (nmsg = 1; nmsg < maxmsg; nmsg++) {
                     err =
@@ -167,6 +168,8 @@ int main(int argc, char *argv[])
                                     "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld, message iteration %d of %d\n",
                                     recv_desc, send_desc, count[0], nmsg, maxmsg);
                             fflush(stderr);
+                            free(recv_desc);
+                            free(send_desc);
                         }
                         errs++;
                     }

--- a/test/mpi/pt2pt/sendrecv1.c
+++ b/test/mpi/pt2pt/sendrecv1.c
@@ -147,6 +147,8 @@ int main(int argc, char *argv[])
                         fprintf(stderr,
                                 "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
                                 recv_desc, send_desc, count[0]);
+                        free(recv_desc);
+                        free(send_desc);
                     }
                     errs++;
                 }

--- a/test/mpi/pt2pt/sendself.c
+++ b/test/mpi/pt2pt/sendself.c
@@ -126,6 +126,8 @@ int main(int argc, char *argv[])
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
                         recv_desc, send_desc, count[0]);
                 fflush(stderr);
+                free(recv_desc);
+                free(send_desc);
             }
             errs++;
         }
@@ -164,6 +166,8 @@ int main(int argc, char *argv[])
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
                         recv_desc, send_desc, count[0]);
                 fflush(stderr);
+                free(recv_desc);
+                free(send_desc);
             }
             errs++;
         }
@@ -202,6 +206,8 @@ int main(int argc, char *argv[])
                         "Data in target buffer did not match for destination datatype %s and source datatype %s, count = %ld\n",
                         recv_desc, send_desc, count[0]);
                 fflush(stderr);
+                free(recv_desc);
+                free(send_desc);
             }
             errs++;
         }

--- a/test/mpi/rma/accfence1.c
+++ b/test/mpi/rma/accfence1.c
@@ -147,6 +147,8 @@ int main(int argc, char *argv[])
                         DTP_obj_get_description(target_obj, &target_desc);
                         error("Accumulate types: send %s, recv %s\n", orig_desc, target_desc);
                         MTestPrintError(err);
+                        free(orig_desc);
+                        free(target_desc);
                     }
                 }
                 err = MPI_Win_fence(0, win);
@@ -172,6 +174,8 @@ int main(int argc, char *argv[])
                               target_desc, orig_desc);
                     }
                     errs++;
+                    free(orig_desc);
+                    free(target_desc);
                 }
             } else {
                 MPI_Win_fence(0, win);

--- a/test/mpi/rma/accpscw1.c
+++ b/test/mpi/rma/accpscw1.c
@@ -168,6 +168,8 @@ int main(int argc, char *argv[])
                                 "Data received with type %s does not match data sent with type %s\n",
                                 target_desc, orig_desc);
                         fflush(stderr);
+                        free(target_desc);
+                        free(orig_desc);
                     }
                 }
             } else {

--- a/test/mpi/rma/epochtest.c
+++ b/test/mpi/rma/epochtest.c
@@ -253,6 +253,8 @@ int main(int argc, char **argv)
                 }
             }
 
+            free(orig_desc);
+            free(target_desc);
             free(origbuf);
             DTP_obj_free(orig_obj);
             DTP_obj_free(target_obj);

--- a/test/mpi/rma/fence.c
+++ b/test/mpi/rma/fence.c
@@ -141,6 +141,9 @@ static inline int test(MPI_Comm comm, int rank, int orig, int target,
         MPI_Win_fence(0, win);
     }
 
+    free(orig_desc);
+    free(target_desc);
+
     return errs;
 }
 

--- a/test/mpi/rma/putpscw1.c
+++ b/test/mpi/rma/putpscw1.c
@@ -173,6 +173,8 @@ int main(int argc, char *argv[])
                                 "Data received with type %s does not match data sent with type %s\n",
                                 target_desc, orig_desc);
                         fflush(stderr);
+                        free(target_desc);
+                        free(orig_desc);
                     }
                 }
             } else {


### PR DESCRIPTION
## Pull Request Description
dtpools no longer manages the description string. This is now generated
on demand by tests for single cases in which debugging info is needed.
The description string is thus handled by the test and should be freed
afterwards.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
