### PR TITLE
romio/daos: fix some build warnings & update daos configure

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos_io.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_io.c
@@ -25,7 +25,6 @@ static void DAOS_IOContig(ADIO_File fd, void *buf, int count,
 {
     MPI_Count datatype_size;
     uint64_t len;
-    daos_range_t *rg, loc_rg;
     d_sg_list_t *sgl, loc_sgl;
     d_iov_t *iov, loc_iov;
     daos_size_t *nbytes, loc_nbytes;

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -788,10 +788,9 @@ AC_ARG_WITH([cart],
 
 AS_IF([test "x$with_cart" != xno], [
     CART="yes"
-    LDFLAGS="$LDFLAGS -L$with_cart/lib"
-    CPPFLAGS="$CPPFLAGS -I$with_cart/include/"
-    AC_CHECK_HEADERS(gurt/common.h,, [unset CART])
-    AC_CHECK_LIB([gurt], [d_hash_murmur64],, [unset CART])
+    PAC_SET_HEADER_LIB_PATH(cart)
+    AC_CHECK_HEADERS(gurt/hash.h,, [unset CART])
+    AC_CHECK_LIB([gurt], [d_hash_table_create],, [unset CART])
 ])
 
 AC_ARG_WITH([daos],
@@ -801,8 +800,7 @@ AC_ARG_WITH([daos],
 
 AS_IF([test "x$with_daos" != xno], [
     DAOS="yes"
-    LDFLAGS="$LDFLAGS -L$with_daos/lib -L$with_daos/lib64"
-    CPPFLAGS="$CPPFLAGS -I$with_daos/include"
+    PAC_SET_HEADER_LIB_PATH(daos)
     AC_CHECK_HEADERS(daos_types.h,, [unset DAOS])
     AC_CHECK_LIB([uuid], [uuid_generate],, [unset DAOS])
     AC_CHECK_LIB([daos_common], [daos_sgl_init],, [unset DAOS])

--- a/src/mpi/romio/test/runtests.in
+++ b/src/mpi/romio/test/runtests.in
@@ -19,7 +19,6 @@ MAKE="@MAKE@"
 srcdir=@srcdir@
 check_canrun=0
 subset_only=0
-daos_pool=0
 FILENAME=test
 # Using shifts should remove args from the list.
 for arg in "$@" ; do
@@ -52,10 +51,6 @@ for arg in "$@" ; do
 	shift
 	subset_only=1
 	;;
-	-daos)
-	shift
-	daos_pool=1
-	;;
 	-fname=*)
 	FILENAME=`echo $arg|sed 's/-*fname=//'`
 	;;
@@ -75,8 +70,6 @@ for arg in "$@" ; do
 	echo "is used to check that mpirun can run an MPI program."
 	echo "If -subset is used, we skip tests for atomicity and shared"
 	echo "file pointers which can fail on some distributed file systems" 
-	echo "If -daos is used, a DAOS pool is created before tests are run"
-	echo "and destroyed after."
 	exit 1
 	;;
 	*)
@@ -171,22 +164,6 @@ if [ ! -x simple -a $makeeach = 0 ] ; then
     $MAKE default
 fi
 #
-
-if [ $daos_pool = 1 ] ; then
-echo '**** Creating DAOS Pool ****'
-pool=`dmg_old create --size=1GB`
-value=$pool
-echo $value
-OLDIFS=$IFS
-IFS=" "
-read -a array <<< "$(printf "%s" "$value")"
-IFS=$OLDIFS
-export DAOS_POOL=${array[0]}
-export DAOS_SVCL=${array[1]}
-export DAOS_CONT=`uuidgen`
-echo '**** Creating DAOS Container ****'
-daos cont create --pool=$DAOS_POOL --svc=$DAOS_SVCL --cont=$DAOS_CONT --type=POSIX
-fi
 
 testfiles=""
 if [ $runtests = 1 ] ; then
@@ -466,11 +443,6 @@ else
 	echo "No output files remain from previous test!"
 	exit 1
     fi
-fi
-
-if [ $daos_pool = 1 ] ; then
-echo '**** Destroying DAOS Pool ****'
-pool=`mpirun -np 1 dmg_old destroy --force --pool=${array[0]}`
 fi
 
 #


### PR DESCRIPTION
## Pull Request Description

- Update to use PAC_SET_HEADER_LIB_PATH in configure for DAOS and
  CART libs & headers
- fix some build warnings.
- get rid of the daos option in romio runtests and let user create
  pool.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>

## Expected Impact

N/A

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Remove xfail from the test suite when fixing a test
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes warning tests
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Add Devel Docs in the `doc/` directory for any new code design
