### PR TITLE
mpi: Add MPICH Custom Information to MPI_Get_library_version

### DIFF
--- a/src/mpi/misc/library_version.c
+++ b/src/mpi/misc/library_version.c
@@ -43,6 +43,7 @@ Output Parameters:
 int MPI_Get_library_version(char *version, int *resultlen)
 {
     int mpi_errno = MPI_SUCCESS;
+    int printed_len;
     MPIR_FUNC_TERSE_STATE_DECL(MPID_STATE_MPI_GET_LIBRARY_VERSION);
 
     /* Note that this routine may be called before MPI_Init */
@@ -63,19 +64,22 @@ int MPI_Get_library_version(char *version, int *resultlen)
 
     /* ... body of routine ...  */
 
-    MPL_snprintf(version, MPI_MAX_LIBRARY_VERSION_STRING,
-                 "MPICH Version:\t%s\n"
-                 "MPICH Release date:\t%s\n"
-                 "MPICH ABI:\t%s\n"
-                 "MPICH Device:\t%s\n"
-                 "MPICH configure:\t%s\n"
-                 "MPICH CC:\t%s\n"
-                 "MPICH CXX:\t%s\n"
-                 "MPICH F77:\t%s\n"
-                 "MPICH FC:\t%s\n",
-                 MPII_Version_string, MPII_Version_date, MPII_Version_ABI, MPII_Version_device,
-                 MPII_Version_configure, MPII_Version_CC, MPII_Version_CXX,
-                 MPII_Version_F77, MPII_Version_FC);
+    printed_len = MPL_snprintf(version, MPI_MAX_LIBRARY_VERSION_STRING,
+                               "MPICH Version:\t%s\n"
+                               "MPICH Release date:\t%s\n"
+                               "MPICH ABI:\t%s\n"
+                               "MPICH Device:\t%s\n"
+                               "MPICH configure:\t%s\n"
+                               "MPICH CC:\t%s\n"
+                               "MPICH CXX:\t%s\n"
+                               "MPICH F77:\t%s\n"
+                               "MPICH FC:\t%s\n",
+                               MPII_Version_string, MPII_Version_date, MPII_Version_ABI,
+                               MPII_Version_device, MPII_Version_configure, MPII_Version_CC,
+                               MPII_Version_CXX, MPII_Version_F77, MPII_Version_FC);
+    if (strlen(MPII_Version_custom) > 0)
+        MPL_snprintf(version + printed_len, MPI_MAX_LIBRARY_VERSION_STRING - printed_len,
+                     "MPICH Custom Information:\t%s\n", MPII_Version_custom);
 
     *resultlen = (int) strlen(version);
 


### PR DESCRIPTION
## Pull Request Description
With this patch, MPI_Get_library_version will print the custom version string at the end of its output, when a custom string is passed during config. E.g.: if mpich is configured with `--with-custom-version-string=foo`, output will contain:

```MPICH Custom Information:       foo```

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Add Devel Docs in the `doc/` directory for any new code design
