### PR TITLE
ch4/shm: Use gte for XPMEM check

### DIFF
--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -24,8 +24,8 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
       description : >-
-        If a send message size is larger than MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE (in bytes),
-        then enable XPMEM-based single copy protocol for intranode communication. The
+        If a send message size is greater than or equal to MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE (in
+        bytes), then enable XPMEM-based single copy protocol for intranode communication. The
         environment variable is valid only when then XPMEM shmmod is enabled.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
 
     MPIDI_Datatype_check_contig_size(datatype, count, dt_contig, data_sz);
     if (MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE > -1 &&
-        dt_contig && data_sz > MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE && rank != comm->rank) {
+        dt_contig && data_sz >= MPIR_CVAR_CH4_XPMEM_LMT_MSG_SIZE && rank != comm->rank) {
         /* SHM only issues contig large message through XPMEM.
          * TODO: support noncontig send message */
         mpi_errno = MPIDI_XPMEM_lmt_isend(buf, count, datatype, rank, tag, comm,


### PR DESCRIPTION
## Pull Request Description

Instead of just using greater than, use greater than or equal to when
deciding whether to use XPMEM. This is more in line with what users
would expect when setting a threshold.

## Expected Impact

N/A

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes warning tests
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
